### PR TITLE
chore: improve contribution docs & local tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,15 +106,6 @@ the likelihood of the PR getting merged.
 Please also make sure that the following commands pass if you have changed the code:
 
 ```sh
-cargo check --all
-cargo test --all --all-features
-cargo +nightly fmt -- --check
-cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
-```
-
-or alternatively:
-
-```sh
 make build
 make pr
 ```
@@ -169,6 +160,8 @@ That said, if you have a number of commits that are "checkpoints" and don't repr
 #### Opening the pull request
 
 From within GitHub, opening a new pull request will present you with a template that should be filled out. Please try your best at filling out the details, but feel free to skip parts if you're not sure what to put.
+
+Pull requests must add or update a `.changelog/*.md` entry unless a maintainer applies the `L-ignore` label; see the [changelog instructions](.changelog/README.md#pull-requests).
 
 #### Discuss and update
 

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -1,4 +1,4 @@
-//! Helper types for working with [revm](foundry_evm::revm)
+//! Helper types for working with [revm]
 
 use std::{
     collections::BTreeMap,

--- a/crates/anvil/src/eth/backend/mod.rs
+++ b/crates/anvil/src/eth/backend/mod.rs
@@ -1,6 +1,6 @@
 //! blockchain Backend
 
-/// [revm](foundry_evm::revm) related types
+/// [revm] related types
 pub mod db;
 /// In-memory Backend
 pub mod mem;

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -577,14 +577,22 @@ pub struct TestArgs {
     ///
     /// A flame graph is used to visualize which functions or operations within the smart contract
     /// are consuming the most gas overall in a sorted manner.
-    #[arg(long, conflicts_with_all = ["flamechart", "evm_profile", "json", "junit", "list"])]
+    #[arg(
+        long,
+        group = "trace_output",
+        conflicts_with_all = ["flamechart", "evm_profile", "json", "junit", "list"]
+    )]
     flamegraph: bool,
 
     /// Generate a flamechart for a single test. Implies `--decode-internal`.
     ///
     /// A flame chart shows the gas usage over time, illustrating when each function is
     /// called (execution order) and how much gas it consumes at each point in the timeline.
-    #[arg(long, conflicts_with_all = ["flamegraph", "evm_profile", "json", "junit", "list"])]
+    #[arg(
+        long,
+        group = "trace_output",
+        conflicts_with_all = ["flamegraph", "evm_profile", "json", "junit", "list"]
+    )]
     flamechart: bool,
 
     /// Generate an execution profile for a single test.
@@ -598,14 +606,15 @@ pub struct TestArgs {
         num_args = 0..=1,
         default_missing_value = "speedscope",
         value_enum,
+        group = "trace_output",
         conflicts_with_all = ["flamegraph", "flamechart", "json", "junit", "list"]
     )]
     evm_profile: Option<EvmProfileFormat>,
 
-    /// Don't open the profile in the browser (for `--evm-profile`).
+    /// Don't open the generated profile, flamegraph, or flamechart.
     ///
     /// The profile is saved to disk without starting the local viewer server.
-    #[arg(long, requires = "evm_profile")]
+    #[arg(long, requires = "trace_output")]
     no_open: bool,
 
     #[command(flatten)]
@@ -2205,7 +2214,9 @@ impl TestArgs {
                     .wrap_err("failed to write svg")?;
                     sh_println!("Saved to {file_name}")?;
 
-                    if let Err(e) = opener::open(&file_name) {
+                    if !self.no_open
+                        && let Err(e) = opener::open(&file_name)
+                    {
                         sh_err!("Failed to open {file_name}; please open it manually: {e}")?;
                     }
                 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -695,8 +695,7 @@ forgetest!(fail_init_nonexistent_template, |prj, cmd| {
     prj.wipe();
     cmd.args(["init", "--template", "a"]).arg(prj.root()).assert_failure().stderr_eq(str![[r#"
 Initializing [..] from https://github.com/a...
-remote: Not Found
-fatal: repository 'https://github.com/a/' not found
+...
 Error: git fetch exited with code 128
 
 "#]]);

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -309,7 +309,7 @@ contract FlameBeforeTestSetupTest {
 "#,
     );
 
-    cmd.args(["test", "--match-test", "testProfile", "--flamegraph"]).assert_success();
+    cmd.args(["test", "--match-test", "testProfile", "--flamegraph", "--no-open"]).assert_success();
     let flamegraph = std::fs::read_to_string(
         prj.root().join("cache/flamegraph_FlameBeforeTestSetupTest_testProfile.svg"),
     )
@@ -317,7 +317,9 @@ contract FlameBeforeTestSetupTest {
     assert!(flamegraph.contains("FlameBeforeTestSetupTest.testProfile()"));
     assert!(!flamegraph.contains("FlameBeforeTestSetupTest.beforeOnly()"));
 
-    cmd.forge_fuse().args(["test", "--match-test", "testProfile", "--flamechart"]).assert_success();
+    cmd.forge_fuse()
+        .args(["test", "--match-test", "testProfile", "--flamechart", "--no-open"])
+        .assert_success();
     let flamechart = std::fs::read_to_string(
         prj.root().join("cache/flamechart_FlameBeforeTestSetupTest_testProfile.svg"),
     )


### PR DESCRIPTION
## Motivation

The commands in `CONTRIBUTING.md` were outdated. While running the current `make pr` workflow locally, I ran into some failures that I fixed.

## Solution

Update `CONTRIBUTING.md` to use `make build` and `make pr`.

Allow the Git error snapshot test to work with both HTTPS and SSH configurations.

Stop flamegraph and flamechart tests from opening the generated files.

Clean up redundant Anvil rustdoc links that fail with newer nightly toolchains.

Let me know if you want other parts of the docs cleaned up 🫡

Codex was used to help understand the existing code and assist with the implementation. I fully understand and manually reviewed the resulting changes.