### PR TITLE
fix(doc): preserve notices with multiline params

### DIFF
--- a/.changelog/inheritdoc-multiline-parameter.md
+++ b/.changelog/inheritdoc-multiline-parameter.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Preserve inherited NatSpec notices when an override documents a parameter across multiple lines.

--- a/crates/doc/src/hir_ext.rs
+++ b/crates/doc/src/hir_ext.rs
@@ -328,18 +328,20 @@ fn effective_natspec_doc(
     let mut local_dev = false;
     let mut local_param = false;
     let mut local_return = false;
-    for comment in raw.iter() {
-        for entry in comment.natspec.iter() {
-            match entry.kind {
-                NatSpecKind::Inheritdoc { contract } if inheritdoc.is_none() => {
-                    inheritdoc = Some(contract)
-                }
-                NatSpecKind::Notice => local_notice = true,
-                NatSpecKind::Dev => local_dev = true,
-                NatSpecKind::Param { .. } => local_param = true,
-                NatSpecKind::Return { .. } => local_return = true,
-                _ => {}
+    let raw_items =
+        raw.iter().flat_map(|comment| comment.natspec.iter().copied()).collect::<Vec<_>>();
+    for entry in &raw_items {
+        match entry.kind {
+            NatSpecKind::Inheritdoc { contract } if inheritdoc.is_none() => {
+                inheritdoc = Some(contract)
             }
+            NatSpecKind::Notice if continuation_parent(gcx, &raw_items, entry).is_none() => {
+                local_notice = true
+            }
+            NatSpecKind::Dev => local_dev = true,
+            NatSpecKind::Param { .. } => local_param = true,
+            NatSpecKind::Return { .. } => local_return = true,
+            _ => {}
         }
     }
     let Some(alias) = inheritdoc else { return Some(local) };

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -2206,6 +2206,47 @@ interface IMultiline {
     );
 });
 
+forgetest_init!(inheritdoc_multiline_param_preserves_inherited_notice, |prj, cmd| {
+    prj.add_source(
+        "MultilineInheritdoc.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface Root {
+    /// @notice Runs the operation
+    /// @param value The input value
+    function run(uint256 value) external;
+}
+
+interface Mid is Root {
+    function run(uint256 value) external override;
+}
+
+contract Child is Mid {
+    /// @inheritdoc Mid
+    /// @param value Local first line.
+    ///        Local second line.
+    function run(uint256 value) external override {}
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Child.mdx"), None),
+        str![[r#"
+...
+### run
+
+Runs the operation
+...
+| value | `uint256` | Local first line.<br/>Local second line. |
+...
+"#]],
+    );
+});
+
 // Inherited multiline NatSpec retains continuation lines and strips block-comment decorations.
 forgetest_init!(inherited_param_return_multiline_continuation, |prj, cmd| {
     prj.add_source(


### PR DESCRIPTION
Preserves inherited NatSpec notices when an override provides a multiline parameter description. Forge now recognizes synthetic notice entries as parameter continuations instead of treating them as local notices that suppress inheritance.