### PR TITLE
perf(cast): target storage layout compile

### DIFF
--- a/.changelog/perf-cast-target-storage-layout.md
+++ b/.changelog/perf-cast-target-storage-layout.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Accelerated human-readable local `cast storage` layout discovery by recompiling only the matching contract's source and imports.

--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -1,7 +1,7 @@
 use crate::{Cast, opts::parse_slot};
 use alloy_ens::NameOrAddress;
 use alloy_network::AnyNetwork;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockId;
 use clap::Parser;
@@ -18,7 +18,7 @@ use foundry_common::{
     shell,
 };
 use foundry_compilers::{
-    Artifact, Project,
+    Artifact, ArtifactId, Project, ProjectCompileOutput,
     artifacts::{ConfigurableContractArtifact, Contract, StorageLayout},
     compilers::{
         Compiler,
@@ -126,17 +126,12 @@ impl StorageArgs {
         }
 
         // Check if we're in a forge project and if we can find the address' code
-        let mut project = build.project()?;
-        if project.paths.has_input_files() {
-            // Find in artifacts and pretty print
-            add_storage_layout_output(&mut project);
-            let out = ProjectCompiler::new().quiet(shell::is_json()).compile(&project)?;
-            let artifact = out.artifacts().find(|(_, artifact)| {
-                artifact.get_deployed_bytecode_bytes().is_some_and(|b| *b == address_code)
-            });
-            if let Some((_, artifact)) = artifact {
-                return fetch_and_print_storage(provider, address, block, artifact).await;
-            }
+        let project = build.project()?;
+        if project.paths.has_input_files()
+            && let Some(artifact) =
+                compile_local_storage_layout(&project, &address_code, shell::is_json())?
+        {
+            return fetch_and_print_storage(provider, address, block, &artifact).await;
         }
 
         let chain = utils::get_chain(config.chain, &provider).await?;
@@ -238,6 +233,100 @@ impl StorageArgs {
         drop(temp_dir);
         fetch_and_print_storage(provider, address, block, artifact).await
     }
+}
+
+/// Finds the local artifact matching `address_code` and produces its storage layout.
+///
+/// Human-readable output compiles only the target's source and imports when safe. JSON and unsafe
+/// cases retain the full-project compile to preserve existing behavior.
+fn compile_local_storage_layout(
+    project: &Project,
+    address_code: &Bytes,
+    json: bool,
+) -> Result<Option<ConfigurableContractArtifact>> {
+    // The JSON output exposes compiler-assigned AST IDs, which change when the compilation unit is
+    // reduced to the target's dependency graph. Preserve those IDs by retaining the full compile.
+    if json
+        || project.build_info
+        || !project.cache_path().is_file()
+        || !project.paths.artifacts.is_dir()
+    {
+        let output = compile_full_storage_layout(project, json)?;
+        return Ok(find_artifact_by_code(output, address_code).map(|(_, artifact)| artifact));
+    }
+
+    let output = ProjectCompiler::new().quiet(json).compile(project)?;
+    let Some((target, artifact)) = find_artifact_by_code(output, address_code) else {
+        return Ok(None);
+    };
+
+    if artifact.storage_layout.is_some() {
+        return Ok(Some(artifact));
+    }
+
+    if let Ok(output) = compile_target_storage_layout(project, &target)
+        && let Some(artifact) = find_target_artifact(output, &target, address_code)
+    {
+        return Ok(Some(artifact));
+    }
+
+    let output = compile_full_storage_layout(project, json)?;
+    Ok(find_artifact_by_code(output, address_code).map(|(_, artifact)| artifact))
+}
+
+fn find_artifact_by_code(
+    output: ProjectCompileOutput,
+    address_code: &Bytes,
+) -> Option<(ArtifactId, ConfigurableContractArtifact)> {
+    output.into_artifacts().find(|(_, artifact)| matches_deployed_bytecode(artifact, address_code))
+}
+
+fn find_target_artifact(
+    output: ProjectCompileOutput,
+    target: &ArtifactId,
+    address_code: &Bytes,
+) -> Option<ConfigurableContractArtifact> {
+    output.into_artifacts().find_map(|(id, artifact)| {
+        (same_artifact(&id, target)
+            && artifact.storage_layout.is_some()
+            && matches_deployed_bytecode(&artifact, address_code))
+        .then_some(artifact)
+    })
+}
+
+fn matches_deployed_bytecode(
+    artifact: &ConfigurableContractArtifact,
+    address_code: &Bytes,
+) -> bool {
+    artifact.get_deployed_bytecode_bytes().is_some_and(|bytecode| bytecode.as_ref() == address_code)
+}
+
+fn compile_target_storage_layout(
+    project: &Project,
+    target: &ArtifactId,
+) -> Result<ProjectCompileOutput> {
+    let mut project = project.clone();
+    project.no_artifacts = true;
+    add_storage_layout_output(&mut project);
+    ProjectCompiler::new().quiet(true).files([target.source.clone()]).compile(&project)
+}
+
+fn compile_full_storage_layout(project: &Project, quiet: bool) -> Result<ProjectCompileOutput> {
+    let mut project = project.clone();
+    add_storage_layout_output(&mut project);
+    ProjectCompiler::new().quiet(quiet).compile(&project)
+}
+
+/// Returns whether two artifact IDs identify the same contract across compiler runs.
+///
+/// Changing the output selection changes the build ID, and compiling fewer files can change an
+/// artifact path that was disambiguated due to a name collision. Neither can be used to match the
+/// normal compile against the targeted storage-layout compile.
+fn same_artifact(left: &ArtifactId, right: &ArtifactId) -> bool {
+    left.name == right.name
+        && left.source == right.source
+        && left.version == right.version
+        && left.profile == right.profile
 }
 
 /// Represents the value of a storage slot `eth_getStorageAt` call.
@@ -396,6 +485,248 @@ const fn is_storage_layout_empty(storage_layout: &Option<StorageLayout>) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
+    use foundry_compilers::PathStyle;
+    use foundry_config::{CompilationRestrictions, SettingsOverrides, filter::GlobMatcher};
+    use foundry_test_utils::{
+        TestProject,
+        util::{OTHER_SOLC_VERSION, SOLC_VERSION},
+    };
+
+    fn test_project(name: &str) -> TestProject {
+        let project = TestProject::new(name, PathStyle::Dapptools);
+        foundry_test_utils::util::initialize(project.root());
+        project
+    }
+
+    fn load_project(project: &TestProject) -> Project {
+        load_project_with_config(project, Config::with_root(project.root()))
+    }
+
+    fn load_project_with_config(project: &TestProject, config: Config) -> Project {
+        let project = config.canonic_at(project.root()).project().unwrap();
+        assert!(project.paths.has_input_files(), "{:?}", project.paths);
+        project
+    }
+
+    #[test]
+    fn local_storage_layout_targets_exact_artifact_and_imports() {
+        let prj = test_project("cast-storage-target");
+        let base_path = prj.add_source("Base", "contract Base { uint256 baseValue; }");
+        let unrelated_path = prj.add_source("Target", "contract Target { uint256 unrelated; }");
+        let target_path = prj.add_source(
+            "nested/Target",
+            r#"
+import "src/Base.sol";
+
+contract Target is Base {
+    uint256 value;
+
+    function marker() external pure returns (bool) {
+        return true;
+    }
+}
+"#,
+        );
+        let project = load_project(&prj);
+
+        let output = ProjectCompiler::new().quiet(true).compile(&project).unwrap();
+        let (target, artifact) = output
+            .artifact_ids()
+            .find(|(id, _)| id.source == target_path && id.name == "Target")
+            .unwrap();
+        let address_code = artifact.get_deployed_bytecode_bytes().unwrap().into_owned();
+        let artifact_before = std::fs::read(&target.path).unwrap();
+        let cache_before = std::fs::read(project.cache_path()).unwrap();
+
+        let output = compile_target_storage_layout(&project, &target).unwrap();
+        assert!(output.artifact_ids().any(|(id, _)| id.source == base_path));
+        assert!(!output.artifact_ids().any(|(id, _)| id.source == unrelated_path));
+        let artifact = find_target_artifact(output, &target, &address_code).unwrap();
+        let labels = artifact
+            .storage_layout
+            .as_ref()
+            .unwrap()
+            .storage
+            .iter()
+            .map(|slot| slot.label.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(labels, ["baseValue", "value"]);
+
+        let artifact =
+            compile_local_storage_layout(&project, &address_code, false).unwrap().unwrap();
+        assert!(artifact.storage_layout.is_some());
+        assert_eq!(std::fs::read(&target.path).unwrap(), artifact_before);
+        assert_eq!(std::fs::read(project.cache_path()).unwrap(), cache_before);
+    }
+
+    #[test]
+    fn local_storage_layout_rechecks_bytecode_after_source_change() {
+        let prj = test_project("cast-storage-source-change");
+        let target_path = prj.add_source("Target", "contract Target { uint256 originalValue; }");
+        let project = load_project(&prj);
+        let output = ProjectCompiler::new().quiet(true).compile(&project).unwrap();
+        let (target, artifact) = output
+            .artifact_ids()
+            .find(|(id, _)| id.source == target_path && id.name == "Target")
+            .unwrap();
+        let address_code = artifact.get_deployed_bytecode_bytes().unwrap().into_owned();
+
+        std::fs::write(
+            &target_path,
+            format!(
+                "// SPDX-License-Identifier: MIT\npragma solidity ={SOLC_VERSION};\ncontract Target {{ uint256 changedValue; }}\n"
+            ),
+        )
+        .unwrap();
+
+        let output = compile_target_storage_layout(&project, &target).unwrap();
+        assert!(find_target_artifact(output, &target, &address_code).is_none());
+        assert!(compile_local_storage_layout(&project, &address_code, false).unwrap().is_none());
+    }
+
+    #[test]
+    fn local_storage_layout_preserves_compiler_profile() {
+        let prj = test_project("cast-storage-profile");
+        let target_path = prj.add_source("Profiled", "contract Profiled { uint256 value; }");
+        let mut config = Config::with_root(prj.root());
+        config.additional_compiler_profiles = vec![SettingsOverrides {
+            name: "optimized".to_string(),
+            via_ir: Some(true),
+            evm_version: None,
+            optimizer: Some(true),
+            optimizer_runs: Some(1),
+            bytecode_hash: None,
+        }];
+        config.compilation_restrictions = vec![CompilationRestrictions {
+            paths: GlobMatcher::from_str("src/Profiled.sol").unwrap(),
+            version: None,
+            via_ir: Some(true),
+            bytecode_hash: None,
+            min_optimizer_runs: None,
+            optimizer_runs: Some(1),
+            max_optimizer_runs: None,
+            min_evm_version: None,
+            evm_version: None,
+            max_evm_version: None,
+        }];
+        let project = load_project_with_config(&prj, config);
+        let output = ProjectCompiler::new().quiet(true).compile(&project).unwrap();
+        let (target, artifact) = output
+            .artifact_ids()
+            .find(|(id, _)| id.source == target_path && id.name == "Profiled")
+            .unwrap();
+        assert_eq!(target.profile, "optimized");
+        let address_code = artifact.get_deployed_bytecode_bytes().unwrap().into_owned();
+
+        let output = compile_target_storage_layout(&project, &target).unwrap();
+        let (compiled, _) = output
+            .artifact_ids()
+            .find(|(id, artifact)| {
+                same_artifact(id, &target) && matches_deployed_bytecode(artifact, &address_code)
+            })
+            .unwrap();
+        assert_eq!(compiled.version, target.version);
+        assert_eq!(compiled.profile, target.profile);
+        assert!(find_target_artifact(output, &target, &address_code).is_some());
+    }
+
+    #[test]
+    fn local_storage_layout_preserves_compiler_version_in_multi_version_project() {
+        let prj = test_project("cast-storage-multi-version");
+        let old_path = prj.add_raw_source(
+            "Old",
+            &format!(
+                "// SPDX-License-Identifier: MIT\npragma solidity ={OTHER_SOLC_VERSION};\ncontract Old {{ uint256 oldValue; }}\n"
+            ),
+        );
+        let new_path = prj.add_raw_source(
+            "New",
+            &format!(
+                "// SPDX-License-Identifier: MIT\npragma solidity ={SOLC_VERSION};\ncontract New {{ uint256 newValue; }}\n"
+            ),
+        );
+        let mut config = Config::with_root(prj.root());
+        config.solc = None;
+        let project = load_project_with_config(&prj, config);
+        let output = ProjectCompiler::new().quiet(true).compile(&project).unwrap();
+        let (target, artifact) = output
+            .artifact_ids()
+            .find(|(id, _)| id.source == old_path && id.name == "Old")
+            .unwrap();
+        assert_eq!(target.version, Version::parse(OTHER_SOLC_VERSION).unwrap());
+        let address_code = artifact.get_deployed_bytecode_bytes().unwrap().into_owned();
+
+        let output = compile_target_storage_layout(&project, &target).unwrap();
+        assert!(!output.artifact_ids().any(|(id, _)| id.source == new_path));
+        assert!(find_target_artifact(output, &target, &address_code).is_some());
+        let artifact =
+            compile_local_storage_layout(&project, &address_code, false).unwrap().unwrap();
+        assert_eq!(artifact.storage_layout.unwrap().storage[0].label, "oldValue");
+    }
+
+    #[test]
+    fn local_storage_layout_preserves_full_json_ast_ids() {
+        let prj = test_project("cast-storage-json-ast-ids");
+        prj.add_source("First", "contract First { uint256 first; }");
+        let target_path = prj.add_source("Target", "contract Target { uint256 value; }");
+        let project = load_project(&prj);
+        let output = ProjectCompiler::new().quiet(true).compile(&project).unwrap();
+        let (target, artifact) = output
+            .artifact_ids()
+            .find(|(id, _)| id.source == target_path && id.name == "Target")
+            .unwrap();
+        let address_code = artifact.get_deployed_bytecode_bytes().unwrap().into_owned();
+
+        let targeted = find_target_artifact(
+            compile_target_storage_layout(&project, &target).unwrap(),
+            &target,
+            &address_code,
+        )
+        .unwrap();
+        let full = compile_local_storage_layout(&project, &address_code, true).unwrap().unwrap();
+
+        assert_ne!(full.storage_layout, targeted.storage_layout);
+        assert_eq!(full.storage_layout.unwrap().storage[0].label, "value");
+    }
+
+    #[test]
+    fn local_storage_layout_uses_full_compile_with_build_info() {
+        let prj = test_project("cast-storage-build-info");
+        let target_path = prj.add_source("Target", "contract Target { uint256 value; }");
+        let mut config = Config::with_root(prj.root());
+        config.build_info = true;
+        let project = load_project_with_config(&prj, config);
+        let output = ProjectCompiler::new().quiet(true).compile(&project).unwrap();
+        let (_, artifact) = output
+            .artifact_ids()
+            .find(|(id, _)| id.source == target_path && id.name == "Target")
+            .unwrap();
+        let address_code = artifact.get_deployed_bytecode_bytes().unwrap().into_owned();
+
+        let artifact =
+            compile_local_storage_layout(&project, &address_code, true).unwrap().unwrap();
+        assert!(artifact.storage_layout.is_some());
+    }
+
+    #[test]
+    fn local_storage_layout_uses_full_compile_without_cache() {
+        let prj = test_project("cast-storage-no-cache");
+        let target_path = prj.add_source("Target", "contract Target { uint256 value; }");
+        let project = load_project(&prj);
+        let mut code_project = project.clone();
+        code_project.no_artifacts = true;
+        let output = ProjectCompiler::new().quiet(true).compile(&code_project).unwrap();
+        let (_, artifact) = output
+            .artifact_ids()
+            .find(|(id, _)| id.source == target_path && id.name == "Target")
+            .unwrap();
+        let address_code = artifact.get_deployed_bytecode_bytes().unwrap().into_owned();
+        assert!(!project.cache_path().exists());
+
+        let artifact =
+            compile_local_storage_layout(&project, &address_code, true).unwrap().unwrap();
+        assert!(artifact.storage_layout.is_some());
+    }
 
     #[test]
     fn parse_storage_etherscan_api_key() {

--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -252,11 +252,16 @@ fn compile_local_storage_layout(
         || !project.paths.artifacts.is_dir()
     {
         let output = compile_full_storage_layout(project, json)?;
-        return Ok(find_artifact_by_code(output, address_code).map(|(_, artifact)| artifact));
+        return Ok(output.into_artifacts().find_map(|(_, artifact)| {
+            (artifact.get_deployed_bytecode_bytes().as_deref() == Some(address_code))
+                .then_some(artifact)
+        }));
     }
 
     let output = ProjectCompiler::new().quiet(json).compile(project)?;
-    let Some((target, artifact)) = find_artifact_by_code(output, address_code) else {
+    let Some((target, artifact)) = output.into_artifacts().find(|(_, artifact)| {
+        artifact.get_deployed_bytecode_bytes().as_deref() == Some(address_code)
+    }) else {
         return Ok(None);
     };
 
@@ -271,14 +276,10 @@ fn compile_local_storage_layout(
     }
 
     let output = compile_full_storage_layout(project, json)?;
-    Ok(find_artifact_by_code(output, address_code).map(|(_, artifact)| artifact))
-}
-
-fn find_artifact_by_code(
-    output: ProjectCompileOutput,
-    address_code: &Bytes,
-) -> Option<(ArtifactId, ConfigurableContractArtifact)> {
-    output.into_artifacts().find(|(_, artifact)| matches_deployed_bytecode(artifact, address_code))
+    Ok(output.into_artifacts().find_map(|(_, artifact)| {
+        (artifact.get_deployed_bytecode_bytes().as_deref() == Some(address_code))
+            .then_some(artifact)
+    }))
 }
 
 fn find_target_artifact(
@@ -289,16 +290,9 @@ fn find_target_artifact(
     output.into_artifacts().find_map(|(id, artifact)| {
         (same_artifact(&id, target)
             && artifact.storage_layout.is_some()
-            && matches_deployed_bytecode(&artifact, address_code))
+            && artifact.get_deployed_bytecode_bytes().as_deref() == Some(address_code))
         .then_some(artifact)
     })
-}
-
-fn matches_deployed_bytecode(
-    artifact: &ConfigurableContractArtifact,
-    address_code: &Bytes,
-) -> bool {
-    artifact.get_deployed_bytecode_bytes().is_some_and(|bytecode| bytecode.as_ref() == address_code)
 }
 
 fn compile_target_storage_layout(
@@ -622,7 +616,8 @@ contract Target is Base {
         let (compiled, _) = output
             .artifact_ids()
             .find(|(id, artifact)| {
-                same_artifact(id, &target) && matches_deployed_bytecode(artifact, &address_code)
+                same_artifact(id, &target)
+                    && artifact.get_deployed_bytecode_bytes().as_deref() == Some(&address_code)
             })
             .unwrap();
         assert_eq!(compiled.version, target.version);


### PR DESCRIPTION
This identifies the local artifact from the ordinary cache before requesting a storage layout, then recompiles only that contract's source and import graph with the exact compiler version and profile and without writing artifacts. The targeted result must match the original source, name, version, profile, and deployed bytecode; cold caches, build-info projects, JSON output (whose compiler-local AST IDs must remain unchanged), errors, and mismatches retain the full-project fallback.

Benchmarks used profiling builds from current master `7c271517a3` and this branch with identical inputs. The large fixture was Aave v4 at `3f1db8ad1a` (426 Solidity files), targeting the dependency-free WETH9 source; hyperfine used 3 runs for Aave and 10 for the two-source small fixture.

### Results

| Fixture | Cache | Master | This branch | Change |
| --- | --- | ---: | ---: | ---: |
| Small | Cold | 20.3 ± 1.3 ms | 19.3 ± 0.8 ms | -4.8% (noise) |
| Small | Warm | 19.3 ± 0.5 ms | 19.8 ± 0.1 ms | +2.2% (noise) |
| Aave v4 | Cold | 87.043 ± 0.078 s | 86.980 ± 0.035 s | -0.07% (neutral) |
| Aave v4 | Warm | 87.065 ± 0.217 s | 170.2 ± 4.3 ms | 511.7× faster |
| Aave v4 peak RSS | Warm | 2,917 MiB | 243 MiB | -91.7% |

AI assistance: Codex was used for historical investigation, implementation, regression coverage, benchmarking, and PR drafting.