### PR TITLE
fix(doc): preserve multiline notice metadata

### DIFF
--- a/.changelog/multiline-notice-frontmatter.md
+++ b/.changelog/multiline-notice-frontmatter.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Preserve complete multiline NatSpec notices in Forge documentation page metadata.

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -772,7 +772,7 @@ struct Description {
 struct CommentData {
     titles: Vec<String>,
     authors: Vec<String>,
-    /// Real `@notice` items (used for inheritdoc merging and frontmatter description).
+    /// Real `@notice` items used for inheritdoc merging.
     notices: Vec<String>,
     /// Real `@dev` items (used for inheritdoc merging).
     devs: Vec<String>,
@@ -980,7 +980,10 @@ fn inheritdoc_base(docs: &DocComments<'_>) -> Option<String> {
 }
 
 fn first_notice(data: &CommentData) -> Option<String> {
-    data.notices.first().cloned()
+    data.descriptions
+        .iter()
+        .find(|description| description.kind == DescKind::Notice)
+        .map(|description| description.content.clone())
 }
 
 // ── markdown output helpers ───────────────────────────────────────────────────

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -740,6 +740,38 @@ function act(uint256 v) external override;
     );
 });
 
+forgetest_init!(multiline_notice_populates_frontmatter_description, |prj, cmd| {
+    prj.add_source(
+        "Vault.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @notice Stores deposited assets for users
+///         and enforces withdrawal limits.
+contract Vault {}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Vault.mdx"), None),
+        str![[r#"
+---
+title: "Vault"
+description: "Stores deposited assets for users and enforces withdrawal limits."
+---
+
+# Vault
+
+Stores deposited assets for users
+and enforces withdrawal limits.
+
+
+"#]],
+    );
+});
+
 // An override inherits the base overload with the matching signature, continuing past a nearer
 // base that declares a different same-name overload.
 forgetest_init!(implicit_inheritance_matches_the_overload_signature, |prj, cmd| {


### PR DESCRIPTION
Preserves complete multiline NatSpec notices in generated page metadata. Forge now derives the frontmatter description from the joined notice used by the rendered body instead of dropping continuation lines.