### PR TITLE
fix(verify-bytecode): report the default optimizer runs, not "unknown"

### DIFF
--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -206,6 +206,12 @@ fn find_mismatch_in_settings(
     etherscan_settings: &Metadata,
     local_settings: &Config,
 ) -> Vec<String> {
+    // The verify path never calls `normalize_optimizer_settings`, so an unset `optimizer_runs`
+    // arrives here as `None` and used to be reported as "unknown", making every contract built
+    // with the default look like a mismatch. Normalize a copy rather than hardcoding the default,
+    // so the two cannot drift.
+    let local_settings = &local_settings.clone().normalized_optimizer_settings();
+
     let mut mismatches: Vec<String> = vec![];
     if etherscan_settings.evm_version != local_settings.evm_version.to_string().to_lowercase() {
         let str = format!(
@@ -223,12 +229,10 @@ fn find_mismatch_in_settings(
         );
         mismatches.push(str);
     }
-    if local_settings.optimizer_runs.is_some_and(|runs| etherscan_settings.runs != runs as u64)
-        || (local_settings.optimizer_runs.is_none() && etherscan_settings.runs > 0)
-    {
+    let local_runs = local_settings.optimizer_runs.unwrap_or_default() as u64;
+    if etherscan_settings.runs != local_runs {
         let str = format!(
-            "Optimizer runs mismatch: local={}, onchain={}",
-            local_settings.optimizer_runs.map_or("unknown".to_string(), |runs| runs.to_string()),
+            "Optimizer runs mismatch: local={local_runs}, onchain={}",
             etherscan_settings.runs
         );
         mismatches.push(str);
@@ -510,6 +514,47 @@ pub async fn ensure_solc_build_metadata(version: Version) -> Result<Version> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Builds [`Metadata`] with the compiler settings a caller cares about here.
+    fn metadata(evm_version: &str, optimization_used: u64, runs: u64) -> Metadata {
+        serde_json::from_value(serde_json::json!({
+            "SourceCode": "",
+            "ABI": "[]",
+            "ContractName": "C",
+            "CompilerVersion": "v0.8.24+commit.e11b9ed9",
+            "OptimizationUsed": optimization_used.to_string(),
+            "Runs": runs.to_string(),
+            "ConstructorArguments": "",
+            "EVMVersion": evm_version,
+            "Library": "",
+            "LicenseType": "",
+            "Proxy": "0",
+            "Implementation": "",
+            "SwarmSource": "",
+        }))
+        .expect("metadata fixture should deserialize")
+    }
+
+    #[test]
+    fn unset_optimizer_runs_is_the_default_not_a_mismatch() {
+        // A project that never sets `optimizer_runs` compiles with 200, and the verify path does
+        // not normalize the config, so this used to report `local=unknown` against a contract
+        // that agrees with it.
+        let local = Config { optimizer_runs: None, optimizer: Some(true), ..Default::default() };
+        let onchain = metadata(&local.evm_version.to_string().to_lowercase(), 1, 200);
+
+        assert!(find_mismatch_in_settings(&onchain, &local).is_empty());
+    }
+
+    #[test]
+    fn optimizer_runs_mismatch_is_still_reported() {
+        let local = Config { optimizer_runs: None, optimizer: Some(true), ..Default::default() };
+        let onchain = metadata(&local.evm_version.to_string().to_lowercase(), 1, 999);
+
+        let mismatches = find_mismatch_in_settings(&onchain, &local);
+        assert_eq!(mismatches, vec!["Optimizer runs mismatch: local=200, onchain=999"]);
+    }
+
     use crate::verify::VerifierArgs;
     use foundry_cli::opts::EtherscanOpts;
     use foundry_compilers::PathStyle;


### PR DESCRIPTION
## Motivation

When `forge verify-bytecode` fails to match, `find_mismatch_in_settings` prints hints about which compiler settings differ. For `optimizer_runs` it prints the local value as `unknown` and reports a mismatch whenever the on-chain value is non-zero:

```rust
if local_settings.optimizer_runs.is_some_and(|runs| etherscan_settings.runs != runs as u64)
    || (local_settings.optimizer_runs.is_none() && etherscan_settings.runs > 0)
```

A project that never sets `optimizer_runs` compiles with 200. `Config::normalize_optimizer_settings` is what turns the unset value into `Some(200)`, and the verify path never calls it, so the field is still `None` here. A contract compiled with the default 200 therefore gets:

```
Optimizer runs mismatch: local=unknown, onchain=200
```

There is no mismatch. The message appears only after verification has already failed, which is exactly when a false lead is most expensive: the reader goes looking for a settings problem that does not exist.

## Solution

Normalize a copy of the config before comparing, rather than hardcoding 200 in a second place where it could drift from `normalize_optimizer_settings`.

## Testing

Two unit tests in `crates/verify/src/utils.rs`, no network needed. Both fail on `master`:

```
left:  ["Optimizer runs mismatch: local=unknown, onchain=999"]
right: ["Optimizer runs mismatch: local=200, onchain=999"]

assertion failed: find_mismatch_in_settings(&onchain, &local).is_empty()
```

`cargo clippy -p forge-verify` is clean.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## AI disclosure

This PR was written with Claude Code, including the code, tests and this description. I reviewed and verified every line, ran the tests against both the old and new behaviour, and am responsible for the change.
