### PR TITLE
fix(anvil): add transaction status RPC

### DIFF
--- a/.changelog/anvil-dropped-transaction-receipts.md
+++ b/.changelog/anvil-dropped-transaction-receipts.md
@@ -2,4 +2,4 @@
 anvil: patch
 ---
 
-Anvil now reports when an accepted transaction was dropped from the mempool instead of leaving receipt consumers polling indefinitely.
+Added `anvil_getTransactionStatus` to report whether a transaction is pending, mined, or recently dropped without changing standard receipt behavior.

--- a/.changelog/anvil-dropped-transaction-receipts.md
+++ b/.changelog/anvil-dropped-transaction-receipts.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Anvil now reports when an accepted transaction was dropped from the mempool instead of leaving receipt consumers polling indefinitely.

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -268,6 +268,10 @@ pub enum EthRequest {
     #[serde(rename = "anvil_getBlobsByTransactionHash", with = "sequence")]
     GetBlobByTransactionHash(TxHash),
 
+    /// Returns the lifecycle status of a transaction known to Anvil.
+    #[serde(rename = "anvil_getTransactionStatus", with = "sequence")]
+    GetTransactionStatus(TxHash),
+
     /// Returns the genesis time for the chain
     #[serde(rename = "anvil_getGenesisTime", with = "empty_params")]
     GetGenesisTime(()),

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -15,6 +15,18 @@ use revm::interpreter::InstructionResult;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
+/// The lifecycle status of a transaction known to Anvil.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AnvilTransactionStatus {
+    /// The transaction is currently in the mempool.
+    Pending,
+    /// The transaction has been mined and its receipt is still available.
+    Mined,
+    /// The transaction recently left the mempool without being mined.
+    Dropped,
+}
+
 /// A wrapper for a transaction envelope that allows impersonating accounts.
 ///
 /// This is a helper that carries the `impersonated` sender so that the right hash

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3395,7 +3395,17 @@ impl EthApi<FoundryNetwork> {
     /// Handler for ETH RPC call: `eth_getTransactionReceipt`
     pub async fn transaction_receipt(&self, hash: B256) -> Result<Option<FoundryTxReceipt>> {
         node_info!("eth_getTransactionReceipt");
-        self.backend.transaction_receipt(hash).await
+        if let Some(receipt) = self.backend.transaction_receipt(hash).await? {
+            return Ok(Some(receipt));
+        }
+        if self.pool.is_dropped(&hash) {
+            return Err(BlockchainError::RpcError(RpcError {
+                code: ErrorCode::ServerError(-32000),
+                message: "transaction dropped from mempool".into(),
+                data: Some(serde_json::Value::String(hash.to_string())),
+            }));
+        }
+        Ok(None)
     }
 
     /// Returns block receipts by block number.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -80,7 +80,7 @@ use anvil_core::{
     eth::{
         EthRequest,
         block::{BlockInfo, canonical_block},
-        transaction::{MaybeImpersonatedTransaction, PendingTransaction},
+        transaction::{AnvilTransactionStatus, MaybeImpersonatedTransaction, PendingTransaction},
     },
     types::{ReorgOptions, TransactionData},
 };
@@ -1958,6 +1958,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::GetBlobByTransactionHash(hash) => {
                 self.anvil_get_blob_by_tx_hash(hash).to_rpc_result()
             }
+            EthRequest::GetTransactionStatus(hash) => {
+                self.anvil_get_transaction_status(hash).await.to_rpc_result()
+            }
             EthRequest::GetGenesisTime(()) => self.anvil_get_genesis_time().to_rpc_result(),
             EthRequest::EthGetRawTransactionByBlockHashAndIndex(hash, index) => {
                 self.raw_transaction_by_block_hash_and_index(hash, index).await.to_rpc_result()
@@ -3258,6 +3261,19 @@ impl EthApi<FoundryNetwork> {
         Ok(self.backend.get_blob_by_tx_hash(hash)?)
     }
 
+    /// Handler for RPC call: `anvil_getTransactionStatus`.
+    pub async fn anvil_get_transaction_status(
+        &self,
+        hash: B256,
+    ) -> Result<Option<AnvilTransactionStatus>> {
+        node_info!("anvil_getTransactionStatus");
+        let pool_status = self.pool.transaction_status(&hash);
+        if self.backend.transaction_receipt(hash).await?.is_some() {
+            return Ok(Some(AnvilTransactionStatus::Mined));
+        }
+        Ok(pool_status)
+    }
+
     /// Get transaction by its hash.
     ///
     /// This will check the storage for a matching transaction, if no transaction exists in storage
@@ -3395,17 +3411,7 @@ impl EthApi<FoundryNetwork> {
     /// Handler for ETH RPC call: `eth_getTransactionReceipt`
     pub async fn transaction_receipt(&self, hash: B256) -> Result<Option<FoundryTxReceipt>> {
         node_info!("eth_getTransactionReceipt");
-        if let Some(receipt) = self.backend.transaction_receipt(hash).await? {
-            return Ok(Some(receipt));
-        }
-        if self.pool.is_dropped(&hash) {
-            return Err(BlockchainError::RpcError(RpcError {
-                code: ErrorCode::ServerError(-32000),
-                message: "transaction dropped from mempool".into(),
-                data: Some(serde_json::Value::String(hash.to_string())),
-            }));
-        }
-        Ok(None)
+        self.backend.transaction_receipt(hash).await
     }
 
     /// Returns block receipts by block number.

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     mem::storage::MinedBlockOutcome,
 };
 use alloy_consensus::Transaction;
-use alloy_primitives::{Address, TxHash};
+use alloy_primitives::{Address, TxHash, map::HashSet};
 use alloy_rpc_types::txpool::TxpoolStatus;
 use anvil_core::eth::transaction::PendingTransaction;
 use futures::channel::mpsc::{Receiver, Sender, channel};
@@ -45,6 +45,46 @@ use parking_lot::{Mutex, RwLock};
 use std::{collections::VecDeque, fmt, sync::Arc};
 
 pub mod transactions;
+
+const DROPPED_TRANSACTION_LIMIT: usize = 10_000;
+
+/// A bounded index of transactions that left the pool without being mined.
+#[derive(Debug, Default)]
+struct DroppedTransactions {
+    hashes: HashSet<TxHash>,
+    order: VecDeque<TxHash>,
+}
+
+impl DroppedTransactions {
+    fn insert(&mut self, hash: TxHash) {
+        if !self.hashes.insert(hash) {
+            return;
+        }
+        self.order.push_back(hash);
+
+        while self.order.len() > DROPPED_TRANSACTION_LIMIT {
+            if let Some(oldest) = self.order.pop_front() {
+                self.hashes.remove(&oldest);
+            }
+        }
+    }
+
+    fn extend(&mut self, hashes: impl IntoIterator<Item = TxHash>) {
+        for hash in hashes {
+            self.insert(hash);
+        }
+    }
+
+    fn remove(&mut self, hash: &TxHash) {
+        if self.hashes.remove(hash) {
+            self.order.retain(|entry| entry != hash);
+        }
+    }
+
+    fn contains(&self, hash: &TxHash) -> bool {
+        self.hashes.contains(hash)
+    }
+}
 
 /// Transaction pool that performs validation.
 pub struct Pool<T> {
@@ -95,6 +135,11 @@ impl<T> Pool<T> {
         self.inner.read().contains(tx_hash)
     }
 
+    /// Returns true if the transaction recently left the pool without being mined.
+    pub fn is_dropped(&self, tx_hash: &TxHash) -> bool {
+        self.inner.read().dropped_transactions.contains(tx_hash)
+    }
+
     /// Returns true if this pool contains a transaction from `sender` with `nonce`.
     pub fn contains_sender_nonce(&self, sender: Address, nonce: u64) -> bool
     where
@@ -128,18 +173,7 @@ impl<T> Pool<T> {
     ///
     /// **Note**: this will also drop any transaction that depend on the `tx`
     pub fn drop_transaction(&self, tx: TxHash) -> Option<Arc<PoolTransaction<T>>> {
-        trace!(target: "txpool", "Dropping transaction: [{:?}]", tx);
-        let removed = {
-            let mut pool = self.inner.write();
-            pool.ready_transactions.remove_with_markers(vec![tx], None)
-        };
-        trace!(target: "txpool", "Dropped transactions: {:?}", removed.iter().map(|tx| tx.hash()).collect::<Vec<_>>());
-
-        if removed.is_empty() {
-            None
-        } else {
-            removed.into_iter().find(|t| *t.pending_transaction.hash() == tx)
-        }
+        self.inner.write().drop_transaction(tx)
     }
 
     /// Notifies listeners if the transaction was added to the ready queue.
@@ -193,13 +227,30 @@ impl<T: Transaction> Pool<T> {
     /// This will remove the transactions from the pool.
     pub fn on_mined_block(self: &Arc<Self>, outcome: MinedBlockOutcome<T>) -> PruneResult<T> {
         let MinedBlockOutcome { block_number, included, invalid, not_yet_valid } = outcome;
+        debug!(target: "txpool", ?block_number, "pruning transactions");
+        let res = {
+            let mut pool = self.inner.write();
+            let included_hashes = included.iter().map(|tx| tx.hash()).collect::<HashSet<_>>();
 
-        // remove invalid transactions from the pool
-        self.remove_invalid(invalid.into_iter().map(|tx| tx.hash()).collect());
+            // Remove invalid transactions and prune markers supplied by mined transactions while
+            // holding one lock, so membership and dropped-state transitions remain atomic.
+            pool.remove_invalid(invalid.into_iter().map(|tx| tx.hash()).collect());
+            let res = pool.prune_markers(included.iter().flat_map(|tx| tx.provides.clone()));
 
-        // prune all the markers the mined transactions provide
-        let res = self
-            .prune_markers(block_number, included.into_iter().flat_map(|tx| tx.provides.clone()));
+            pool.dropped_transactions.extend(
+                res.pruned
+                    .iter()
+                    .map(|tx| tx.hash())
+                    .filter(|hash| !included_hashes.contains(hash)),
+            );
+            for hash in included_hashes {
+                pool.dropped_transactions.remove(&hash);
+            }
+            res
+        };
+        for tx in &res.promoted {
+            self.notify_ready(tx);
+        }
         trace!(target: "txpool", "pruned transaction markers {:?}", res);
 
         // Re-notify the miner about not-yet-valid transactions so they'll be retried.
@@ -254,11 +305,16 @@ impl<T: Transaction> Pool<T> {
 struct PoolInner<T> {
     ready_transactions: ReadyTransactions<T>,
     pending_transactions: PendingTransactions<T>,
+    dropped_transactions: DroppedTransactions,
 }
 
 impl<T> Default for PoolInner<T> {
     fn default() -> Self {
-        Self { ready_transactions: Default::default(), pending_transactions: Default::default() }
+        Self {
+            ready_transactions: Default::default(),
+            pending_transactions: Default::default(),
+            dropped_transactions: Default::default(),
+        }
     }
 }
 
@@ -272,8 +328,14 @@ impl<T> PoolInner<T> {
 
     /// Clears
     fn clear(&mut self) {
+        let hashes = self
+            .ready_transactions()
+            .chain(self.pending_transactions.transactions())
+            .map(|tx| tx.hash())
+            .collect::<Vec<_>>();
         self.ready_transactions.clear();
         self.pending_transactions.clear();
+        self.dropped_transactions.extend(hashes);
     }
 
     /// Returns an iterator over all transactions in the pool filtered by the sender
@@ -312,6 +374,8 @@ impl<T> PoolInner<T> {
 
         trace!(target: "txpool", "Removed invalid transactions: {:?}", removed.iter().map(|tx| tx.hash()).collect::<Vec<_>>());
 
+        self.dropped_transactions.extend(removed.iter().map(|tx| tx.hash()));
+
         removed
     }
 
@@ -331,7 +395,18 @@ impl<T> PoolInner<T> {
 
         trace!(target: "txpool", "Removed transactions: {:?}", removed.iter().map(|tx| tx.hash()).collect::<Vec<_>>());
 
+        self.dropped_transactions.extend(removed.iter().map(|tx| tx.hash()));
+
         removed
+    }
+
+    fn drop_transaction(&mut self, tx: TxHash) -> Option<Arc<PoolTransaction<T>>> {
+        trace!(target: "txpool", "Dropping transaction: [{:?}]", tx);
+        let removed = self.ready_transactions.remove_with_markers(vec![tx], None);
+        trace!(target: "txpool", "Dropped transactions: {:?}", removed.iter().map(|tx| tx.hash()).collect::<Vec<_>>());
+
+        self.dropped_transactions.extend(removed.iter().map(|tx| tx.hash()));
+        removed.into_iter().find(|removed_tx| removed_tx.hash() == tx)
     }
 }
 
@@ -354,9 +429,10 @@ impl<T: Transaction> PoolInner<T> {
         &mut self,
         tx: PoolTransaction<T>,
     ) -> Result<AddedTransaction<T>, PoolError> {
-        if self.contains(&tx.hash()) {
-            debug!(target: "txpool", "[{:?}] Already imported", tx.hash());
-            return Err(PoolError::AlreadyImported(tx.hash()));
+        let submitted_hash = tx.hash();
+        if self.contains(&submitted_hash) {
+            debug!(target: "txpool", "[{:?}] Already imported", submitted_hash);
+            return Err(PoolError::AlreadyImported(submitted_hash));
         }
 
         let tx = PendingPoolTransaction::new(tx, self.ready_transactions.provided_markers());
@@ -366,15 +442,19 @@ impl<T: Transaction> PoolInner<T> {
         if !tx.is_ready() {
             let hash = tx.transaction.hash();
             self.pending_transactions.add_transaction(tx)?;
+            self.dropped_transactions.remove(&hash);
             return Ok(AddedTransaction::Pending { hash });
         }
-        self.add_ready_transaction(tx)
+        let added = self.add_ready_transaction(tx, submitted_hash)?;
+        self.dropped_transactions.remove(&submitted_hash);
+        Ok(added)
     }
 
     /// Adds the transaction to the ready queue
     fn add_ready_transaction(
         &mut self,
         tx: PendingPoolTransaction<T>,
+        submitted_hash: TxHash,
     ) -> Result<AddedTransaction<T>, PoolError> {
         let hash = tx.transaction.hash();
         trace!(target: "txpool", "adding ready transaction [{:?}]", hash);
@@ -399,6 +479,12 @@ impl<T: Transaction> PoolInner<T> {
                         ready.promoted.push(current_hash);
                     }
                     // tx removed from ready pool
+                    self.dropped_transactions.extend(
+                        replaced_transactions
+                            .iter()
+                            .map(|tx| tx.hash())
+                            .filter(|hash| *hash != submitted_hash),
+                    );
                     ready.removed.extend(replaced_transactions);
                 }
                 Err(err) => {
@@ -408,6 +494,7 @@ impl<T: Transaction> PoolInner<T> {
         err);
                         return Err(err);
                     }
+                    self.dropped_transactions.insert(current_hash);
                     ready.discarded.push(current_hash);
                 }
             }
@@ -418,7 +505,10 @@ impl<T: Transaction> PoolInner<T> {
         // added while removing current transaction. in which case we move this transaction back to
         // the pending queue
         if ready.removed.iter().any(|tx| *tx.hash() == hash) {
-            self.ready_transactions.clear_transactions(&ready.promoted);
+            let rolled_back = self.ready_transactions.clear_transactions(&ready.promoted);
+            self.dropped_transactions.extend(
+                rolled_back.into_iter().map(|tx| tx.hash()).filter(|hash| *hash != submitted_hash),
+            );
             return Err(PoolError::CyclicTransaction);
         }
 
@@ -444,10 +534,11 @@ impl<T: Transaction> PoolInner<T> {
         let mut failed = vec![];
         for tx in imports {
             let hash = tx.transaction.hash();
-            match self.add_ready_transaction(tx) {
+            match self.add_ready_transaction(tx, hash) {
                 Ok(res) => promoted.push(res),
                 Err(e) => {
                     warn!(target: "txpool", "Failed to promote tx [{:?}] : {:?}", hash, e);
+                    self.dropped_transactions.insert(hash);
                     failed.push(hash)
                 }
             }

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -39,7 +39,7 @@ use crate::{
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, TxHash, map::HashSet};
 use alloy_rpc_types::txpool::TxpoolStatus;
-use anvil_core::eth::transaction::PendingTransaction;
+use anvil_core::eth::transaction::{AnvilTransactionStatus, PendingTransaction};
 use futures::channel::mpsc::{Receiver, Sender, channel};
 use parking_lot::{Mutex, RwLock};
 use std::{collections::VecDeque, fmt, sync::Arc};
@@ -135,9 +135,16 @@ impl<T> Pool<T> {
         self.inner.read().contains(tx_hash)
     }
 
-    /// Returns true if the transaction recently left the pool without being mined.
-    pub fn is_dropped(&self, tx_hash: &TxHash) -> bool {
-        self.inner.read().dropped_transactions.contains(tx_hash)
+    /// Returns the transaction's current mempool lifecycle status, if known.
+    pub fn transaction_status(&self, tx_hash: &TxHash) -> Option<AnvilTransactionStatus> {
+        let pool = self.inner.read();
+        if pool.contains(tx_hash) {
+            Some(AnvilTransactionStatus::Pending)
+        } else if pool.dropped_transactions.contains(tx_hash) {
+            Some(AnvilTransactionStatus::Dropped)
+        } else {
+            None
+        }
     }
 
     /// Returns true if this pool contains a transaction from `sender` with `nonce`.
@@ -441,7 +448,9 @@ impl<T: Transaction> PoolInner<T> {
         // If all markers are not satisfied import to future
         if !tx.is_ready() {
             let hash = tx.transaction.hash();
-            self.pending_transactions.add_transaction(tx)?;
+            if let Some(replaced) = self.pending_transactions.add_transaction(tx)? {
+                self.dropped_transactions.insert(replaced.hash());
+            }
             self.dropped_transactions.remove(&hash);
             return Ok(AddedTransaction::Pending { hash });
         }

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -273,24 +273,25 @@ impl<T> PendingTransactions<T> {
 
 impl<T: Transaction> PendingTransactions<T> {
     /// Adds a transaction to Pending queue of transactions
-    pub fn add_transaction(&mut self, tx: PendingPoolTransaction<T>) -> Result<(), PoolError> {
+    pub fn add_transaction(
+        &mut self,
+        tx: PendingPoolTransaction<T>,
+    ) -> Result<Option<Arc<PoolTransaction<T>>>, PoolError> {
         assert!(!tx.is_ready(), "transaction must not be ready");
         assert!(
             !self.waiting_queue.contains_key(&tx.transaction.hash()),
             "transaction is already added"
         );
 
-        if let Some(replace) = self
-            .waiting_markers
-            .get(&tx.transaction.provides)
-            .and_then(|hash| self.waiting_queue.get(hash))
-        {
+        let replaced_hash = self.waiting_markers.get(&tx.transaction.provides).copied();
+        if let Some(replace) = replaced_hash.and_then(|hash| self.waiting_queue.get(&hash)) {
             // check if underpriced
             if tx.transaction.max_fee_per_gas() <= replace.transaction.max_fee_per_gas() {
                 warn!(target: "txpool", "pending replacement transaction underpriced [{:?}]", tx.transaction.hash());
                 return Err(PoolError::ReplacementUnderpriced(tx.transaction.hash()));
             }
         }
+        let replaced = replaced_hash.and_then(|hash| self.remove(vec![hash]).pop());
 
         // add all missing markers
         for marker in &tx.missing_markers {
@@ -302,7 +303,7 @@ impl<T: Transaction> PendingTransactions<T> {
         // add tx to the queue
         self.waiting_queue.insert(tx.transaction.hash(), tx);
 
-        Ok(())
+        Ok(replaced)
     }
 }
 

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -10,7 +10,7 @@ use alloy_consensus::{SignableTransaction, TxEip1559};
 use alloy_eips::eip2718::Decodable2718;
 use alloy_network::{EthereumWallet, TransactionBuilder, TxSignerSync};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256, fixed_bytes, keccak256};
-use alloy_provider::{PendingTransactionBuilder, Provider, ext::TxPoolApi};
+use alloy_provider::{Provider, ext::TxPoolApi};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, TransactionRequest,
     anvil::{
@@ -1165,7 +1165,7 @@ async fn failed_anvil_mine_preserves_interval_adjustment() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn dropped_transaction_receipt_returns_terminal_error() {
+async fn can_get_transaction_status() {
     let (api, handle) =
         spawn(NodeConfig::test().with_no_mining(true).with_transaction_block_keeper(Some(1usize)))
             .await;
@@ -1179,36 +1179,52 @@ async fn dropped_transaction_receipt_returns_terminal_error() {
     let pending = provider.send_transaction(WithOtherFields::new(tx.clone())).await.unwrap();
     let tx_hash = *pending.tx_hash();
     assert!(provider.get_transaction_receipt(tx_hash).await.unwrap().is_none());
-    assert!(
-        provider.get_transaction_receipt(B256::repeat_byte(0x42)).await.unwrap().is_none(),
-        "unknown transaction hashes must continue to return null",
-    );
+    let status = provider
+        .raw_request::<_, Option<String>>("anvil_getTransactionStatus".into(), (tx_hash,))
+        .await
+        .unwrap();
+    assert_eq!(status.as_deref(), Some("pending"));
+
+    let unknown_hash = B256::repeat_byte(0x42);
+    assert!(provider.get_transaction_receipt(unknown_hash).await.unwrap().is_none());
+    let status = provider
+        .raw_request::<_, Option<String>>("anvil_getTransactionStatus".into(), (unknown_hash,))
+        .await
+        .unwrap();
+    assert_eq!(status, None);
 
     assert_eq!(api.anvil_drop_transaction(tx_hash).await.unwrap(), Some(tx_hash));
-    let error = provider.get_transaction_receipt(tx_hash).await.unwrap_err();
-    assert_eq!(error.tx_hash_data(), Some(tx_hash));
-    let response = error.as_error_resp().unwrap();
-    assert_eq!(response.code, -32000);
-    assert_eq!(response.message, "transaction dropped from mempool");
-
-    let receipt = PendingTransactionBuilder::new(provider.root().clone(), tx_hash).get_receipt();
-    let error = tokio::time::timeout(Duration::from_secs(1), receipt)
+    assert!(provider.get_transaction_receipt(tx_hash).await.unwrap().is_none());
+    let status = provider
+        .raw_request::<_, Option<String>>("anvil_getTransactionStatus".into(), (tx_hash,))
         .await
-        .expect("receipt polling should stop on a dropped transaction")
-        .unwrap_err();
-    assert!(error.to_string().contains("transaction dropped from mempool"));
+        .unwrap();
+    assert_eq!(status.as_deref(), Some("dropped"));
 
-    // Reaccepting the same transaction clears its dropped state, and mining it still yields the
-    // normal receipt.
+    // Reaccepting the same transaction clears its dropped state.
     let reaccepted = provider.send_transaction(WithOtherFields::new(tx)).await.unwrap();
     assert_eq!(*reaccepted.tx_hash(), tx_hash);
-    assert!(provider.get_transaction_receipt(tx_hash).await.unwrap().is_none());
+    let status = provider
+        .raw_request::<_, Option<String>>("anvil_getTransactionStatus".into(), (tx_hash,))
+        .await
+        .unwrap();
+    assert_eq!(status.as_deref(), Some("pending"));
     api.mine_one().await.unwrap();
     assert_eq!(reaccepted.get_receipt().await.unwrap().transaction_hash, tx_hash);
+    let status = provider
+        .raw_request::<_, Option<String>>("anvil_getTransactionStatus".into(), (tx_hash,))
+        .await
+        .unwrap();
+    assert_eq!(status.as_deref(), Some("mined"));
 
-    // Once the retained receipt is pruned, the mined transaction must not look dropped.
+    // Once its retained receipt is pruned, the transaction is no longer known to Anvil.
     api.mine_one().await.unwrap();
     assert!(provider.get_transaction_receipt(tx_hash).await.unwrap().is_none());
+    let status = provider
+        .raw_request::<_, Option<String>>("anvil_getTransactionStatus".into(), (tx_hash,))
+        .await
+        .unwrap();
+    assert_eq!(status, None);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1253,8 +1269,7 @@ async fn instant_mining_reselects_from_live_pool_after_failure() {
         .await
         .unwrap();
         if drop_failed_transaction {
-            let error = provider.get_transaction_receipt(first_hash).await.unwrap_err();
-            assert_eq!(error.as_error_resp().unwrap().code, -32000);
+            assert!(provider.get_transaction_receipt(first_hash).await.unwrap().is_none());
         } else {
             assert!(provider.get_transaction_receipt(first_hash).await.unwrap().is_some());
         }

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -9,8 +9,8 @@ use alloy_chains::NamedChain;
 use alloy_consensus::{SignableTransaction, TxEip1559};
 use alloy_eips::eip2718::Decodable2718;
 use alloy_network::{EthereumWallet, TransactionBuilder, TxSignerSync};
-use alloy_primitives::{Address, Bytes, TxKind, U256, address, b256, fixed_bytes, keccak256};
-use alloy_provider::{Provider, ext::TxPoolApi};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256, fixed_bytes, keccak256};
+use alloy_provider::{PendingTransactionBuilder, Provider, ext::TxPoolApi};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, TransactionRequest,
     anvil::{
@@ -1165,6 +1165,53 @@ async fn failed_anvil_mine_preserves_interval_adjustment() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn dropped_transaction_receipt_returns_terminal_error() {
+    let (api, handle) =
+        spawn(NodeConfig::test().with_no_mining(true).with_transaction_block_keeper(Some(1usize)))
+            .await;
+    let provider = handle.http_provider();
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let tx = TransactionRequest::default()
+        .from(accounts[0].address())
+        .to(accounts[1].address())
+        .value(U256::from(1));
+
+    let pending = provider.send_transaction(WithOtherFields::new(tx.clone())).await.unwrap();
+    let tx_hash = *pending.tx_hash();
+    assert!(provider.get_transaction_receipt(tx_hash).await.unwrap().is_none());
+    assert!(
+        provider.get_transaction_receipt(B256::repeat_byte(0x42)).await.unwrap().is_none(),
+        "unknown transaction hashes must continue to return null",
+    );
+
+    assert_eq!(api.anvil_drop_transaction(tx_hash).await.unwrap(), Some(tx_hash));
+    let error = provider.get_transaction_receipt(tx_hash).await.unwrap_err();
+    assert_eq!(error.tx_hash_data(), Some(tx_hash));
+    let response = error.as_error_resp().unwrap();
+    assert_eq!(response.code, -32000);
+    assert_eq!(response.message, "transaction dropped from mempool");
+
+    let receipt = PendingTransactionBuilder::new(provider.root().clone(), tx_hash).get_receipt();
+    let error = tokio::time::timeout(Duration::from_secs(1), receipt)
+        .await
+        .expect("receipt polling should stop on a dropped transaction")
+        .unwrap_err();
+    assert!(error.to_string().contains("transaction dropped from mempool"));
+
+    // Reaccepting the same transaction clears its dropped state, and mining it still yields the
+    // normal receipt.
+    let reaccepted = provider.send_transaction(WithOtherFields::new(tx)).await.unwrap();
+    assert_eq!(*reaccepted.tx_hash(), tx_hash);
+    assert!(provider.get_transaction_receipt(tx_hash).await.unwrap().is_none());
+    api.mine_one().await.unwrap();
+    assert_eq!(reaccepted.get_receipt().await.unwrap().transaction_hash, tx_hash);
+
+    // Once the retained receipt is pruned, the mined transaction must not look dropped.
+    api.mine_one().await.unwrap();
+    assert!(provider.get_transaction_receipt(tx_hash).await.unwrap().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn instant_mining_reselects_from_live_pool_after_failure() {
     for drop_failed_transaction in [false, true] {
         let config = NodeConfig::test()
@@ -1205,8 +1252,12 @@ async fn instant_mining_reselects_from_live_pool_after_failure() {
         })
         .await
         .unwrap();
-        let first_receipt = provider.get_transaction_receipt(first_hash).await.unwrap();
-        assert_eq!(first_receipt.is_some(), !drop_failed_transaction);
+        if drop_failed_transaction {
+            let error = provider.get_transaction_receipt(first_hash).await.unwrap_err();
+            assert_eq!(error.as_error_resp().unwrap().code, -32000);
+        } else {
+            assert!(provider.get_transaction_receipt(first_hash).await.unwrap().is_some());
+        }
     }
 }
 

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -223,11 +223,41 @@ async fn can_replace_transaction() {
     let higher_priced_pending_tx = provider.send_transaction(tx).await.unwrap();
 
     let higher_tx_hash = *higher_priced_pending_tx.tx_hash();
-    let error = provider.get_transaction_receipt(lower_tx_hash).await.unwrap_err();
-    let response = error.as_error_resp().unwrap();
-    assert_eq!(response.code, -32000);
-    assert_eq!(response.message, "transaction dropped from mempool");
+    let status = provider
+        .raw_request::<_, Option<String>>("anvil_getTransactionStatus".into(), (lower_tx_hash,))
+        .await
+        .unwrap();
+    assert_eq!(status.as_deref(), Some("dropped"));
+    let status = provider
+        .raw_request::<_, Option<String>>("anvil_getTransactionStatus".into(), (higher_tx_hash,))
+        .await
+        .unwrap();
+    assert_eq!(status.as_deref(), Some("pending"));
     assert!(provider.get_transaction_receipt(higher_tx_hash).await.unwrap().is_none());
+
+    // Replacements in the queued pool must remove the old hash as well.
+    let mut queued_tx =
+        WithOtherFields::new(TransactionRequest::default().to(to).from(from).nonce(nonce + 2));
+    queued_tx.set_gas_price(gas_price);
+    let lower_priced_queued_tx = provider.send_transaction(queued_tx.clone()).await.unwrap();
+    let lower_queued_hash = *lower_priced_queued_tx.tx_hash();
+    queued_tx.set_gas_price(gas_price + 1);
+    let higher_priced_queued_tx = provider.send_transaction(queued_tx).await.unwrap();
+    let higher_queued_hash = *higher_priced_queued_tx.tx_hash();
+
+    let status = provider
+        .raw_request::<_, Option<String>>("anvil_getTransactionStatus".into(), (lower_queued_hash,))
+        .await
+        .unwrap();
+    assert_eq!(status.as_deref(), Some("dropped"));
+    let status = provider
+        .raw_request::<_, Option<String>>(
+            "anvil_getTransactionStatus".into(),
+            (higher_queued_hash,),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status.as_deref(), Some("pending"));
 
     // mine exactly one block
     api.mine_one().await.unwrap();

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -215,13 +215,20 @@ async fn can_replace_transaction() {
 
     tx.set_gas_price(gas_price);
     // send transaction with lower gas price
-    let _lower_priced_pending_tx = provider.send_transaction(tx.clone()).await.unwrap();
+    let lower_priced_pending_tx = provider.send_transaction(tx.clone()).await.unwrap();
+    let lower_tx_hash = *lower_priced_pending_tx.tx_hash();
 
     tx.set_gas_price(gas_price + 1);
     // send the same transaction with higher gas price
     let higher_priced_pending_tx = provider.send_transaction(tx).await.unwrap();
 
     let higher_tx_hash = *higher_priced_pending_tx.tx_hash();
+    let error = provider.get_transaction_receipt(lower_tx_hash).await.unwrap_err();
+    let response = error.as_error_resp().unwrap();
+    assert_eq!(response.code, -32000);
+    assert_eq!(response.message, "transaction dropped from mempool");
+    assert!(provider.get_transaction_receipt(higher_tx_hash).await.unwrap().is_none());
+
     // mine exactly one block
     api.mine_one().await.unwrap();
 


### PR DESCRIPTION
Anvil now exposes `anvil_getTransactionStatus` for querying whether a transaction is pending, mined, recently dropped, or unknown while preserving the standard receipt-or-null behavior of `eth_getTransactionReceipt`. The bounded dropped-transaction index covers explicit drops, invalidation, clearing, and ready or queued replacements without introducing an additional canonical source of truth.

Fixes #13352.

This PR was developed with AI assistance.