### PR TITLE
feat(fmt): use nearest project configs

### DIFF
--- a/.changelog/forge-fmt-nearest-config.md
+++ b/.changelog/forge-fmt-nearest-config.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added `forge fmt --use-nearest-config` to format monorepo inputs with each file's nearest `foundry.toml` settings.

--- a/.changelog/forge-fmt-nearest-config.md
+++ b/.changelog/forge-fmt-nearest-config.md
@@ -2,4 +2,4 @@
 forge: minor
 ---
 
-Added `forge fmt --use-nearest-config` to format monorepo inputs with each file's nearest `foundry.toml` settings.
+Added `forge fmt --nearest` to format monorepo inputs with each file's nearest `foundry.toml` settings.

--- a/crates/forge/src/cmd/fmt.rs
+++ b/crates/forge/src/cmd/fmt.rs
@@ -4,11 +4,15 @@ use eyre::Result;
 use foundry_cli::utils::{FoundryPathExt, LoadConfig};
 use foundry_common::{errors::convert_solar_errors, fs};
 use foundry_compilers::{compilers::solc::SolcLanguage, solc::SOLC_EXTENSIONS};
-use foundry_config::{filter::expand_globs, impl_figment_convert_basic};
+use foundry_config::{
+    Config, filter::expand_globs, find_project_root, fmt::FormatterConfig,
+    impl_figment_convert_basic,
+};
 use rayon::prelude::*;
 use similar::{ChangeTag, TextDiff};
 use solar::sema::Compiler;
 use std::{
+    collections::{HashMap, hash_map::Entry},
     fmt::{self, Write},
     io,
     io::Write as _,
@@ -31,6 +35,10 @@ pub struct FmtArgs {
     #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
 
+    /// Use each input file's nearest `foundry.toml` for formatter settings.
+    #[arg(long, conflicts_with = "root")]
+    use_nearest_config: bool,
+
     /// Run in 'check' mode.
     ///
     /// Exits with 0 if input is formatted correctly.
@@ -50,6 +58,13 @@ impl_figment_convert_basic!(FmtArgs);
 
 impl FmtArgs {
     pub fn run(self) -> Result<()> {
+        if self.use_nearest_config {
+            for var in ["FOUNDRY_CONFIG", "FOUNDRY_ROOT", "DAPP_ROOT"] {
+                if std::env::var_os(var).is_some() {
+                    eyre::bail!("`--use-nearest-config` cannot be used when `{var}` is set");
+                }
+            }
+        }
         let config = self.load_config()?;
         let cwd = std::env::current_dir()?;
 
@@ -65,28 +80,29 @@ impl FmtArgs {
             .flat_map(fs::canonicalize_path)
             .collect::<Vec<_>>();
 
-        // Helper to check if a file path is under any ignored or lib directory
-        let is_under_ignored_dir = |file_path: &Path, include_libs: bool| -> bool {
+        // Helper to check if a file path is under any of the given directories.
+        let is_under_dir = |file_path: &Path, dirs: &[PathBuf]| -> bool {
             let check_against_dir = |dir: &PathBuf| {
                 file_path.starts_with(dir)
                     || cwd.join(file_path).starts_with(dir)
                     || fs::canonicalize_path(file_path).is_ok_and(|p| p.starts_with(dir))
             };
 
-            ignored.iter().any(&check_against_dir)
-                || (include_libs && libs.iter().any(&check_against_dir))
+            dirs.iter().any(check_against_dir)
         };
 
-        let input = match &self.paths[..] {
+        let mut input = match &self.paths[..] {
             [] => {
                 // Retrieve the project paths, and filter out the ignored ones and libs.
                 let project_paths: Vec<PathBuf> = config
                     .project_paths::<SolcLanguage>()
                     .input_files_iter()
                     .filter(|p| {
-                        !(ignored.contains(p)
-                            || ignored.contains(&cwd.join(p))
-                            || is_under_ignored_dir(p, true))
+                        !((!self.use_nearest_config
+                            && (ignored.contains(p)
+                                || ignored.contains(&cwd.join(p))
+                                || is_under_dir(p, &ignored)))
+                            || is_under_dir(p, &libs))
                     })
                     .collect();
                 Input::Paths(project_paths)
@@ -96,7 +112,8 @@ impl FmtArgs {
                 let mut inputs = Vec::with_capacity(paths.len());
                 for path in paths {
                     // Check if path is in ignored directories
-                    if !ignored.is_empty()
+                    if !self.use_nearest_config
+                        && !ignored.is_empty()
                         && ((path.is_absolute() && ignored.contains(path))
                             || ignored.contains(&cwd.join(path)))
                     {
@@ -105,13 +122,15 @@ impl FmtArgs {
 
                     if path.is_dir() {
                         // If the input directory is not a lib directory, make sure to ignore libs.
-                        let exclude_libs = !is_under_ignored_dir(path, true);
+                        let exclude_libs = !is_under_dir(path, &libs);
                         inputs.extend(
                             foundry_compilers::utils::source_files_iter(path, SOLC_EXTENSIONS)
                                 .filter(|p| {
-                                    !(ignored.contains(p)
-                                        || ignored.contains(&cwd.join(p))
-                                        || is_under_ignored_dir(p, exclude_libs))
+                                    !((!self.use_nearest_config
+                                        && (ignored.contains(p)
+                                            || ignored.contains(&cwd.join(p))
+                                            || is_under_dir(p, &ignored)))
+                                        || (exclude_libs && is_under_dir(p, &libs)))
                                 }),
                         );
                     } else if path.is_sol() {
@@ -123,6 +142,42 @@ impl FmtArgs {
                 }
                 Input::Paths(inputs)
             }
+        };
+
+        let nearest_fmt_configs = if self.use_nearest_config {
+            let Input::Paths(paths) = &mut input else {
+                eyre::bail!("`--use-nearest-config` cannot be used with stdin");
+            };
+            let mut root_configs: HashMap<PathBuf, (Arc<FormatterConfig>, Vec<PathBuf>)> =
+                HashMap::new();
+            let mut path_configs = HashMap::new();
+            let mut filtered_paths = Vec::with_capacity(paths.len());
+
+            for path in std::mem::take(paths) {
+                let path = fs::canonicalize_path(path)?;
+                let root = find_project_root(path.parent())?;
+                let (fmt_config, ignored) = match root_configs.entry(root) {
+                    Entry::Occupied(entry) => entry.into_mut(),
+                    Entry::Vacant(entry) => {
+                        let nearest_config = Config::load_with_root(entry.key())?.sanitized();
+                        let ignored =
+                            expand_globs(&nearest_config.root, nearest_config.fmt.ignore.iter())?
+                                .iter()
+                                .flat_map(fs::canonicalize_path)
+                                .collect();
+                        entry.insert((Arc::new(nearest_config.fmt), ignored))
+                    }
+                };
+                if ignored.iter().any(|ignored| path.starts_with(ignored)) {
+                    continue;
+                }
+                path_configs.insert(path.clone(), fmt_config.clone());
+                filtered_paths.push(path);
+            }
+            *paths = filtered_paths;
+            Some(path_configs)
+        } else {
+            None
         };
 
         let mut compiler = Compiler::new(
@@ -156,7 +211,28 @@ impl FmtArgs {
                 .filter_map(|source_unit| {
                     let path = source_unit.file.name.as_real();
                     let original = source_unit.file.src.as_str();
-                    let formatted = forge_fmt::format_ast(gcx, source_unit, fmt_config.clone())?;
+                    let source_fmt_config =
+                        if let Some(nearest_fmt_configs) = nearest_fmt_configs.as_ref() {
+                            let Some(source_path) = path else {
+                                return Some(Err(eyre::eyre!(
+                                    "could not resolve formatter config for stdin"
+                                )));
+                            };
+                            let source_path = match fs::canonicalize_path(source_path) {
+                                Ok(path) => path,
+                                Err(err) => return Some(Err(err.into())),
+                            };
+                            let Some(fmt_config) = nearest_fmt_configs.get(&source_path) else {
+                                return Some(Err(eyre::eyre!(
+                                    "could not resolve formatter config for {}",
+                                    source_path.display()
+                                )));
+                            };
+                            fmt_config.clone()
+                        } else {
+                            fmt_config.clone()
+                        };
+                    let formatted = forge_fmt::format_ast(gcx, source_unit, source_fmt_config)?;
                     let from_stdin = path.is_none();
 
                     // Return formatted code when read from stdin and raw enabled.

--- a/crates/forge/src/cmd/fmt.rs
+++ b/crates/forge/src/cmd/fmt.rs
@@ -37,7 +37,7 @@ pub struct FmtArgs {
 
     /// Use each input file's nearest `foundry.toml` for formatter settings.
     #[arg(long, conflicts_with = "root")]
-    use_nearest_config: bool,
+    nearest: bool,
 
     /// Run in 'check' mode.
     ///
@@ -58,10 +58,10 @@ impl_figment_convert_basic!(FmtArgs);
 
 impl FmtArgs {
     pub fn run(self) -> Result<()> {
-        if self.use_nearest_config {
+        if self.nearest {
             for var in ["FOUNDRY_CONFIG", "FOUNDRY_ROOT", "DAPP_ROOT"] {
                 if std::env::var_os(var).is_some() {
-                    eyre::bail!("`--use-nearest-config` cannot be used when `{var}` is set");
+                    eyre::bail!("`--nearest` cannot be used when `{var}` is set");
                 }
             }
         }
@@ -98,7 +98,7 @@ impl FmtArgs {
                     .project_paths::<SolcLanguage>()
                     .input_files_iter()
                     .filter(|p| {
-                        !((!self.use_nearest_config
+                        !((!self.nearest
                             && (ignored.contains(p)
                                 || ignored.contains(&cwd.join(p))
                                 || is_under_dir(p, &ignored)))
@@ -112,7 +112,7 @@ impl FmtArgs {
                 let mut inputs = Vec::with_capacity(paths.len());
                 for path in paths {
                     // Check if path is in ignored directories
-                    if !self.use_nearest_config
+                    if !self.nearest
                         && !ignored.is_empty()
                         && ((path.is_absolute() && ignored.contains(path))
                             || ignored.contains(&cwd.join(path)))
@@ -126,7 +126,7 @@ impl FmtArgs {
                         inputs.extend(
                             foundry_compilers::utils::source_files_iter(path, SOLC_EXTENSIONS)
                                 .filter(|p| {
-                                    !((!self.use_nearest_config
+                                    !((!self.nearest
                                         && (ignored.contains(p)
                                             || ignored.contains(&cwd.join(p))
                                             || is_under_dir(p, &ignored)))
@@ -144,9 +144,9 @@ impl FmtArgs {
             }
         };
 
-        let nearest_fmt_configs = if self.use_nearest_config {
+        let nearest_fmt_configs = if self.nearest {
             let Input::Paths(paths) = &mut input else {
-                eyre::bail!("`--use-nearest-config` cannot be used with stdin");
+                eyre::bail!("`--nearest` cannot be used with stdin");
             };
             let mut root_configs: HashMap<PathBuf, (Arc<FormatterConfig>, Vec<PathBuf>)> =
                 HashMap::new();

--- a/crates/forge/src/cmd/fmt.rs
+++ b/crates/forge/src/cmd/fmt.rs
@@ -68,11 +68,16 @@ impl FmtArgs {
         let config = self.load_config()?;
         let cwd = std::env::current_dir()?;
 
-        // Expand ignore globs and canonicalize from the get go
-        let ignored = expand_globs(&config.root, config.fmt.ignore.iter())?
-            .iter()
-            .flat_map(fs::canonicalize_path)
-            .collect::<Vec<_>>();
+        // Expand ignore globs and canonicalize from the get go. In nearest mode, ignores are
+        // expanded from the config nearest each input file instead.
+        let ignored = if self.nearest {
+            Vec::new()
+        } else {
+            expand_globs(&config.root, config.fmt.ignore.iter())?
+                .iter()
+                .flat_map(fs::canonicalize_path)
+                .collect::<Vec<_>>()
+        };
 
         // Expand lib globs separately - we only exclude these during discovery, not explicit paths
         let libs = expand_globs(&config.root, config.libs.iter().filter_map(|p| p.to_str()))?
@@ -160,6 +165,11 @@ impl FmtArgs {
                     Entry::Occupied(entry) => entry.into_mut(),
                     Entry::Vacant(entry) => {
                         let nearest_config = Config::load_with_root(entry.key())?.sanitized();
+                        if entry.key() != &config.root {
+                            for warning in &nearest_config.warnings {
+                                let _ = sh_warn!("{warning}");
+                            }
+                        }
                         let ignored =
                             expand_globs(&nearest_config.root, nearest_config.fmt.ignore.iter())?
                                 .iter()
@@ -168,6 +178,8 @@ impl FmtArgs {
                         entry.insert((Arc::new(nearest_config.fmt), ignored))
                     }
                 };
+                // Both the input path and expanded ignore paths are canonicalized above, so a
+                // component-wise prefix check correctly covers ignored files and directories.
                 if ignored.iter().any(|ignored| path.starts_with(ignored)) {
                     continue;
                 }

--- a/crates/forge/tests/cli/fmt.rs
+++ b/crates/forge/tests/cli/fmt.rs
@@ -139,6 +139,59 @@ Diff in src/FmtTest.sol:
 "#]]);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/5686>
+forgetest!(fmt_uses_nearest_config, |prj, cmd| {
+    let source = r#"contract Test {
+    function test(uint256 a, uint256 b) public returns (uint256) { return a + b; }
+}
+"#;
+    let first = prj.create_file("first/src/Test.sol", source);
+    let second = prj.create_file("second/src/Test.sol", source);
+    let ignored = prj.create_file("first/src/Ignored.sol", source);
+    prj.create_file(
+        "foundry.toml",
+        r#"[fmt]
+ignore = ["first/src/Test.sol"]
+"#,
+    );
+    prj.create_file(
+        "first/foundry.toml",
+        r#"[fmt]
+multiline_func_header = "params_first"
+tab_width = 2
+ignore = ["src/Ignored.sol"]
+"#,
+    );
+    prj.create_file(
+        "second/foundry.toml",
+        r#"[fmt]
+multiline_func_header = "attributes_first"
+tab_width = 6
+"#,
+    );
+
+    cmd.args(["fmt", "--use-nearest-config", "."]).assert_success();
+
+    assert!(std::fs::read_to_string(first).unwrap().contains("  function test(\n"));
+    assert!(
+        std::fs::read_to_string(second)
+            .unwrap()
+            .contains("      function test(uint256 a, uint256 b)")
+    );
+    assert_eq!(std::fs::read_to_string(ignored).unwrap(), source);
+});
+
+forgetest!(fmt_nearest_config_rejects_config_env, |prj, cmd| {
+    prj.create_file("src/Test.sol", "contract Test {}\n");
+    cmd.env("FOUNDRY_CONFIG", "custom.toml");
+    cmd.args(["fmt", "--use-nearest-config", "src/Test.sol"]).assert_failure().stderr_eq(str![[
+        r#"
+Error: `--use-nearest-config` cannot be used when `FOUNDRY_CONFIG` is set
+
+"#
+    ]]);
+});
+
 // https://github.com/foundry-rs/foundry/issues/12000
 forgetest_init!(fmt_only_cmnts_file, |prj, cmd| {
     // Only line breaks

--- a/crates/forge/tests/cli/fmt.rs
+++ b/crates/forge/tests/cli/fmt.rs
@@ -170,7 +170,7 @@ tab_width = 6
 "#,
     );
 
-    cmd.args(["fmt", "--use-nearest-config", "."]).assert_success();
+    cmd.args(["fmt", "--nearest", "."]).assert_success();
 
     assert!(std::fs::read_to_string(first).unwrap().contains("  function test(\n"));
     assert!(
@@ -184,12 +184,10 @@ tab_width = 6
 forgetest!(fmt_nearest_config_rejects_config_env, |prj, cmd| {
     prj.create_file("src/Test.sol", "contract Test {}\n");
     cmd.env("FOUNDRY_CONFIG", "custom.toml");
-    cmd.args(["fmt", "--use-nearest-config", "src/Test.sol"]).assert_failure().stderr_eq(str![[
-        r#"
-Error: `--use-nearest-config` cannot be used when `FOUNDRY_CONFIG` is set
+    cmd.args(["fmt", "--nearest", "src/Test.sol"]).assert_failure().stderr_eq(str![[r#"
+Error: `--nearest` cannot be used when `FOUNDRY_CONFIG` is set
 
-"#
-    ]]);
+"#]]);
 });
 
 // https://github.com/foundry-rs/foundry/issues/12000

--- a/crates/forge/tests/cli/fmt.rs
+++ b/crates/forge/tests/cli/fmt.rs
@@ -151,7 +151,7 @@ forgetest!(fmt_uses_nearest_config, |prj, cmd| {
     prj.create_file(
         "foundry.toml",
         r#"[fmt]
-ignore = ["first/src/Test.sol"]
+ignore = ["first/src/Test.sol", "["]
 "#,
     );
     prj.create_file(
@@ -170,7 +170,14 @@ tab_width = 6
 "#,
     );
 
-    cmd.args(["fmt", "--nearest", "."]).assert_success();
+    let output = cmd.args(["fmt", "--nearest", "--check", "."]).assert_failure();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    assert!(stdout.contains("Diff in first/src/Test.sol"), "{stdout}");
+    assert!(stdout.contains("|+  function test("), "{stdout}");
+    assert!(stdout.contains("Diff in second/src/Test.sol"), "{stdout}");
+    assert!(stdout.contains("|+      function test(uint256 a, uint256 b)"), "{stdout}");
+
+    cmd.forge_fuse().args(["fmt", "--nearest", "."]).assert_success();
 
     assert!(std::fs::read_to_string(first).unwrap().contains("  function test(\n"));
     assert!(
@@ -179,6 +186,53 @@ tab_width = 6
             .contains("      function test(uint256 a, uint256 b)")
     );
     assert_eq!(std::fs::read_to_string(ignored).unwrap(), source);
+});
+
+forgetest!(fmt_without_nearest_uses_invocation_config, |prj, cmd| {
+    let file = prj.create_file(
+        "nested/src/Test.sol",
+        r#"contract Test {
+    function test(uint256 a, uint256 b) public returns (uint256) { return a + b; }
+}
+"#,
+    );
+    prj.create_file(
+        "foundry.toml",
+        r#"[fmt]
+multiline_func_header = "params_first"
+tab_width = 4
+"#,
+    );
+    prj.create_file(
+        "nested/foundry.toml",
+        r#"[fmt]
+multiline_func_header = "attributes_first"
+tab_width = 2
+"#,
+    );
+
+    cmd.args(["fmt", "nested/src/Test.sol"]).assert_success();
+
+    assert!(std::fs::read_to_string(file).unwrap().contains("    function test(\n"));
+});
+
+forgetest!(fmt_nearest_config_emits_nested_warnings, |prj, cmd| {
+    prj.create_file("nested/src/Test.sol", "contract Test {}\n");
+    prj.create_file(
+        "nested/foundry.toml",
+        r#"[default]
+src = "src"
+"#,
+    );
+
+    cmd.args(["fmt", "--nearest", "nested/src/Test.sol"])
+        .assert_success()
+        .stderr_eq(str![[r#"
+Warning: Found unknown config section in nested/foundry.toml: [default]
+This notation for profiles has been deprecated and may result in the profile not being registered in future versions.
+Please use [profile.default] instead or run `forge config --fix`.
+
+"#]]);
 });
 
 forgetest!(fmt_nearest_config_rejects_config_env, |prj, cmd| {


### PR DESCRIPTION
## Motivation

`forge fmt` applies one config to every input, making mixed-config Solidity monorepos require separate invocations.

Closes #5686.

## Solution

Add `forge fmt --nearest` to resolve each file's nearest `foundry.toml`, including its formatter settings and ignore rules. Existing behavior is unchanged without the flag.

## Validation

- CLI coverage for per-project formatting, nested ignore ownership, and config conflicts.
- `sablier-labs/evm-monorepo`: 645 files across 6 projects matched independent `--root` runs byte-for-byte; its ignored deployed source remained untouched.
- `latticexyz/mud`: 495 files across 25 projects matched independent `--root` runs byte-for-byte, including 487 reformatted files.
