### PR TITLE
fix(anvil): restore fork-backed eth_simulateV1

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -6830,10 +6830,12 @@ impl Backend<FoundryNetwork> {
                     Default::default()
                 };
 
-                // TODO: Assess restoring fork-backed simulations by deriving a canonical
-                // post-state root.
-                let accounts = cache_db.maybe_full_db().ok_or(BlockchainError::DataUnavailable)?;
-                let state_root = state_root(&accounts);
+                // Fork-backed databases do not contain the full state required to calculate a
+                // canonical root. Match Reth's default `eth_simulateV1` behavior in that case.
+                let state_root = cache_db
+                    .maybe_full_db()
+                    .map(|accounts| state_root(&accounts))
+                    .unwrap_or_default();
                 let header = Header {
                     logs_bloom: receipts.iter().fold(Bloom::ZERO, |mut bloom, receipt| {
                         bloom.accrue_bloom(receipt.logs_bloom());

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -68,8 +68,12 @@ fn deposit_event_runtime(event: DepositEvent) -> Bytes {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_simulate_v1() {
     crate::init_tracing();
-    let (_, handle) =
-        spawn(NodeConfig::test().with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))).await;
+    let (_, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))
+            .with_fork_block_number(Some(24_000_000u64)),
+    )
+    .await;
     let block_overrides =
         Some(BlockOverrides { base_fee: Some(U256::from(9)), ..Default::default() });
     let account_override =
@@ -96,8 +100,8 @@ async fn test_fork_simulate_v1() {
         return_full_transactions: true,
     };
     let response = rpc_request(&handle.http_endpoint(), "eth_simulateV1", json!([payload])).await;
-    assert_eq!(response["error"]["code"], -32603);
-    assert_eq!(response["error"]["message"], "Required data unavailable");
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"][0]["calls"][0]["status"], "0x1");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Restores fork-backed `eth_simulateV1` by using the established zero state-root fallback when Anvil cannot access full fork state. Pins the regression test to mainnet block 24,000,000.

Fixes https://github.com/foundry-rs/foundry/issues/16121

This pull request was prepared with AI assistance.
