### PR TITLE
fix(forge): key coverage by build ID

### DIFF
--- a/.changelog/coverage-build-identity.md
+++ b/.changelog/coverage-build-identity.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-coverage: patch
+---
+
+Fixed coverage reports dropping or misattributing sources compiled in separate jobs with the same Solidity version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5830,7 +5830,6 @@ dependencies = [
  "foundry-evm-core",
  "rayon",
  "revm",
- "semver 1.0.28",
  "solar-compiler",
  "tracing",
 ]

--- a/crates/evm/coverage/Cargo.toml
+++ b/crates/evm/coverage/Cargo.toml
@@ -21,7 +21,6 @@ foundry-evm-core.workspace = true
 alloy-primitives.workspace = true
 eyre.workspace = true
 revm.workspace = true
-semver.workspace = true
 tracing.workspace = true
 rayon.workspace = true
 solar.workspace = true

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -474,9 +474,8 @@ impl SourceAnalysis {
     /// source ID the item is in, the source code range of the item, and the contract name the item
     /// is in.
     ///
-    /// Note: Source IDs are only unique per compilation job; that is, a code base compiled with
-    /// two different solc versions will produce overlapping source IDs if the compiler version is
-    /// not taken into account.
+    /// Note: Source IDs are only unique per compilation job. A code base compiled in multiple
+    /// jobs can produce overlapping source IDs even when those jobs use the same compiler version.
     #[instrument(name = "SourceAnalysis::new", skip_all)]
     pub fn new(data: &SourceFiles, output: &ProjectCompileOutput) -> eyre::Result<Self> {
         let mut sourced_items = output.parser().solc().compiler().enter(|compiler| {

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -15,7 +15,6 @@ use alloy_primitives::{
 use analysis::SourceAnalysis;
 use eyre::Result;
 use foundry_compilers::artifacts::sourcemap::SourceMap;
-use semver::Version;
 use std::{
     collections::BTreeMap,
     fmt,
@@ -37,12 +36,12 @@ pub use inspector::LineCoverageCollector;
 /// "anchors"). A single coverage item may be referred to by multiple anchors.
 #[derive(Clone, Debug, Default)]
 pub struct CoverageReport {
-    /// A map of source IDs to the source path.
-    pub source_paths: HashMap<(Version, usize), PathBuf>,
-    /// A map of source paths to source IDs.
-    pub source_paths_to_ids: HashMap<(Version, PathBuf), usize>,
-    /// All coverage items for the codebase, keyed by the compiler version.
-    pub analyses: HashMap<Version, SourceAnalysis>,
+    /// A map of build and source IDs to the source path.
+    pub source_paths: HashMap<(String, usize), PathBuf>,
+    /// A map of build IDs and source paths to source IDs.
+    pub source_paths_to_ids: HashMap<(String, PathBuf), usize>,
+    /// All coverage items for the codebase, keyed by the compiler build ID.
+    pub analyses: HashMap<String, SourceAnalysis>,
     /// All item anchors for the codebase, keyed by their contract ID.
     ///
     /// `(id, (creation, runtime))`
@@ -55,14 +54,14 @@ pub struct CoverageReport {
 
 impl CoverageReport {
     /// Add a source file path.
-    pub fn add_source(&mut self, version: Version, source_id: usize, path: PathBuf) {
-        self.source_paths.insert((version.clone(), source_id), path.clone());
-        self.source_paths_to_ids.insert((version, path), source_id);
+    pub fn add_source(&mut self, build_id: String, source_id: usize, path: PathBuf) {
+        self.source_paths.insert((build_id.clone(), source_id), path.clone());
+        self.source_paths_to_ids.insert((build_id, path), source_id);
     }
 
     /// Get the source ID for a specific source file path.
-    pub fn get_source_id(&self, version: Version, path: PathBuf) -> Option<usize> {
-        self.source_paths_to_ids.get(&(version, path)).copied()
+    pub fn get_source_id(&self, build_id: String, path: PathBuf) -> Option<usize> {
+        self.source_paths_to_ids.get(&(build_id, path)).copied()
     }
 
     /// Add the source maps.
@@ -74,8 +73,8 @@ impl CoverageReport {
     }
 
     /// Add a [`SourceAnalysis`] to this report.
-    pub fn add_analysis(&mut self, version: Version, analysis: SourceAnalysis) {
-        self.analyses.insert(version, analysis);
+    pub fn add_analysis(&mut self, build_id: String, analysis: SourceAnalysis) {
+        self.analyses.insert(build_id, analysis);
     }
 
     /// Add anchors to this report.
@@ -90,7 +89,10 @@ impl CoverageReport {
 
     /// Returns an iterator over coverage summaries by source file path.
     pub fn summary_by_file(&self) -> impl Iterator<Item = (&Path, CoverageSummary)> {
-        self.by_file(|summary: &mut CoverageSummary, item| summary.add_item(item))
+        self.coalesced_items_by_file().map(|(path, items)| {
+            let summary = CoverageSummary::from_items(items.iter());
+            (path, summary)
+        })
     }
 
     /// Returns an iterator over coverage items by source file path.
@@ -98,14 +100,36 @@ impl CoverageReport {
         self.by_file(|list: &mut Vec<_>, item| list.push(item))
     }
 
+    /// Returns coverage items coalesced by their logical source location.
+    ///
+    /// The same physical source can participate in multiple compiler builds. Its coverage items
+    /// are identical across those builds, so reporters should count each item once and combine
+    /// its hits.
+    pub fn coalesced_items_by_file(&self) -> impl Iterator<Item = (&Path, Vec<CoverageItem>)> {
+        let mut by_file = BTreeMap::<&Path, BTreeMap<CoverageItemKey<'_>, CoverageItem>>::new();
+        for (build_id, items) in &self.analyses {
+            for item in items.all_items() {
+                let key = (build_id.clone(), item.loc.source_id);
+                let Some(path) = self.source_paths.get(&key) else { continue };
+                by_file
+                    .entry(path)
+                    .or_default()
+                    .entry(item.report_key())
+                    .and_modify(|existing| existing.hits = existing.hits.saturating_add(item.hits))
+                    .or_insert_with(|| item.clone());
+            }
+        }
+        by_file.into_iter().map(|(path, items)| (path, items.into_values().collect()))
+    }
+
     fn by_file<'a, T: Default>(
         &'a self,
         mut f: impl FnMut(&mut T, &'a CoverageItem),
     ) -> impl Iterator<Item = (&'a Path, T)> {
         let mut by_file: BTreeMap<&Path, T> = BTreeMap::new();
-        for (version, items) in &self.analyses {
+        for (build_id, items) in &self.analyses {
             for item in items.all_items() {
-                let key = (version.clone(), item.loc.source_id);
+                let key = (build_id.clone(), item.loc.source_id);
                 let Some(path) = self.source_paths.get(&key) else { continue };
                 f(by_file.entry(path).or_default(), item);
             }
@@ -136,7 +160,7 @@ impl CoverageReport {
             for anchor in anchors {
                 if let Some(hits) = hit_map.get(anchor.instruction) {
                     self.analyses
-                        .get_mut(&contract_id.version)
+                        .get_mut(&contract_id.build_id)
                         .and_then(|items| items.all_items_mut().get_mut(anchor.item_id as usize))
                         .expect("Anchor refers to non-existent coverage item")
                         .hits += hits.get();
@@ -164,7 +188,7 @@ impl CoverageReport {
             }
         }
 
-        let Some(items) = self.analyses.get(&contract_id.version) else { return Vec::new() };
+        let Some(items) = self.analyses.get(&contract_id.build_id) else { return Vec::new() };
         hits_by_item
             .into_iter()
             .filter_map(|(item_id, hits)| {
@@ -180,8 +204,8 @@ impl CoverageReport {
     /// will be missing the ones that are dependent on them.
     pub fn retain_sources(&mut self, mut predicate: impl FnMut(&Path) -> bool) {
         self.source_paths.retain(|_, path| predicate(path));
-        self.source_paths_to_ids.retain(|(version, _), source_id| {
-            self.source_paths.contains_key(&(version.clone(), *source_id))
+        self.source_paths_to_ids.retain(|(build_id, _), source_id| {
+            self.source_paths.contains_key(&(build_id.clone(), *source_id))
         });
     }
 }
@@ -305,7 +329,7 @@ impl HitMap {
 /// A unique identifier for a contract
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ContractId {
-    pub version: Version,
+    pub build_id: String,
     pub source_id: usize,
     pub contract_name: Arc<str>,
 }
@@ -314,8 +338,8 @@ impl fmt::Display for ContractId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Contract \"{}\" (solc {}, source ID {})",
-            self.contract_name, self.version, self.source_id
+            "Contract \"{}\" (build {}, source ID {})",
+            self.contract_name, self.build_id, self.source_id
         )
     }
 }
@@ -432,6 +456,31 @@ impl fmt::Display for CoverageItem {
 }
 
 impl CoverageItem {
+    fn report_key(&self) -> CoverageItemKey<'_> {
+        let (kind, detail) = match &self.kind {
+            CoverageItemKind::Line => (0, CoverageItemKindDetail::None),
+            CoverageItemKind::Statement => (1, CoverageItemKindDetail::None),
+            CoverageItemKind::Branch { branch_id, path_id, is_first_opcode } => (
+                2,
+                CoverageItemKindDetail::Branch {
+                    branch_id: *branch_id,
+                    path_id: *path_id,
+                    is_first_opcode: *is_first_opcode,
+                },
+            ),
+            CoverageItemKind::Function { name } => (3, CoverageItemKindDetail::Function { name }),
+        };
+        (
+            self.loc.lines.start,
+            self.loc.lines.end,
+            kind,
+            self.loc.bytes.start,
+            self.loc.bytes.end,
+            self.loc.contract_name.as_ref(),
+            detail,
+        )
+    }
+
     fn ord_key(&self) -> impl Ord + use<> {
         (
             self.loc.source_id,
@@ -481,6 +530,15 @@ impl CoverageItem {
             Ok(())
         })
     }
+}
+
+type CoverageItemKey<'a> = (u32, u32, u8, u32, u32, &'a str, CoverageItemKindDetail<'a>);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum CoverageItemKindDetail<'a> {
+    None,
+    Branch { branch_id: u32, path_id: u32, is_first_opcode: bool },
+    Function { name: &'a str },
 }
 
 /// A source location.

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -300,32 +300,34 @@ impl CoverageArgs {
         let output = &*output;
 
         // Collect source files.
-        let mut versioned_sources = HashMap::<Version, SourceFiles>::default();
-        for (path, source_file, version) in output.output().sources.sources_with_version() {
-            // Filter out vyper sources.
-            if path
-                .extension()
-                .and_then(|s| s.to_str())
-                .is_some_and(|ext| VYPER_EXTENSIONS.contains(&ext))
-            {
-                continue;
+        let mut sources_by_build = HashMap::<String, SourceFiles>::default();
+        for (build_id, context) in output.builds() {
+            for (&source_id, path) in &context.source_id_to_path {
+                // Filter out vyper sources.
+                if path
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|ext| VYPER_EXTENSIONS.contains(&ext))
+                {
+                    continue;
+                }
+
+                let report_path = path.strip_prefix(&project_paths.root).unwrap_or(path);
+                report.add_source(build_id.clone(), source_id as usize, report_path.to_path_buf());
+
+                // Filter out libs dependencies and tests.
+                if (!self.include_libs && project_paths.has_library_ancestor(path))
+                    || (self.exclude_tests && project_paths.is_test(path))
+                {
+                    continue;
+                }
+
+                sources_by_build
+                    .entry(build_id.clone())
+                    .or_default()
+                    .sources
+                    .insert(source_id, project_paths.root.join(report_path));
             }
-
-            report.add_source(version.clone(), source_file.id as usize, path.clone());
-
-            // Filter out libs dependencies and tests.
-            if (!self.include_libs && project_paths.has_library_ancestor(path))
-                || (self.exclude_tests && project_paths.is_test(path))
-            {
-                continue;
-            }
-
-            let path = project_paths.root.join(path);
-            versioned_sources
-                .entry(version.clone())
-                .or_default()
-                .sources
-                .insert(source_file.id, path);
         }
 
         // Get source maps and bytecodes.
@@ -333,17 +335,17 @@ impl CoverageArgs {
             .artifact_ids()
             .par_bridge() // This parses source maps, so we want to run it in parallel.
             .filter_map(|(id, artifact)| {
-                let source_id = report.get_source_id(id.version.clone(), id.source.clone())?;
+                let source_id = report.get_source_id(id.build_id.clone(), id.source.clone())?;
                 ArtifactData::new(&id, source_id, artifact)
             })
             .collect();
 
         // Add coverage items.
-        for (version, sources) in &versioned_sources {
+        for (build_id, sources) in &sources_by_build {
             let source_analysis = SourceAnalysis::new(sources, output)?;
             let anchors = artifacts
                 .par_iter()
-                .filter(|artifact| artifact.contract_id.version == *version)
+                .filter(|artifact| artifact.contract_id.build_id == *build_id)
                 .map(|artifact| {
                     let creation_code_anchors = artifact.creation.find_anchors(&source_analysis);
                     let deployed_code_anchors = artifact.deployed.find_anchors(&source_analysis);
@@ -351,7 +353,7 @@ impl CoverageArgs {
                 })
                 .collect_vec_list();
             report.add_anchors(anchors.into_iter().flatten());
-            report.add_analysis(version.clone(), source_analysis);
+            report.add_analysis(build_id.clone(), source_analysis);
         }
 
         if self.reporters.iter().any(|reporter| reporter.needs_source_maps()) {
@@ -418,12 +420,12 @@ impl CoverageArgs {
                     };
 
                     let Some(source_id) = report
-                        .get_source_id(artifact_id.version.clone(), artifact_id.source.clone())
+                        .get_source_id(artifact_id.build_id.clone(), artifact_id.source.clone())
                     else {
                         continue;
                     };
                     let contract_id = ContractId {
-                        version: artifact_id.version.clone(),
+                        build_id: artifact_id.build_id.clone(),
                         source_id,
                         contract_name: artifact_id.name.as_str().into(),
                     };
@@ -529,7 +531,7 @@ impl ArtifactData {
     pub fn new(id: &ArtifactId, source_id: usize, artifact: &impl Artifact) -> Option<Self> {
         Some(Self {
             contract_id: ContractId {
-                version: id.version.clone(),
+                build_id: id.build_id.clone(),
                 source_id,
                 contract_name: id.name.as_str().into(),
             },

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -142,8 +142,8 @@ impl CoverageReporter for LcovReporter {
         let mut out = std::io::BufWriter::new(fs::create_file(&self.path)?);
 
         let mut fn_index = 0usize;
-        for (path, items) in report.items_by_file() {
-            let summary = CoverageSummary::from_items(items.iter().copied());
+        for (path, items) in report.coalesced_items_by_file() {
+            let summary = CoverageSummary::from_items(items.iter());
 
             writeln!(out, "TN:")?;
             writeln!(out, "SF:{}", path.display())?;
@@ -372,7 +372,7 @@ fn attributed_items(
         {
             let Some(source_path) = report
                 .source_paths
-                .get(&(resolved.contract_id.version.clone(), item.loc.source_id))
+                .get(&(resolved.contract_id.build_id.clone(), item.loc.source_id))
             else {
                 continue;
             };
@@ -457,7 +457,7 @@ impl CoverageReporter for DebugReporter {
     }
 
     fn report(&mut self, report: &CoverageReport) -> eyre::Result<()> {
-        for (path, items) in report.items_by_file() {
+        for (path, items) in report.coalesced_items_by_file() {
             let src = fs::read_to_string(path)?;
             sh_println!("{}:", path.display())?;
             for item in items {
@@ -478,13 +478,13 @@ impl CoverageReporter for DebugReporter {
                 .filter_map(|(is_runtime, anchor)| {
                     let item = report
                         .analyses
-                        .get(&contract_id.version)
+                        .get(&contract_id.build_id)
                         .and_then(|items| items.get(anchor.item_id))?;
                     // Source filters retain analyses to keep anchor item IDs stable, so debug
                     // output must apply the same reportable-source filter as other reporters.
                     report
                         .source_paths
-                        .contains_key(&(contract_id.version.clone(), item.loc.source_id))
+                        .contains_key(&(contract_id.build_id.clone(), item.loc.source_id))
                         .then_some((is_runtime, anchor, item))
                 })
                 .collect::<Vec<_>>();
@@ -546,7 +546,7 @@ impl CoverageReporter for BytecodeReporter {
                     .unwrap_or("     ".to_owned());
                 let source_id = source_element.index();
                 let source_path = source_id.and_then(|i| {
-                    report.source_paths.get(&(contract_id.version.clone(), i as usize))
+                    report.source_paths.get(&(contract_id.build_id.clone(), i as usize))
                 });
 
                 let code = format!("{code:?}");

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -2975,6 +2975,172 @@ contract ReportScript {
     );
 });
 
+forgetest!(coverage_separates_same_version_compiler_jobs, |prj, cmd| {
+    fs::write(
+        prj.config(),
+        r#"
+[profile.default]
+optimizer = false
+via_ir = false
+
+[[profile.default.additional_compiler_profiles]]
+name = "via-ir"
+via_ir = true
+
+[[profile.default.compilation_restrictions]]
+paths = "src/A.sol"
+via_ir = true
+"#,
+    )
+    .unwrap();
+
+    prj.add_raw_source(
+        "A.sol",
+        "pragma solidity >=0.8.0;\ncontract A { function value() external pure returns (uint256) { return 1; } }",
+    );
+    prj.add_raw_source(
+        "B.sol",
+        "pragma solidity >=0.8.0;\ncontract B { function value() external pure returns (uint256) { return 2; } }",
+    );
+    prj.add_raw_test(
+        "ATest.t.sol",
+        r#"
+pragma solidity >=0.8.0;
+import {A} from "../src/A.sol";
+contract ATest { function testA() public { require(new A().value() == 1); } }
+"#,
+    );
+    prj.add_raw_test(
+        "BTest.t.sol",
+        r#"
+pragma solidity >=0.8.0;
+import {B} from "../src/B.sol";
+contract BTest { function testB() public { require(new B().value() == 2); } }
+"#,
+    );
+
+    assert_lcov(
+        cmd.arg("coverage"),
+        str![[r#"
+TN:
+SF:src/A.sol
+DA:2,1
+FN:2,A.value
+FNDA:1,A.value
+FNF:1
+FNH:1
+LF:1
+LH:1
+BRF:0
+BRH:0
+end_of_record
+TN:
+SF:src/B.sol
+DA:2,1
+FN:2,B.value
+FNDA:1,B.value
+FNF:1
+FNH:1
+LF:1
+LH:1
+BRF:0
+BRH:0
+end_of_record
+
+"#]],
+    );
+});
+
+forgetest!(coverage_coalesces_shared_sources_across_compiler_jobs, |prj, cmd| {
+    fs::write(
+        prj.config(),
+        r#"
+[profile.default]
+optimizer = false
+via_ir = false
+
+[[profile.default.additional_compiler_profiles]]
+name = "via-ir"
+via_ir = true
+
+[[profile.default.compilation_restrictions]]
+paths = "src/A.sol"
+via_ir = true
+"#,
+    )
+    .unwrap();
+
+    prj.add_raw_source(
+        "Common.sol",
+        "pragma solidity >=0.8.0;\nlibrary Common { function value(uint256 n) internal pure returns (uint256) { return n; } }",
+    );
+    prj.add_raw_source(
+        "A.sol",
+        "pragma solidity >=0.8.0;\nimport {Common} from \"./Common.sol\";\ncontract A { function value() external pure returns (uint256) { return Common.value(1); } }",
+    );
+    prj.add_raw_source(
+        "B.sol",
+        "pragma solidity >=0.8.0;\nimport {Common} from \"./Common.sol\";\ncontract B { function value() external pure returns (uint256) { return Common.value(2); } }",
+    );
+    prj.add_raw_test(
+        "Coverage.t.sol",
+        r#"
+pragma solidity >=0.8.0;
+import {A} from "../src/A.sol";
+import {B} from "../src/B.sol";
+contract CoverageTest {
+    function testBothBuilds() public {
+        require(new A().value() == 1);
+        require(new B().value() == 2);
+    }
+}
+"#,
+    );
+
+    assert_lcov(
+        cmd.arg("coverage"),
+        str![[r#"
+TN:
+SF:src/A.sol
+DA:3,1
+FN:3,A.value
+FNDA:1,A.value
+FNF:1
+FNH:1
+LF:1
+LH:1
+BRF:0
+BRH:0
+end_of_record
+TN:
+SF:src/B.sol
+DA:3,1
+FN:3,B.value
+FNDA:1,B.value
+FNF:1
+FNH:1
+LF:1
+LH:1
+BRF:0
+BRH:0
+end_of_record
+TN:
+SF:src/Common.sol
+DA:2,2
+FN:2,Common.value
+FNDA:2,Common.value
+FNF:1
+FNH:1
+LF:1
+LH:1
+BRF:0
+BRH:0
+end_of_record
+
+"#]],
+    );
+});
+
 #[test]
 fn coverage_help_renders_notes() {
     let help = CoverageArgs::command().render_long_help().to_string();


### PR DESCRIPTION
Fixes #16084.

Coverage currently scopes Solidity source IDs by compiler version even though those IDs are unique only within a compiler build. Same-version jobs can therefore overwrite one another and attribute executed code to the wrong file. This change threads `ArtifactId.build_id` through source, analysis, anchor, and reporter lookups, then coalesces logically identical items from shared physical sources while summing their hits. The regressions cover both separate A/B jobs and a shared `Common.sol` import so report denominators remain unique.

AI assistance disclosure: I used OpenAI Codex to inspect the codebase, implement the patch, and run and review the tests. I reviewed and take responsibility for the final changes.