### PR TITLE
fix(cast): detect uppercase numeric prefixes

### DIFF
--- a/.changelog/cast-uppercase-base-prefixes.md
+++ b/.changelog/cast-uppercase-base-prefixes.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fixed automatic base detection for numbers with uppercase binary, octal, and hexadecimal prefixes.

--- a/crates/cast/src/base.rs
+++ b/crates/cast/src/base.rs
@@ -120,9 +120,13 @@ impl Base {
             // anyway;
             // strip prefix when using u128::from_str_radix because it does not recognize it as
             // valid.
-            _ if s.starts_with("0b") => Self::detect_prefixed(s, 2, Self::Binary, "binary"),
-            _ if s.starts_with("0o") => Self::detect_prefixed(s, 8, Self::Octal, "octal"),
-            _ if s.starts_with("0x") => {
+            _ if s.get(..2).is_some_and(|prefix| prefix.eq_ignore_ascii_case("0b")) => {
+                Self::detect_prefixed(s, 2, Self::Binary, "binary")
+            }
+            _ if s.get(..2).is_some_and(|prefix| prefix.eq_ignore_ascii_case("0o")) => {
+                Self::detect_prefixed(s, 8, Self::Octal, "octal")
+            }
+            _ if s.get(..2).is_some_and(|prefix| prefix.eq_ignore_ascii_case("0x")) => {
                 Self::detect_prefixed(s, 16, Self::Hexadecimal, "hexadecimal")
             }
             // No prefix => first try parsing as decimal
@@ -623,6 +627,14 @@ mod tests {
         assert_eq!(Base::detect("0o100").unwrap(), Octal);
         assert_eq!(Base::detect("100").unwrap(), Decimal);
         assert_eq!(Base::detect("0x100").unwrap(), Hexadecimal);
+
+        assert_eq!(Base::detect("0B100").unwrap(), Binary);
+        assert_eq!(Base::detect("0O100").unwrap(), Octal);
+        assert_eq!(Base::detect("0X100").unwrap(), Hexadecimal);
+
+        assert_eq!(Base::detect("-0B100").unwrap(), Binary);
+        assert_eq!(Base::detect("-0O100").unwrap(), Octal);
+        assert_eq!(Base::detect("-0X100").unwrap(), Hexadecimal);
 
         assert_eq!(Base::detect("0123456789abcdef").unwrap(), Hexadecimal);
 

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -2932,6 +2932,14 @@ mod tests {
     }
 
     #[test]
+    fn to_base_accepts_uppercase_prefixes() {
+        assert_eq!(Cast::to_base("0B10", None, "dec").unwrap(), "2");
+        assert_eq!(Cast::to_base("0O10", None, "dec").unwrap(), "8");
+        assert_eq!(Cast::to_base("0X10", None, "dec").unwrap(), "16");
+        assert_eq!(Cast::to_base("-0X10", None, "dec").unwrap(), "-16");
+    }
+
+    #[test]
     fn disassemble_incomplete_sequence() {
         let incomplete = &hex!("60"); // PUSH1
         let disassembled = Cast::disassemble(incomplete).unwrap();


### PR DESCRIPTION
## Motivation

Automatic base detection only recognized lowercase prefixes, while numeric parsing already accepted uppercase variants. This caused uppercase binary inputs to be misinterpreted as hexadecimal and uppercase octal and hexadecimal inputs to fail.

```shell
$ cast to-dec 0b10
2
$ cast to-dec 0B10
16
```

## Solution

Detect prefixes case-insensitively and add regression coverage for uppercase and signed inputs.

Codex was used to help understand the existing code and assist with the implementation. I fully understand and manually reviewed the resulting changes.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
