### PR TITLE
feat(cast): add cast memory subcommand

### DIFF
--- a/.changelog/cast-memory.md
+++ b/.changelog/cast-memory.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Add `cast memory` (alias `cast mem`) to lay ABI-encoded calldata out as a `bytes` memory value.

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -286,6 +286,21 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             let out = SimpleCast::calldata_encode(sig, &final_args)?;
             print_scalar(out)?;
         }
+        CastSubcommand::Memory { sig, args, file } => {
+            let final_args = if let Some(file_path) = file {
+                let contents = fs::read_to_string(file_path)?;
+                contents
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(String::from)
+                    .collect()
+            } else {
+                args
+            };
+            let out = SimpleCast::memory_encode(sig, &final_args)?;
+            print_scalar(out)?;
+        }
         CastSubcommand::DecodeString { data } => {
             let tokens = SimpleCast::calldata_decode("Any(string)", &data, true)?;
             print_tokens(&tokens)?;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -2069,6 +2069,46 @@ impl SimpleCast {
         Ok(hex::encode_prefixed(calldata))
     }
 
+    /// ABI-encodes the function signature and arguments into calldata, then lays it out as a
+    /// `bytes` value in memory.
+    ///
+    /// The layout mirrors how Solidity stores `bytes memory`: a 32-byte big-endian length
+    /// prefix, followed by the calldata right-padded with zero bytes to the next 32-byte word
+    /// boundary.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// // `f(uint256)` calldata is 36 bytes: a 4-byte selector + one 32-byte word.
+    /// let out = Cast::memory_encode("f(uint256 a)", &["1"]).unwrap();
+    /// // A 32-byte length prefix (0x24 = 36) followed by the data padded to two words.
+    /// assert!(out.starts_with(
+    ///     "0x0000000000000000000000000000000000000000000000000000000000000024"
+    /// ));
+    /// assert_eq!(out.len(), 2 + 192);
+    /// ```
+    pub fn memory_encode(sig: impl AsRef<str>, args: &[impl AsRef<str>]) -> Result<String> {
+        let func = get_func(sig.as_ref())?;
+        let calldata = encode_function_args(&func, args)?;
+        Ok(hex::encode_prefixed(Self::bytes_memory_layout(&calldata)))
+    }
+
+    /// Lays out arbitrary bytes as a Solidity `bytes memory` value: a 32-byte big-endian length
+    /// prefix followed by the data right-padded with zeros to a whole number of 32-byte words.
+    fn bytes_memory_layout(data: &[u8]) -> Vec<u8> {
+        const WORD: usize = 32;
+        let padded_len = data.len().div_ceil(WORD) * WORD;
+        let mut out = Vec::with_capacity(WORD + padded_len);
+        // 32-byte big-endian length prefix.
+        out.extend_from_slice(&U256::from(data.len()).to_be_bytes::<32>());
+        // The data, right-padded with zeros to a word boundary.
+        out.extend_from_slice(data);
+        out.resize(WORD + padded_len, 0);
+        out
+    }
+
     /// Returns the slot number for a given mapping key and slot.
     ///
     /// Given `mapping(k => v) m`, for a key `k` the slot number of its associated `v` is
@@ -2678,6 +2718,28 @@ mod logs_bisecting {
 mod tests {
     use super::{DynSolValue, SimpleCast as Cast, serialize_value_as_json};
     use alloy_primitives::hex;
+
+    #[test]
+    fn memory_encode_lays_out_bytes() {
+        // `f(uint256)` calldata is 36 bytes: a 4-byte selector + one 32-byte word.
+        let out = Cast::memory_encode("f(uint256 a)", &["1"]).unwrap();
+        // 32-byte big-endian length prefix (0x24 = 36) followed by the data padded to two words.
+        assert!(out.starts_with(
+            "0x0000000000000000000000000000000000000000000000000000000000000024"
+        ));
+        assert_eq!(out.len(), 2 + 192);
+    }
+
+    #[test]
+    fn memory_encode_pads_to_word_boundary() {
+        // `f()` calldata is the 4-byte selector only.
+        let out = Cast::memory_encode("f()", &[] as &[&str]).unwrap();
+        // Length prefix 0x04 followed by one padded data word = 64 bytes total.
+        assert!(out.starts_with(
+            "0x0000000000000000000000000000000000000000000000000000000000000004"
+        ));
+        assert_eq!(out.len(), 2 + 128);
+    }
 
     /// Compares [`super::encode_event_topic`] against alloy's static [`EventTopic`]
     /// implementation, which `sol!`-generated events use to compute indexed topics.

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -469,6 +469,29 @@ pub enum CastSubcommand {
         file: Option<PathBuf>,
     },
 
+    /// ABI-encode a function with arguments and lay the calldata out in `bytes` memory.
+    ///
+    /// Produces the full in-memory representation of the calldata as a `bytes` value: a
+    /// 32-byte big-endian length prefix, followed by the encoded calldata right-padded with
+    /// zeros to a whole number of 32-byte words.
+    ///
+    /// Examples:
+    /// - cast memory "transfer(address,uint256)" 0x... 200
+    /// - cast mem "f(uint256 a)" 1
+    #[command(verbatim_doc_comment, name = "memory", visible_alias = "mem")]
+    Memory {
+        /// The function signature in the format `<name>(<in-types>)(<out-types>)`
+        sig: String,
+
+        /// The arguments to encode.
+        #[arg(allow_hyphen_values = true)]
+        args: Vec<String>,
+
+        // Path to file containing arguments to encode.
+        #[arg(long, value_name = "PATH")]
+        file: Option<PathBuf>,
+    },
+
     /// Get the symbolic name of the current chain.
     Chain {
         #[command(flatten)]


### PR DESCRIPTION
Adds a cast memory subcommand (alias cast mem) that ABI-encodes a function signature and args like cast calldata, then lays the result out as a Solidity bytes memory value: a 32-byte big-endian length prefix followed by the data right-padded to a whole number of 32-byte words. The layout is factored into a bytes_memory_layout helper with unit tests and a doctest. Closes #16088.