### PR TITLE
fix(doc): preserve docs for unnamed params

### DIFF
--- a/.changelog/unnamed-inheritdoc-parameters.md
+++ b/.changelog/unnamed-inheritdoc-parameters.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Preserve inherited NatSpec descriptions for unnamed function parameters in Forge documentation.

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -423,7 +423,7 @@ fn render_contract<'ast, 'gcx>(
             let c = collect_comments(docs, name_to_page, page_path, local);
             write_comment_block(&mut out, &c);
             write_code_block(&mut out, &ctx.dedented_snippet(*span));
-            write_param_table(&mut out, "Parameters", &e.parameters, &c, ctx);
+            write_param_table(&mut out, "Parameters", &e.parameters, &c, None, ctx);
         }
     }
 
@@ -436,7 +436,7 @@ fn render_contract<'ast, 'gcx>(
             let c = collect_comments(docs, name_to_page, page_path, local);
             write_comment_block(&mut out, &c);
             write_code_block(&mut out, &ctx.dedented_snippet(*span));
-            write_param_table(&mut out, "Parameters", &e.parameters, &c, ctx);
+            write_param_table(&mut out, "Parameters", &e.parameters, &c, None, ctx);
         }
     }
 
@@ -616,7 +616,7 @@ fn render_error<'ast>(
     write_git_source(&mut out, git_url);
     write_comment_block(&mut out, &c);
     write_code_block(&mut out, &ctx.dedented_snippet(span));
-    write_param_table(&mut out, "Parameters", &e.parameters, &c, ctx);
+    write_param_table(&mut out, "Parameters", &e.parameters, &c, None, ctx);
     out
 }
 
@@ -638,7 +638,7 @@ fn render_event<'ast>(
     write_git_source(&mut out, git_url);
     write_comment_block(&mut out, &c);
     write_code_block(&mut out, &ctx.dedented_snippet(span));
-    write_param_table(&mut out, "Parameters", &e.parameters, &c, ctx);
+    write_param_table(&mut out, "Parameters", &e.parameters, &c, None, ctx);
     out
 }
 
@@ -663,6 +663,7 @@ fn render_function_section(
     writeln!(out, "### {heading}").unwrap();
     writeln!(out).unwrap();
     let mut c = collect_comments(docs, name_to_page, page_path, local);
+    let mut inherited_params = None;
     // Merge inherited natspec for missing tags.
     if let Some(inherited) = inherited {
         let sanitize = |s: &str| hir_ext::replace_inline_links(s, name_to_page, page_path, local);
@@ -687,11 +688,13 @@ fn render_function_section(
             );
         }
         if c.params.is_empty() {
-            for (index, desc) in inherited.params.iter().enumerate() {
+            let params = inherited.params.iter().map(|desc| sanitize(desc)).collect::<Vec<_>>();
+            for (index, desc) in params.iter().enumerate() {
                 if let Some(name) = f.header.parameters.get(index).and_then(|param| param.name) {
-                    c.params.push((name.as_str().to_string(), sanitize(desc)));
+                    c.params.push((name.as_str().to_string(), desc.clone()));
                 }
             }
+            inherited_params = Some(params);
         }
         if c.returns.is_empty() {
             for (index, desc) in inherited.returns.iter().enumerate() {
@@ -711,9 +714,16 @@ fn render_function_section(
     let hspan = if f.header.span.lo() == f.header.span.hi() { span } else { f.header.span };
     let snippet = ctx.dedented_snippet(hspan);
     write_code_block(out, &format!("{snippet};"));
-    write_param_table(out, "Parameters", &f.header.parameters, &c, ctx);
+    write_param_table(
+        out,
+        "Parameters",
+        &f.header.parameters,
+        &c,
+        inherited_params.as_deref(),
+        ctx,
+    );
     if let Some(returns) = &f.header.returns {
-        write_param_table(out, "Returns", returns, &c, ctx);
+        write_param_table(out, "Returns", returns, &c, None, ctx);
     }
 }
 
@@ -1194,6 +1204,7 @@ fn write_param_table(
     heading: &str,
     params: &ParameterList<'_>,
     comments: &CommentData,
+    inherited_params: Option<&[String]>,
     ctx: &Ctx<'_>,
 ) {
     if params.is_empty() {
@@ -1217,7 +1228,16 @@ fn write_param_table(
         let desc = if is_return {
             return_description(comments, index, var.name.map(|_| name.as_str()))
         } else {
-            comments.params.iter().find(|(n, _)| n == &name).map(|(_, d)| d.as_str()).unwrap_or("")
+            let named = comments.params.iter().find(|(n, _)| n == &name).map(|(_, d)| d.as_str());
+            if var.name.is_none() {
+                inherited_params
+                    .and_then(|params| params.get(index))
+                    .map(String::as_str)
+                    .or(named)
+                    .unwrap_or("")
+            } else {
+                named.unwrap_or("")
+            }
         };
         let name = escape_table_cell(&name);
         let desc = escape_table_cell(desc);

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -354,6 +354,84 @@ contract Effective is IMid {
     );
 });
 
+forgetest_init!(inheritdoc_documents_unnamed_parameters, |prj, cmd| {
+    prj.add_source(
+        "Unnamed.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IProcessor {
+    /// @param amount The amount to process
+    function single(uint256 amount) external;
+
+    /// @param first The first value
+    /// @param third The third value
+    function sparse(uint256 first, address second, bytes32 third) external;
+
+    /// @param first The named underscore
+    /// @param second The unnamed value
+    function underscoreCollision(uint256 first, uint256 second) external;
+
+    /// @param first The named display value
+    /// @param second The custom-named value
+    function customNameCollision(uint256 first, uint256 second) external;
+}
+
+contract Processor is IProcessor {
+    /// @inheritdoc IProcessor
+    function single(uint256) external override {}
+
+    /// @inheritdoc IProcessor
+    function sparse(uint256, address, bytes32) external override {}
+
+    /// @inheritdoc IProcessor
+    function underscoreCollision(uint256 _, uint256) external override {}
+
+    /// @inheritdoc IProcessor
+    /// @custom:name display
+    function customNameCollision(uint256 display, uint256) external override {}
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Processor.mdx"), None),
+        str![[r#"
+...
+### single
+...
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _ | `uint256` | The amount to process |
+...
+### sparse
+...
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _ | `uint256` | The first value |
+| _ | `address` |  |
+| _ | `bytes32` | The third value |
+...
+### underscoreCollision
+...
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _ | `uint256` | The named underscore |
+| _ | `uint256` | The unnamed value |
+...
+### customNameCollision
+...
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| display | `uint256` | The named display value |
+| display | `uint256` | The custom-named value |
+...
+"#]],
+    );
+});
+
 forgetest_init!(inheritdoc_mapping_getter_uses_generated_signature, |prj, cmd| {
     prj.add_source(
         "ExplicitGetter.sol",


### PR DESCRIPTION
Preserves inherited NatSpec parameter descriptions when an overriding function leaves its parameters unnamed. Forge now uses the parameter position as a fallback while retaining existing behavior for named and locally documented parameters.