### PR TITLE
fix(forge): scope duplicate remappings

### DIFF
--- a/.changelog/contextual-auto-remappings.md
+++ b/.changelog/contextual-auto-remappings.md
@@ -1,7 +1,8 @@
 ---
 forge: patch
+foundry-cli: patch
+foundry-config: patch
 ---
 
 Scoped ambiguous auto-detected transitive remappings to their owning dependencies. Root imports
-retain a deterministic global fallback selected by shortest target path, then a `src` target, then
-lexical path order.
+retain the existing auto-detected global fallback.

--- a/.changelog/contextual-auto-remappings.md
+++ b/.changelog/contextual-auto-remappings.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+---
+
+Scoped ambiguous auto-detected transitive remappings to their owning dependencies. Root imports
+retain a deterministic global fallback selected by shortest target path, then a `src` target, then
+lexical path order.

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -197,8 +197,19 @@ impl<'a> From<&'a BuildOpts> for Figment {
         let mut figment = Config::figment_with_root(&root);
 
         // remappings should stack
-        let mut remappings = Remappings::new_with_remappings(args.project_paths.get_remappings())
-            .with_figment(&figment);
+        let remappings_root = canonicalized(&root);
+        let cli_remappings = args
+            .project_paths
+            .get_remappings()
+            .into_iter()
+            .map(|remapping| {
+                let remapping = relative_remapping_preserving_context_boundary(remapping, &root)
+                    .to_relative_remapping();
+                relative_remapping_preserving_context_boundary(remapping, &remappings_root)
+                    .to_relative_remapping()
+            })
+            .collect();
+        let mut remappings = Remappings::new_with_remappings(cli_remappings).with_figment(&figment);
         let generated_remappings = Remappings::generated_from_figment(&figment);
         remappings.extend_with_config_remappings(
             figment.extract_inner::<Vec<Remapping>>("remappings").unwrap_or_default(),

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -15,7 +15,7 @@ use std::{
         BTreeMap, BTreeSet, HashMap, HashSet, btree_map::Entry, hash_map::Entry as HashEntry,
     },
     fs,
-    path::{MAIN_SEPARATOR, Path, PathBuf},
+    path::{Component, MAIN_SEPARATOR, Path, PathBuf},
 };
 
 const GENERATED_REMAPPINGS_KEY: &str = "__generated_remappings";
@@ -69,18 +69,14 @@ impl Remappings {
         self
     }
 
-    /// Filters the remappings vector by name and context.
-    fn filter_key(r: &Remapping) -> String {
-        match &r.context {
-            Some(str) => str.clone() + &r.name.clone(),
-            None => r.name.clone(),
-        }
-    }
-
     /// Consumes the wrapper and returns the inner remappings vector.
     pub fn into_inner(self) -> Vec<Remapping> {
         let mut seen = HashSet::new();
-        self.remappings.iter().filter(|r| seen.insert(Self::filter_key(r))).cloned().collect()
+        self.remappings
+            .iter()
+            .filter(|r| seen.insert((r.context.as_deref(), r.name.as_str())))
+            .cloned()
+            .collect()
     }
 
     /// Push an element to the remappings vector, but only if it's not already present.
@@ -625,6 +621,19 @@ fn rebase_nested_remapping(
     canonical: &Path,
     lexical: &Path,
 ) -> Remapping {
+    let normalize = |path: &Path| {
+        let mut normalized = PathBuf::new();
+        for component in path.components() {
+            match component {
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    normalized.pop();
+                }
+                _ => normalized.push(component.as_os_str()),
+            }
+        }
+        normalized
+    };
     let rebase = |value: &str| {
         let path = Path::new(value);
         path.strip_prefix(canonical)
@@ -637,7 +646,7 @@ fn rebase_nested_remapping(
         *context = if Path::new(context).is_absolute() {
             rebase(context)
         } else {
-            lexical.join(&*context).display().to_string()
+            normalize(&lexical.join(&*context)).display().to_string()
         };
         if has_boundary && !context.ends_with(['/', '\\']) {
             context.push(MAIN_SEPARATOR);

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -594,7 +594,8 @@ fn configured_auto_remapping(
     if let Some((_, (_, configured))) = configured_package_entries
         .iter()
         .filter(|(lib, configured)| {
-            configured.name == remapping.name && context.is_none_or(|context| lib != context)
+            configured.name == remapping.name
+                && context.is_none_or(|owner| lib != owner && lib.starts_with(owner))
         })
         .filter_map(|entry @ (lib, _)| {
             if path.starts_with(lib) {
@@ -1064,7 +1065,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_auto_remapping_uses_nearest_lexical_package() {
+    fn configured_auto_remapping_uses_nearest_owned_package() {
         let configured = vec![
             (
                 PathBuf::from("lib/shared"),
@@ -1083,19 +1084,29 @@ mod tests {
                 },
             ),
         ];
-        let candidate = |path: &str| Remapping {
-            context: Some("lib/shared/".to_string()),
+        let candidate = |context: &str, path: &str| Remapping {
+            context: Some(context.to_string()),
             name: "shared/".to_string(),
             path: path.to_string(),
         };
 
         assert_eq!(
-            configured_auto_remapping(candidate("lib/shared/lib/shared/src/"), &configured),
-            candidate("lib/shared/lib/shared/inner-src/")
+            configured_auto_remapping(
+                candidate("lib/shared/", "lib/shared/lib/shared/src/"),
+                &configured,
+            ),
+            candidate("lib/shared/", "lib/shared/lib/shared/inner-src/")
         );
         assert_eq!(
-            configured_auto_remapping(candidate("lib/shared/lib/"), &configured),
-            candidate("lib/shared/lib/shared/inner-src/")
+            configured_auto_remapping(candidate("lib/shared/", "lib/shared/lib/"), &configured),
+            candidate("lib/shared/", "lib/shared/lib/shared/inner-src/")
+        );
+
+        let nested = candidate("lib/shared/lib/nested/", "lib/shared/lib/nested/lib/shared/src/");
+        assert_eq!(
+            configured_auto_remapping(nested.clone(), &configured),
+            nested,
+            "configured ancestors must not rewrite remappings owned by nested dependencies",
         );
     }
 

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -6,7 +6,7 @@ use figment::{
     Error, Figment, Metadata, Profile, Provider,
     value::{Dict, Map},
 };
-use foundry_compilers::artifacts::remappings::{RelativeRemapping, Remapping};
+use foundry_compilers::artifacts::remappings::{RelativeRemapping, Remapping, RemappingDiscovery};
 use rayon::prelude::*;
 use std::{
     borrow::Cow,
@@ -150,12 +150,7 @@ impl Remappings {
         config_remappings: Vec<Remapping>,
         generated_contextual_remappings: &[Remapping],
     ) {
-        let authoritative = self
-            .remappings
-            .iter()
-            .filter(|remapping| remapping.context.is_none())
-            .cloned()
-            .collect::<Vec<_>>();
+        let authoritative = self.remappings.clone();
         let mut suppressed = HashSet::new();
         let mut overlays = Vec::new();
         for (index, remapping) in config_remappings.iter().enumerate().filter(|(_, remapping)| {
@@ -216,8 +211,9 @@ impl RemappingsProvider<'_> {
     /// - CLI parameters
     fn get_remappings(&self, remappings: Vec<Remapping>) -> Result<RemappingsOutput, Error> {
         trace!("get all remappings from {:?}", self.root);
-        /// prioritizes remappings that are closer: shorter `path`
+        /// Prioritizes remappings by shortest path, then a `src` target, then lexical path.
         ///   - ("a", "1/2") over ("a", "1/2/3")
+        ///   - ("a", "1/src") over ("a", "1/lib")
         ///
         /// grouped by remapping context
         fn insert_closest(
@@ -228,15 +224,17 @@ impl RemappingsProvider<'_> {
         ) {
             let context_mappings = mappings.entry(context).or_default();
             match context_mappings.entry(key) {
-                Entry::Occupied(mut e)
-                    if e.get().components().count() > path.components().count() =>
-                {
-                    e.insert(path);
+                Entry::Occupied(mut entry) => {
+                    let existing = entry.get();
+                    if (path.components().count(), !path.ends_with("src"), &path)
+                        < (existing.components().count(), !existing.ends_with("src"), existing)
+                    {
+                        entry.insert(path);
+                    }
                 }
-                Entry::Vacant(e) => {
-                    e.insert(path);
+                Entry::Vacant(entry) => {
+                    entry.insert(path);
                 }
-                _ => {}
             }
         }
 
@@ -263,66 +261,121 @@ impl RemappingsProvider<'_> {
         }
 
         user_remappings.extend(remappings);
-        let global_user_remappings =
-            user_remappings.iter().filter(|r| r.context.is_none()).cloned().collect::<Vec<_>>();
+        let mut authoritative_user_remappings = user_remappings.clone();
+        for remapping in &mut authoritative_user_remappings {
+            if let Some(context) = &mut remapping.context {
+                *context = format!("{}/", self.root.join(&*context).display());
+            }
+        }
         // Let's now use the wrapper to conditionally extend the remappings with the autodetected
         // ones. We want to avoid duplicates, and the wrapper will handle this for us.
         let mut all_remappings = Remappings::new_with_remappings(user_remappings);
 
         // scan all library dirs and autodetect remappings
-        // TODO: if a lib specifies contexts for remappings manually, we need to figure out how to
-        // resolve that
         if self.auto_detect_remappings {
             let (nested_foundry_remappings, auto_detected_remappings) = rayon::join(
                 || self.find_nested_foundry_remappings(),
                 || self.auto_detect_remappings(),
             );
             let nested_foundry_remappings = nested_foundry_remappings?;
-            let auto_detected_remappings = auto_detected_remappings.collect::<Vec<_>>();
 
             let configured_package_entries = nested_foundry_remappings
                 .iter()
                 .filter(|(_, _, is_package_entry)| *is_package_entry)
                 .map(|(lib, remapping, _)| (lib.clone(), remapping.clone()))
                 .collect::<Vec<_>>();
+            let RemappingDiscovery { global, contextual } = auto_detected_remappings;
+            let mut global = global
+                .into_iter()
+                .map(|remapping| configured_auto_remapping(remapping, &configured_package_entries))
+                .collect::<Vec<_>>();
+            let mut contextual = contextual
+                .into_iter()
+                .map(|remapping| configured_auto_remapping(remapping, &configured_package_entries))
+                .collect::<Vec<_>>();
+            let safe_alias = |remapping: &Remapping| {
+                !["lib/", "src/", "contracts/"].contains(&remapping.name.as_str())
+            };
+            global.retain(&safe_alias);
+            contextual.retain(safe_alias);
+            let mut targets_by_alias = BTreeMap::<_, BTreeSet<_>>::new();
+            for remapping in global.iter().chain(&contextual) {
+                targets_by_alias
+                    .entry(remapping.name.clone())
+                    .or_default()
+                    .insert(PathBuf::from(&remapping.path));
+            }
+            let ambiguous_aliases = targets_by_alias
+                .into_iter()
+                .filter_map(|(name, targets)| (targets.len() > 1).then_some(name))
+                .collect::<BTreeSet<_>>();
             let mut lib_remappings = BTreeMap::new();
+            let mut explicit_contextual_remappings = Vec::new();
+            for (_, r, _) in &nested_foundry_remappings {
+                if r.context.is_some()
+                    && let Some(overlays) = contextual_overlays(&authoritative_user_remappings, r)
+                {
+                    explicit_contextual_remappings.extend(overlays);
+                    explicit_contextual_remappings.push(r.clone());
+                }
+            }
+            let mut authoritative_remappings = authoritative_user_remappings;
+            authoritative_remappings.extend(explicit_contextual_remappings.iter().cloned());
             let mut contextual_remappings = Vec::new();
-            for (lib, r, is_package_entry) in nested_foundry_remappings {
+            for (lib, r, is_package_entry) in &nested_foundry_remappings {
+                if r.context.is_some() {
+                    continue;
+                }
                 // A dependency can intentionally refine an auto-detected package root to its
                 // source directory. Scope that refinement to the dependency so root imports keep
                 // the broader package mapping.
                 if !is_package_entry
-                    && r.context.is_none()
-                    && auto_detected_remappings.iter().any(|auto| {
-                        auto.context == r.context
-                            && auto.name == r.name
+                    && global.iter().chain(&contextual).any(|auto| {
+                        auto.name == r.name
                             && Path::new(&r.path) != Path::new(&auto.path)
-                            && Path::new(&r.path).starts_with(&auto.path)
+                            && (auto
+                                .context
+                                .as_deref()
+                                .is_some_and(|context| Path::new(context) == lib)
+                                || (auto.context == r.context
+                                    && Path::new(&r.path).starts_with(&auto.path)))
                     })
                 {
                     let mut contextual = r.clone();
                     contextual.context = Some(format!("{}/", lib.display()));
                     if let Some(overlays) =
-                        contextual_overlays(&global_user_remappings, &contextual)
+                        contextual_overlays(&authoritative_remappings, &contextual)
                     {
                         contextual_remappings.extend(overlays);
                         contextual_remappings.push(contextual);
                     }
                 }
-                insert_closest(&mut lib_remappings, r.context, r.name, r.path.into());
+                insert_closest(
+                    &mut lib_remappings,
+                    r.context.clone(),
+                    r.name.clone(),
+                    PathBuf::from(&r.path),
+                );
             }
-            for r in auto_detected_remappings {
-                // this is an additional safety check for weird auto-detected remappings
-                if ["lib/", "src/", "contracts/"].contains(&r.name.as_str())
-                    || configured_package_entries.iter().any(|(lib, configured)| {
-                        configured.context == r.context
-                            && configured.name == r.name
-                            && dependency_owns_path(lib, Path::new(&r.path))
-                    })
-                {
-                    trace!(target: "forge", "- skipping the remapping");
-                    continue;
+            for remapping in contextual
+                .into_iter()
+                .filter(|remapping| ambiguous_aliases.contains(&remapping.name))
+            {
+                if let Some(overlays) = contextual_overlays(&authoritative_remappings, &remapping) {
+                    contextual_remappings.extend(overlays);
+                    contextual_remappings.push(remapping);
                 }
+            }
+            contextual_remappings.sort_by(|a, b| {
+                let a_context = a.context.as_deref().unwrap_or_default();
+                let b_context = b.context.as_deref().unwrap_or_default();
+                Path::new(b_context)
+                    .components()
+                    .count()
+                    .cmp(&Path::new(a_context).components().count())
+                    .then_with(|| a_context.cmp(b_context))
+            });
+            for r in global {
                 insert_closest(&mut lib_remappings, r.context, r.name, r.path.into());
             }
 
@@ -331,6 +384,22 @@ impl RemappingsProvider<'_> {
                 .iter()
                 .map(|r| relative_remapping_preserving_context_boundary(r.clone(), self.root))
                 .collect::<Vec<_>>();
+            explicit_contextual_remappings.sort_by(|a, b| {
+                let a_context = a.context.as_deref().unwrap_or_default();
+                let b_context = b.context.as_deref().unwrap_or_default();
+                Path::new(b_context)
+                    .components()
+                    .count()
+                    .cmp(&Path::new(a_context).components().count())
+                    .then_with(|| a_context.cmp(b_context))
+            });
+            for contextual in explicit_contextual_remappings {
+                let relative =
+                    relative_remapping_preserving_context_boundary(contextual.clone(), self.root);
+                if !explicit_remappings.contains(&relative) {
+                    all_remappings.push(contextual);
+                }
+            }
             let mut generated_remappings = Vec::new();
             for contextual in contextual_remappings {
                 let relative =
@@ -445,16 +514,22 @@ impl RemappingsProvider<'_> {
     }
 
     /// Auto detect remappings from the lib paths
-    fn auto_detect_remappings(&self) -> impl Iterator<Item = Remapping> + '_ {
-        self.lib_paths
+    fn auto_detect_remappings(&self) -> RemappingDiscovery {
+        let mut discovery = RemappingDiscovery::default();
+        for mut current in self
+            .lib_paths
             .par_iter()
-            .flat_map_iter(|lib| {
+            .map(|lib| {
                 let lib = self.root.join(lib);
                 trace!(?lib, "find all remappings");
-                Remapping::find_many(&lib)
+                Remapping::find_many_with_context(&lib)
             })
             .collect::<Vec<_>>()
-            .into_iter()
+        {
+            discovery.global.append(&mut current.global);
+            discovery.contextual.append(&mut current.contextual);
+        }
+        discovery
     }
 }
 
@@ -486,12 +561,24 @@ fn contextual_overlays(
     authoritative: &[Remapping],
     refinement: &Remapping,
 ) -> Option<Vec<Remapping>> {
-    if authoritative.iter().any(|mapping| remapping_name_is_prefix(&mapping.name, &refinement.name))
+    let applicable = |mapping: &&Remapping| {
+        mapping.context.as_deref().is_none_or(|context| {
+            refinement
+                .context
+                .as_deref()
+                .is_some_and(|refinement| Path::new(refinement).starts_with(context))
+        })
+    };
+    if authoritative
+        .iter()
+        .filter(applicable)
+        .any(|mapping| remapping_name_is_prefix(&mapping.name, &refinement.name))
     {
         return None;
     }
     let mut overlays = authoritative
         .iter()
+        .filter(applicable)
         .filter(|mapping| remapping_name_is_prefix(&refinement.name, &mapping.name))
         .cloned()
         .collect::<Vec<_>>();
@@ -502,12 +589,35 @@ fn contextual_overlays(
     Some(overlays)
 }
 
-fn dependency_owns_path(dependency: &Path, path: &Path) -> bool {
-    path.starts_with(dependency)
-        || dunce::canonicalize(dependency)
-            .ok()
-            .zip(dunce::canonicalize(path).ok())
-            .is_some_and(|(dependency, path)| path.starts_with(dependency))
+fn configured_auto_remapping(
+    mut remapping: Remapping,
+    configured_package_entries: &[(PathBuf, Remapping)],
+) -> Remapping {
+    let path = Path::new(&remapping.path);
+    let context = remapping.context.as_deref().map(Path::new);
+    if let Some((_, (_, configured))) = configured_package_entries
+        .iter()
+        .filter(|(lib, configured)| {
+            configured.name == remapping.name && context.is_none_or(|context| lib != context)
+        })
+        .filter_map(|entry @ (lib, _)| {
+            if path.starts_with(lib) {
+                Some(((0, usize::MAX - lib.components().count()), entry))
+            } else if context.is_some_and(|context| lib.starts_with(context))
+                && lib.starts_with(path)
+            {
+                Some(((1, lib.components().count()), entry))
+            } else {
+                None
+            }
+        })
+        .min_by(|(rank_a, (lib_a, _)), (rank_b, (lib_b, _))| {
+            rank_a.cmp(rank_b).then_with(|| lib_a.cmp(lib_b))
+        })
+    {
+        remapping.path.clone_from(&configured.path);
+    }
+    remapping
 }
 
 fn rebase_nested_remapping(
@@ -524,7 +634,11 @@ fn rebase_nested_remapping(
     remapping.path = rebase(&remapping.path);
     if let Some(context) = &mut remapping.context {
         let has_boundary = context.ends_with(['/', '\\']);
-        *context = rebase(context);
+        *context = if Path::new(context).is_absolute() {
+            rebase(context)
+        } else {
+            lexical.join(&*context).display().to_string()
+        };
         if has_boundary && !context.ends_with(['/', '\\']) {
             context.push(MAIN_SEPARATOR);
         }
@@ -765,6 +879,23 @@ mod tests {
             std::slice::from_ref(&contextual),
         );
         assert_eq!(generated.into_inner(), vec![broad_cli, cli]);
+
+        let contextual_cli = Remapping {
+            context: Some("lib/dep/".to_string()),
+            name: "pkg/".to_string(),
+            path: "src/contextual/".to_string(),
+        };
+        let nested_refinement = Remapping {
+            context: Some("lib/dep/lib/nested/".to_string()),
+            name: "pkg/".to_string(),
+            path: "lib/dep/lib/nested/lib/pkg/".to_string(),
+        };
+        let mut generated = Remappings::new_with_remappings(vec![contextual_cli.clone()]);
+        generated.extend_with_config_remappings(
+            vec![nested_refinement.clone()],
+            std::slice::from_ref(&nested_refinement),
+        );
+        assert_eq!(generated.into_inner(), vec![contextual_cli]);
     }
 
     #[test]
@@ -920,6 +1051,42 @@ mod tests {
             result
                 .iter()
                 .any(|r| r.context == Some("prod/".to_string()) && r.path == "prod/Contract.sol")
+        );
+    }
+
+    #[test]
+    fn configured_auto_remapping_uses_nearest_lexical_package() {
+        let configured = vec![
+            (
+                PathBuf::from("lib/shared"),
+                Remapping {
+                    context: None,
+                    name: "shared/".to_string(),
+                    path: "lib/shared/outer-src/".to_string(),
+                },
+            ),
+            (
+                PathBuf::from("lib/shared/lib/shared"),
+                Remapping {
+                    context: None,
+                    name: "shared/".to_string(),
+                    path: "lib/shared/lib/shared/inner-src/".to_string(),
+                },
+            ),
+        ];
+        let candidate = |path: &str| Remapping {
+            context: Some("lib/shared/".to_string()),
+            name: "shared/".to_string(),
+            path: path.to_string(),
+        };
+
+        assert_eq!(
+            configured_auto_remapping(candidate("lib/shared/lib/shared/src/"), &configured),
+            candidate("lib/shared/lib/shared/inner-src/")
+        );
+        assert_eq!(
+            configured_auto_remapping(candidate("lib/shared/lib/"), &configured),
+            candidate("lib/shared/lib/shared/inner-src/")
         );
     }
 

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -260,7 +260,7 @@ impl RemappingsProvider<'_> {
         let mut authoritative_user_remappings = user_remappings.clone();
         for remapping in &mut authoritative_user_remappings {
             if let Some(context) = &mut remapping.context {
-                *context = format!("{}/", self.root.join(&*context).display());
+                *context = self.root.join(&*context).display().to_string();
             }
         }
         // Let's now use the wrapper to conditionally extend the remappings with the autodetected
@@ -559,10 +559,7 @@ fn contextual_overlays(
 ) -> Option<Vec<Remapping>> {
     let applicable = |mapping: &&Remapping| {
         mapping.context.as_deref().is_none_or(|context| {
-            refinement
-                .context
-                .as_deref()
-                .is_some_and(|refinement| Path::new(refinement).starts_with(context))
+            refinement.context.as_deref().is_some_and(|refinement| refinement.starts_with(context))
         })
     };
     if authoritative

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1195,6 +1195,248 @@ outer/=lib/outer/src/
     cmd.forge_fuse().arg("lint").assert_success();
 });
 
+forgetest!(duplicate_transitive_remappings_are_scoped_to_their_owners, |prj, cmd| {
+    let a = prj.root().join("deps-a/a");
+    let b = prj.root().join("deps-b/b");
+    pretty_err(&a, fs::create_dir_all(a.join("src")));
+    pretty_err(&a, fs::create_dir_all(a.join("lib/shared/src")));
+    pretty_err(&b, fs::create_dir_all(b.join("src")));
+    pretty_err(&b, fs::create_dir_all(b.join("lib/shared/src")));
+    prj.update_config(|config| config.libs = vec!["deps-b".into(), "deps-a".into()]);
+    pretty_err(
+        &a,
+        fs::write(
+            a.join("src/A.sol"),
+            "import {VersionA} from \"shared/Version.sol\"; contract A is VersionA {}\n",
+        ),
+    );
+    pretty_err(&a, fs::write(a.join("lib/shared/src/Version.sol"), "contract VersionA {}\n"));
+    pretty_err(
+        &b,
+        fs::write(
+            b.join("src/B.sol"),
+            "import {VersionB} from \"shared/Version.sol\"; contract B is VersionB {}\n",
+        ),
+    );
+    pretty_err(&b, fs::write(b.join("lib/shared/src/Version.sol"), "contract VersionB {}\n"));
+    prj.add_source("UsesDependencies.sol", "import {A} from \"a/A.sol\"; import {B} from \"b/B.sol\"; import {VersionA} from \"shared/Version.sol\"; contract UsesDependencies { A a; B b; VersionA version; }\n");
+
+    let expected = str![[r#"
+deps-a/a/:shared/=deps-a/a/lib/shared/src/
+deps-b/b/:shared/=deps-b/b/lib/shared/src/
+a/=deps-a/a/src/
+b/=deps-b/b/src/
+shared/=deps-a/a/lib/shared/src/
+
+"#]];
+    cmd.arg("remappings").assert_success().stdout_eq(expected.clone());
+    cmd.forge_fuse().arg("build").assert_success();
+    cmd.forge_fuse().arg("lint").assert_success();
+    prj.update_config(|config| config.libs = vec!["deps-a".into(), "deps-b".into()]);
+    cmd.forge_fuse().arg("remappings").assert_success().stdout_eq(expected);
+});
+
+forgetest!(contextual_auto_remapping_uses_configured_dependency_source, |prj, cmd| {
+    let a = prj.root().join("lib/a");
+    let b = prj.root().join("lib/b");
+    let shared_a = a.join("lib/shared");
+    let shared_b = b.join("lib/shared");
+    pretty_err(&a, fs::create_dir_all(a.join("src")));
+    pretty_err(&b, fs::create_dir_all(b.join("src")));
+    pretty_err(&shared_a, fs::create_dir_all(shared_a.join("custom-source")));
+    pretty_err(&shared_b, fs::create_dir_all(shared_b.join("src")));
+    pretty_err(&a, fs::write(a.join("foundry.toml"), "[profile.default]\nlibs = [\"lib\"]\n"));
+    pretty_err(
+        &shared_a,
+        fs::write(shared_a.join("foundry.toml"), "[profile.default]\nsrc = \"custom-source\"\n"),
+    );
+    pretty_err(
+        &a,
+        fs::write(
+            a.join("src/A.sol"),
+            "import {VersionA} from \"shared/Version.sol\"; contract A is VersionA {}\n",
+        ),
+    );
+    pretty_err(
+        &shared_a,
+        fs::write(shared_a.join("custom-source/Version.sol"), "contract VersionA {}\n"),
+    );
+    pretty_err(
+        &b,
+        fs::write(
+            b.join("src/B.sol"),
+            "import {VersionB} from \"shared/Version.sol\"; contract B is VersionB {}\n",
+        ),
+    );
+    pretty_err(&shared_b, fs::write(shared_b.join("src/Version.sol"), "contract VersionB {}\n"));
+    prj.add_source("UsesDependencies.sol", "import {A} from \"a/A.sol\"; import {B} from \"b/B.sol\"; contract UsesDependencies { A a; B b; }\n");
+
+    cmd.arg("remappings").assert_success().stdout_eq(str![[r#"
+lib/a/:shared/=lib/a/lib/shared/custom-source/
+lib/b/:shared/=lib/b/lib/shared/src/
+a/=lib/a/src/
+b/=lib/b/src/
+shared/=lib/b/lib/shared/src/
+
+"#]]);
+    cmd.forge_fuse().arg("build").assert_success();
+    cmd.forge_fuse().arg("lint").assert_success();
+});
+
+forgetest!(explicit_context_precedes_nested_auto_remapping, |prj, cmd| {
+    let a = prj.root().join("lib/a");
+    let shared_a = a.join("lib/shared/src");
+    let x = a.join("lib/x");
+    let shared_x = x.join("lib/shared/src");
+    pretty_err(&a, fs::create_dir_all(a.join("src")));
+    pretty_err(&shared_a, fs::create_dir_all(&shared_a));
+    pretty_err(&x, fs::create_dir_all(x.join("src")));
+    pretty_err(&shared_x, fs::create_dir_all(&shared_x));
+    pretty_err(prj.root(), fs::create_dir_all(prj.root().join("src/override")));
+    prj.update_config(|config| {
+        config.remappings =
+            vec![Remapping::from_str("lib/a/:shared/=src/override/").unwrap().into()];
+    });
+    pretty_err(
+        prj.root(),
+        fs::write(prj.root().join("src/override/Version.sol"), "contract Selected {}\n"),
+    );
+    pretty_err(&shared_a, fs::write(shared_a.join("Version.sol"), "contract ShadowedA {}\n"));
+    pretty_err(&shared_x, fs::write(shared_x.join("Version.sol"), "contract ShadowedX {}\n"));
+    pretty_err(
+        &a,
+        fs::write(
+            a.join("src/A.sol"),
+            "import {Selected} from \"shared/Version.sol\"; import {X} from \"x/X.sol\"; contract A is Selected, X {}\n",
+        ),
+    );
+    pretty_err(
+        &x,
+        fs::write(
+            x.join("src/X.sol"),
+            "import {Selected} from \"shared/Version.sol\"; contract X is Selected {}\n",
+        ),
+    );
+    prj.add_source("UsesA.sol", "import {A} from \"a/A.sol\"; contract UsesA is A {}\n");
+    cmd.arg("build").assert_success();
+    cmd.forge_fuse().arg("lint").assert_success();
+
+    prj.update_config(|config| config.remappings.clear());
+    let remapping = format!("{}:shared/=src/override/", a.display());
+    cmd.forge_fuse().args(["build", "--force", "--remappings", &remapping]).assert_success();
+    cmd.forge_fuse().args(["lint", "--remappings", &remapping]).assert_success();
+
+    #[cfg(unix)]
+    {
+        let linked_parent = tempfile::tempdir().unwrap();
+        let linked_root = linked_parent.path().join("linked-root");
+        std::os::unix::fs::symlink(prj.root(), &linked_root).unwrap();
+        let linked_context = linked_root.join("lib/a");
+        let remapping = format!("{}:shared/=src/override/", linked_context.display());
+        let root = linked_root.to_str().unwrap();
+        cmd.forge_fuse()
+            .args(["build", "--force", "--root", root, "--remappings", &remapping])
+            .assert_success();
+        cmd.forge_fuse()
+            .args(["lint", "--root", root, "--remappings", &remapping])
+            .assert_success();
+    }
+});
+
+forgetest!(nested_auto_remapping_preserves_declared_precedence, |prj, cmd| {
+    let a = prj.root().join("lib/a");
+    let pinned_a = a.join("src/pinned");
+    let shared_a = a.join("lib/shared/src");
+    let x = a.join("lib/x");
+    let shared_x = x.join("lib/shared");
+    pretty_err(&a, fs::create_dir_all(a.join("src")));
+    pretty_err(&pinned_a, fs::create_dir_all(&pinned_a));
+    pretty_err(&shared_a, fs::create_dir_all(&shared_a));
+    pretty_err(&x, fs::create_dir_all(x.join("src")));
+    pretty_err(&shared_x, fs::create_dir_all(shared_x.join("src")));
+    pretty_err(&a, fs::write(a.join("foundry.toml"), "[profile.default]\nlibs = [\"lib\"]\n"));
+    pretty_err(&a, fs::write(a.join("remappings.txt"), "shared/=src/pinned/\n"));
+    pretty_err(&pinned_a, fs::write(pinned_a.join("Marker.sol"), "contract Marker {}\n"));
+    pretty_err(&pinned_a, fs::write(pinned_a.join("Version.sol"), "contract VersionA {}\n"));
+    pretty_err(&shared_a, fs::write(shared_a.join("Version.sol"), "contract ShadowedA {}\n"));
+    pretty_err(
+        &a,
+        fs::write(
+            a.join("src/A.sol"),
+            "import {VersionA} from \"shared/Version.sol\"; import {X} from \"x/X.sol\"; contract A is VersionA, X {}\n",
+        ),
+    );
+    pretty_err(
+        &x,
+        fs::write(
+            x.join("src/X.sol"),
+            "import {VersionX} from \"shared/Version.sol\"; contract X is VersionX {}\n",
+        ),
+    );
+    pretty_err(&shared_x, fs::write(shared_x.join("src/Version.sol"), "contract VersionX {}\n"));
+    prj.add_source("UsesA.sol", "import {A} from \"a/A.sol\"; import {Marker} from \"shared/Marker.sol\"; contract UsesA is A, Marker {}\n");
+
+    cmd.arg("remappings").assert_success().stdout_eq(str![[r#"
+lib/a/lib/x/:shared/=lib/a/lib/x/lib/shared/src/
+lib/a/:shared/=lib/a/src/pinned/
+a/=lib/a/src/
+shared/=lib/a/src/pinned/
+x/=lib/a/lib/x/src/
+
+"#]]);
+    cmd.forge_fuse().arg("build").assert_success();
+    cmd.forge_fuse().arg("lint").assert_success();
+});
+
+forgetest!(nested_contextual_remapping_precedes_auto_detection, |prj, cmd| {
+    let a = prj.root().join("lib/a");
+    let b = prj.root().join("lib/b");
+    pretty_err(&a, fs::create_dir_all(a.join("src/pinned")));
+    pretty_err(&a, fs::create_dir_all(a.join("lib/shared/src")));
+    pretty_err(&b, fs::create_dir_all(b.join("src")));
+    pretty_err(&b, fs::create_dir_all(b.join("lib/shared/src")));
+    pretty_err(
+        &a,
+        fs::write(
+            a.join("foundry.toml"),
+            "[profile.default]\nremappings = [\"src/:shared/=src/pinned/\"]\n",
+        ),
+    );
+    pretty_err(
+        &a,
+        fs::write(
+            a.join("src/A.sol"),
+            "import {Selected} from \"shared/Version.sol\"; contract A is Selected {}\n",
+        ),
+    );
+    pretty_err(&a, fs::write(a.join("src/pinned/Version.sol"), "contract Selected {}\n"));
+    pretty_err(&a, fs::write(a.join("lib/shared/src/Version.sol"), "contract ShadowedA {}\n"));
+    pretty_err(
+        &b,
+        fs::write(
+            b.join("src/B.sol"),
+            "import {VersionB} from \"shared/Version.sol\"; contract B is VersionB {}\n",
+        ),
+    );
+    pretty_err(&b, fs::write(b.join("lib/shared/src/Version.sol"), "contract VersionB {}\n"));
+    prj.add_source(
+        "UsesDependencies.sol",
+        "import {A} from \"a/A.sol\"; import {B} from \"b/B.sol\"; contract UsesDependencies is A, B {}\n",
+    );
+
+    cmd.arg("remappings").assert_success().stdout_eq(str![[r#"
+lib/a/src/:shared/=lib/a/src/pinned/
+lib/a/:shared/=lib/a/lib/shared/src/
+lib/b/:shared/=lib/b/lib/shared/src/
+a/=lib/a/src/
+b/=lib/b/src/
+shared/=lib/a/lib/shared/src/
+
+"#]]);
+    cmd.forge_fuse().arg("build").assert_success();
+    cmd.forge_fuse().arg("lint").assert_success();
+});
+
 forgetest!(cli_preserves_explicit_contextual_remapping_pair, |prj, cmd| {
     let dependency = prj.paths().libraries[0].join("dep");
     pretty_err(&dependency, fs::create_dir_all(dependency.join("src")));

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1236,6 +1236,52 @@ shared/=deps-a/a/lib/shared/src/
     cmd.forge_fuse().arg("remappings").assert_success().stdout_eq(expected);
 });
 
+forgetest!(contextual_remapping_dedup_uses_context_and_name, |prj, cmd| {
+    let a = prj.root().join("lib/a");
+    let z = prj.root().join("lib/z");
+    for dependency in [&a, &z] {
+        pretty_err(dependency, fs::create_dir_all(dependency.join("src")));
+        pretty_err(dependency, fs::create_dir_all(dependency.join("lib/shared/src")));
+    }
+    pretty_err(prj.root(), fs::create_dir_all(prj.root().join("src/collision")));
+    prj.update_config(|config| {
+        config.remappings =
+            vec![Remapping::from_str("lib/z/shared/=src/collision/").unwrap().into()];
+    });
+    pretty_err(
+        &a,
+        fs::write(
+            a.join("src/A.sol"),
+            "import {VersionA} from \"shared/Version.sol\"; contract A is VersionA {}\n",
+        ),
+    );
+    pretty_err(
+        &z,
+        fs::write(
+            z.join("src/Z.sol"),
+            "import {VersionZ} from \"shared/Version.sol\"; contract Z is VersionZ {}\n",
+        ),
+    );
+    pretty_err(&a, fs::write(a.join("lib/shared/src/Version.sol"), "contract VersionA {}\n"));
+    pretty_err(&z, fs::write(z.join("lib/shared/src/Version.sol"), "contract VersionZ {}\n"));
+    prj.add_source(
+        "UsesDependencies.sol",
+        "import {A} from \"a/A.sol\"; import {Z} from \"z/Z.sol\"; contract UsesDependencies is A, Z {}\n",
+    );
+
+    cmd.arg("remappings").assert_success().stdout_eq(str![[r#"
+lib/z/shared/=src/collision/
+lib/a/:shared/=lib/a/lib/shared/src/
+lib/z/:shared/=lib/z/lib/shared/src/
+a/=lib/a/src/
+shared/=lib/a/lib/shared/src/
+z/=lib/z/src/
+
+"#]]);
+    cmd.forge_fuse().arg("build").assert_success();
+    cmd.forge_fuse().arg("lint").assert_success();
+});
+
 forgetest!(contextual_auto_remapping_uses_configured_dependency_source, |prj, cmd| {
     let a = prj.root().join("lib/a");
     let b = prj.root().join("lib/b");
@@ -1399,7 +1445,7 @@ forgetest!(nested_contextual_remapping_precedes_auto_detection, |prj, cmd| {
         &a,
         fs::write(
             a.join("foundry.toml"),
-            "[profile.default]\nremappings = [\"src/:shared/=src/pinned/\"]\n",
+            "[profile.default]\nremappings = [\"src/../src/:shared/=src/pinned/\"]\n",
         ),
     );
     pretty_err(

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1389,6 +1389,41 @@ forgetest!(explicit_context_precedes_nested_auto_remapping, |prj, cmd| {
     }
 });
 
+forgetest!(slashless_context_is_a_lexical_prefix, |prj, cmd| {
+    let abc = prj.root().join("lib/abc");
+    let shared = abc.join("lib/shared/src");
+    pretty_err(&abc, fs::create_dir_all(abc.join("src")));
+    pretty_err(&shared, fs::create_dir_all(&shared));
+    pretty_err(prj.root(), fs::create_dir_all(prj.root().join("src/override")));
+    pretty_err(
+        prj.root(),
+        fs::write(prj.root().join("src/override/Version.sol"), "contract Selected {}\n"),
+    );
+    pretty_err(&shared, fs::write(shared.join("Version.sol"), "contract Shadowed {}\n"));
+    pretty_err(
+        &abc,
+        fs::write(
+            abc.join("src/Abc.sol"),
+            "import {Selected} from \"shared/Version.sol\"; contract Abc is Selected {}\n",
+        ),
+    );
+    prj.add_source(
+        "UsesAbc.sol",
+        "import {Abc} from \"abc/Abc.sol\"; contract UsesAbc is Abc {}\n",
+    );
+
+    let remapping = "lib/a:shared/=src/override/";
+    prj.update_config(|config| {
+        config.remappings = vec![Remapping::from_str(remapping).unwrap().into()];
+    });
+    cmd.arg("build").assert_success();
+    cmd.forge_fuse().arg("lint").assert_success();
+
+    prj.update_config(|config| config.remappings.clear());
+    cmd.forge_fuse().args(["build", "--force", "--remappings", remapping]).assert_success();
+    cmd.forge_fuse().args(["lint", "--remappings", remapping]).assert_success();
+});
+
 forgetest!(nested_auto_remapping_preserves_declared_precedence, |prj, cmd| {
     let a = prj.root().join("lib/a");
     let pinned_a = a.join("src/pinned");

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1368,9 +1368,9 @@ forgetest!(explicit_context_precedes_nested_auto_remapping, |prj, cmd| {
     cmd.forge_fuse().arg("lint").assert_success();
 
     prj.update_config(|config| config.remappings.clear());
-    let remapping = format!("{}:shared/=src/override/", a.display());
-    cmd.forge_fuse().args(["build", "--force", "--remappings", &remapping]).assert_success();
-    cmd.forge_fuse().args(["lint", "--remappings", &remapping]).assert_success();
+    let remapping = "lib/a/:shared/=src/override/";
+    cmd.forge_fuse().args(["build", "--force", "--remappings", remapping]).assert_success();
+    cmd.forge_fuse().args(["lint", "--remappings", remapping]).assert_success();
 
     #[cfg(unix)]
     {


### PR DESCRIPTION
Uses ownership information from foundry-core remapping discovery to scope ambiguous transitive remappings to their declaring dependencies. This preserves explicit and dependency-declared precedence while keeping Forge build resolution consistent with Solar linting.

Closes OSS-583