### PR TITLE
fix(cast): confirm wildcard EIP-7702 auth

### DIFF
--- a/.changelog/cast-confirm-eip7702-wildcard-chain.md
+++ b/.changelog/cast-confirm-eip7702-wildcard-chain.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Added a confirmation prompt before signing wildcard EIP-7702 authorizations.

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -185,6 +185,10 @@ pub enum WalletSubcommands {
         #[arg(long)]
         chain: Option<Chain>,
 
+        /// Skip the confirmation prompt for wildcard chain authorizations.
+        #[arg(long)]
+        force: bool,
+
         /// If set, indicates the authorization will be broadcast by the signing account itself.
         /// This means the nonce used will be the current nonce + 1 (to account for the
         /// transaction that will include this authorization).
@@ -714,9 +718,25 @@ impl WalletSubcommands {
                     print_scalar(format!("0x{}", hex::encode(sig.as_bytes())))?;
                 }
             }
-            Self::SignAuth { rpc, nonce, chain, wallet, address, self_broadcast } => {
-                let wallet = wallet.signer().await?;
+            Self::SignAuth { rpc, nonce, chain, force, wallet, address, self_broadcast } => {
                 let provider = utils::get_provider(&rpc.load_config()?)?;
+                let chain_id = if let Some(chain) = chain {
+                    chain.id()
+                } else {
+                    provider.get_chain_id().await?
+                };
+                if chain_id == 0 && !force {
+                    sh_warn!(
+                        "Chain ID 0 creates an EIP-7702 authorization that is valid on every chain."
+                    )?;
+                    let response: String = foundry_common::prompt!("\nContinue anyway? [y/N] ")?;
+                    if !matches!(response.trim(), "y" | "Y") {
+                        sh_status!("Aborted.")?;
+                        return Ok(());
+                    }
+                }
+
+                let wallet = wallet.signer().await?;
                 let nonce = if let Some(nonce) = nonce {
                     nonce
                 } else {
@@ -728,11 +748,6 @@ impl WalletSubcommands {
                     } else {
                         current_nonce
                     }
-                };
-                let chain_id = if let Some(chain) = chain {
-                    chain.id()
-                } else {
-                    provider.get_chain_id().await?
                 };
                 let auth = Authorization { chain_id: U256::from(chain_id), address, nonce };
                 let signature = wallet.sign_hash(&auth.signature_hash()).await?;

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -965,6 +965,91 @@ casttest!(wallet_sign_auth, |_prj, cmd| {
 "#]]);
 });
 
+casttest!(wallet_sign_auth_zero_chain_requires_confirmation, |_prj, cmd| {
+    use alloy_rlp::Decodable;
+
+    let delegate = "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf";
+    let private_key = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    cmd.args(["wallet", "sign-auth", "--nonce", "100", "--chain", "0", delegate])
+        .stdin("n\n")
+        .assert_success()
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
+Warning: Chain ID 0 creates an EIP-7702 authorization that is valid on every chain.
+
+Continue anyway? [y/N] Aborted.
+
+"#]]);
+
+    let confirmed = cmd
+        .cast_fuse()
+        .args([
+            "wallet",
+            "sign-auth",
+            "--private-key",
+            private_key,
+            "--nonce",
+            "100",
+            "--chain",
+            "0",
+            delegate,
+        ])
+        .stdin("y\n")
+        .assert_success()
+        .stderr_eq(str![[r#"
+Warning: Chain ID 0 creates an EIP-7702 authorization that is valid on every chain.
+
+Continue anyway? [y/N] "#]])
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    let bytes = hex::decode(confirmed.strip_prefix("0x").unwrap()).unwrap();
+    let auth = alloy_eips::eip7702::SignedAuthorization::decode(&mut bytes.as_slice()).unwrap();
+    assert_eq!(*auth.chain_id(), U256::ZERO);
+    assert_eq!(auth.nonce(), 100);
+
+    cmd.cast_fuse()
+        .args([
+            "wallet",
+            "sign-auth",
+            "--private-key",
+            private_key,
+            "--nonce",
+            "100",
+            "--chain",
+            "0",
+            "--force",
+            delegate,
+        ])
+        .assert_success()
+        .stdout_eq(format!("{confirmed}\n"))
+        .stderr_eq(str![""]);
+});
+
+casttest!(wallet_sign_auth_rpc_zero_chain_requires_confirmation, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test().with_chain_id(Some(0u64))).await;
+
+    cmd.args([
+        "wallet",
+        "sign-auth",
+        "--rpc-url",
+        &handle.http_endpoint(),
+        "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+    ])
+    .stdin("n\n")
+    .assert_success()
+    .stdout_eq(str![""])
+    .stderr_eq(str![[r#"
+Warning: Chain ID 0 creates an EIP-7702 authorization that is valid on every chain.
+
+Continue anyway? [y/N] Aborted.
+
+"#]]);
+});
+
 // tests that `cast wallet sign-auth --self-broadcast` uses nonce + 1
 casttest!(wallet_sign_auth_self_broadcast, async |_prj, cmd| {
     use alloy_rlp::Decodable;


### PR DESCRIPTION
## Motivation

EIP-7702 treats chain ID zero as a wildcard, making an authorization valid on every chain. `cast wallet sign-auth` accepted this value from either `--chain` or the configured RPC and signed without warning, which could create a broader authorization than intended.

## Solution

Warn and require confirmation before signing an authorization with chain ID zero. Resolve the chain ID before accessing the signer, and add `--force` for users who intentionally want to skip the confirmation.

```shell
$ cast wallet sign-auth \
    0x1111111111111111111111111111111111111111 \
    --private-key $PRIVATE_KEY \
    --rpc-url http://127.0.0.1:18793 \
    --chain 0 -v

Warning: Chain ID 0 creates an EIP-7702 authorization that is valid on every chain.

Continue anyway? [y/N] y
Successfully signed!
   Nonce: 0
   Chain ID: 0
   Address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
0xf85a...
```

Codex was used to help understand the existing code and assist with the implementation. I fully understand and manually reviewed the resulting changes.
