### PR TITLE
feat(fmt): make disable-line contextual

### DIFF
--- a/.changelog/forgefmt-contextual-disable-line.md
+++ b/.changelog/forgefmt-contextual-disable-line.md
@@ -1,0 +1,5 @@
+---
+forge-fmt: minor
+---
+
+Made isolated `forgefmt: disable-line` directives preserve the following Solidity item.

--- a/crates/fmt/src/lib.rs
+++ b/crates/fmt/src/lib.rs
@@ -255,6 +255,9 @@ fn parse_inline_config<'ast>(
         }
         let item = item.trim_start().strip_prefix("forgefmt:")?.trim();
         match item.parse::<InlineConfigItem<()>>() {
+            Ok(InlineConfigItem::DisableLine(())) if cmnt.style.is_isolated() => {
+                Some((cmnt.span, InlineConfigItem::DisableNextItem(())))
+            }
             Ok(item) => Some((cmnt.span, item)),
             Err(e) => {
                 sess.dcx.warn(e.to_string()).span(cmnt.span).emit();

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -61,6 +61,37 @@ fn chained_named_call_layout_ignores_source_spacing() {
     }
 }
 
+// <https://github.com/foundry-rs/foundry/issues/3831>
+#[test]
+fn disable_line_uses_comment_context() {
+    let source = r#"contract  C {
+    function f() public {
+        // forgefmt: disable-line
+        assembly { sstore(   0, 0)
+            sstore(1,    1)
+        }
+
+        assembly { sstore(   2, 2) } // forgefmt: disable-line
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() public {
+        // forgefmt: disable-line
+        assembly { sstore(   0, 0)
+            sstore(1,    1)
+        }
+        assembly { sstore(   2, 2) } // forgefmt: disable-line
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
 fn tests_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata")
 }


### PR DESCRIPTION
## Motivation

A comment-only `forgefmt: disable-line` does not preserve the following Solidity item, unlike `prettier-ignore`.

Closes #3831.

## Solution

Treat isolated `disable-line` directives as `disable-next-item`. Trailing and mixed directives keep their existing current-line behavior, and `disable-next-line` remains supported.
