### PR TITLE
chore(deps): finalize revm 42 dependency pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=566d19ee21aef0b1235c028bd1a4a98eacb95753#566d19ee21aef0b1235c028bd1a4a98eacb95753"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -458,7 +458,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.5.0"
-source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=566d19ee21aef0b1235c028bd1a4a98eacb95753#566d19ee21aef0b1235c028bd1a4a98eacb95753"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -1043,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=1241b29975eedcfd82bfb85fac186b92cc6dac16#1241b29975eedcfd82bfb85fac186b92cc6dac16"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=d7bf697983d51bb369bc996ce35525c53d412b9c#d7bf697983d51bb369bc996ce35525c53d412b9c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -5517,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5759,7 +5759,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5790,7 +5790,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5799,7 +5799,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5819,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5832,7 +5832,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6164,7 +6164,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6270,7 +6270,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7973,7 +7973,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=1241b29975eedcfd82bfb85fac186b92cc6dac16#1241b29975eedcfd82bfb85fac186b92cc6dac16"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=d7bf697983d51bb369bc996ce35525c53d412b9c#d7bf697983d51bb369bc996ce35525c53d412b9c"
 dependencies = [
  "alloy",
  "async-stream",
@@ -8404,7 +8404,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "op-alloy"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=566d19ee21aef0b1235c028bd1a4a98eacb95753#566d19ee21aef0b1235c028bd1a4a98eacb95753"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -8416,7 +8416,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=566d19ee21aef0b1235c028bd1a4a98eacb95753#566d19ee21aef0b1235c028bd1a4a98eacb95753"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8427,8 +8427,8 @@ dependencies = [
  "alloy-serde",
  "bytes",
  "derive_more",
- "reth-codecs 0.5.2",
- "reth-zstd-compressors 0.5.2",
+ "reth-codecs",
+ "reth-zstd-compressors",
  "serde",
  "serde_with",
  "thiserror 2.0.19",
@@ -8443,7 +8443,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=566d19ee21aef0b1235c028bd1a4a98eacb95753#566d19ee21aef0b1235c028bd1a4a98eacb95753"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8456,7 +8456,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-provider"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=566d19ee21aef0b1235c028bd1a4a98eacb95753#566d19ee21aef0b1235c028bd1a4a98eacb95753"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8470,7 +8470,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=566d19ee21aef0b1235c028bd1a4a98eacb95753#566d19ee21aef0b1235c028bd1a4a98eacb95753"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=566d19ee21aef0b1235c028bd1a4a98eacb95753#566d19ee21aef0b1235c028bd1a4a98eacb95753"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8510,7 +8510,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "20.0.0"
-source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=566d19ee21aef0b1235c028bd1a4a98eacb95753#566d19ee21aef0b1235c028bd1a4a98eacb95753"
 dependencies = [
  "auto_impl",
  "op-alloy-consensus",
@@ -8882,7 +8882,6 @@ checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros 0.13.1",
  "phf_shared 0.13.1",
- "serde",
 ]
 
 [[package]]
@@ -10053,27 +10052,8 @@ dependencies = [
  "derive_more",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "serde_json",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb43f4858fef4e3b42b80954d2edf1ff67c8ad7498347083cdc7d0f6eff2f081"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "parity-scale-codec",
- "reth-codecs-derive 0.5.2",
- "reth-zstd-compressors 0.5.2",
- "serde",
 ]
 
 [[package]]
@@ -10091,21 +10071,10 @@ dependencies = [
  "bytes",
  "modular-bitfield",
  "parity-scale-codec",
- "reth-codecs-derive 0.6.0",
- "reth-zstd-compressors 0.6.0",
+ "reth-codecs-derive",
+ "reth-zstd-compressors",
  "serde",
  "visibility",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5798ae4d6b264764bc0d742468bd32c7fb515e774645d4930f95ff6311f3ae14"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -10129,7 +10098,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "thiserror 2.0.19",
 ]
 
@@ -10143,7 +10112,7 @@ dependencies = [
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
 ]
 
 [[package]]
@@ -10160,10 +10129,10 @@ dependencies = [
  "metrics",
  "modular-bitfield",
  "proptest",
- "reth-codecs 0.6.0",
+ "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10182,8 +10151,8 @@ dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "reth-codecs 0.6.0",
- "reth-primitives-traits 0.6.0",
+ "reth-codecs",
+ "reth-primitives-traits",
  "serde",
 ]
 
@@ -10199,7 +10168,7 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "tracing",
 ]
 
@@ -10225,8 +10194,8 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "reth-codecs 0.6.0",
- "reth-primitives-traits 0.6.0",
+ "reth-codecs",
+ "reth-primitives-traits",
  "serde",
 ]
 
@@ -10247,7 +10216,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
@@ -10269,7 +10238,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "reth-storage-errors",
  "revm",
 ]
@@ -10299,7 +10268,7 @@ dependencies = [
  "alloy-rlp",
  "derive_more",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "reth-trie-common",
  "revm",
  "serde",
@@ -10317,30 +10286,6 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.19",
  "url",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59c928b2865af5bcdbce94800270b7f7798f27a22ca0aabdd2b7d3e6587c9ce"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "bytes",
- "derive_more",
- "once_cell",
- "revm-bytecode 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
- "secp256k1 0.30.0",
- "serde",
- "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -10366,10 +10311,10 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "quanta",
- "reth-codecs 0.6.0",
- "revm-bytecode 42.0.0",
- "revm-primitives 42.0.0",
- "revm-state 42.0.0",
+ "reth-codecs",
+ "revm-bytecode",
+ "revm-primitives",
+ "revm-state",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.19",
@@ -10384,7 +10329,7 @@ dependencies = [
  "arbitrary",
  "derive_more",
  "modular-bitfield",
- "reth-codecs 0.6.0",
+ "reth-codecs",
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.19",
@@ -10398,7 +10343,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
  "revm",
@@ -10406,16 +10351,16 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace77dbcdd59c014fda4565ebfec76cd1fe6f5d98584b4655e8d22a947b9eee3"
+checksum = "b417a50d3fa9b58bb1a22e46fb47e0866006f24abffa1fbe75ae60116b5b2efa"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits",
  "thiserror 2.0.19",
 ]
 
@@ -10428,7 +10373,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "reth-codecs 0.6.0",
+ "reth-codecs",
  "reth-trie-common",
  "serde",
 ]
@@ -10462,7 +10407,7 @@ dependencies = [
  "reth-db-models",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10481,8 +10426,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-codecs 0.6.0",
- "reth-primitives-traits 0.6.0",
+ "reth-codecs",
+ "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
  "revm",
@@ -10518,20 +10463,11 @@ dependencies = [
  "itertools 0.14.0",
  "nybbles",
  "plain_hasher",
- "reth-codecs 0.6.0",
- "reth-primitives-traits 0.6.0",
+ "reth-codecs",
+ "reth-primitives-traits",
  "revm",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bd4ae4f54a2ba813eef082910bc646bd31cab8ed134308fa71f1068331fb84"
-dependencies = [
- "zstd",
 ]
 
 [[package]]
@@ -10549,7 +10485,7 @@ version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
- "revm-bytecode 42.0.0",
+ "revm-bytecode",
  "revm-context",
  "revm-context-interface",
  "revm-database",
@@ -10558,20 +10494,8 @@ dependencies = [
  "revm-inspector",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives 42.0.0",
- "revm-state 42.0.0",
-]
-
-[[package]]
-name = "revm-bytecode"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
-dependencies = [
- "bitvec",
- "phf 0.13.1",
- "revm-primitives 41.0.0",
- "serde",
+ "revm-primitives",
+ "revm-state",
 ]
 
 [[package]]
@@ -10583,7 +10507,7 @@ dependencies = [
  "bitvec",
  "paste",
  "phf 0.14.0",
- "revm-primitives 42.0.0",
+ "revm-primitives",
  "serde",
 ]
 
@@ -10596,11 +10520,11 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode 42.0.0",
+ "revm-bytecode",
  "revm-context-interface",
  "revm-database-interface",
- "revm-primitives 42.0.0",
- "revm-state 42.0.0",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10615,8 +10539,8 @@ dependencies = [
  "auto_impl",
  "either",
  "revm-database-interface",
- "revm-primitives 42.0.0",
- "revm-state 42.0.0",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10629,10 +10553,10 @@ dependencies = [
  "alloy-eips",
  "derive_more",
  "either",
- "revm-bytecode 42.0.0",
+ "revm-bytecode",
  "revm-database-interface",
- "revm-primitives 42.0.0",
- "revm-state 42.0.0",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10644,8 +10568,8 @@ checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives 42.0.0",
- "revm-state 42.0.0",
+ "revm-primitives",
+ "revm-state",
  "serde",
  "thiserror 2.0.19",
 ]
@@ -10658,14 +10582,14 @@ checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode 42.0.0",
+ "revm-bytecode",
  "revm-context",
  "revm-context-interface",
  "revm-database-interface",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives 42.0.0",
- "revm-state 42.0.0",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10681,8 +10605,8 @@ dependencies = [
  "revm-database-interface",
  "revm-handler",
  "revm-interpreter",
- "revm-primitives 42.0.0",
- "revm-state 42.0.0",
+ "revm-primitives",
+ "revm-state",
  "serde",
  "serde_json",
 ]
@@ -10713,10 +10637,10 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
 dependencies = [
- "revm-bytecode 42.0.0",
+ "revm-bytecode",
  "revm-context-interface",
- "revm-primitives 42.0.0",
- "revm-state 42.0.0",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10739,21 +10663,10 @@ dependencies = [
  "k256",
  "p256 0.13.2",
  "revm-context-interface",
- "revm-primitives 42.0.0",
+ "revm-primitives",
  "ripemd 0.2.0",
  "secp256k1 0.31.1",
  "sha2 0.11.0",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
-dependencies = [
- "alloy-primitives",
- "once_cell",
- "serde",
 ]
 
 [[package]]
@@ -10769,20 +10682,6 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
-dependencies = [
- "alloy-eip7928",
- "bitflags 2.13.1",
- "nonmax",
- "revm-bytecode 41.0.0",
- "revm-primitives 41.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-state"
 version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
@@ -10790,8 +10689,8 @@ dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.1",
  "nonmax",
- "revm-bytecode 42.0.0",
- "revm-primitives 42.0.0",
+ "revm-bytecode",
+ "revm-primitives",
  "serde",
 ]
 
@@ -12640,7 +12539,7 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-evm",
  "reth-evm-ethereum",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "reth-revm",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12715,10 +12614,10 @@ dependencies = [
  "derive_more",
  "once_cell",
  "p256 0.13.2",
- "reth-codecs 0.6.0",
+ "reth-codecs",
  "reth-db-api",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.6.0",
+ "reth-primitives-traits",
  "revm",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "2a5b28096bb94c048e79f0a76748e59d89444d00", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "94b10d5c0108da0a4e58eb05fefe24b717a5c8f0", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -411,7 +411,7 @@ alloy-op-evm = "0.32.0"
 # revm
 revm = { version = "42.0.1", default-features = false }
 revm-inspectors = { version = "0.42.0", features = ["serde"] }
-op-revm = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2", default-features = false }
+op-revm = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753", default-features = false }
 
 ## cli
 anstream = "1.0"
@@ -512,10 +512,10 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "1241b29975eedcfd82bfb85fac186b92cc6dac16", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "d7bf697983d51bb369bc996ce35525c53d412b9c", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "1241b29975eedcfd82bfb85fac186b92cc6dac16", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "d7bf697983d51bb369bc996ce35525c53d412b9c", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",
@@ -553,9 +553,9 @@ solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e22
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e2267c549555a980aef6b0b1f249eb" }
 
 ## foundry-core
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "2a5b28096bb94c048e79f0a76748e59d89444d00" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "2a5b28096bb94c048e79f0a76748e59d89444d00" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "2a5b28096bb94c048e79f0a76748e59d89444d00" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "94b10d5c0108da0a4e58eb05fefe24b717a5c8f0" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "94b10d5c0108da0a4e58eb05fefe24b717a5c8f0" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "94b10d5c0108da0a4e58eb05fefe24b717a5c8f0" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
@@ -607,11 +607,11 @@ foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "2
 
 ## op-revm / op-alloy / alloy-op-evm
 ## Pinned to foundry-rs forks for the revm 42 stack.
-alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
-op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
-op-alloy-network = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
-op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
-alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
+alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753" }
+op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753" }
+op-alloy-network = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753" }
+op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753" }
+alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }


### PR DESCRIPTION
This completes the dependency cleanup after #16029 by replacing the preparatory pins with the merged revisions from foundry-rs/foundry-core#152, foundry-rs/optimism#9, and tempoxyz/mpp-rs#374.

The regenerated lockfile resolves each repository from a single immutable revision and removes the remaining REVM 41 dependency graph.

This PR was prepared with AI assistance.
