### PR TITLE
feat(forge): rerun watched tests with `a`

### DIFF
--- a/.changelog/forge-watch-rerun-key.md
+++ b/.changelog/forge-watch-rerun-key.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added an `a` shortcut to `forge test --watch` for rerunning all tests without changing a file.

--- a/crates/forge/src/cmd/watch.rs
+++ b/crates/forge/src/cmd/watch.rs
@@ -12,7 +12,7 @@ use std::{
     io::IsTerminal,
     path::PathBuf,
     sync::{
-        Arc,
+        Arc, OnceLock, Weak,
         atomic::{AtomicU8, Ordering},
     },
     time::Duration,
@@ -33,6 +33,7 @@ use watchexec_signals::Signal;
 use yansi::{Color, Paint};
 
 type SpawnHook = Arc<dyn Fn(&[Event], &mut TokioCommand) + Send + Sync + 'static>;
+type KeyboardConfig = Arc<OnceLock<Weak<watchexec::Config>>>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum KeyboardAction {
@@ -56,6 +57,12 @@ fn keyboard_action(events: &[Event]) -> Option<KeyboardAction> {
     }
 
     rerun.then_some(KeyboardAction::Rerun)
+}
+
+fn set_keyboard_events(config: &Option<KeyboardConfig>, enable: bool) {
+    if let Some(config) = config.as_ref().and_then(|config| config.get()).and_then(Weak::upgrade) {
+        config.keyboard_events(enable);
+    }
 }
 
 #[derive(Clone, Debug, Default, Parser)]
@@ -110,25 +117,34 @@ impl WatchArgs {
         &self,
         default_paths: impl FnOnce() -> Result<PS>,
     ) -> Result<watchexec::Config> {
-        self.watchexec_config_generic(default_paths, None)
+        self.watchexec_config_generic(default_paths, None, None)
     }
 
-    /// Creates a new [`watchexec::Config`] with a custom command spawn hook.
+    /// Creates a new [`watchexec::Config`] with a custom command spawn hook and optional keyboard
+    /// events while the command is idle.
     ///
     /// If paths were provided as arguments the these will be used as the watcher's pathset,
     /// otherwise the path the closure returns will be used.
-    pub fn watchexec_config_with_override<PS: IntoIterator<Item = P>, P: Into<PathBuf>>(
+    fn watchexec_config_with_override<PS: IntoIterator<Item = P>, P: Into<PathBuf>>(
         &self,
         default_paths: impl FnOnce() -> Result<PS>,
+        watch_keyboard: bool,
         spawn_hook: impl Fn(&[Event], &mut TokioCommand) + Send + Sync + 'static,
-    ) -> Result<watchexec::Config> {
-        self.watchexec_config_generic(default_paths, Some(Arc::new(spawn_hook)))
+    ) -> Result<(watchexec::Config, Option<KeyboardConfig>)> {
+        let keyboard_config = watch_keyboard.then(|| Arc::new(OnceLock::new()));
+        let config = self.watchexec_config_generic(
+            default_paths,
+            Some(Arc::new(spawn_hook)),
+            keyboard_config.clone(),
+        )?;
+        Ok((config, keyboard_config))
     }
 
     fn watchexec_config_generic<PS: IntoIterator<Item = P>, P: Into<PathBuf>>(
         &self,
         default_paths: impl FnOnce() -> Result<PS>,
         spawn_hook: Option<SpawnHook>,
+        keyboard_config: Option<KeyboardConfig>,
     ) -> Result<watchexec::Config> {
         let mut paths = self.watch.as_deref().unwrap_or_default();
         let storage: Vec<_>;
@@ -136,13 +152,14 @@ impl WatchArgs {
             storage = default_paths()?.into_iter().map(Into::into).filter(|p| p.exists()).collect();
             paths = &storage;
         }
-        self.watchexec_config_inner(paths, spawn_hook)
+        self.watchexec_config_inner(paths, spawn_hook, keyboard_config)
     }
 
     fn watchexec_config_inner(
         &self,
         paths: &[PathBuf],
         spawn_hook: Option<SpawnHook>,
+        keyboard_config: Option<KeyboardConfig>,
     ) -> Result<watchexec::Config> {
         let config = watchexec::Config::default();
 
@@ -248,8 +265,13 @@ impl WatchArgs {
                 }
             }
 
+            // Let the child own stdin while it runs. This keeps prompts and the debugger from
+            // racing Watchexec's keyboard event source for terminal input.
+            set_keyboard_events(&keyboard_config, false);
+
             job.run({
                 let job = job.clone();
+                let keyboard_config = keyboard_config.clone();
                 move |context| {
                     if context.current.is_running() && no_restart {
                         return;
@@ -259,7 +281,7 @@ impl WatchArgs {
                         let job = job.clone();
                         move |context| {
                             clear_screen();
-                            setup_process(job, &context.command)
+                            setup_process(job, &context.command, keyboard_config)
                         }
                     });
                 }
@@ -272,14 +294,14 @@ impl WatchArgs {
     }
 }
 
-fn setup_process(job: Job, _command: &Command) {
+fn setup_process(job: Job, _command: &Command, keyboard_config: Option<KeyboardConfig>) {
     tokio::spawn(async move {
         job.to_wait().await;
-        job.run(move |context| end_of_process(context.current));
+        job.run(move |context| end_of_process(context.current, keyboard_config));
     });
 }
 
-fn end_of_process(state: &CommandState) {
+fn end_of_process(state: &CommandState, keyboard_config: Option<KeyboardConfig>) {
     let CommandState::Finished { status, started, finished } = state else {
         return;
     };
@@ -301,6 +323,7 @@ fn end_of_process(state: &CommandState) {
     };
 
     let quiet = false;
+    set_keyboard_events(&keyboard_config, true);
     if !quiet {
         let _ = sh_eprintln!("{}", format!("[{msg}]").paint(fg.foreground()));
     }
@@ -308,7 +331,17 @@ fn end_of_process(state: &CommandState) {
 
 /// Runs the given [`watchexec::Config`].
 pub async fn run(config: watchexec::Config) -> Result<()> {
+    run_inner(config, None).await
+}
+
+async fn run_inner(
+    config: watchexec::Config,
+    keyboard_config: Option<KeyboardConfig>,
+) -> Result<()> {
     let wx = Watchexec::with_config(config)?;
+    if let Some(config) = keyboard_config {
+        debug_assert!(config.set(Arc::downgrade(&wx.config)).is_ok());
+    }
     wx.send_event(Event::default(), Priority::Urgent).await?;
     wx.main().await??;
     Ok(())
@@ -343,9 +376,11 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
     let project_root = config.root.to_string_lossy().into_owned();
     let test_failures_file = config.test_failures_file.clone();
     let rerun_failed = args.watch.rerun_failed;
+    let watch_keyboard = std::io::stdin().is_terminal();
 
-    let config = args.watch.watchexec_config_with_override(
+    let (config, keyboard_config) = args.watch.watchexec_config_with_override(
         || Ok([&config.test, &config.src]),
+        watch_keyboard,
         move |events, command| {
             if keyboard_action(events) == Some(KeyboardAction::Rerun) {
                 return;
@@ -402,12 +437,11 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
         },
     )?;
 
-    if std::io::stdin().is_terminal() {
-        config.keyboard_events(true);
+    if watch_keyboard {
         let _ = sh_eprintln!("[Press 'a' to rerun all tests]");
     }
 
-    run(config).await
+    run_inner(config, keyboard_config).await
 }
 
 pub async fn watch_coverage(args: CoverageArgs) -> Result<()> {

--- a/crates/forge/src/cmd/watch.rs
+++ b/crates/forge/src/cmd/watch.rs
@@ -9,6 +9,7 @@ use foundry_cli::utils::{self, FoundryPathExt, LoadConfig};
 use foundry_config::Config;
 use parking_lot::Mutex;
 use std::{
+    io::IsTerminal,
     path::PathBuf,
     sync::{
         Arc,
@@ -25,13 +26,37 @@ use watchexec::{
     paths::summarise_events_to_env,
 };
 use watchexec_events::{
-    Event, Priority, ProcessEnd, Tag,
+    Event, KeyCode, Keyboard, Priority, ProcessEnd, Tag,
     filekind::{AccessKind, FileEventKind},
 };
 use watchexec_signals::Signal;
 use yansi::{Color, Paint};
 
 type SpawnHook = Arc<dyn Fn(&[Event], &mut TokioCommand) + Send + Sync + 'static>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KeyboardAction {
+    Rerun,
+    Quit,
+}
+
+fn keyboard_action(events: &[Event]) -> Option<KeyboardAction> {
+    let mut rerun = false;
+
+    for tag in events.iter().flat_map(|event| &event.tags) {
+        match tag {
+            Tag::Keyboard(Keyboard::Eof) => return Some(KeyboardAction::Quit),
+            Tag::Keyboard(Keyboard::Key { key: KeyCode::Char('a'), modifiers })
+                if modifiers.is_empty() =>
+            {
+                rerun = true;
+            }
+            _ => {}
+        }
+    }
+
+    rerun.then_some(KeyboardAction::Rerun)
+}
 
 #[derive(Clone, Debug, Default, Parser)]
 #[command(next_help_heading = "Watch options")]
@@ -178,18 +203,25 @@ impl WatchArgs {
             };
 
             let signals = action.signals().collect::<Vec<_>>();
+            let keyboard_action = keyboard_action(&action.events);
 
-            if signals.contains(&Signal::Terminate) || signals.contains(&Signal::Interrupt) {
+            if signals.contains(&Signal::Terminate)
+                || signals.contains(&Signal::Interrupt)
+                || keyboard_action == Some(KeyboardAction::Quit)
+            {
                 return quit(action);
             }
 
-            // Only filesystem events below here (or empty synthetic events).
-            if action.paths().next().is_none() && !action.events.iter().any(|e| e.is_empty()) {
-                debug!("no filesystem or synthetic events, skip without doing more");
+            // Only filesystem, keyboard rerun, or empty synthetic events below here.
+            if action.paths().next().is_none()
+                && keyboard_action != Some(KeyboardAction::Rerun)
+                && !action.events.iter().any(|e| e.is_empty())
+            {
+                debug!("no filesystem, rerun, or synthetic events, skip without doing more");
                 return action;
             }
 
-            if cfg!(target_os = "linux") {
+            if cfg!(target_os = "linux") && keyboard_action != Some(KeyboardAction::Rerun) {
                 // Reading a file now triggers `Access(Open)` events on Linux due to:
                 // https://github.com/notify-rs/notify/pull/612
                 // This causes an infinite rebuild loop: the build reads a file,
@@ -315,6 +347,10 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
     let config = args.watch.watchexec_config_with_override(
         || Ok([&config.test, &config.src]),
         move |events, command| {
+            if keyboard_action(events) == Some(KeyboardAction::Rerun) {
+                return;
+            }
+
             // Check if we should prioritize rerunning failed tests
             let has_failures = rerun_failed && test_failures_file.exists();
 
@@ -365,6 +401,12 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
             }
         },
     )?;
+
+    if std::io::stdin().is_terminal() {
+        config.keyboard_events(true);
+        let _ = sh_eprintln!("[Press 'a' to rerun all tests]");
+    }
+
     run(config).await
 }
 
@@ -505,6 +547,33 @@ fn clean_cmd_args(num: usize, mut cmd_args: Vec<String>) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use watchexec_events::Modifiers;
+
+    fn key_event(key: char, modifiers: Modifiers) -> Event {
+        Event {
+            tags: vec![Tag::Keyboard(Keyboard::Key { key: KeyCode::Char(key), modifiers })],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn classifies_keyboard_actions() {
+        assert_eq!(
+            keyboard_action(&[key_event('a', Modifiers::default())]),
+            Some(KeyboardAction::Rerun)
+        );
+        assert_eq!(keyboard_action(&[key_event('x', Modifiers::default())]), None);
+        assert_eq!(
+            keyboard_action(&[key_event('a', Modifiers { ctrl: true, ..Default::default() })]),
+            None
+        );
+
+        let eof = Event { tags: vec![Tag::Keyboard(Keyboard::Eof)], ..Default::default() };
+        assert_eq!(
+            keyboard_action(&[key_event('a', Modifiers::default()), eof]),
+            Some(KeyboardAction::Quit)
+        );
+    }
 
     #[test]
     fn parse_cmd_args() {

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -33,6 +33,7 @@ mod test_cmd;
 mod verify;
 mod verify_bytecode;
 mod version;
+mod watch;
 
 mod ext_integration;
 mod fmt;

--- a/crates/forge/tests/cli/watch.rs
+++ b/crates/forge/tests/cli/watch.rs
@@ -1,0 +1,63 @@
+#[cfg(unix)]
+use rexpect::{
+    Encoding,
+    process::{signal, wait::WaitStatus},
+    reader::Options,
+    spawn_with_options,
+};
+
+forgetest!(
+    #[cfg(unix)]
+    watch_yields_stdin_to_tests,
+    |prj, _cmd| {
+        const TIMEOUT_MS: u64 = 30_000;
+
+        prj.add_test(
+            "Prompt.t.sol",
+            r#"
+interface Vm {
+    function prompt(string calldata promptText) external returns (string memory input);
+}
+
+contract PromptTest {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function testPrompt() public {
+        string memory input = vm.prompt("Enter ok");
+        require(keccak256(bytes(input)) == keccak256("ok"), "unexpected input");
+    }
+}
+"#,
+        );
+
+        let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_forge"));
+        command
+            .current_dir(prj.root())
+            .env_remove("CI")
+            .env("NO_COLOR", "1")
+            .env("TERM", "dumb")
+            .args(["test", "--watch", "--match-test", "testPrompt"]);
+
+        let mut session = spawn_with_options(
+            command,
+            Options {
+                timeout_ms: Some(TIMEOUT_MS),
+                strip_ansi_escape_codes: true,
+                encoding: Encoding::UTF8,
+            },
+        )
+        .unwrap();
+
+        session.exp_string("Enter ok:").unwrap();
+        session.send_line("ok").unwrap();
+        session.exp_string("[PASS] testPrompt()").unwrap();
+        session.exp_string("[Command was successful").unwrap();
+
+        session.process.signal(signal::SIGINT).unwrap();
+        let output = session.exp_eof().unwrap();
+        assert!(
+            matches!(session.process.wait().unwrap(), WaitStatus::Exited(_, 0)),
+            "watch command failed: {output}"
+        );
+    }
+);


### PR DESCRIPTION
`forge test --watch` previously only reacted to file changes, which made it impossible to rerun fuzz tests without touching the project. This enables Watchexec keyboard events while the watcher is idle and maps an unmodified `a` to a rerun without the automatic last-file filter, while preserving explicit CLI filters. Keyboard monitoring is suspended for the full child lifetime so prompts and the debugger retain deterministic ownership of terminal input, then resumes after the child exits.

Closes #4734.

AI disclosure: This PR was written and tested with Codex.