### PR TITLE
perf(cast): skip prefix transaction traces

### DIFF
--- a/.changelog/cast-run-prefix-tracing.md
+++ b/.changelog/cast-run-prefix-tracing.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Reduced `cast run` replay overhead by skipping trace collection for transactions before the selected transaction.

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -372,7 +372,7 @@ impl RunArgs {
         }
         apply_chain_specific_tx_replay_env_changes(&mut evm_env);
 
-        let trace_requirements = TraceRequirements::none()
+        let target_trace_requirements = TraceRequirements::none()
             .with_calls(true)
             .with_debug(self.debug)
             .with_decode_internal(if tracing.decode_internal {
@@ -385,7 +385,7 @@ impl RunArgs {
             (evm_env.clone(), tx_env),
             fork,
             evm_version,
-            trace_requirements,
+            TraceRequirements::none(),
             networks,
             create2_deployer,
             None,
@@ -503,6 +503,7 @@ impl RunArgs {
 
         // Execute our transaction
         let result = {
+            executor.set_trace_requirements(target_trace_requirements);
             executor.set_trace_printer(self.trace_printer);
 
             let tx_env = TxEnvFor::<FEN>::from_recovered_tx(tx.as_ref(), tx.from());

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -372,15 +372,6 @@ impl RunArgs {
         }
         apply_chain_specific_tx_replay_env_changes(&mut evm_env);
 
-        let target_trace_requirements = TraceRequirements::none()
-            .with_calls(true)
-            .with_debug(self.debug)
-            .with_decode_internal(if tracing.decode_internal {
-                InternalTraceMode::Full
-            } else {
-                InternalTraceMode::None
-            })
-            .with_state_changes(verbosity > 4);
         let mut executor = TracingExecutor::<FEN>::new(
             (evm_env.clone(), tx_env),
             fork,
@@ -503,6 +494,17 @@ impl RunArgs {
 
         // Execute our transaction
         let result = {
+            // Enable tracing only for the target transaction; the prefix replay above ran with
+            // tracing disabled.
+            let target_trace_requirements = TraceRequirements::none()
+                .with_calls(true)
+                .with_debug(self.debug)
+                .with_decode_internal(if tracing.decode_internal {
+                    InternalTraceMode::Full
+                } else {
+                    InternalTraceMode::None
+                })
+                .with_state_changes(verbosity > 4);
             executor.set_trace_requirements(target_trace_requirements);
             executor.set_trace_printer(self.trace_printer);
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4206,6 +4206,146 @@ async fn deploy_counter_and_set_number(
         .tx_hash()
 }
 
+// `cast run` must replay a transaction's block prefix without changing the trace requested for the
+// selected transaction. A single block covers a deployment in the first position, a revert in the
+// middle, and an internally traced state change in the last position.
+forgetest_async!(cast_run_fork_traces_only_target_transaction, |prj, cmd| {
+    let (api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let provider = handle.http_provider();
+    let sender = handle.dev_wallets().next().unwrap().address();
+
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_source(
+        "ReplayTarget",
+        r#"
+contract ReplayTarget {
+    uint256 public number;
+
+    constructor() {
+        number = 1;
+    }
+
+    function revertingIncrement() external {
+        number++;
+        revert("expected revert");
+    }
+
+    function increment() external {
+        _increment();
+    }
+
+    function _increment() internal {
+        number++;
+    }
+}
+"#,
+    );
+    let bytecode = cmd
+        .forge_fuse()
+        .args(["inspect", "ReplayTarget", "bytecode"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let bytecode = Bytes::from_str(bytecode.trim()).unwrap();
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let nonce = provider.get_transaction_count(sender).await.unwrap();
+    let target = sender.create(nonce);
+    let deployment = provider
+        .send_transaction(
+            TransactionRequest::default()
+                .from(sender)
+                .with_deploy_code(bytecode)
+                .nonce(nonce)
+                .gas_limit(1_000_000)
+                .into(),
+        )
+        .await
+        .unwrap();
+    let revert = provider
+        .send_transaction(
+            TransactionRequest::default()
+                .from(sender)
+                .to(target)
+                .with_input(Bytes::copy_from_slice(&keccak256(b"revertingIncrement()")[..4]))
+                .nonce(nonce + 1)
+                .gas_limit(1_000_000)
+                .into(),
+        )
+        .await
+        .unwrap();
+    let increment = provider
+        .send_transaction(
+            TransactionRequest::default()
+                .from(sender)
+                .to(target)
+                .with_input(Bytes::copy_from_slice(&keccak256(b"increment()")[..4]))
+                .nonce(nonce + 2)
+                .gas_limit(1_000_000)
+                .into(),
+        )
+        .await
+        .unwrap();
+    let tx_hashes = [*deployment.tx_hash(), *revert.tx_hash(), *increment.tx_hash()];
+    api.mine_one().await.unwrap();
+
+    for (index, tx_hash) in tx_hashes.iter().enumerate() {
+        let block_tx = api
+            .transaction_by_block_number_and_index(BlockNumberOrTag::Latest, Index::from(index))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(block_tx.tx_hash(), *tx_hash);
+    }
+    assert!(!api.transaction_receipt(tx_hashes[1]).await.unwrap().unwrap().status());
+
+    cmd.set_current_dir(prj.root());
+    let deployment_output = cmd
+        .cast_fuse()
+        .args(["run", &tx_hashes[0].to_string(), "--rpc-url", &endpoint, "--with-local-artifacts"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(deployment_output.contains("new ReplayTarget"));
+    assert!(deployment_output.contains("Transaction successfully executed."));
+
+    let revert_output = cmd
+        .cast_fuse()
+        .args(["run", &tx_hashes[1].to_string(), "--rpc-url", &endpoint, "--with-local-artifacts"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(revert_output.contains("ReplayTarget::revertingIncrement()"));
+    assert!(revert_output.contains("expected revert"));
+
+    let increment_output = cmd
+        .cast_fuse()
+        .args(["run", &tx_hashes[2].to_string(), "--rpc-url", &endpoint, "--with-local-artifacts"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(increment_output.contains("ReplayTarget::increment()"));
+    assert!(increment_output.contains("Transaction successfully executed."));
+
+    let decoded_output = cmd
+        .cast_fuse()
+        .args([
+            "run",
+            &tx_hashes[2].to_string(),
+            "--rpc-url",
+            &endpoint,
+            "--with-local-artifacts",
+            "--decode-internal",
+            "-vvvvv",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(decoded_output.contains("ReplayTarget::_increment()"));
+    assert!(decoded_output.contains("@ 0: 1 → 2"));
+});
+
 // `cast run --prestate-tracer` uses the prestate tracer when the node exposes the debug API
 // (Anvil does), skipping the block replay while still producing correct traces. The block replay
 // message must be absent from stderr.

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1583,6 +1583,7 @@ mod tests {
     };
     use foundry_config::Config;
     use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
+    use foundry_evm_traces::InternalTraceMode;
     use revm::context::{Cfg, TxEnv};
     use std::{sync::mpsc, thread};
 
@@ -1699,6 +1700,48 @@ mod tests {
             &revm::context_interface::cfg::GasParams::new_spec(SpecId::AMSTERDAM),
         );
         assert!(executor.evm_env().cfg_env.is_amsterdam_eip8037_enabled());
+    }
+
+    #[test]
+    fn set_trace_requirements_replaces_trace_mode_between_transactions() {
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(1 << 20).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+        );
+        executor.evm_env_mut().cfg_env.disable_nonce_check = true;
+        let target = Address::repeat_byte(0x11);
+        // PUSH1 4; JUMP; STOP; JUMPDEST; PUSH1 1; PUSH1 0; SSTORE; STOP.
+        executor
+            .set_code(
+                target,
+                Bytecode::new_raw(Bytes::from_static(&[
+                    0x60, 0x04, 0x56, 0x00, 0x5b, 0x60, 0x01, 0x60, 0x00, 0x55, 0x00,
+                ])),
+            )
+            .unwrap();
+
+        let untraced = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO).unwrap();
+        assert!(untraced.traces.is_none());
+
+        executor.set_trace_requirements(TraceRequirements::none().with_debug(true));
+        let debug = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO).unwrap();
+        let debug_steps = &debug.traces.as_ref().unwrap().nodes()[0].trace.steps;
+        assert_eq!(debug_steps.len(), 7);
+        assert!(debug_steps.iter().all(|step| step.stack.is_some() && step.memory.is_some()));
+
+        executor.set_trace_requirements(
+            TraceRequirements::none().with_decode_internal(InternalTraceMode::Full),
+        );
+        let internal = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO).unwrap();
+        let internal_steps = &internal.traces.as_ref().unwrap().nodes()[0].trace.steps;
+        assert_eq!(internal_steps.len(), 2);
+        assert!(internal_steps.iter().all(|step| step.stack.is_some() && step.memory.is_some()));
+
+        executor.set_trace_requirements(TraceRequirements::none());
+        let untraced = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO).unwrap();
+        assert!(untraced.traces.is_none());
     }
 
     #[test]


### PR DESCRIPTION
`cast run` now replays transactions before the selected transaction with tracing disabled, then installs the requested trace requirements immediately before executing the target. Prefix transactions still commit the same state transitions and revert behavior, while the target retains call traces, storage changes, internal decoding, and debugger data. This PR was prepared with Codex assistance for implementation, tests, and benchmarks.

### Results

Profiling builds at `origin/master` (`7c271517a3`) and this branch replayed targets at indices 0, 99, and 199 in the same 200-transaction local Anvil block running `work(200)`. Values are mean ± standard deviation over 10 runs for `--decode-internal` and 5 runs for `--debug`; debugger wall time includes fixed pseudo-terminal startup and exit overhead.

| Mode | Target | master | This PR | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `--decode-internal` | 0 | 0.301 ± 0.073 s | 0.339 ± 0.078 s | 0.89× |
| `--decode-internal` | 99 | 1.383 ± 0.183 s | 0.299 ± 0.050 s | 4.63× |
| `--decode-internal` | 199 | 1.775 ± 0.313 s | 0.246 ± 0.015 s | 7.23× |
| `--debug` | 0 | 2.272 ± 0.041 s | 2.265 ± 0.053 s | 1.00× |
| `--debug` | 99 | 2.593 ± 0.065 s | 2.382 ± 0.043 s | 1.09× |
| `--debug` | 199 | 3.536 ± 0.090 s | 2.344 ± 0.059 s | 1.51× |

For the late target, retired instructions fell from 5.592B to 0.765B in `--decode-internal` and from 6.003B to 0.761B in `--debug` (86.3% and 87.3% reductions). Peak RSS was effectively flat at 85.8 MB to 84.8 MB and 86.0 MB to 85.4 MB, respectively.