### PR TITLE
perf(anvil): speed up block receipt queries

### DIFF
--- a/.changelog/anvil-block-receipts.md
+++ b/.changelog/anvil-block-receipts.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Speed up `eth_getBlockReceipts` for blocks with many transactions.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5689,25 +5689,20 @@ where
 
     /// Returns all transaction receipts of the block
     pub fn mined_block_receipts(&self, id: impl Into<BlockId>) -> Option<Vec<FoundryTxReceipt>> {
-        let (block, transactions, hash) = {
-            let storage = self.blockchain.storage.read();
-            let hash = match id.into() {
-                BlockId::Hash(hash) => hash.block_hash,
-                BlockId::Number(number) => storage.hash(number, self.slots_in_an_epoch)?,
-            };
-            let block = storage.blocks.get(&hash)?.clone();
-            let transactions = block
-                .body
-                .transactions
-                .iter()
-                .map(|transaction| storage.transactions.get(&transaction.hash()).cloned())
-                .collect::<Option<Vec<_>>>()?;
-            (block, transactions, hash)
+        let storage = self.blockchain.storage.read();
+        let hash = match id.into() {
+            BlockId::Hash(hash) => hash.block_hash,
+            BlockId::Number(number) => storage.hash(number, self.slots_in_an_epoch)?,
         };
+        let block = storage.blocks.get(&hash)?.clone();
 
-        if transactions.iter().enumerate().any(|(index, transaction)| {
-            transaction.block_hash != hash || transaction.info.transaction_index as usize != index
+        if block.body.transactions.iter().enumerate().any(|(index, transaction)| {
+            storage.transactions.get(&transaction.hash()).is_none_or(|transaction| {
+                transaction.block_hash != hash
+                    || transaction.info.transaction_index as usize != index
+            })
         }) {
+            drop(storage);
             return block
                 .body
                 .transactions
@@ -5721,9 +5716,16 @@ where
         let mut receipts = Vec::with_capacity(block.body.transactions.len());
         let mut next_log_index = 0;
 
-        for transaction in transactions {
+        for block_transaction in &block.body.transactions {
+            let transaction = storage.transactions.get(&block_transaction.hash())?;
             let log_count = transaction.receipt.logs().len();
-            let receipt = self.build_mined_transaction_receipt(transaction, &block, next_log_index);
+            let receipt = self.build_mined_transaction_receipt(
+                &transaction.info,
+                transaction.receipt.clone(),
+                transaction.block_hash,
+                &block,
+                next_log_index,
+            );
             receipts.push(receipt.inner);
             next_log_index += log_count;
         }
@@ -5743,16 +5745,24 @@ where
         let receipts = self.get_receipts(block.body.transactions.iter().map(|tx| tx.hash()));
         let next_log_index = receipts[..index].iter().map(|r| r.logs().len()).sum::<usize>();
 
-        Some(self.build_mined_transaction_receipt(transaction, &block, next_log_index))
+        let MinedTransaction { info, receipt, block_hash, .. } = transaction;
+        Some(self.build_mined_transaction_receipt(
+            &info,
+            receipt,
+            block_hash,
+            &block,
+            next_log_index,
+        ))
     }
 
     fn build_mined_transaction_receipt(
         &self,
-        transaction: MinedTransaction<N>,
+        info: &TransactionInfo,
+        tx_receipt: FoundryReceiptEnvelope,
+        block_hash: B256,
         block: &Block,
         next_log_index: usize,
     ) -> MinedTransactionReceipt<FoundryNetwork> {
-        let MinedTransaction { info, receipt: tx_receipt, block_hash, .. } = transaction;
         let transaction = block.body.transactions[info.transaction_index as usize].clone();
 
         // Cancun specific
@@ -5815,7 +5825,7 @@ where
                 inner = inner.with_fee_token(fee_token);
             }
         }
-        MinedTransactionReceipt { inner, out: info.out }
+        MinedTransactionReceipt { inner, out: info.out.clone() }
     }
 
     /// Returns the blocks receipts for the given number

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5689,12 +5689,43 @@ where
 
     /// Returns all transaction receipts of the block
     pub fn mined_block_receipts(&self, id: impl Into<BlockId>) -> Option<Vec<FoundryTxReceipt>> {
-        let mut receipts = Vec::new();
-        let block = self.get_block(id)?;
+        let (block, transactions, hash) = {
+            let storage = self.blockchain.storage.read();
+            let hash = match id.into() {
+                BlockId::Hash(hash) => hash.block_hash,
+                BlockId::Number(number) => storage.hash(number, self.slots_in_an_epoch)?,
+            };
+            let block = storage.blocks.get(&hash)?.clone();
+            let transactions = block
+                .body
+                .transactions
+                .iter()
+                .map(|transaction| storage.transactions.get(&transaction.hash()).cloned())
+                .collect::<Option<Vec<_>>>()?;
+            (block, transactions, hash)
+        };
 
-        for transaction in block.body.transactions {
-            let receipt = self.mined_transaction_receipt(transaction.hash())?;
+        if transactions.iter().enumerate().any(|(index, transaction)| {
+            transaction.block_hash != hash || transaction.info.transaction_index as usize != index
+        }) {
+            return block
+                .body
+                .transactions
+                .into_iter()
+                .map(|transaction| {
+                    self.mined_transaction_receipt(transaction.hash()).map(|receipt| receipt.inner)
+                })
+                .collect();
+        }
+
+        let mut receipts = Vec::with_capacity(block.body.transactions.len());
+        let mut next_log_index = 0;
+
+        for transaction in transactions {
+            let log_count = transaction.receipt.logs().len();
+            let receipt = self.build_mined_transaction_receipt(transaction, &block, next_log_index);
             receipts.push(receipt.inner);
+            next_log_index += log_count;
         }
 
         Some(receipts)
@@ -5705,12 +5736,24 @@ where
         &self,
         hash: B256,
     ) -> Option<MinedTransactionReceipt<FoundryNetwork>> {
-        let MinedTransaction { info, receipt: tx_receipt, block_hash, .. } =
-            self.blockchain.get_transaction_by_hash(&hash)?;
+        let transaction = self.blockchain.get_transaction_by_hash(&hash)?;
 
-        let index = info.transaction_index as usize;
-        let block = self.blockchain.get_block_by_hash(&block_hash)?;
-        let transaction = block.body.transactions[index].clone();
+        let index = transaction.info.transaction_index as usize;
+        let block = self.blockchain.get_block_by_hash(&transaction.block_hash)?;
+        let receipts = self.get_receipts(block.body.transactions.iter().map(|tx| tx.hash()));
+        let next_log_index = receipts[..index].iter().map(|r| r.logs().len()).sum::<usize>();
+
+        Some(self.build_mined_transaction_receipt(transaction, &block, next_log_index))
+    }
+
+    fn build_mined_transaction_receipt(
+        &self,
+        transaction: MinedTransaction<N>,
+        block: &Block,
+        next_log_index: usize,
+    ) -> MinedTransactionReceipt<FoundryNetwork> {
+        let MinedTransaction { info, receipt: tx_receipt, block_hash, .. } = transaction;
+        let transaction = block.body.transactions[info.transaction_index as usize].clone();
 
         // Cancun specific
         let excess_blob_gas = block.header.excess_blob_gas();
@@ -5719,9 +5762,6 @@ where
         let blob_gas_used = transaction.blob_gas_used();
 
         let effective_gas_price = transaction.effective_gas_price(block.header.base_fee_per_gas());
-
-        let receipts = self.get_receipts(block.body.transactions.iter().map(|tx| tx.hash()));
-        let next_log_index = receipts[..index].iter().map(|r| r.logs().len()).sum::<usize>();
 
         let tx_receipt = tx_receipt.convert_logs_rpc(
             BlockNumHash::new(block.header.number(), block_hash),
@@ -5775,7 +5815,7 @@ where
                 inner = inner.with_fee_token(fee_token);
             }
         }
-        Some(MinedTransactionReceipt { inner, out: info.out })
+        MinedTransactionReceipt { inner, out: info.out }
     }
 
     /// Returns the blocks receipts for the given number

--- a/crates/anvil/tests/it/logs.rs
+++ b/crates/anvil/tests/it/logs.rs
@@ -5,9 +5,10 @@ use crate::{
     utils::{http_provider_with_signer, ws_provider_with_signer},
 };
 use alloy_network::EthereumWallet;
-use alloy_primitives::{B256, map::B256HashSet};
+use alloy_primitives::{Address, B256, bytes, map::B256HashSet};
 use alloy_provider::Provider;
-use alloy_rpc_types::{BlockNumberOrTag, Filter, Log};
+use alloy_rpc_types::{BlockNumberOrTag, Filter, Log, TransactionRequest};
+use alloy_serde::WithOtherFields;
 use anvil::{NodeConfig, spawn};
 use anvil_core::types::ReorgOptions;
 use futures::StreamExt;
@@ -140,6 +141,49 @@ async fn get_all_events() {
         assert_eq!(receipt_log.transaction_hash, log.transaction_hash);
         assert_eq!(receipt_log.block_number, log.block_number);
         assert_eq!(receipt_log.log_index, log.log_index);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_block_receipts_assigns_log_indices() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let sender = handle.dev_wallets().next().unwrap().address();
+    let one_log = Address::random();
+    let two_logs = Address::random();
+    api.anvil_set_code(one_log, bytes!("60006000a000")).await.unwrap();
+    api.anvil_set_code(two_logs, bytes!("60006000a060006000a000")).await.unwrap();
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let mut hashes = Vec::new();
+    for (nonce, target) in [one_log, Address::random(), two_logs].into_iter().enumerate() {
+        let transaction = TransactionRequest::default()
+            .from(sender)
+            .to(target)
+            .nonce(nonce as u64)
+            .gas_limit(30_000);
+        hashes.push(api.send_transaction(WithOtherFields::new(transaction)).await.unwrap());
+    }
+    api.mine_one().await.unwrap();
+
+    let receipts = api.block_receipts(BlockNumberOrTag::Latest.into()).await.unwrap().unwrap();
+    assert_eq!(receipts.len(), 3);
+    let log_indices = receipts
+        .iter()
+        .map(|receipt| {
+            receipt
+                .0
+                .inner
+                .inner
+                .logs()
+                .iter()
+                .map(|log| log.log_index.unwrap())
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(log_indices, [vec![0], vec![], vec![1, 2]]);
+
+    for (hash, receipt) in hashes.into_iter().zip(&receipts) {
+        assert_eq!(api.transaction_receipt(hash).await.unwrap().as_ref(), Some(receipt));
     }
 }
 


### PR DESCRIPTION
## Summary

- build local block receipts from one coherent storage snapshot instead of rerunning the single-transaction receipt path for every transaction
- assign cumulative log indices in one pass, removing the repeated receipt-prefix scans that made `eth_getBlockReceipts` quadratic
- preserve the legacy lookup path for inconsistent block/transaction mappings loaded through `anvil_loadState`

## Performance

Benchmarked release builds with a loaded Anvil state containing one block with 10,000 transactions and one log per receipt. The measured request was `eth_getBlockReceipts("latest")`, with the 13 MiB response redirected to `/dev/null`.

| | Mean |
|---|---:|
| `master` | 17.098 s ± 0.182 s |
| this PR | 47.7 ms ± 0.2 ms |

This is about **358× faster**. The full JSON responses were byte-for-byte identical (SHA-256 `9968ce09d038a05739f0e5a9e097b9cbcf0ec9f654866dcbb414f473212bb58f`).

## Validation

- `cargo nextest run --package anvil --test it 'logs::'`
- `cargo check --package anvil`
- `cargo clippy --package anvil --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `python3 .github/scripts/validate_changelog.py --base origin/master --head HEAD`
