### PR TITLE
perf(anvil): avoid block conversion for receipts

### DIFF
--- a/.changelog/perf-anvil-mined-receipts.md
+++ b/.changelog/perf-anvil-mined-receipts.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Improved mined block receipt lookup performance.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3759,14 +3759,16 @@ where
 
     /// Returns all receipts of the block
     pub fn mined_receipts(&self, hash: B256) -> Option<Vec<N::ReceiptEnvelope>> {
-        let block = self.mined_block_by_hash(hash)?;
-        let mut receipts = Vec::new();
         let storage = self.blockchain.storage.read();
-        for tx in block.transactions.hashes() {
-            let receipt = storage.transactions.get(&tx)?.receipt.clone();
-            receipts.push(receipt);
-        }
-        Some(receipts)
+        let block = storage.blocks.get(&hash)?;
+        block
+            .body
+            .transactions
+            .iter()
+            .map(|transaction| {
+                storage.transactions.get(&transaction.hash()).map(|tx| tx.receipt.clone())
+            })
+            .collect()
     }
 }
 

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -963,6 +963,26 @@ async fn can_get_raw_receipts() {
     assert!(second_decoded.status());
     assert_eq!(first_decoded.cumulative_gas_used(), 21_000);
     assert_eq!(second_decoded.cumulative_gas_used(), 42_000);
+
+    // Loaded state can contain transaction metadata that is inconsistent with the block body.
+    // Receipt lookup must continue to use transaction hashes in block-body order.
+    let mut state = api.serialized_state(false).await.unwrap();
+    state.transactions.reverse();
+    for transaction in &mut state.transactions {
+        transaction.info.transaction_index = 99;
+        transaction.block_hash = B256::repeat_byte(0xff);
+        transaction.block_number = 999;
+    }
+    let (loaded_api, _loaded_handle) =
+        spawn(NodeConfig::test().with_init_state(Some(state.clone()))).await;
+    let loaded_raw = loaded_api.raw_receipts(BlockId::number(1)).await.unwrap();
+    assert_eq!(loaded_raw, raw_by_number);
+
+    // A block with any missing stored transaction must not return a partial receipt list.
+    state.transactions.pop();
+    let (incomplete_api, _incomplete_handle) =
+        spawn(NodeConfig::test().with_init_state(Some(state))).await;
+    assert!(incomplete_api.raw_receipts(BlockId::number(1)).await.is_err());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Anvil's internal mined-receipt lookup previously converted the stored block into an RPC block, including cloning, canonicalizing, RLP-encoding it for its size, and materializing all transaction hashes before reading receipts. This changes the lookup to hold one coherent storage read, walk the stored transaction hashes in block-body order, and clone only their receipts. Missing blocks or transactions still return no result, stale transaction metadata from legacy or inconsistent `anvil_loadState` data remains compatible, and fork routing is unchanged.

### Results

Matched profiling builds at current master `7c271517a3` and this branch used the same generated loaded-state blocks and real HTTP `debug_getRawReceipts` requests. Values are medians of five alternating samples after warmup.

| Benchmark | master | this PR | delta |
| --- | ---: | ---: | ---: |
| 1k receipts wall time | 7.75 ms | 4.95 ms | -36.1% |
| 1k allocations/request | 23,224 | 8,220 | -64.6% |
| 1k allocated bytes/request | 9.61 MB | 6.67 MB | -30.6% |
| 10k receipts wall time | 102.38 ms | 49.94 ms | -51.2% |
| 10k allocations/request | 230,288 | 80,284 | -65.1% |
| 10k allocated bytes/request | 104.76 MB | 75.41 MB | -28.0% |

The encoded JSON response sizes and hashes matched between revisions for both the 1k and 10k blocks.

This PR and its description were written with Codex assistance, including code, tests, and benchmarking.
