### PR TITLE
fix(doc): preserve unnamed return docs

### DIFF
--- a/.changelog/unnamed-return-descriptions.md
+++ b/.changelog/unnamed-return-descriptions.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Preserve complete NatSpec descriptions for unnamed function return values in Forge documentation.

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -1247,7 +1247,7 @@ fn return_description<'a>(
 
     match return_name {
         Some(return_name) => desc.strip_prefix(return_name).and_then(strip_one_ws).unwrap_or(desc),
-        None => split_first_word(desc).map(|(_, desc)| desc).unwrap_or(desc),
+        None => desc,
     }
 }
 
@@ -1255,13 +1255,6 @@ fn strip_one_ws(s: &str) -> Option<&str> {
     let mut chars = s.char_indices();
     let (_, first) = chars.next()?;
     first.is_whitespace().then(|| chars.next().map(|(idx, _)| &s[idx..]).unwrap_or(""))
-}
-
-fn split_first_word(s: &str) -> Option<(&str, &str)> {
-    let trimmed = s.trim_start();
-    let split = trimmed.find(char::is_whitespace)?;
-    let (first, rest) = trimmed.split_at(split);
-    Some((first, rest.trim_start()))
 }
 
 fn write_struct_properties_table(

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -1941,6 +1941,12 @@ import "./IUnsafe.sol";
 contract Safe is IUnsafe {
     /// @inheritdoc IUnsafe
     function transfer(uint256 amount) external returns (uint256) {}
+
+    /// @return First local result
+    /// @return Second local result
+    function localResults() external pure returns (uint256, address) {
+        return (1, address(0));
+    }
 }
 "#,
     );
@@ -1969,7 +1975,14 @@ function transfer(uint256 amount) external returns (uint256);
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| &lt;none&gt; | `uint256` | new balance |
+| &lt;none&gt; | `uint256` | The new balance |
+...
+### localResults
+...
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| &lt;none&gt; | `uint256` | First local result |
+| &lt;none&gt; | `address` | Second local result |
 ...
 "#]],
     );


### PR DESCRIPTION
Preserves complete NatSpec descriptions for unnamed function return values. Solar already separates optional return names from their descriptions, so Forge no longer removes the first word from unnamed return prose.