### PR TITLE
test(forge): fix Windows CLI path assertions

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -78,7 +78,7 @@ t_linux_arm = Target(
 t_macos = Target("depot-macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
 t_windows = Target("depot-windows-latest-16", "x86_64-pc-windows-msvc", "windows-amd64")
 if is_pr:
-    targets = [t_linux_x86, t_windows]
+    targets = [t_linux_x86]
 else:
     targets = [t_linux_x86, t_linux_arm, t_macos, t_windows]
 

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -78,7 +78,7 @@ t_linux_arm = Target(
 t_macos = Target("depot-macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
 t_windows = Target("depot-windows-latest-16", "x86_64-pc-windows-msvc", "windows-amd64")
 if is_pr:
-    targets = [t_linux_x86]
+    targets = [t_linux_x86, t_windows]
 else:
     targets = [t_linux_x86, t_linux_arm, t_macos, t_windows]
 

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -3,9 +3,10 @@ use foundry_compilers::artifacts::EvmVersion;
 use foundry_test_utils::{forgetest, forgetest_init, snapbox::IntoData, str, util::OutputExt};
 use globset::Glob;
 use std::{
+    collections::BTreeMap,
     fs,
     io::Write,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
@@ -1092,10 +1093,10 @@ forgetest_init!(build_locked_supports_dependency_paths_with_spaces, |prj, cmd| {
     git(root, &["mv", "lib/forge-std", "lib/forge std"]);
 
     let foundry_lock = root.join("foundry.lock");
-    let mut lockfile: serde_json::Value =
+    let mut lockfile: BTreeMap<PathBuf, serde_json::Value> =
         serde_json::from_str(&fs::read_to_string(&foundry_lock).unwrap()).unwrap();
-    let forge_std = lockfile.as_object_mut().unwrap().remove("lib/forge-std").unwrap();
-    lockfile["lib/forge std"] = forge_std;
+    let forge_std = lockfile.remove(Path::new("lib/forge-std")).unwrap();
+    lockfile.insert("lib/forge std".into(), forge_std);
     fs::write(foundry_lock, serde_json::to_vec_pretty(&lockfile).unwrap()).unwrap();
 
     cmd.args(["build", "--locked"]).assert_success();
@@ -1139,10 +1140,10 @@ forgetest_init!(build_locked_supports_custom_dependency_directory, |prj, cmd| {
     prj.update_config(|config| config.libs = vec!["dependencies".into()]);
 
     let foundry_lock = root.join("foundry.lock");
-    let mut lockfile: serde_json::Value =
+    let mut lockfile: BTreeMap<PathBuf, serde_json::Value> =
         serde_json::from_str(&fs::read_to_string(&foundry_lock).unwrap()).unwrap();
-    let forge_std = lockfile.as_object_mut().unwrap().remove("lib/forge-std").unwrap();
-    lockfile["dependencies/forge-std"] = forge_std;
+    let forge_std = lockfile.remove(Path::new("lib/forge-std")).unwrap();
+    lockfile.insert("dependencies/forge-std".into(), forge_std);
     fs::write(foundry_lock, serde_json::to_vec_pretty(&lockfile).unwrap()).unwrap();
 
     cmd.args(["build", "--locked"]).assert_success();

--- a/crates/forge/tests/cli/fmt.rs
+++ b/crates/forge/tests/cli/fmt.rs
@@ -171,7 +171,7 @@ tab_width = 6
     );
 
     let output = cmd.args(["fmt", "--nearest", "--check", "."]).assert_failure();
-    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout).replace('\\', "/");
     assert!(stdout.contains("Diff in first/src/Test.sol"), "{stdout}");
     assert!(stdout.contains("|+  function test("), "{stdout}");
     assert!(stdout.contains("Diff in second/src/Test.sol"), "{stdout}");


### PR DESCRIPTION
Windows uses native separators when serializing lockfile paths and printing formatter diff paths. The affected CLI tests assumed forward slashes, causing the locked-build tests to panic during setup and the formatter test to reject otherwise correct output.

Deserialize the lockfile fixtures using `PathBuf` keys and normalize formatter output before asserting paths so the tests behave consistently across platforms.
