### PR TITLE
fix(verify-bytecode): fail when supplied constructor args are not the deployed ones

### DIFF
--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -255,6 +255,62 @@ forgetest_async!(flaky_verify_bytecode_with_constructor_args, |prj, cmd| {
     .await;
 });
 
+// Wrong `--constructor-args` used to verify clean, because supplied args that were not the tail
+// of the creation code were silently replaced by the real ones.
+forgetest_async!(flaky_verify_bytecode_warns_on_wrong_constructor_args, |prj, cmd| {
+    let etherscan_key = next_etherscan_api_key();
+    let rpc_url = next_http_archive_rpc_url();
+    let addr = "0x70f44C13944d49a236E3cD7a94f48f5daB6C619b";
+
+    let source_code = fetch_etherscan_source_flattened(addr, &etherscan_key, Chain::mainnet())
+        .await
+        .expect("failed to fetch source code from etherscan");
+    prj.add_source("StrategyManager", &source_code);
+    prj.write_config(Config {
+        evm_version: EvmVersion::London,
+        optimizer: Some(true),
+        optimizer_runs: Some(200),
+        ..Default::default()
+    });
+
+    let etherscan_key = next_etherscan_api_key();
+    let run = cmd
+        .forge_fuse()
+        .args([
+            "verify-bytecode",
+            addr,
+            "StrategyManager",
+            "--etherscan-api-key",
+            &etherscan_key,
+            "--verifier",
+            "etherscan",
+            "--verifier-url",
+            "https://api.etherscan.io/v2/api?chainid=1",
+            "--rpc-url",
+            &rpc_url,
+            // Three zero addresses instead of the real constructor arguments.
+            "--constructor-args",
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+        ])
+        .assert_success();
+    let output = run.get_output();
+
+    // The warning goes to stderr, the match verdict to stdout.
+    let stderr = output.stderr_lossy();
+    let stdout = output.stdout_lossy();
+
+    assert!(
+        stderr.contains("Provided constructor args are not the ones used at deployment"),
+        "expected a warning that the supplied args do not match the deployment, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("Creation code matched"),
+        "wrong constructor args must not produce a creation match, got:\n{stdout}"
+    );
+});
+
 // `--ignore` tests
 forgetest_async!(flaky_verify_bytecode_can_ignore_creation, |prj, cmd| {
     test_verify_bytecode_with_ignore(
@@ -432,10 +488,10 @@ forgetest_async!(can_verify_bytecode_without_explorer, |prj, cmd| {
     cmd.unset_env("ETHERSCAN_API_KEY");
     cmd.unset_env("VERIFIER_API_KEY");
     cmd.unset_env("VERIFIER_URL");
-    let assert = cmd
+    let run = cmd
         .args(["verify-bytecode", &address, "Counter", "--rpc-url", rpc.as_str()])
         .assert_success();
-    let output = assert.get_output();
+    let output = run.get_output();
     let stdout = output.stdout_lossy();
     let stderr = output.stderr_lossy();
 
@@ -461,7 +517,7 @@ forgetest_async!(can_verify_bytecode_without_explorer, |prj, cmd| {
     cmd.unset_env("ETHERSCAN_API_KEY");
     cmd.unset_env("VERIFIER_API_KEY");
     cmd.unset_env("VERIFIER_URL");
-    let assert = cmd
+    let run = cmd
         .args([
             "verify-bytecode",
             &address,
@@ -472,7 +528,7 @@ forgetest_async!(can_verify_bytecode_without_explorer, |prj, cmd| {
             "runtime",
         ])
         .assert_success();
-    let output = assert.get_output();
+    let output = run.get_output();
     let stdout = output.stdout_lossy();
     let stderr = output.stderr_lossy();
 
@@ -626,7 +682,7 @@ contract LinkedContract {
     cmd.unset_env("ETHERSCAN_API_KEY");
     cmd.unset_env("VERIFIER_API_KEY");
     cmd.unset_env("VERIFIER_URL");
-    let assert = cmd
+    let run = cmd
         .args([
             "verify-bytecode",
             contract.as_str(),
@@ -639,7 +695,7 @@ contract LinkedContract {
             second_lib_spec.as_str(),
         ])
         .assert_success();
-    let output = assert.get_output();
+    let output = run.get_output();
     let stdout = output.stdout_lossy();
     let stderr = output.stderr_lossy();
 
@@ -657,7 +713,7 @@ contract LinkedContract {
     cmd.unset_env("ETHERSCAN_API_KEY");
     cmd.unset_env("VERIFIER_API_KEY");
     cmd.unset_env("VERIFIER_URL");
-    let assert = cmd
+    let run = cmd
         .args([
             "verify-bytecode",
             contract.as_str(),
@@ -666,7 +722,7 @@ contract LinkedContract {
             rpc.as_str(),
         ])
         .assert_success();
-    let output = assert.get_output();
+    let output = run.get_output();
     let stdout = output.stdout_lossy();
     let stderr = output.stderr_lossy();
 

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -349,6 +349,7 @@ impl VerifyBytecodeArgs {
         .transpose()?
         .or(self.encoded_constructor_args.clone().map(hex::decode).transpose()?);
 
+        let args_from_user = provided_constructor_args.is_some();
         let mut constructor_args = if let Some(provided) = provided_constructor_args {
             provided.into()
         } else if let Some(source_code) = &source_code {
@@ -547,12 +548,29 @@ impl VerifyBytecodeArgs {
             })?
         };
 
+        // `is_partial_match` cuts `constructor_args.len()` bytes off both sides before comparing,
+        // so argument *values* never reach the creation comparison and wrong ones of the right
+        // length always match. Whether the supplied args are the on-chain tail is decided here
+        // instead, and a mismatch is a failed verification rather than something to paper over.
+        let args_are_creation_tail = maybe_creation_code.ends_with(&constructor_args);
+        let user_args_mismatch = args_from_user && !args_are_creation_tail;
+
         // In some cases, Etherscan will return incorrect constructor arguments. If this
-        // happens, try extracting arguments ourselves.
-        if !maybe_creation_code.ends_with(&constructor_args) {
-            trace!("mismatch of constructor args with etherscan");
-            // If local bytecode is longer than on-chain one, this is probably not a match.
-            if maybe_creation_code.len() >= local_bytecode.len() {
+        // happens, try extracting arguments ourselves. Args the user passed are never replaced:
+        // substituting them is what let a deployment with different immutables verify clean.
+        if !args_are_creation_tail {
+            trace!(from_user = args_from_user, "constructor args are not the creation code tail");
+            // Do not fold into `user_args_mismatch && !shell::is_json()`: that falls through to
+            // the `else if` under --json and substitutes the args again.
+            if user_args_mismatch {
+                if !shell::is_json() {
+                    sh_warn!(
+                        "Provided constructor args are not the ones used at deployment, so the \
+                         contract's immutables differ. Omit --constructor-args to use those."
+                    )?;
+                }
+            } else if maybe_creation_code.len() >= local_bytecode.len() {
+                // If local bytecode is longer than on-chain one, this is probably not a match.
                 constructor_args =
                     Bytes::copy_from_slice(&maybe_creation_code[local_bytecode.len()..]);
                 trace!(
@@ -572,13 +590,17 @@ impl VerifyBytecodeArgs {
         // Check if `--ignore` is set to `creation`.
         if self.ignore.is_none_or(|b| !b.is_creation()) {
             // Compare creation code with locally built bytecode and `maybe_creation_code`.
-            let match_type = crate::utils::match_bytecodes(
-                local_bytecode_vec.as_slice(),
-                &maybe_creation_code,
-                &constructor_args,
-                false,
-                config.bytecode_hash,
-            );
+            let match_type = if user_args_mismatch {
+                None
+            } else {
+                crate::utils::match_bytecodes(
+                    local_bytecode_vec.as_slice(),
+                    &maybe_creation_code,
+                    &constructor_args,
+                    false,
+                    config.bytecode_hash,
+                )
+            };
 
             crate::utils::print_result(
                 match_type,


### PR DESCRIPTION
## Motivation

Closes #11102.

`forge verify-bytecode` reports a match for a contract whose deployed immutables are not the ones the supplied constructor args would produce. In the issue, five zero addresses verify clean against a contract whose immutables are all non-zero.

Two separate things cause it.

The supplied args are silently replaced. When they are not the trailing bytes of the on-chain creation code, that tail is copied over them and verification continues against the real values:

```rust
if !maybe_creation_code.ends_with(&constructor_args) {
    if maybe_creation_code.len() >= local_bytecode.len() {
        constructor_args = Bytes::copy_from_slice(&maybe_creation_code[local_bytecode.len()..]);
```

The branch is there because Etherscan sometimes returns wrong args, which is reasonable, but it also swallows args the user typed on the command line.

And even without the substitution, the values never reach the comparison. `is_partial_match` cuts `constructor_args.len()` bytes off both sides before comparing, so any wrong args of the right length still match:

```rust
bytecode = &bytecode[..bytecode.len() - constructor_args.len()];
local_bytecode = &local_bytecode[..local_bytecode.len() - constructor_args.len()];
```

Together these make the question "do these args reproduce the deployment" one that cannot be answered no, which is what `yash-atreya` described as the intended behaviour on #8510: *"we do check them. Runtime codes are compared entirely."*

## Solution

Track whether the args came from the user, keep them if so, and treat supplied args that are not the on-chain tail as a failed creation match. The existing "if creation did not match, runtime will not either" branch then reports both honestly. Explorer-derived args keep the current behaviour, so the Etherscan workaround is untouched.

The `!shell::is_json()` check is nested rather than folded into the outer condition: collapsing them makes it false under `--json`, control reaches the `else if`, and the substitution comes back for JSON callers only.

One thing I left alone and would take direction on: under `--json` the result message is still "code did not match - this may be due to varying compiler settings", which now misattributes an argument mismatch. Threading a reason through `print_result` touches every mismatch path, so it seemed out of scope here.

## Testing

`flaky_verify_bytecode_warns_on_wrong_constructor_args` supplies three zero addresses for `StrategyManager`, and asserts the warning appears and no creation match is reported. It fails on `main`.

All 11 tests in `crates/forge/tests/cli/verify_bytecode.rs` pass locally with an Etherscan key, including `flaky_verify_bytecode_with_constructor_args`, which supplies the correct args and must still report partial/partial. `cargo clippy -p forge-verify` is clean.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Behaviour does change for anyone passing constructor args that do not match the deployment: that now reports a mismatch instead of a partial match. That is the point of the fix, but it could surface in a pipeline that was relying on the lenient result.

## AI disclosure

This PR was written with Claude Code. It was used for code generation, the test, and this description. I reviewed and verified every line, ran the test suite, and am responsible for the change.
