### PR TITLE
fix(coverage): report file-level (free) functions

### DIFF
--- a/.changelog/coverage-free-functions.md
+++ b/.changelog/coverage-free-functions.md
@@ -1,5 +1,6 @@
 ---
 forge: patch
+foundry-evm-coverage: patch
 ---
 
 Include file-level (free) functions in `forge coverage` reports.

--- a/.changelog/coverage-free-functions.md
+++ b/.changelog/coverage-free-functions.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Include file-level (free) functions in `forge coverage` reports.

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -5,7 +5,7 @@ use foundry_compilers::ProjectCompileOutput;
 use rayon::prelude::*;
 use solar::{
     ast::{self, ExprKind, ItemKind, StmtKind, yul},
-    data_structures::{Never, map::FxHashSet},
+    data_structures::{Never, map::FxHashMap},
     interface::{BytePos, Span},
     sema::{Gcx, hir},
 };
@@ -33,8 +33,10 @@ struct SourceVisitor<'gcx> {
     items: Vec<CoverageItem>,
 
     all_lines: Vec<u32>,
-    function_calls: Vec<Span>,
-    function_calls_set: FxHashSet<Span>,
+    /// Deferred function-call spans, each paired with the contract scope active where the call
+    /// was collected, so scope travels with the span to the delayed HIR resolution pass.
+    function_calls: Vec<(Span, Arc<str>)>,
+    function_call_scopes: FxHashMap<Span, Arc<str>>,
 }
 
 struct SourceVisitorCheckpoint {
@@ -52,7 +54,7 @@ impl<'gcx> SourceVisitor<'gcx> {
             branch_id: 0,
             all_lines: Default::default(),
             function_calls: Default::default(),
-            function_calls_set: Default::default(),
+            function_call_scopes: Default::default(),
             items: Default::default(),
         }
     }
@@ -109,7 +111,7 @@ impl<'gcx> SourceVisitor<'gcx> {
     }
 
     fn resolve_function_calls(&mut self, hir_source_id: hir::SourceId) {
-        self.function_calls_set = self.function_calls.iter().copied().collect();
+        self.function_call_scopes = self.function_calls.iter().cloned().collect();
         let _ = hir::Visit::visit_nested_source(self, hir_source_id);
     }
 
@@ -325,8 +327,8 @@ impl<'ast> ast::Visit<'ast> for SourceVisitor<'_> {
                 }
             }
             ExprKind::Call(callee, _args) => {
-                // Resolve later.
-                self.function_calls.push(expr.span);
+                // Resolve later. Capture the current contract scope so it travels with the span.
+                self.function_calls.push((expr.span, self.contract_name.clone()));
 
                 if let ExprKind::Ident(ident) = &callee.kind {
                     // Might be a require call, add branch coverage.
@@ -421,10 +423,14 @@ impl<'gcx> hir::Visit<'gcx> for SourceVisitor<'gcx> {
 
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         if let hir::ExprKind::Call(lhs, ..) = &expr.kind
-            && self.function_calls_set.contains(&expr.span)
             && is_regular_call(lhs)
+            && let Some(scope) = self.function_call_scopes.get(&expr.span).cloned()
         {
+            // Attribute the call with the scope captured where it was collected, not the
+            // visitor's final scope (which leaks across free functions and contracts).
+            let prev = std::mem::replace(&mut self.contract_name, scope);
             self.push_stmt(expr.span);
+            self.contract_name = prev;
         }
         self.walk_expr(expr)
     }
@@ -510,6 +516,10 @@ impl SourceAnalysis {
                             // defined inside a contract. Without this, a file of only free
                             // functions gets no coverage record at all.
                             ItemKind::Function(_) => {
+                                // A free function is not scoped to any contract. Clear any scope
+                                // left by a previously visited contract so it is attributed at
+                                // file level, not as `Contract.freeFn`.
+                                visitor.contract_name = Arc::default();
                                 let _ = ast::Visit::visit_item(&mut visitor, item);
                             }
                             _ => {}

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -464,11 +464,12 @@ pub struct SourceAnalysis {
 }
 
 impl SourceAnalysis {
-    /// Analyzes contracts in the sources held by the source analyzer.
+    /// Analyzes the sources held by the source analyzer.
     ///
     /// Coverage items are found by:
     /// - Walking the AST of each contract (except interfaces)
-    /// - Recording the items of each contract
+    /// - Walking file-level (free) functions
+    /// - Recording the items found
     ///
     /// Each coverage item contains relevant information to find opcodes corresponding to them: the
     /// source ID the item is in, the source code range of the item, and the contract name the item
@@ -491,18 +492,27 @@ impl SourceAnalysis {
 
                     let mut visitor = SourceVisitor::new(source_id, compiler.gcx());
                     for item in ast.items.iter() {
-                        // Visit only top-level contracts.
-                        let ItemKind::Contract(contract) = &item.kind else { continue };
+                        match &item.kind {
+                            // Contracts: walk their functions, dropping test contracts.
+                            ItemKind::Contract(contract) => {
+                                // Skip interfaces which have no function implementations.
+                                if contract.kind.is_interface() {
+                                    continue;
+                                }
 
-                        // Skip interfaces which have no function implementations.
-                        if contract.kind.is_interface() {
-                            continue;
-                        }
-
-                        let checkpoint = visitor.checkpoint();
-                        visitor.visit_contract(contract);
-                        if visitor.has_tests(&checkpoint) {
-                            visitor.restore_checkpoint(checkpoint);
+                                let checkpoint = visitor.checkpoint();
+                                visitor.visit_contract(contract);
+                                if visitor.has_tests(&checkpoint) {
+                                    visitor.restore_checkpoint(checkpoint);
+                                }
+                            }
+                            // File-level (free) functions are covered too, not only functions
+                            // defined inside a contract. Without this, a file of only free
+                            // functions gets no coverage record at all.
+                            ItemKind::Function(_) => {
+                                let _ = ast::Visit::visit_item(&mut visitor, item);
+                            }
+                            _ => {}
                         }
                     }
 

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -170,7 +170,13 @@ impl CoverageReporter for LcovReporter {
                 let hits = item.hits;
                 match item.kind {
                     CoverageItemKind::Function { ref name } => {
-                        let name = format!("{}.{name}", item.loc.contract_name);
+                        // Free (file-level) functions have no contract scope; emit the bare
+                        // name rather than a leading-dot `.name`.
+                        let name = if item.loc.contract_name.is_empty() {
+                            name.to_string()
+                        } else {
+                            format!("{}.{name}", item.loc.contract_name)
+                        };
                         if self.version >= Version::new(2, 2, 0) {
                             // v2.2 changed the FN format.
                             writeln!(out, "FNL:{fn_index},{line},{end_line}")?;

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -2975,37 +2975,77 @@ contract ReportScript {
     );
 });
 
-// A file of only file-level (free) functions must still appear in the coverage report.
+// forge coverage must report file-level (free) functions, and attribute them at file level
+// rather than leaking the scope of a contract declared earlier in the same file.
 // Regression for https://github.com/foundry-rs/foundry/issues/16085
 forgetest!(coverage_reports_free_functions, |prj, cmd| {
     prj.insert_ds_test();
+    // A contract declared *before* a free function in the same file. The contract method calls
+    // the free function, so the test below executes both.
     prj.add_source(
-        "Free.sol",
+        "Mixed.sol",
         r#"
-function double(uint256 x) pure returns (uint256) {
-    return x * 2;
+contract Counter {
+    function bump(uint256 x) public pure returns (uint256) {
+        return triple(x);
+    }
+}
+
+function triple(uint256 x) pure returns (uint256) {
+    return x * 3;
 }
 "#,
     );
     prj.add_source(
-        "FreeTest.sol",
+        "MixedTest.sol",
         r#"
 import "./test.sol";
-import {double} from "./Free.sol";
+import {Counter} from "./Mixed.sol";
 
-contract FreeTest is DSTest {
-    function testDouble() public {
-        require(double(3) == 6);
+contract MixedTest is DSTest {
+    function testMixed() public {
+        Counter c = new Counter();
+        require(c.bump(2) == 6);
     }
 }
 "#,
     );
 
-    let output = cmd.arg("coverage").assert_success().get_output().stdout_lossy();
-    // Before the fix, a file of only free functions produced no coverage record at all.
+    cmd.args(["coverage", "--report=lcov", "--lcov-version=2"]).assert_success();
+    let lcov = std::fs::read_to_string(prj.root().join("lcov.info")).unwrap();
+
+    // The file is reported at all (before the fix a free-function-only file was dropped).
+    assert!(lcov.contains("SF:src/Mixed.sol"), "coverage must include Mixed.sol:\n{lcov}");
+    // The contract method keeps its contract scope.
     assert!(
-        output.contains("src/Free.sol"),
-        "free-function-only file must appear in coverage:\n{output}"
+        lcov.lines().any(|l| l.starts_with("FN") && l.ends_with(",Counter.bump")),
+        "contract function must be scoped as `Counter.bump`:\n{lcov}"
+    );
+    // The free function is attributed at file level: bare `triple`, with no contract prefix
+    // (`Counter.triple`) and no malformed empty scope (`.triple`).
+    assert!(
+        lcov.lines().any(|l| l.starts_with("FN") && l.ends_with(",triple")),
+        "free function must be attributed as bare `triple`:\n{lcov}"
+    );
+    assert!(
+        !lcov.contains(",Counter.triple"),
+        "free function must not leak into the contract scope:\n{lcov}"
+    );
+    assert!(
+        !lcov.contains(",.triple"),
+        "free function must not be emitted with a malformed empty scope:\n{lcov}"
+    );
+    // Both functions were executed, so both record a nonzero hit count.
+    assert!(
+        lcov.lines()
+            .any(|l| l.starts_with("FNDA:") && !l.starts_with("FNDA:0,") && l.ends_with(",triple")),
+        "free function must record its hits:\n{lcov}"
+    );
+    assert!(
+        lcov.lines().any(|l| l.starts_with("FNDA:")
+            && !l.starts_with("FNDA:0,")
+            && l.ends_with(",Counter.bump")),
+        "contract function must record its hits:\n{lcov}"
     );
 });
 

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -3089,8 +3089,12 @@ contract MixedTest is DSTest {
 "#,
     );
 
-    cmd.args(["coverage", "--report=lcov", "--lcov-version=2"]).assert_success();
+    cmd.args(["coverage", "--report=lcov", "--report=attribution", "--lcov-version=2"])
+        .assert_success();
     let lcov = std::fs::read_to_string(prj.root().join("lcov.info")).unwrap();
+    let attribution =
+        std::fs::read_to_string(prj.root().join("coverage-attribution.json")).unwrap();
+    let attribution: Value = serde_json::from_str(&attribution).unwrap();
 
     assert!(lcov.contains("SF:src/Mixed.sol"), "coverage must include Mixed.sol:\n{lcov}");
     // The contract method keeps its contract scope.
@@ -3123,6 +3127,19 @@ contract MixedTest is DSTest {
             && !l.starts_with("FNDA:0,")
             && l.ends_with(",Counter.bump")),
         "contract function must record its hits:\n{lcov}"
+    );
+    let covered = attribution["tests"][0]["covered"].as_array().unwrap();
+    assert_eq!(
+        covered
+            .iter()
+            .filter(|item| {
+                item["source"] == "src/Mixed.sol"
+                    && item["contract"] == "Counter"
+                    && item["kind"] == "statement"
+            })
+            .count(),
+        2,
+        "the return statement and its deferred call must retain the contract scope:\n{attribution}"
     );
 });
 

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -2975,6 +2975,40 @@ contract ReportScript {
     );
 });
 
+// A file of only file-level (free) functions must still appear in the coverage report.
+// Regression for https://github.com/foundry-rs/foundry/issues/16085
+forgetest!(coverage_reports_free_functions, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "Free.sol",
+        r#"
+function double(uint256 x) pure returns (uint256) {
+    return x * 2;
+}
+"#,
+    );
+    prj.add_source(
+        "FreeTest.sol",
+        r#"
+import "./test.sol";
+import {double} from "./Free.sol";
+
+contract FreeTest is DSTest {
+    function testDouble() public {
+        require(double(3) == 6);
+    }
+}
+"#,
+    );
+
+    let output = cmd.arg("coverage").assert_success().get_output().stdout_lossy();
+    // Before the fix, a file of only free functions produced no coverage record at all.
+    assert!(
+        output.contains("src/Free.sol"),
+        "free-function-only file must appear in coverage:\n{output}"
+    );
+});
+
 #[test]
 fn coverage_help_renders_notes() {
     let help = CoverageArgs::command().render_long_help().to_string();


### PR DESCRIPTION
## Motivation

`forge coverage` never reports file-level (free) functions. `SourceAnalysis::new` only walked `ItemKind::Contract`, so a source file whose executable code lives in free functions is analyzed as if it had no code and shows no coverage.

Closes #16085

## Solution

Match on `ItemKind` in the top-level loop and also visit `ItemKind::Function` via `ast::Visit::visit_item`, so file-level functions get coverage items the same way contract functions do. Contract handling (interface skip, test-file checkpointing) is unchanged.

## Tests

Adds `coverage_reports_free_functions`, which asserts a source file whose only code is a free function appears in the coverage report. It fails on `master` and passes with the fix.