### PR TITLE
fix(ci): resolve nightly Clippy lints

### DIFF
--- a/.changelog/update-async-trait-0.1.92.md
+++ b/.changelog/update-async-trait-0.1.92.md
@@ -2,7 +2,10 @@
 anvil: patch
 anvil-server: patch
 forge-verify: patch
+forge-lint: patch
+foundry-evm-fuzz: patch
+foundry-evm-symbolic: patch
 foundry-evm-traces: patch
 ---
 
-Updated `async-trait` to 0.1.92 to avoid a Clippy warning in generated code.
+Updated `async-trait` to 0.1.92 and resolved additional nightly Clippy warnings.

--- a/.changelog/update-async-trait-0.1.92.md
+++ b/.changelog/update-async-trait-0.1.92.md
@@ -1,0 +1,8 @@
+---
+anvil: patch
+anvil-server: patch
+forge-verify: patch
+foundry-evm-traces: patch
+---
+
+Updated `async-trait` to 0.1.92 to avoid a Clippy warning in generated code.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/evm/fuzz/src/strategies/mutators.rs
+++ b/crates/evm/fuzz/src/strategies/mutators.rs
@@ -482,7 +482,7 @@ fn apply_scale_to_bytes(bytes: &mut [u8], scale_factor: f64) -> Option<()> {
 
     for i in (0..bytes.len()).rev() {
         let byte_val = bytes[i] as f64;
-        let scaled = (byte_val + carry_down * 256.0) * scale_factor;
+        let scaled = f64::mul_add(carry_down, 256.0, byte_val) * scale_factor;
 
         if i == 0 && scaled >= 256.0 {
             for b in bytes.iter_mut() {

--- a/crates/evm/symbolic/src/runtime/bytes.rs
+++ b/crates/evm/symbolic/src/runtime/bytes.rs
@@ -505,7 +505,6 @@ impl SymBytes {
                 if len > take {
                     out.resize(out.len() + len - take, 0);
                 }
-                Ok(())
             }
             SymBytesKind::Exprs(bytes) => {
                 for idx in 0..len {
@@ -518,7 +517,6 @@ impl SymBytes {
                     };
                     out.push(byte.to::<u8>());
                 }
-                Ok(())
             }
             SymBytesKind::Concat(values) => {
                 for bytes in values {
@@ -541,7 +539,6 @@ impl SymBytes {
                 if len != 0 {
                     out.resize(out.len() + len, 0);
                 }
-                Ok(())
             }
             SymBytesKind::Slice { bytes, offset: base_offset, len: slice_len } => {
                 if offset >= *slice_len {
@@ -562,13 +559,12 @@ impl SymBytes {
                     let bytes = self.slice_concrete(cx, offset, len).materialize(cx);
                     out.extend(concrete_expr_bytes(&bytes, reason)?);
                 }
-                Ok(())
             }
             _ => {
                 let bytes = self.slice_concrete(cx, offset, len).materialize(cx);
                 out.extend(concrete_expr_bytes(&bytes, reason)?);
-                Ok(())
             }
         }
+        Ok(())
     }
 }

--- a/crates/lint/src/sol/high/enumerable_loop_removal.rs
+++ b/crates/lint/src/sol/high/enumerable_loop_removal.rs
@@ -244,7 +244,6 @@ const fn real_body<'hir>(source: LoopSource, body: &'hir [Stmt<'hir>]) -> &'hir 
             {
                 return std::slice::from_ref(*then);
             }
-            body
         }
         LoopSource::DoWhile => {
             if let Some((last, rest)) = body.split_last()
@@ -254,9 +253,9 @@ const fn real_body<'hir>(source: LoopSource, body: &'hir [Stmt<'hir>]) -> &'hir 
             {
                 return rest;
             }
-            body
         }
     }
+    body
 }
 
 /// Whether every statement of a loop body runs on one straight line: no branch (`if`/`try`), no


### PR DESCRIPTION
Nightly Clippy introduced `double_must_use` diagnostics in `async-trait`-generated code alongside `suboptimal_flops` and `branches_sharing_code` warnings in Foundry. This updates `async-trait` from 0.1.91 to 0.1.92 to resolve the generated warning and applies the behavior-preserving floating-point and shared match-arm-tail rewrites, restoring the workspace Clippy gate without a global lint allowance.

This PR was authored with OpenAI Codex, including dependency and CI investigation, implementation, validation, and PR preparation.
