### PR TITLE
fix(ci): avoid restoring Cargo binaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,10 +73,6 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
-        with:
-          tool: nextest
-
       # External tests dependencies
       - name: Setup Node.js
         if: contains(matrix.name, 'external')
@@ -110,6 +106,11 @@ jobs:
             ${{ runner.os }}-foundry-${{ matrix.name }}-
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: false
+      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        with:
+          tool: nextest
       - name: Setup Git config
         run: |
           git config --global user.name "GitHub Actions Bot"


### PR DESCRIPTION
The macOS test jobs restored a Rust cache that replaced the active Cargo and Rustup proxies, causing `cargo nextest` to invoke `rustup-init` and fail before running any tests.

This disables caching of `CARGO_HOME/bin` and installs Nextest after restoring the Rust cache. Cargo registries and build targets remain cached, while the test runner is always installed from a clean binary.

AI assistance was used to diagnose the CI failure and prepare this change.
