### PR TITLE
chore(ci): ignore bitmaps maintenance advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,9 @@ ignore = [
     # declaration handling can allocate without a bound. No fixed quick-junit,
     # inferno, or soldeer release is available for either advisory yet.
     "RUSTSEC-2026-0195",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0247 bitmaps is unmaintained.
+    # No fixed imbl release is available yet: https://github.com/jneem/imbl/issues/170
+    "RUSTSEC-2026-0247",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Cargo deny began failing after RUSTSEC-2026-0247 marked every `bitmaps` release unmaintained. Anvil receives `bitmaps` transitively through `imbl`, and no fixed `imbl` release is available yet, so this temporarily ignores the maintenance-only advisory while linking the upstream tracking issue.


> This PR was prepared with Codex assistance for the CI diagnosis and deny policy change.
