### PR TITLE
feature(forge): support transient storage inspection

### DIFF
--- a/.changelog/forge-inspect-transient-storage-layout.md
+++ b/.changelog/forge-inspect-transient-storage-layout.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added a `transientStorageLayout` field to `forge inspect` for inspecting a contract's transient storage layout.

--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -129,7 +129,14 @@ impl InspectArgs {
                 print_json(&artifact.gas_estimates)?;
             }
             ContractArtifactField::StorageLayout => {
-                print_storage_layout(artifact.storage_layout.as_ref(), wrap)?;
+                print_storage_layout(artifact.storage_layout.as_ref(), "storage layout", wrap)?;
+            }
+            ContractArtifactField::TransientStorageLayout => {
+                print_storage_layout(
+                    artifact.transient_storage_layout.as_ref(),
+                    "transient storage layout",
+                    wrap,
+                )?;
             }
             ContractArtifactField::DevDoc => {
                 print_json(&artifact.devdoc)?;
@@ -337,10 +344,11 @@ fn internal_ty(ty: &InternalType) -> String {
 
 pub fn print_storage_layout(
     storage_layout: Option<&StorageLayout>,
+    field: &str,
     should_wrap: bool,
 ) -> Result<()> {
     let Some(storage_layout) = storage_layout else {
-        return Err(missing_error("storage layout"));
+        return Err(missing_error(field));
     };
 
     if shell::is_json() {
@@ -558,6 +566,7 @@ pub enum ContractArtifactField {
     MethodIdentifiers,
     GasEstimates,
     StorageLayout,
+    TransientStorageLayout,
     DevDoc,
     Ir,
     IrOptimized,
@@ -645,6 +654,10 @@ impl_value_enum! {
                              | "gasestimates",
         StorageLayout     => "storageLayout" | "storage_layout" | "storage-layout"
                              | "storagelayout" | "storage",
+        TransientStorageLayout => "transientStorageLayout" | "transient_storage_layout"
+                             | "transient-storage-layout" | "transientstoragelayout"
+                             | "transientStorage" | "transient-storage" | "transient_storage"
+                             | "transientstorage" | "transient" | "tsl",
         DevDoc            => "devdoc" | "dev-doc" | "devDoc",
         Ir                => "ir" | "iR" | "IR",
         IrOptimized       => "irOptimized" | "ir-optimized" | "iroptimized" | "iro" | "iropt",
@@ -680,6 +693,7 @@ impl TryFrom<ContractArtifactField> for ContractOutputSelection {
             Caf::MethodIdentifiers => Ok(Self::Evm(EvmOutputSelection::MethodIdentifiers)),
             Caf::GasEstimates => Ok(Self::Evm(EvmOutputSelection::GasEstimates)),
             Caf::StorageLayout => Ok(Self::StorageLayout),
+            Caf::TransientStorageLayout => Ok(Self::TransientStorageLayout),
             Caf::DevDoc => Ok(Self::DevDoc),
             Caf::Ir => Ok(Self::Ir),
             Caf::IrOptimized => Ok(Self::IrOptimized),
@@ -713,6 +727,7 @@ impl PartialEq<ContractOutputSelection> for ContractArtifactField {
                 | (Self::MethodIdentifiers, Cos::Evm(Eos::MethodIdentifiers))
                 | (Self::GasEstimates, Cos::Evm(Eos::GasEstimates))
                 | (Self::StorageLayout, Cos::StorageLayout)
+                | (Self::TransientStorageLayout, Cos::TransientStorageLayout)
                 | (Self::DevDoc, Cos::DevDoc)
                 | (Self::Ir, Cos::Ir)
                 | (Self::IrOptimized, Cos::IrOptimized)

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1393,6 +1393,77 @@ contract Foo {
 "#]]);
 });
 
+// tests that `forge inspect <contract> transientStorageLayout` works
+forgetest!(can_inspect_transient_storage_layout, |prj, cmd| {
+    prj.add_source(
+        "Transient.sol",
+        r#"
+contract Transient {
+    uint256 transient counter;
+    address transient owner;
+}
+    "#,
+    );
+
+    cmd.arg("inspect").args(["Transient", "transientStorageLayout"]).assert_success().stdout_eq(
+        str![[r#"
+
+╭---------+---------+------+--------+-------+-----------------------------╮
+| Name    | Type    | Slot | Offset | Bytes | Contract                    |
++=========================================================================+
+| counter | uint256 | 0    | 0      | 32    | src/Transient.sol:Transient |
+|---------+---------+------+--------+-------+-----------------------------|
+| owner   | address | 1    | 0      | 20    | src/Transient.sol:Transient |
+╰---------+---------+------+--------+-------+-----------------------------╯
+
+
+"#]],
+    );
+
+    // `--json` prints the raw storage layout object.
+    cmd.forge_fuse()
+        .args(["inspect", "Transient", "transientStorageLayout", "--json"])
+        .assert_success()
+        .stdout_eq(
+            str![[r#"
+{
+  "storage": [
+    {
+      "astId": "{...}",
+      "contract": "src/Transient.sol:Transient",
+      "label": "counter",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_uint256"
+    },
+    {
+      "astId": "{...}",
+      "contract": "src/Transient.sol:Transient",
+      "label": "owner",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_address"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "encoding": "inplace",
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_uint256": {
+      "encoding": "inplace",
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}
+
+"#]]
+            .is_json(),
+        );
+});
+
 forgetest!(can_inspect_linearization_markdown, |prj, cmd| {
     prj.add_source("A.sol", "contract A {}");
     prj.add_source("B.sol", r#"import {A} from "./A.sol"; contract B is A {}"#);


### PR DESCRIPTION
## Motivation

`forge inspect` command must support `transient` storage

## Solution

Add new variant to: https://github.com/foundry-rs/foundry/blob/50dd4b8accae878391b0825885f0632d1e0a1e4c/crates/forge/src/cmd/inspect.rs#L550

The solution just use `transient_storage_layout` from `foundry-core` https://github.com/foundry-rs/foundry-core/blob/c5b3c4f0c40c81c8f6a5e18fac77d3a54d7a3fd2/crates/compilers/crates/artifacts/solc/src/configurable.rs#L15



## PR Checklist

- [X] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
