### PR TITLE
fix(anvil): restore fork simulations

### DIFF
--- a/.changelog/anvil-fork-simulate-state-root.md
+++ b/.changelog/anvil-fork-simulate-state-root.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Restored `eth_simulateV1` on fork-backed Anvil nodes with canonical post-simulation state roots.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,8 @@ dependencies = [
  "rand 0.8.7",
  "rand 0.9.5",
  "reqwest 0.13.4",
+ "reth-trie-common",
+ "reth-trie-sparse",
  "revm",
  "revm-inspectors",
  "serde",
@@ -10311,6 +10313,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "quanta",
+ "rayon",
  "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
@@ -10468,6 +10471,26 @@ dependencies = [
  "revm",
  "serde",
  "serde_with",
+]
+
+[[package]]
+name = "reth-trie-sparse"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+dependencies = [
+ "alloy-primitives",
+ "alloy-trie",
+ "either",
+ "rayon",
+ "reth-execution-errors",
+ "reth-primitives-traits",
+ "reth-trie-common",
+ "serde",
+ "serde_json",
+ "slotmap",
+ "smallvec",
+ "strum 0.27.2",
+ "tracing",
 ]
 
 [[package]]
@@ -11725,6 +11748,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "small_btree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -413,6 +413,10 @@ revm = { version = "42.0.1", default-features = false }
 revm-inspectors = { version = "0.42.0", features = ["serde"] }
 op-revm = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753", default-features = false }
 
+## reth
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false, features = ["std"] }
+
 ## cli
 anstream = "1.0"
 anstyle = "1.0"

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -77,6 +77,8 @@ revm = { workspace = true, features = [
 ] }
 revm-inspectors.workspace = true
 op-revm = { workspace = true, optional = true }
+reth-trie-common.workspace = true
+reth-trie-sparse.workspace = true
 
 # axum related
 axum.workspace = true

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -70,6 +70,13 @@ pub trait MaybeFullDatabase: DatabaseRef<Error = DatabaseError> + Debug {
         self.maybe_as_full_db().cloned()
     }
 
+    /// Returns the local state changes layered on top of a remote fork.
+    ///
+    /// `None` identifies a complete database, while `Some` identifies a partial fork database.
+    fn maybe_fork_state(&self) -> Option<AddressMap<DbAccount>> {
+        None
+    }
+
     /// Returns whether snapshots of this database use structural sharing.
     fn is_persistent(&self) -> bool {
         false
@@ -102,6 +109,10 @@ where
         T::maybe_full_db(self)
     }
 
+    fn maybe_fork_state(&self) -> Option<AddressMap<DbAccount>> {
+        T::maybe_fork_state(self)
+    }
+
     fn is_persistent(&self) -> bool {
         T::is_persistent(self)
     }
@@ -129,6 +140,10 @@ where
 
     fn maybe_full_db(&self) -> Option<AddressMap<DbAccount>> {
         T::maybe_full_db(self)
+    }
+
+    fn maybe_fork_state(&self) -> Option<AddressMap<DbAccount>> {
+        T::maybe_fork_state(self)
     }
 
     fn is_persistent(&self) -> bool {
@@ -159,6 +174,31 @@ pub trait MaybeForkedDatabase {
     fn maybe_flush_cache(&self) -> Result<(), String>;
 
     fn maybe_inner(&self) -> Result<&BlockchainDb, String>;
+}
+
+/// Merges an account overlay into the local changes layered on top of a remote fork.
+pub(crate) fn merge_fork_account(
+    accounts: &mut AddressMap<DbAccount>,
+    address: Address,
+    overlay: &DbAccount,
+) {
+    if matches!(overlay.account_state, AccountState::NotExisting | AccountState::StorageCleared) {
+        accounts.insert(address, overlay.clone());
+        return;
+    }
+
+    let mut account = accounts.remove(&address).unwrap_or_default();
+    let reset_storage = matches!(account.account_state, AccountState::NotExisting);
+    let storage_cleared =
+        reset_storage || matches!(account.account_state, AccountState::StorageCleared);
+    if reset_storage {
+        account.storage.clear();
+    }
+    account.info = overlay.info.clone();
+    account.account_state =
+        if storage_cleared { AccountState::StorageCleared } else { overlay.account_state.clone() };
+    account.storage.extend(overlay.storage.clone());
+    accounts.insert(address, account);
 }
 
 /// `dyn Db` satisfies all `alloy_evm::Database` requirements via its supertraits, but the
@@ -421,6 +461,17 @@ impl<T: MaybeFullDatabase> MaybeFullDatabase for CacheDB<T> {
             account.account_state = overlay.account_state.clone();
             account.storage.extend(overlay.storage.clone());
             accounts.insert(*address, account);
+        }
+        Some(accounts)
+    }
+
+    fn maybe_fork_state(&self) -> Option<AddressMap<DbAccount>> {
+        let mut accounts = self.db.maybe_fork_state()?;
+        for (address, overlay) in &self.cache.accounts {
+            if overlay.account_state == AccountState::None {
+                continue;
+            }
+            merge_fork_account(&mut accounts, *address, overlay);
         }
         Some(accounts)
     }
@@ -962,6 +1013,50 @@ mod test {
             cache.maybe_full_db().map(|accounts| crate::mem::state::state_root(&accounts)),
             Some(crate::mem::state::state_root(&expected))
         );
+    }
+
+    #[test]
+    fn fork_state_merges_nested_overlays() {
+        let address = Address::with_last_byte(1);
+        let preserved_slot = U256::from(1);
+        let updated_slot = U256::from(2);
+        let mut accounts = AddressMap::from_iter([(
+            address,
+            DbAccount {
+                info: AccountInfo::from_balance(U256::from(1)),
+                account_state: AccountState::Touched,
+                storage: HashMap::from_iter([
+                    (preserved_slot, U256::from(10)),
+                    (updated_slot, U256::from(11)),
+                ]),
+            },
+        )]);
+        let overlay = DbAccount {
+            info: AccountInfo::from_balance(U256::from(2)),
+            account_state: AccountState::Touched,
+            storage: HashMap::from_iter([(updated_slot, U256::from(12))]),
+        };
+
+        merge_fork_account(&mut accounts, address, &overlay);
+        assert_eq!(accounts[&address].info.balance, U256::from(2));
+        assert_eq!(accounts[&address].storage[&preserved_slot], U256::from(10));
+        assert_eq!(accounts[&address].storage[&updated_slot], U256::from(12));
+
+        let cleared = DbAccount {
+            info: AccountInfo::from_balance(U256::from(3)),
+            account_state: AccountState::StorageCleared,
+            storage: HashMap::from_iter([(updated_slot, U256::from(13))]),
+        };
+        merge_fork_account(&mut accounts, address, &cleared);
+        assert_eq!(accounts[&address].info, cleared.info);
+        assert_eq!(accounts[&address].account_state, cleared.account_state);
+        assert_eq!(accounts[&address].storage, cleared.storage);
+
+        accounts.get_mut(&address).unwrap().account_state = AccountState::NotExisting;
+        merge_fork_account(&mut accounts, address, &overlay);
+        assert_eq!(accounts[&address].account_state, AccountState::StorageCleared);
+        assert!(!accounts[&address].storage.contains_key(&preserved_slot));
+        assert_eq!(accounts[&address].storage[&updated_slot], U256::from(12));
     }
 
     #[test]

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -1,7 +1,7 @@
 use crate::eth::backend::db::{
     Db, MaybeForkedDatabase, MaybeFullDatabase, SerializableAccountRecord, SerializableBlock,
     SerializableHistoricalStates, SerializableState, SerializableTransaction, StateDb,
-    cache_block_hash,
+    cache_block_hash, merge_fork_account,
 };
 use alloy_network::Network;
 use alloy_primitives::{Address, B256, U256, map::AddressMap};
@@ -14,13 +14,17 @@ use foundry_evm::{
 };
 use revm::{
     context::BlockEnv,
-    database::{Database, DbAccount},
+    database::{AccountState, Database, DbAccount},
     state::AccountInfo,
 };
 
 pub use foundry_evm::fork::database::ForkedDatabase;
 
 impl<N: Network> MaybeFullDatabase for SharedBackend<N> {
+    fn maybe_fork_state(&self) -> Option<AddressMap<DbAccount>> {
+        Some(AddressMap::default())
+    }
+
     fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
         StateSnapshot::default()
     }
@@ -36,13 +40,21 @@ impl<N: Network> MaybeFullDatabase for SharedBackend<N> {
 
 impl<N: Network> Db for ForkedDatabase<N> {
     fn insert_account(&mut self, address: Address, account: AccountInfo) {
-        self.database_mut().insert_account(address, account)
+        let database = self.database_mut();
+        database.insert_account(address, account);
+        database.cache.accounts.get_mut(&address).unwrap().account_state = AccountState::Touched;
     }
 
     fn set_storage_at(&mut self, address: Address, slot: B256, val: B256) -> DatabaseResult<()> {
         // this ensures the account is loaded first
         let _ = Database::basic(self, address)?;
-        self.database_mut().set_storage_at(address, slot, val)
+        let database = self.database_mut();
+        database.set_storage_at(address, slot, val)?;
+        let account = database.cache.accounts.get_mut(&address).unwrap();
+        if account.account_state == AccountState::None {
+            account.account_state = AccountState::Touched;
+        }
+        Ok(())
     }
 
     fn insert_block_hash(&mut self, number: U256, hash: B256) {
@@ -117,6 +129,18 @@ impl<N: Network> MaybeFullDatabase for ForkedDatabase<N> {
         None
     }
 
+    fn maybe_fork_state(&self) -> Option<AddressMap<DbAccount>> {
+        Some(
+            self.database()
+                .cache
+                .accounts
+                .iter()
+                .filter(|(_, account)| account.account_state != AccountState::None)
+                .map(|(address, account)| (*address, account.clone()))
+                .collect(),
+        )
+    }
+
     fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
         let db = self.inner().db();
         let accounts = std::mem::take(&mut *db.accounts.write());
@@ -154,6 +178,16 @@ impl<N: Network> MaybeFullDatabase for ForkDbStateSnapshot<N> {
 
     fn maybe_full_db(&self) -> Option<AddressMap<DbAccount>> {
         None
+    }
+
+    fn maybe_fork_state(&self) -> Option<AddressMap<DbAccount>> {
+        let mut accounts = AddressMap::default();
+        for (address, account) in &self.local.cache.accounts {
+            if account.account_state != AccountState::None {
+                merge_fork_account(&mut accounts, *address, account);
+            }
+        }
+        Some(accounts)
     }
 
     fn clear_into_state_snapshot(&mut self) -> StateSnapshot {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -73,7 +73,7 @@ use alloy_network::{
 use alloy_op_evm::{OpEvmContext, OpEvmFactory, OpTx};
 use alloy_primitives::{
     Address, B256, Bloom, Bytes, Signature, TxHash, TxKind, U64, U256, address, hex, keccak256,
-    map::{AddressMap, HashMap, HashSet},
+    map::{AddressMap, B256Map, HashMap, HashSet},
 };
 use alloy_rlp::Decodable;
 use alloy_rpc_types::{
@@ -105,7 +105,11 @@ use alloy_rpc_types::{
 use alloy_rpc_types_eth::{AccountInfo as RpcAccountInfo, Bundle, EthCallResponse};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use alloy_serde::{OtherFields, WithOtherFields};
-use alloy_trie::{HashBuilder, Nibbles, proof::ProofRetainer};
+use alloy_trie::{
+    EMPTY_ROOT_HASH, HashBuilder, Nibbles,
+    nodes::TrieNode,
+    proof::{ProofNodes, ProofRetainer},
+};
 use anvil_core::eth::{
     block::{Block, BlockInfo, canonical_block, create_block},
     transaction::{MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo},
@@ -143,11 +147,16 @@ use foundry_primitives::{
     FoundryHeader, FoundryNetwork, FoundryReceiptEnvelope, FoundryTransactionRequest,
     FoundryTxEnvelope, FoundryTxReceipt, TempoTransactionRequest,
 };
-use futures::channel::mpsc::{UnboundedSender, unbounded};
+use futures::{
+    StreamExt, TryStreamExt,
+    channel::mpsc::{UnboundedSender, unbounded},
+};
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, POST_EXEC_TX_TYPE_ID};
 #[cfg(feature = "optimism")]
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
+use reth_trie_common::{MultiProof, StorageMultiProof};
+use reth_trie_sparse::{LeafUpdate, SparseStateTrie, SparseTrie as _, TrieNodeEpoch};
 
 /// Side-channel container for OP-specific deposit info produced by
 /// [`Backend::build_call_env`] and consumed by the OP transact path.
@@ -170,6 +179,238 @@ const HOLESKY_DEPOSIT_CONTRACT_ADDRESS: Address =
 
 /// Fixed transaction context for direct Tempo RPC simulations.
 const TEMPO_RPC_SIMULATION_CONTEXT: B256 = B256::new(*b"TEMPO_RPC_SIMULATION_MPP_CONTEXT");
+
+const FORK_PROOF_CONCURRENCY: usize = 16;
+
+#[derive(Clone, Default)]
+struct ForkProofTargets(AddressMap<HashSet<B256>>);
+
+impl ForkProofTargets {
+    fn record(&mut self, accounts: &AddressMap<DbAccount>) {
+        for (address, account) in accounts {
+            let slots = self.0.entry(*address).or_default();
+            if !matches!(
+                account.account_state,
+                AccountState::NotExisting | AccountState::StorageCleared
+            ) {
+                slots.extend(account.storage.keys().map(|slot| B256::from(*slot)));
+            }
+        }
+    }
+
+    fn missing(&self, accounts: &AddressMap<DbAccount>) -> Self {
+        let mut required = Self::default();
+        required.record(accounts);
+        required.0.retain(|address, slots| {
+            let Some(covered) = self.0.get(address) else { return true };
+            slots.retain(|slot| !covered.contains(slot));
+            !slots.is_empty()
+        });
+        required
+    }
+
+    fn extend(&mut self, other: Self) {
+        for (address, slots) in other.0 {
+            self.0.entry(address).or_default().extend(slots);
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+struct ForkStateRoot {
+    trie: Option<SparseStateTrie>,
+    storage_roots: B256Map<B256>,
+    covered: ForkProofTargets,
+    missing: ForkProofTargets,
+    root: B256,
+    epoch: u64,
+}
+
+impl ForkStateRoot {
+    fn new(
+        proof: MultiProof,
+        storage_roots: B256Map<B256>,
+        covered: ForkProofTargets,
+        expected_root: B256,
+    ) -> Result<Self, BlockchainError> {
+        if proof.is_empty() {
+            return Ok(Self {
+                trie: None,
+                storage_roots,
+                covered,
+                missing: ForkProofTargets::default(),
+                root: expected_root,
+                epoch: 1,
+            });
+        }
+        let mut trie = SparseStateTrie::new();
+        trie.reveal_multiproof(proof)
+            .map_err(|err| BlockchainError::Message(format!("invalid fork state proof: {err}")))?;
+        let actual_root = trie
+            .root(TrieNodeEpoch::UNMODIFIED)
+            .map_err(|err| BlockchainError::Message(format!("invalid fork state proof: {err}")))?;
+        if actual_root != expected_root {
+            return Err(BlockchainError::Message(format!(
+                "fork state proof root mismatch: expected {expected_root}, got {actual_root}"
+            )));
+        }
+        Ok(Self {
+            trie: Some(trie),
+            storage_roots,
+            covered,
+            missing: ForkProofTargets::default(),
+            root: actual_root,
+            epoch: 1,
+        })
+    }
+
+    fn root(&mut self, accounts: &AddressMap<DbAccount>) -> Result<B256, BlockchainError> {
+        if accounts.is_empty() {
+            return Ok(self.root);
+        }
+        let missing = self.covered.missing(accounts);
+        if !missing.is_empty() {
+            self.missing.extend(missing);
+            return Err(BlockchainError::DataUnavailable);
+        }
+        let trie = self.trie.as_mut().ok_or(BlockchainError::DataUnavailable)?;
+        for (address, account) in accounts {
+            let hashed_address = keccak256(address);
+            let update = if account.account_state == AccountState::NotExisting {
+                LeafUpdate::Changed(Vec::new())
+            } else {
+                let storage_root = if account.account_state == AccountState::StorageCleared {
+                    storage_root(&account.storage)
+                } else if account.storage.is_empty() {
+                    self.storage_roots.get(&hashed_address).copied().unwrap_or(EMPTY_ROOT_HASH)
+                } else {
+                    let storage_trie = trie.storage_trie_mut(&hashed_address).ok_or_else(|| {
+                        BlockchainError::Message(format!(
+                            "missing fork storage proof for account {address}"
+                        ))
+                    })?;
+                    let mut updates = account
+                        .storage
+                        .iter()
+                        .map(|(slot, value)| {
+                            let value =
+                                if value.is_zero() { Vec::new() } else { alloy_rlp::encode(value) };
+                            (keccak256(slot.to_be_bytes::<32>()), LeafUpdate::Changed(value))
+                        })
+                        .collect::<B256Map<_>>();
+                    storage_trie.update_leaves(&mut updates, |_, _| {}).map_err(|err| {
+                        BlockchainError::Message(format!(
+                            "failed to update fork storage proof: {err}"
+                        ))
+                    })?;
+                    if !updates.is_empty() {
+                        return Err(BlockchainError::DataUnavailable);
+                    }
+                    storage_trie.root(TrieNodeEpoch::new(self.epoch))
+                };
+                LeafUpdate::Changed(alloy_rlp::encode(TrieAccount {
+                    nonce: account.info.nonce,
+                    balance: account.info.balance,
+                    storage_root,
+                    code_hash: account.info.code_hash,
+                }))
+            };
+
+            let mut updates = B256Map::from_iter([(hashed_address, update)]);
+            trie.trie_mut().update_leaves(&mut updates, |_, _| {}).map_err(|err| {
+                BlockchainError::Message(format!("failed to update fork state proof: {err}"))
+            })?;
+            if !updates.is_empty() {
+                return Err(BlockchainError::DataUnavailable);
+            }
+        }
+
+        let root = trie.root(TrieNodeEpoch::new(self.epoch)).map_err(|err| {
+            BlockchainError::Message(format!("failed to update fork root: {err}"))
+        })?;
+        self.epoch = self.epoch.saturating_add(1);
+        self.root = root;
+        Ok(root)
+    }
+
+    fn take_missing(&mut self) -> ForkProofTargets {
+        std::mem::take(&mut self.missing)
+    }
+}
+
+enum SimulationStateRoots<'a> {
+    Full,
+    Collect(&'a mut ForkProofTargets),
+    Fork(&'a mut ForkStateRoot),
+}
+
+impl SimulationStateRoots<'_> {
+    const fn is_collecting(&self) -> bool {
+        matches!(self, Self::Collect(_))
+    }
+
+    fn root<T: MaybeFullDatabase>(
+        &mut self,
+        database: &CacheDB<T>,
+    ) -> Result<B256, BlockchainError> {
+        match self {
+            Self::Full => {
+                let accounts = database.maybe_full_db().ok_or(BlockchainError::DataUnavailable)?;
+                Ok(state_root(&accounts))
+            }
+            Self::Collect(targets) => {
+                let accounts =
+                    database.maybe_fork_state().ok_or(BlockchainError::DataUnavailable)?;
+                targets.record(&accounts);
+                Ok(B256::ZERO)
+            }
+            Self::Fork(state_root) => {
+                let accounts =
+                    database.maybe_fork_state().ok_or(BlockchainError::DataUnavailable)?;
+                state_root.root(&accounts)
+            }
+        }
+    }
+}
+
+fn merge_proof_nodes(
+    target: B256,
+    proof: &[Bytes],
+    nodes: &mut ProofNodes,
+) -> Result<(), alloy_rlp::Error> {
+    let target = Nibbles::unpack(target);
+    let mut path = Nibbles::default();
+    for encoded in proof {
+        let node = TrieNode::decode(&mut &encoded[..])?;
+        nodes.insert(path, encoded.clone());
+        match node {
+            TrieNode::Branch(_) if path.len() < target.len() => {
+                path.push(target.get_unchecked(path.len()))
+            }
+            TrieNode::Extension(extension) => path.extend(&extension.key),
+            TrieNode::EmptyRoot | TrieNode::Leaf(_) | TrieNode::Branch(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn normalize_storage_root(root: B256) -> B256 {
+    if root.is_zero() { EMPTY_ROOT_HASH } else { root }
+}
+
+struct SimulationBase {
+    block_env: BlockEnv,
+    number: u64,
+    timestamp: u64,
+    hash: B256,
+    next_base_fee: u64,
+    base_fee_per_gas: u64,
+    excess_blob_gas: u64,
+    blob_gas_used: u64,
+}
 
 /// Ethereum handler that skips blob fee cap validation for non-validating calls with a zero cap.
 struct SimulationHandler<EVM, ERROR, FRAME> {
@@ -512,6 +753,7 @@ struct SimulationPrecompileOverrides {
 }
 
 /// A block request, which includes the Pool Transactions if it's Pending
+#[derive(Clone)]
 pub enum BlockRequest<T> {
     Pending(Vec<Arc<PoolTransaction<T>>>),
     Number(u64),
@@ -6317,6 +6559,131 @@ impl Backend<FoundryNetwork> {
         .await?
     }
 
+    async fn with_simulation_base<F, T>(
+        &self,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
+        f: F,
+    ) -> Result<T, BlockchainError>
+    where
+        F: FnOnce(Box<dyn MaybeFullDatabase + '_>, SimulationBase) -> T,
+    {
+        let block_request = match block_request {
+            Some(BlockRequest::Pending(pool_transactions)) => {
+                return Ok(self
+                    .with_pending_block(pool_transactions, |state, block| {
+                        let header = &block.block.header;
+                        let next_base_fee = self.fees.calculate_next_block_base_fee_per_gas(
+                            header.gas_used(),
+                            header.gas_limit(),
+                            header.base_fee_per_gas().unwrap_or_default(),
+                        );
+                        f(
+                            state,
+                            SimulationBase {
+                                block_env: block_env_from_header(header),
+                                number: header.number(),
+                                timestamp: header.timestamp(),
+                                hash: header.hash_slow(),
+                                next_base_fee,
+                                base_fee_per_gas: header.base_fee_per_gas().unwrap_or_default(),
+                                excess_blob_gas: header.excess_blob_gas().unwrap_or_default(),
+                                blob_gas_used: header.blob_gas_used().unwrap_or_default(),
+                            },
+                        )
+                    })
+                    .await);
+            }
+            block_request => block_request,
+        };
+
+        let base_block_number = match block_request.as_ref() {
+            Some(BlockRequest::Number(number)) => BlockNumber::Number(*number),
+            Some(BlockRequest::Pending(_)) => unreachable!(),
+            None => BlockNumber::Latest,
+        };
+        let base_block =
+            self.block_by_number(base_block_number).await?.ok_or(BlockchainError::BlockNotFound)?;
+        let header = &base_block.header;
+        let base = SimulationBase {
+            block_env: block_env_from_header(header),
+            number: header.number(),
+            timestamp: header.timestamp(),
+            hash: header.hash,
+            next_base_fee: self.fees.calculate_next_block_base_fee_per_gas(
+                header.gas_used(),
+                header.gas_limit(),
+                header.base_fee_per_gas().unwrap_or_default(),
+            ),
+            base_fee_per_gas: header.base_fee_per_gas().unwrap_or_default(),
+            excess_blob_gas: header.excess_blob_gas().unwrap_or_default(),
+            blob_gas_used: header.blob_gas_used().unwrap_or_default(),
+        };
+        self.with_database_at(block_request, |state, _| f(state, base)).await
+    }
+
+    async fn build_fork_state_root(
+        &self,
+        targets: ForkProofTargets,
+    ) -> Result<ForkStateRoot, BlockchainError> {
+        let fork = self.fork.read().clone().ok_or(BlockchainError::DataUnavailable)?;
+        let fork_number = fork.block_number();
+        let fork_block = self
+            .block_by_number(BlockNumber::Number(fork_number))
+            .await?
+            .ok_or(BlockchainError::BlockNotFound)?;
+        let expected_root = fork_block.header.state_root();
+
+        let proofs =
+            futures::stream::iter(targets.0.clone().into_iter().map(|(address, slots)| {
+                let fork = fork.clone();
+                async move {
+                    let proof = fork
+                        .get_proof(address, slots.into_iter().collect(), Some(fork_number.into()))
+                        .await?;
+                    Ok::<_, alloy_transport::TransportError>(proof)
+                }
+            }))
+            .buffer_unordered(FORK_PROOF_CONCURRENCY)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut multiproof = MultiProof::default();
+        let mut storage_roots = B256Map::default();
+        for proof in proofs {
+            let hashed_address = keccak256(proof.address);
+            merge_proof_nodes(
+                hashed_address,
+                &proof.account_proof,
+                &mut multiproof.account_subtree,
+            )
+            .map_err(|err| BlockchainError::TrieError(err.to_string()))?;
+
+            let storage_root = normalize_storage_root(proof.storage_hash);
+            storage_roots.insert(hashed_address, storage_root);
+            if !proof.storage_proof.is_empty() {
+                let mut subtree = ProofNodes::default();
+                for storage_proof in proof.storage_proof {
+                    merge_proof_nodes(
+                        keccak256(storage_proof.key.as_b256()),
+                        &storage_proof.proof,
+                        &mut subtree,
+                    )
+                    .map_err(|err| BlockchainError::TrieError(err.to_string()))?;
+                }
+                multiproof.storages.insert(
+                    hashed_address,
+                    StorageMultiProof {
+                        root: storage_root,
+                        subtree,
+                        branch_node_masks: Default::default(),
+                    },
+                );
+            }
+        }
+
+        ForkStateRoot::new(multiproof, storage_roots, targets, expected_root)
+    }
+
     /// Simulates the payload by executing the calls in request.
     pub async fn simulate(
         &self,
@@ -6339,15 +6706,20 @@ impl Backend<FoundryNetwork> {
         block_request: Option<BlockRequest<FoundryTxEnvelope>>,
         block_interval: u64,
     ) -> Result<Vec<SimulatedBlock<AnyRpcBlock>>, BlockchainError> {
-        let simulate_at = |state: Box<dyn MaybeFullDatabase + '_>,
-                           base_block_env: BlockEnv,
-                           base_number,
-                           base_timestamp,
-                           base_hash,
-                           base_fee,
-                           base_base_fee_per_gas,
-                           base_excess_blob_gas,
-                           base_blob_gas_used| {
+        let simulate_at = |request: SimulatePayload<WithOtherFields<TransactionRequest>>,
+                           state: Box<dyn MaybeFullDatabase + '_>,
+                           base: SimulationBase,
+                           state_roots: &mut SimulationStateRoots<'_>| {
+            let SimulationBase {
+                block_env: base_block_env,
+                number: base_number,
+                timestamp: base_timestamp,
+                hash: base_hash,
+                next_base_fee: base_fee,
+                base_fee_per_gas: base_base_fee_per_gas,
+                excess_blob_gas: base_excess_blob_gas,
+                blob_gas_used: base_blob_gas_used,
+            } = base;
             let SimulatePayload {
                 block_state_calls,
                 trace_transfers,
@@ -6675,9 +7047,11 @@ impl Backend<FoundryNetwork> {
                     let (response_logs, attempted_log_count) = inspector
                         .take_simulation_logs(&canonical_logs, result.is_success())
                         .expect("simulation log collector is installed");
-                    inspector.print_logs();
-                    if self.print_traces {
-                        inspector.into_print_traces(self.call_trace_decoder.clone());
+                    if !state_roots.is_collecting() {
+                        inspector.print_logs();
+                        if self.print_traces {
+                            inspector.into_print_traces(self.call_trace_decoder.clone());
+                        }
                     }
 
                     // REVM turns a previously deleted account into `Touched` when a later call
@@ -6692,9 +7066,7 @@ impl Backend<FoundryNetwork> {
                     cache_db.commit(state);
                     preserve_deleted_storage(&mut cache_db.cache.accounts, previously_deleted);
                     let post_state = if spec_id < SpecId::BYZANTIUM {
-                        let accounts =
-                            cache_db.maybe_full_db().ok_or(BlockchainError::DataUnavailable)?;
-                        Some(state_root(&accounts))
+                        Some(state_roots.root(&cache_db)?)
                     } else {
                         None
                     };
@@ -6830,10 +7202,7 @@ impl Backend<FoundryNetwork> {
                     Default::default()
                 };
 
-                // TODO: Assess restoring fork-backed simulations by deriving a canonical
-                // post-state root.
-                let accounts = cache_db.maybe_full_db().ok_or(BlockchainError::DataUnavailable)?;
-                let state_root = state_root(&accounts);
+                let state_root = state_roots.root(&cache_db)?;
                 let header = Header {
                     logs_bloom: receipts.iter().fold(Bloom::ZERO, |mut bloom, receipt| {
                         bloom.accrue_bloom(receipt.logs_bloom());
@@ -6922,62 +7291,45 @@ impl Backend<FoundryNetwork> {
             Ok(block_res)
         };
 
-        match block_request {
-            Some(BlockRequest::Pending(pool_transactions)) => {
-                self.with_pending_block(pool_transactions, |state, block| {
-                    let header = &block.block.header;
-                    let base_fee = self.fees.calculate_next_block_base_fee_per_gas(
-                        header.gas_used(),
-                        header.gas_limit(),
-                        header.base_fee_per_gas().unwrap_or_default(),
-                    );
-                    simulate_at(
-                        state,
-                        block_env_from_header(header),
-                        header.number(),
-                        header.timestamp(),
-                        header.hash_slow(),
-                        base_fee,
-                        header.base_fee_per_gas().unwrap_or_default(),
-                        header.excess_blob_gas().unwrap_or_default(),
-                        header.blob_gas_used().unwrap_or_default(),
-                    )
+        if self.fork.read().is_some() {
+            let mut targets = ForkProofTargets::default();
+            {
+                // Fork databases only retain local changes. Run once to discover the remote
+                // account and storage proofs needed to authenticate those changes.
+                let mut state_roots = SimulationStateRoots::Collect(&mut targets);
+                self.with_simulation_base(block_request.clone(), |state, base| {
+                    simulate_at(request.clone(), state, base, &mut state_roots)
                 })
-                .await
+                .await??;
             }
-            block_request => {
-                let base_block_number = match block_request.as_ref() {
-                    Some(BlockRequest::Number(number)) => BlockNumber::Number(*number),
-                    Some(BlockRequest::Pending(_)) => unreachable!(),
-                    None => BlockNumber::Latest,
-                };
-                let base_block = self
-                    .block_by_number(base_block_number)
-                    .await?
-                    .ok_or(BlockchainError::BlockNotFound)?;
-                let base_number = base_block.header.number();
-                let base_timestamp = base_block.header.timestamp();
-                let base_hash = base_block.header.hash;
-                let base_fee = self.fees.calculate_next_block_base_fee_per_gas(
-                    base_block.header.gas_used(),
-                    base_block.header.gas_limit(),
-                    base_block.header.base_fee_per_gas().unwrap_or_default(),
-                );
-                self.with_database_at(block_request, |state, block_env| {
-                    simulate_at(
-                        state,
-                        block_env,
-                        base_number,
-                        base_timestamp,
-                        base_hash,
-                        base_fee,
-                        base_block.header.base_fee_per_gas().unwrap_or_default(),
-                        base_block.header.excess_blob_gas().unwrap_or_default(),
-                        base_block.header.blob_gas_used().unwrap_or_default(),
-                    )
-                })
-                .await?
+
+            loop {
+                let mut fork_state_root = self.build_fork_state_root(targets.clone()).await?;
+                let mut state_roots = SimulationStateRoots::Fork(&mut fork_state_root);
+                let result = self
+                    .with_simulation_base(block_request.clone(), |state, base| {
+                        simulate_at(request.clone(), state, base, &mut state_roots)
+                    })
+                    .await?;
+                match result {
+                    Ok(blocks) => break Ok(blocks),
+                    Err(err) => {
+                        // A later block can take a different path once prior simulated block
+                        // hashes use canonical roots. Fetch any newly discovered proofs and retry.
+                        let missing = fork_state_root.take_missing();
+                        if missing.is_empty() {
+                            break Err(err);
+                        }
+                        targets.extend(missing);
+                    }
+                }
             }
+        } else {
+            let mut state_roots = SimulationStateRoots::Full;
+            self.with_simulation_base(block_request, |state, base| {
+                simulate_at(request, state, base, &mut state_roots)
+            })
+            .await?
         }
     }
 

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -70,34 +70,92 @@ async fn test_fork_simulate_v1() {
     crate::init_tracing();
     let (_, handle) =
         spawn(NodeConfig::test().with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))).await;
-    let block_overrides =
-        Some(BlockOverrides { base_fee: Some(U256::from(9)), ..Default::default() });
-    let account_override =
-        AccountOverride { balance: Some(U256::from(999999999999u64)), ..Default::default() };
-    let state_overrides = Some(
-        StateOverridesBuilder::with_capacity(1)
-            .append(address!("0xc000000000000000000000000000000000000001"), account_override)
-            .build(),
-    );
-    let tx_request = TransactionRequest {
-        from: Some(address!("0xc000000000000000000000000000000000000001")),
-        to: Some(TxKind::from(address!("0xc000000000000000000000000000000000000001"))),
-        value: Some(U256::from(1)),
-        ..Default::default()
-    };
+    let from = address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266");
     let payload = SimulatePayload {
         block_state_calls: vec![SimBlock {
-            block_overrides,
-            state_overrides,
-            calls: vec![tx_request],
+            calls: vec![
+                TransactionRequest {
+                    from: Some(from),
+                    to: Some(TxKind::from(address!("0x1000000000000000000000000000000000000001"))),
+                    value: Some(U256::from(1)),
+                    ..Default::default()
+                },
+                TransactionRequest {
+                    from: Some(from),
+                    to: Some(TxKind::from(address!("0x1000000000000000000000000000000000000002"))),
+                    value: Some(U256::from(1)),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
         }],
-        trace_transfers: true,
         validation: false,
-        return_full_transactions: true,
+        ..Default::default()
     };
-    let response = rpc_request(&handle.http_endpoint(), "eth_simulateV1", json!([payload])).await;
-    assert_eq!(response["error"]["code"], -32603);
-    assert_eq!(response["error"]["message"], "Required data unavailable");
+    let response =
+        rpc_request(&handle.http_endpoint(), "eth_simulateV1", json!([payload, "latest"])).await;
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"][0]["calls"].as_array().unwrap().len(), 2);
+    assert_ne!(response["result"][0]["stateRoot"], serde_json::to_value(B256::ZERO).unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_simulate_state_root_matches_source_rpc() {
+    let (source_api, source_handle) =
+        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Shanghai.into()))).await;
+    let contract = Address::with_last_byte(0x42);
+    source_api
+        .anvil_set_code(
+            contract,
+            Bytes::from_static(&[0x60, 0x01, 0x43, 0x60, 0x01, 0x03, 0x40, 0x55, 0x00]),
+        )
+        .await
+        .unwrap();
+    source_api.mine_one().await.unwrap();
+    let accounts = source_handle.dev_accounts().take(2).collect::<Vec<_>>();
+    let payload = json!({
+        "blockStateCalls": [
+            {
+                "calls": [{
+                    "from": accounts[0],
+                    "to": accounts[1],
+                    "value": "0x1"
+                }]
+            },
+            {
+                "calls": [{
+                    "from": accounts[0],
+                    "to": contract
+                }]
+            }
+        ],
+        "validation": false
+    });
+    let source_response = rpc_request(
+        &source_handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([payload.clone(), "0x1"]),
+    )
+    .await;
+    assert!(source_response.get("error").is_none(), "{source_response}");
+
+    let (_, fork_handle) = spawn(
+        NodeConfig::test()
+            .with_hardfork(Some(EthereumHardfork::Shanghai.into()))
+            .with_eth_rpc_url(Some(source_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64)),
+    )
+    .await;
+    let fork_response =
+        rpc_request(&fork_handle.http_endpoint(), "eth_simulateV1", json!([payload, "latest"]))
+            .await;
+    assert!(fork_response.get("error").is_none(), "{fork_response}");
+    for index in 0..2 {
+        assert_eq!(
+            fork_response["result"][index]["stateRoot"],
+            source_response["result"][index]["stateRoot"]
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Fork-backed Anvil databases only retain state read or mutated locally, so #16028's complete-database requirement rejected every `eth_simulateV1` call before it could return a non-fabricated root.

This derives canonical post-simulation roots from EIP-1186 proofs at the pinned fork block and applies the local and simulated delta with a sparse trie. Fork simulations first collect proof targets and then replay with authenticated roots; if canonical intermediate block hashes alter later execution, newly encountered targets are fetched and replayed again. Proof requests are bounded, and nested local fork overlays retain deletion and storage-clear semantics.

The regression coverage mirrors the two native transfers from the issue against Ethereum mainnet and compares two chained fork roots against a full source node, including storage chosen from the prior simulated block hash. A patch changelog entry is included.

Fixes #16121

AI assistance was used for investigation, code generation, and test development. The changes were reviewed and validated by the contributor.
