### PR TITLE
fix(forge): hide auth from create help

### DIFF
--- a/.changelog/forge-create-hide-auth.md
+++ b/.changelog/forge-create-hide-auth.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Removed the unsupported `--auth` option from `forge create` help output.

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -50,6 +50,7 @@ merge_impl_figment_convert!(CreateArgs, build, eth);
 
 /// CLI arguments for `forge create`.
 #[derive(Clone, Debug, Parser)]
+#[command(mut_arg("auth", |arg| arg.hide(true)))]
 pub struct CreateArgs {
     /// The contract identifier in the form `<path>:<contractname>`.
     contract: ContractInfo,
@@ -913,6 +914,12 @@ mod tests {
         assert_eq!(args.retry.retries, 10);
         assert_eq!(args.retry.delay, 30);
         assert_eq!(args.license_type.as_deref(), Some("13"));
+    }
+
+    #[test]
+    fn create_help_hides_auth() {
+        let help = <CreateArgs as clap::CommandFactory>::command().render_long_help().to_string();
+        assert!(!help.contains("--auth"));
     }
 
     #[test]


### PR DESCRIPTION
`forge create` inherits `--auth` from the shared transaction options even though EIP-7702 transactions require a destination and cannot deploy contracts. This hides the unsupported option from this command's help without changing its availability for Cast, and adds a regression test for the generated help output.

This pull request was prepared with AI assistance.
