### PR TITLE
chore(deps): bump alloy-chains to 0.2.37

### DIFF
--- a/.changelog/bump-alloy-chains-0.2.37.md
+++ b/.changelog/bump-alloy-chains-0.2.37.md
@@ -1,0 +1,7 @@
+---
+cast: patch
+anvil: patch
+forge: patch
+---
+
+Updated chain metadata to alloy-chains 0.2.37, including BSC helpers and Tempo devnet explorer support.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36ddb69f5e41407e7a93aead3480f7c8ff076e73d01a951ae8f7ea4542c1ca0"
+checksum = "e5fdcfed8f106be3df944054aaa42bc13ae103a3ac8a9f4b08d4f053e3a743f8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",


### PR DESCRIPTION
Bumps `alloy-chains` from 0.2.36 to 0.2.37 so Foundry picks up the new BSC helpers and Tempo devnet explorer metadata. The workspace dependency already accepts 0.2.x releases, so this updates the resolved version and checksum and adds the corresponding release note.

This PR was prepared with Codex, which updated the dependency lockfile and changelog entry.
