### PR TITLE
fix(verify-bytecode): fail when provided constructor args do not match the deployment

### DIFF
--- a/.changelog/verify-bytecode-constructor-arguments.md
+++ b/.changelog/verify-bytecode-constructor-arguments.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-verify: patch
+---
+
+Fixed `forge verify-bytecode` accepting constructor arguments that do not match the deployment.

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -312,9 +312,9 @@ forgetest_async!(flaky_verify_bytecode_warns_on_wrong_constructor_args, |prj, cm
         "wrong constructor args must not produce a creation match, got:\n{stdout}"
     );
 
-    // Ignoring creation verification must not allow runtime verification to continue with
-    // constructor arguments already known not to match the deployment. JSON must retain the
-    // specific mismatch reason because warnings are suppressed in JSON mode.
+    // Ignoring creation verification must still compare the runtime produced by the supplied
+    // arguments. StrategyManager embeds its constructor arguments as immutables, so they produce
+    // a runtime mismatch.
     let etherscan_key = next_etherscan_api_key();
     cmd.forge_fuse()
         .args([
@@ -338,7 +338,7 @@ forgetest_async!(flaky_verify_bytecode_warns_on_wrong_constructor_args, |prj, cm
             "--json",
         ])
         .assert_json_stdout(
-            r#"[{"bytecode_type":"runtime","match_type":null,"message":"Provided constructor args could not be validated against deployment creation code"}]"#,
+            r#"[{"bytecode_type":"runtime","match_type":null,"message":"Runtime code did not match - this may be due to varying compiler settings"}]"#,
         );
 });
 

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -255,6 +255,62 @@ forgetest_async!(flaky_verify_bytecode_with_constructor_args, |prj, cmd| {
     .await;
 });
 
+// Wrong `--constructor-args` used to verify clean, because supplied args that were not the tail
+// of the creation code were silently replaced by the real ones.
+forgetest_async!(flaky_verify_bytecode_warns_on_wrong_constructor_args, |prj, cmd| {
+    let etherscan_key = next_etherscan_api_key();
+    let rpc_url = next_http_archive_rpc_url();
+    let addr = "0x70f44C13944d49a236E3cD7a94f48f5daB6C619b";
+
+    let source_code = fetch_etherscan_source_flattened(addr, &etherscan_key, Chain::mainnet())
+        .await
+        .expect("failed to fetch source code from etherscan");
+    prj.add_source("StrategyManager", &source_code);
+    prj.write_config(Config {
+        evm_version: EvmVersion::London,
+        optimizer: Some(true),
+        optimizer_runs: Some(200),
+        ..Default::default()
+    });
+
+    let etherscan_key = next_etherscan_api_key();
+    let run = cmd
+        .forge_fuse()
+        .args([
+            "verify-bytecode",
+            addr,
+            "StrategyManager",
+            "--etherscan-api-key",
+            &etherscan_key,
+            "--verifier",
+            "etherscan",
+            "--verifier-url",
+            "https://api.etherscan.io/v2/api?chainid=1",
+            "--rpc-url",
+            &rpc_url,
+            // Three zero addresses instead of the real constructor arguments.
+            "--constructor-args",
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+        ])
+        .assert_success();
+    let output = run.get_output();
+
+    // The warning goes to stderr, the match verdict to stdout.
+    let stderr = output.stderr_lossy();
+    let stdout = output.stdout_lossy();
+
+    assert!(
+        stderr.contains("Provided constructor args do not match the ones used at deployment"),
+        "expected a warning that the supplied args do not match the deployment, got:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("Creation code matched"),
+        "wrong constructor args must not produce a creation match, got:\n{stdout}"
+    );
+});
+
 // `--ignore` tests
 forgetest_async!(flaky_verify_bytecode_can_ignore_creation, |prj, cmd| {
     test_verify_bytecode_with_ignore(

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -302,7 +302,9 @@ forgetest_async!(flaky_verify_bytecode_warns_on_wrong_constructor_args, |prj, cm
     let stdout = output.stdout_lossy();
 
     assert!(
-        stderr.contains("Provided constructor args do not match the ones used at deployment"),
+        stderr.contains(
+            "Provided constructor args could not be validated against deployment creation code"
+        ),
         "expected a warning that the supplied args do not match the deployment, got:\n{stderr}"
     );
     assert!(
@@ -336,7 +338,7 @@ forgetest_async!(flaky_verify_bytecode_warns_on_wrong_constructor_args, |prj, cm
             "--json",
         ])
         .assert_json_stdout(
-            r#"[{"bytecode_type":"runtime","match_type":null,"message":"Provided constructor args do not match the ones used at deployment"}]"#,
+            r#"[{"bytecode_type":"runtime","match_type":null,"message":"Provided constructor args could not be validated against deployment creation code"}]"#,
         );
 });
 

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -309,6 +309,35 @@ forgetest_async!(flaky_verify_bytecode_warns_on_wrong_constructor_args, |prj, cm
         !stdout.contains("Creation code matched"),
         "wrong constructor args must not produce a creation match, got:\n{stdout}"
     );
+
+    // Ignoring creation verification must not allow runtime verification to continue with
+    // constructor arguments already known not to match the deployment. JSON must retain the
+    // specific mismatch reason because warnings are suppressed in JSON mode.
+    let etherscan_key = next_etherscan_api_key();
+    cmd.forge_fuse()
+        .args([
+            "verify-bytecode",
+            addr,
+            "StrategyManager",
+            "--etherscan-api-key",
+            &etherscan_key,
+            "--verifier",
+            "etherscan",
+            "--verifier-url",
+            "https://api.etherscan.io/v2/api?chainid=1",
+            "--rpc-url",
+            &rpc_url,
+            "--constructor-args",
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "--ignore",
+            "creation",
+            "--json",
+        ])
+        .assert_json_stdout(
+            r#"[{"bytecode_type":"runtime","match_type":null,"message":"Provided constructor args do not match the ones used at deployment"}]"#,
+        );
 });
 
 // `--ignore` tests

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -697,17 +697,18 @@ impl VerifyBytecodeArgs {
             false,
             config.bytecode_hash,
         );
-        if args_from_user && creation_match_type.is_none() {
+        if args_from_user
+            && creation_match_type.is_none()
+            && self.ignore.is_none_or(|b| !b.is_creation())
+        {
             let message =
                 "Provided constructor args could not be validated against deployment creation code";
             if shell::is_json() {
-                if self.ignore.is_none_or(|b| !b.is_creation()) {
-                    json_results.push(JsonResult {
-                        bytecode_type: BytecodeType::Creation,
-                        match_type: None,
-                        message: Some(message.to_string()),
-                    });
-                }
+                json_results.push(JsonResult {
+                    bytecode_type: BytecodeType::Creation,
+                    match_type: None,
+                    message: Some(message.to_string()),
+                });
                 if self.ignore.is_none_or(|b| !b.is_runtime()) {
                     json_results.push(JsonResult {
                         bytecode_type: BytecodeType::Runtime,
@@ -718,15 +719,13 @@ impl VerifyBytecodeArgs {
                 sh_println!("{}", serde_json::to_string(&json_results)?)?;
             } else {
                 sh_warn!("{message}")?;
-                if self.ignore.is_none_or(|b| !b.is_creation()) {
-                    crate::utils::print_result(
-                        None,
-                        BytecodeType::Creation,
-                        &mut json_results,
-                        etherscan_metadata,
-                        &config,
-                    );
-                }
+                crate::utils::print_result(
+                    None,
+                    BytecodeType::Creation,
+                    &mut json_results,
+                    etherscan_metadata,
+                    &config,
+                );
                 if self.ignore.is_none_or(|b| !b.is_runtime()) {
                     crate::utils::print_result(
                         None,

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -4,6 +4,7 @@ use crate::{
     utils::{
         BytecodeType, JsonResult, check_and_encode_args, check_explorer_args,
         load_fork_config_and_evm_opts, maybe_predeploy_contract, synthetic_deployment_context,
+        validate_encoded_constructor_args,
     },
     verify::VerifierArgs,
 };
@@ -444,15 +445,18 @@ impl VerifyBytecodeArgs {
             .ok_or_eyre("Unlinked bytecode is not supported for verification")?;
 
         // Get and encode user provided constructor args
-        let provided_constructor_args = if let Some(path) = self.constructor_args_path.clone() {
-            // Read from file
-            Some(read_constructor_args_file(path)?)
+        let provided_constructor_args = if let Some(encoded) = &self.encoded_constructor_args {
+            Some(validate_encoded_constructor_args(&artifact, hex::decode(encoded)?)?)
         } else {
-            self.constructor_args.clone()
-        }
-        .map(|args| check_and_encode_args(&artifact, args))
-        .transpose()?
-        .or(self.encoded_constructor_args.clone().map(hex::decode).transpose()?);
+            if let Some(path) = self.constructor_args_path.clone() {
+                // Read from file.
+                Some(read_constructor_args_file(path)?)
+            } else {
+                self.constructor_args.clone()
+            }
+            .map(|args| check_and_encode_args(&artifact, args))
+            .transpose()?
+        };
 
         let args_from_user = provided_constructor_args.is_some();
         let mut constructor_args = if let Some(provided) = provided_constructor_args {
@@ -664,16 +668,53 @@ impl VerifyBytecodeArgs {
 
         // In some cases, Etherscan will return incorrect constructor arguments. If this
         // happens, try extracting arguments ourselves.
+        let user_args_mismatch =
+            args_from_user && !maybe_creation_code.ends_with(&constructor_args);
+        if user_args_mismatch {
+            let message = "Provided constructor args do not match the ones used at deployment";
+            if shell::is_json() {
+                if self.ignore.is_none_or(|b| !b.is_creation()) {
+                    json_results.push(JsonResult {
+                        bytecode_type: BytecodeType::Creation,
+                        match_type: None,
+                        message: Some(message.to_string()),
+                    });
+                }
+                if self.ignore.is_none_or(|b| !b.is_runtime()) {
+                    json_results.push(JsonResult {
+                        bytecode_type: BytecodeType::Runtime,
+                        match_type: None,
+                        message: Some(message.to_string()),
+                    });
+                }
+                sh_println!("{}", serde_json::to_string(&json_results)?)?;
+            } else {
+                sh_warn!("{message}")?;
+                if self.ignore.is_none_or(|b| !b.is_creation()) {
+                    crate::utils::print_result(
+                        None,
+                        BytecodeType::Creation,
+                        &mut json_results,
+                        etherscan_metadata,
+                        &config,
+                    );
+                }
+                if self.ignore.is_none_or(|b| !b.is_runtime()) {
+                    crate::utils::print_result(
+                        None,
+                        BytecodeType::Runtime,
+                        &mut json_results,
+                        etherscan_metadata,
+                        &config,
+                    );
+                }
+            }
+            return Ok(());
+        }
+
         if !maybe_creation_code.ends_with(&constructor_args) {
             trace!("mismatch of constructor args with etherscan");
-            if args_from_user {
-                // Keep user-supplied args: substituting them with the onchain tail would make
-                // the creation comparison vacuous and let a deployment with different
-                // constructor args (and immutables) verify clean.
-                if !shell::is_json() {
-                    sh_warn!("Provided constructor args do not match the ones used at deployment")?;
-                }
-            } else if maybe_creation_code.len() >= local_bytecode.len() {
+            if maybe_creation_code.len() >= local_bytecode.len() {
                 // If local bytecode is longer than on-chain one, this is probably not a match.
                 constructor_args =
                     Bytes::copy_from_slice(&maybe_creation_code[local_bytecode.len()..]);

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -454,6 +454,7 @@ impl VerifyBytecodeArgs {
         .transpose()?
         .or(self.encoded_constructor_args.clone().map(hex::decode).transpose()?);
 
+        let args_from_user = provided_constructor_args.is_some();
         let mut constructor_args = if let Some(provided) = provided_constructor_args {
             provided.into()
         } else if let Some(source_code) = &source_code {
@@ -665,8 +666,15 @@ impl VerifyBytecodeArgs {
         // happens, try extracting arguments ourselves.
         if !maybe_creation_code.ends_with(&constructor_args) {
             trace!("mismatch of constructor args with etherscan");
-            // If local bytecode is longer than on-chain one, this is probably not a match.
-            if maybe_creation_code.len() >= local_bytecode.len() {
+            if args_from_user {
+                // Keep user-supplied args: substituting them with the onchain tail would make
+                // the creation comparison vacuous and let a deployment with different
+                // constructor args (and immutables) verify clean.
+                if !shell::is_json() {
+                    sh_warn!("Provided constructor args do not match the ones used at deployment")?;
+                }
+            } else if maybe_creation_code.len() >= local_bytecode.len() {
+                // If local bytecode is longer than on-chain one, this is probably not a match.
                 constructor_args =
                     Bytes::copy_from_slice(&maybe_creation_code[local_bytecode.len()..]);
                 trace!(

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -349,6 +349,7 @@ impl VerifyBytecodeArgs {
         .transpose()?
         .or(self.encoded_constructor_args.clone().map(hex::decode).transpose()?);
 
+        let args_from_user = provided_constructor_args.is_some();
         let mut constructor_args = if let Some(provided) = provided_constructor_args {
             provided.into()
         } else if let Some(source_code) = &source_code {
@@ -551,8 +552,15 @@ impl VerifyBytecodeArgs {
         // happens, try extracting arguments ourselves.
         if !maybe_creation_code.ends_with(&constructor_args) {
             trace!("mismatch of constructor args with etherscan");
-            // If local bytecode is longer than on-chain one, this is probably not a match.
-            if maybe_creation_code.len() >= local_bytecode.len() {
+            if args_from_user {
+                // Keep user-supplied args: substituting them with the onchain tail would make
+                // the creation comparison vacuous and let a deployment with different
+                // constructor args (and immutables) verify clean.
+                if !shell::is_json() {
+                    sh_warn!("Provided constructor args do not match the ones used at deployment")?;
+                }
+            } else if maybe_creation_code.len() >= local_bytecode.len() {
+                // If local bytecode is longer than on-chain one, this is probably not a match.
                 constructor_args =
                     Bytes::copy_from_slice(&maybe_creation_code[local_bytecode.len()..]);
                 trace!(

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -667,11 +667,39 @@ impl VerifyBytecodeArgs {
         Self::ensure_endpoint_identity_unchanged(&config, endpoint_identity.as_ref()).await?;
 
         // In some cases, Etherscan will return incorrect constructor arguments. If this
-        // happens, try extracting arguments ourselves.
-        let user_args_mismatch =
-            args_from_user && !maybe_creation_code.ends_with(&constructor_args);
-        if user_args_mismatch {
-            let message = "Provided constructor args do not match the ones used at deployment";
+        // happens, try extracting arguments ourselves. Never replace user-provided arguments.
+        if !args_from_user && !maybe_creation_code.ends_with(&constructor_args) {
+            trace!("mismatch of constructor args with etherscan");
+            if maybe_creation_code.len() >= local_bytecode.len() {
+                // If local bytecode is longer than on-chain one, this is probably not a match.
+                constructor_args =
+                    Bytes::copy_from_slice(&maybe_creation_code[local_bytecode.len()..]);
+                trace!(
+                    target: "forge::verify",
+                    "setting constructor args to latest {} bytes of bytecode",
+                    constructor_args.len()
+                );
+            }
+        }
+
+        // Append constructor args to the local_bytecode.
+        trace!(%constructor_args);
+        let mut local_bytecode_vec = local_bytecode.to_vec();
+        local_bytecode_vec.extend_from_slice(&constructor_args);
+
+        // A suffix check alone is insufficient for dynamic ABI values: one valid encoding can
+        // be a suffix of a different valid encoding. Always compare the complete creation code
+        // when arguments came from the user, even if creation output is ignored.
+        let creation_match_type = crate::utils::match_bytecodes(
+            local_bytecode_vec.as_slice(),
+            &maybe_creation_code,
+            &constructor_args,
+            false,
+            config.bytecode_hash,
+        );
+        if args_from_user && creation_match_type.is_none() {
+            let message =
+                "Provided constructor args could not be validated against deployment creation code";
             if shell::is_json() {
                 if self.ignore.is_none_or(|b| !b.is_creation()) {
                     json_results.push(JsonResult {
@@ -712,39 +740,12 @@ impl VerifyBytecodeArgs {
             return Ok(());
         }
 
-        if !maybe_creation_code.ends_with(&constructor_args) {
-            trace!("mismatch of constructor args with etherscan");
-            if maybe_creation_code.len() >= local_bytecode.len() {
-                // If local bytecode is longer than on-chain one, this is probably not a match.
-                constructor_args =
-                    Bytes::copy_from_slice(&maybe_creation_code[local_bytecode.len()..]);
-                trace!(
-                    target: "forge::verify",
-                    "setting constructor args to latest {} bytes of bytecode",
-                    constructor_args.len()
-                );
-            }
-        }
-
-        // Append constructor args to the local_bytecode.
-        trace!(%constructor_args);
-        let mut local_bytecode_vec = local_bytecode.to_vec();
-        local_bytecode_vec.extend_from_slice(&constructor_args);
-
         trace!(ignore = ?self.ignore);
         // Check if `--ignore` is set to `creation`.
         if self.ignore.is_none_or(|b| !b.is_creation()) {
             // Compare creation code with locally built bytecode and `maybe_creation_code`.
-            let match_type = crate::utils::match_bytecodes(
-                local_bytecode_vec.as_slice(),
-                &maybe_creation_code,
-                &constructor_args,
-                false,
-                config.bytecode_hash,
-            );
-
             crate::utils::print_result(
-                match_type,
+                creation_match_type,
                 BytecodeType::Creation,
                 &mut json_results,
                 etherscan_metadata,
@@ -752,7 +753,7 @@ impl VerifyBytecodeArgs {
             );
 
             // If the creation code does not match, the runtime also won't match. Hence return.
-            if match_type.is_none() {
+            if creation_match_type.is_none() {
                 crate::utils::print_result(
                     None,
                     BytecodeType::Runtime,

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -187,6 +187,13 @@ fn is_partial_match(
         return try_extract_and_compare_bytecode(local_bytecode, bytecode);
     }
 
+    // The constructor args are part of what is being verified: the onchain creation code must
+    // actually end with them before they can be stripped, otherwise args of the right length
+    // could never fail the comparison.
+    if !bytecode.ends_with(constructor_args) {
+        return false;
+    }
+
     // If not runtime, extract constructor args from the end of the bytecode
     bytecode = &bytecode[..bytecode.len() - constructor_args.len()];
     local_bytecode = &local_bytecode[..local_bytecode.len() - constructor_args.len()];
@@ -515,6 +522,26 @@ mod tests {
     use foundry_compilers::PathStyle;
     use foundry_config::NamedChain;
     use foundry_test_utils::TestProject;
+
+    #[test]
+    fn creation_code_must_end_with_constructor_args() {
+        let code = alloy_primitives::hex!("6080604052348015600e575f5ffd5b50607b80601a5f395ff3fe");
+        let real_args = [0x11u8; 32];
+        let wrong_args = [0x22u8; 32];
+
+        let onchain = [code.as_slice(), &real_args].concat();
+
+        // Wrong args of the right length used to report a partial match because the tails were
+        // stripped from both sides without comparing them.
+        let local = [code.as_slice(), &wrong_args].concat();
+        assert_eq!(match_bytecodes(&local, &onchain, &wrong_args, false, BytecodeHash::Ipfs), None);
+
+        let local = [code.as_slice(), &real_args].concat();
+        assert_eq!(
+            match_bytecodes(&local, &onchain, &real_args, false, BytecodeHash::Ipfs),
+            Some(VerificationType::Full)
+        );
+    }
 
     #[test]
     fn build_project_finds_artifact_by_relative_contract_path() {

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -274,18 +274,20 @@ pub fn check_and_encode_args(
     artifact: &CompactContractBytecode,
     args: Vec<String>,
 ) -> Result<Vec<u8>, eyre::ErrReport> {
-    if let Some(constructor) = artifact.abi.as_ref().and_then(|abi| abi.constructor()) {
-        if constructor.inputs.len() != args.len() {
-            eyre::bail!(
-                "Mismatch of constructor arguments length. Expected {}, got {}",
-                constructor.inputs.len(),
-                args.len()
-            );
+    let Some(constructor) = artifact.abi.as_ref().and_then(|abi| abi.constructor()) else {
+        if args.is_empty() {
+            return Ok(Vec::new());
         }
-        encode_args(&constructor.inputs, &args).map(|args| DynSolValue::Tuple(args).abi_encode())
-    } else {
-        Ok(Vec::new())
+        eyre::bail!("Contract has no constructor arguments, but arguments were provided");
+    };
+    if constructor.inputs.len() != args.len() {
+        eyre::bail!(
+            "Mismatch of constructor arguments length. Expected {}, got {}",
+            constructor.inputs.len(),
+            args.len()
+        );
     }
+    encode_args(&constructor.inputs, &args).map(|args| DynSolValue::Tuple(args).abi_encode())
 }
 
 pub fn validate_encoded_constructor_args(
@@ -644,6 +646,18 @@ mod tests {
         // metadata and must not be accepted as part of the constructor arguments.
         let overlapping = [alloy_primitives::hex!("a1616101").as_slice(), &args].concat();
         assert!(validate_encoded_constructor_args(&artifact, overlapping).is_err());
+    }
+
+    #[test]
+    fn typed_constructor_args_require_a_constructor() {
+        let artifact = CompactContractBytecode {
+            abi: Some(alloy_json_abi::JsonAbi::default()),
+            bytecode: None,
+            deployed_bytecode: None,
+        };
+
+        assert!(check_and_encode_args(&artifact, vec!["1".to_string()]).is_err());
+        assert_eq!(check_and_encode_args(&artifact, Vec::new()).unwrap(), Vec::<u8>::new());
     }
 
     #[test]

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::{bytecode::VerifyBytecodeArgs, types::VerificationType};
-use alloy_dyn_abi::DynSolValue;
+use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_network::{AnyNetwork, AnyRpcBlock};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_provider::{Provider, network::BlockResponse};
@@ -286,6 +286,28 @@ pub fn check_and_encode_args(
     } else {
         Ok(Vec::new())
     }
+}
+
+pub fn validate_encoded_constructor_args(
+    artifact: &CompactContractBytecode,
+    args: Vec<u8>,
+) -> Result<Vec<u8>, eyre::ErrReport> {
+    let Some(constructor) = artifact.abi.as_ref().and_then(|abi| abi.constructor()) else {
+        if args.is_empty() {
+            return Ok(args);
+        }
+        eyre::bail!("Contract has no constructor arguments, but encoded arguments were provided");
+    };
+    let values = constructor
+        .abi_decode_input(&args)
+        .map_err(|err| eyre::eyre!("Invalid ABI-encoded constructor arguments: {err}"))?;
+    let encoded = constructor
+        .abi_encode_input(&values)
+        .map_err(|err| eyre::eyre!("Invalid ABI-encoded constructor arguments: {err}"))?;
+    if encoded != args {
+        eyre::bail!("Constructor arguments are not canonically ABI-encoded");
+    }
+    Ok(args)
 }
 
 pub fn check_explorer_args(source_code: &ContractMetadata) -> Result<Bytes, eyre::ErrReport> {
@@ -598,6 +620,30 @@ mod tests {
         let mut tx = TxEnvFor::<foundry_evm::core::evm::MonadEvmNetwork>::default();
         tx.set_caller(caller);
         tx
+    }
+
+    #[test]
+    fn encoded_constructor_args_must_be_canonical() {
+        let artifact = CompactContractBytecode {
+            abi: Some(alloy_json_abi::JsonAbi::parse(["constructor(uint256 value)"]).unwrap()),
+            bytecode: None,
+            deployed_bytecode: None,
+        };
+        let args = artifact
+            .abi
+            .as_ref()
+            .unwrap()
+            .constructor()
+            .unwrap()
+            .abi_encode_input(&[DynSolValue::Uint(U256::from(1), 256)])
+            .unwrap();
+
+        assert_eq!(validate_encoded_constructor_args(&artifact, args.clone()).unwrap(), args);
+
+        // Arbitrary bytes prepended to valid arguments can overlap the creation bytecode's
+        // metadata and must not be accepted as part of the constructor arguments.
+        let overlapping = [alloy_primitives::hex!("a1616101").as_slice(), &args].concat();
+        assert!(validate_encoded_constructor_args(&artifact, overlapping).is_err());
     }
 
     #[test]

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -188,6 +188,13 @@ fn is_partial_match(
         return try_extract_and_compare_bytecode(local_bytecode, bytecode);
     }
 
+    // The constructor args are part of what is being verified: the onchain creation code must
+    // actually end with them before they can be stripped, otherwise args of the right length
+    // could never fail the comparison.
+    if !bytecode.ends_with(constructor_args) {
+        return false;
+    }
+
     // If not runtime, extract constructor args from the end of the bytecode
     bytecode = &bytecode[..bytecode.len() - constructor_args.len()];
     local_bytecode = &local_bytecode[..local_bytecode.len() - constructor_args.len()];
@@ -591,6 +598,26 @@ mod tests {
         let mut tx = TxEnvFor::<foundry_evm::core::evm::MonadEvmNetwork>::default();
         tx.set_caller(caller);
         tx
+    }
+
+    #[test]
+    fn creation_code_must_end_with_constructor_args() {
+        let code = alloy_primitives::hex!("6080604052348015600e575f5ffd5b50607b80601a5f395ff3fe");
+        let real_args = [0x11u8; 32];
+        let wrong_args = [0x22u8; 32];
+
+        let onchain = [code.as_slice(), &real_args].concat();
+
+        // Wrong args of the right length used to report a partial match because the tails were
+        // stripped from both sides without comparing them.
+        let local = [code.as_slice(), &wrong_args].concat();
+        assert_eq!(match_bytecodes(&local, &onchain, &wrong_args, false, BytecodeHash::Ipfs), None);
+
+        let local = [code.as_slice(), &real_args].concat();
+        assert_eq!(
+            match_bytecodes(&local, &onchain, &real_args, false, BytecodeHash::Ipfs),
+            Some(VerificationType::Full)
+        );
     }
 
     #[test]

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -664,6 +664,21 @@ mod tests {
             match_bytecodes(&local, &onchain, &real_args, false, BytecodeHash::Ipfs),
             Some(VerificationType::Full)
         );
+
+        // A valid dynamic encoding can end with another valid encoding. The suffix alone must
+        // not establish that the supplied arguments match.
+        let suffix_args =
+            DynSolValue::Tuple(vec![DynSolValue::Bytes(real_args.to_vec())]).abi_encode();
+        let deployment_args =
+            DynSolValue::Tuple(vec![DynSolValue::Bytes(suffix_args.clone())]).abi_encode();
+        assert!(deployment_args.ends_with(&suffix_args));
+
+        let onchain = [code.as_slice(), deployment_args.as_slice()].concat();
+        let local = [code.as_slice(), suffix_args.as_slice()].concat();
+        assert_eq!(
+            match_bytecodes(&local, &onchain, &suffix_args, false, BytecodeHash::Ipfs),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`forge verify-bytecode` reports a match for a contract even when the supplied constructor args are not the ones used at deployment. In #11102, five zero addresses verify clean against a contract whose immutables are all non-zero.

Two defects combine to make the args unfalsifiable. Supplied args that are not the tail of the onchain creation code are silently replaced with the real tail, which also feeds the real args into the runtime simulation, so even the full runtime comparison (immutables included) passes. And `is_partial_match` strips `constructor_args.len()` bytes from both sides before comparing, without ever checking that the onchain code actually ends with those args, so wrong args of the right length can never fail the creation comparison either.

## Solution

Fix it at the comparison layer: `is_partial_match` now requires the onchain creation code to end with the constructor args before stripping them. In `verify-bytecode`, user-supplied args are kept instead of substituted (with a warning), while explorer-derived args retain the existing substitution workaround for Etherscan returning incorrect args. With the wrong args kept, the full match fails on the differing tail and the partial match fails on the new check, so the mismatch surfaces through the normal reporting paths, including `--json`.

This supersedes #16054, which fixes the same bug by special-casing the `verify-bytecode` call site and forcing the match result to `None`. Checking the invariant inside the comparison covers all creation-path callers and needs no extra state. Credit to @mkzung for the diagnosis and the regression test; the commit lists them as co-author.

Behaviour changes for anyone passing constructor args that do not match the deployment: that now reports a mismatch instead of a partial match.

A unit test covers the comparison change directly, and `flaky_verify_bytecode_warns_on_wrong_constructor_args` (adapted from #16054) exercises the CLI path against the deployed `StrategyManager`.

Fixes #11102