### PR TITLE
fix(anvil): execute JSON-RPC notifications

### DIFF
--- a/.changelog/execute-rpc-notifications.md
+++ b/.changelog/execute-rpc-notifications.md
@@ -1,0 +1,6 @@
+---
+anvil: patch
+anvil-server: patch
+---
+
+Execute JSON-RPC notifications while continuing to suppress their responses.

--- a/crates/anvil/server/src/handler.rs
+++ b/crates/anvil/server/src/handler.rs
@@ -1,7 +1,7 @@
 use crate::RpcHandler;
 use anvil_rpc::{
     error::RpcError,
-    request::{Request, RpcCall},
+    request::{Id, Request, RpcCall, RpcMethodCall, Version},
     response::{Response, RpcResponse},
 };
 use axum::{
@@ -66,7 +66,14 @@ async fn handle_call<Handler: RpcHandler>(call: RpcCall, handler: Handler) -> Op
             Some(handler.on_call(call).await)
         }
         RpcCall::Notification(notification) => {
-            trace!(target: "rpc", method = ?notification.method, "received rpc notification");
+            let call = RpcMethodCall {
+                jsonrpc: notification.jsonrpc.unwrap_or(Version::V2),
+                method: notification.method,
+                params: notification.params,
+                id: Id::Null,
+            };
+            trace!(target: "rpc", method = ?call.method, "handling rpc notification");
+            drop(handler.on_call(call).await);
             None
         }
         RpcCall::Invalid { id } => {
@@ -80,32 +87,48 @@ async fn handle_call<Handler: RpcHandler>(call: RpcCall, handler: Handler) -> Op
 mod tests {
     use super::*;
     use anvil_rpc::{
-        request::{RequestParams, RpcNotification, Version},
+        request::{RequestParams, RpcNotification},
         response::ResponseResult,
     };
     use axum::body::to_bytes;
     use std::{
         pin::pin,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
         task::{Context, Poll, Waker},
     };
 
-    #[derive(Clone)]
-    struct TestHandler;
+    #[derive(Clone, Default)]
+    struct TestHandler {
+        requests: Arc<AtomicUsize>,
+    }
 
     #[async_trait::async_trait]
     impl RpcHandler for TestHandler {
         type Request = serde_json::Value;
 
-        async fn on_request(&self, request: Self::Request) -> ResponseResult {
-            ResponseResult::success(request)
+        async fn on_request(&self, _request: Self::Request) -> ResponseResult {
+            self.requests.fetch_add(1, Ordering::Relaxed);
+            ResponseResult::success(())
         }
     }
 
     fn notification() -> RpcCall {
         RpcCall::Notification(RpcNotification {
             jsonrpc: Some(Version::V2),
-            method: "eth_subscribe".to_owned(),
+            method: "record".to_owned(),
             params: RequestParams::None,
+        })
+    }
+
+    fn method_call(id: i64) -> RpcCall {
+        RpcCall::MethodCall(RpcMethodCall {
+            jsonrpc: Version::V2,
+            method: "record".to_owned(),
+            params: RequestParams::None,
+            id: Id::Number(id),
         })
     }
 
@@ -121,26 +144,51 @@ mod tests {
 
     #[test]
     fn empty_batch_returns_invalid_request() {
-        let response = run_ready(handle_request(Request::Batch(vec![]), TestHandler));
+        let response = run_ready(handle_request(Request::Batch(vec![]), TestHandler::default()));
 
         assert_eq!(response, Some(Response::error(RpcError::invalid_request())));
     }
 
     #[test]
-    fn notification_only_batch_returns_no_response() {
-        let response = run_ready(handle_request(Request::Batch(vec![notification()]), TestHandler));
+    fn notification_only_batch_executes_without_response() {
+        let handler = TestHandler::default();
+        let response = run_ready(handle_request(
+            Request::Batch(vec![notification(), notification()]),
+            handler.clone(),
+        ));
 
         assert_eq!(response, None);
+        assert_eq!(handler.requests.load(Ordering::Relaxed), 2);
     }
 
     #[test]
-    fn http_notification_only_batch_returns_no_content() {
+    fn mixed_batch_executes_notification_without_including_response() {
+        let handler = TestHandler::default();
+        let response = run_ready(handle_request(
+            Request::Batch(vec![notification(), method_call(1)]),
+            handler.clone(),
+        ));
+
+        assert_eq!(
+            response,
+            Some(Response::Batch(vec![RpcResponse::new(
+                Id::Number(1),
+                ResponseResult::success(())
+            )]))
+        );
+        assert_eq!(handler.requests.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn http_notification_returns_no_content_after_execution() {
+        let handler = TestHandler::default();
         let response = run_ready(handle(
-            State((TestHandler, ())),
-            Ok(Json(Request::Batch(vec![notification()]))),
+            State((handler.clone(), ())),
+            Ok(Json(Request::Single(notification()))),
         ));
 
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
         assert!(run_ready(to_bytes(response.into_body(), usize::MAX)).unwrap().is_empty());
+        assert_eq!(handler.requests.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -88,7 +88,8 @@ pub trait RpcHandler: Clone + Send + Sync + 'static {
     /// Invoked when the request was received
     async fn on_request(&self, request: Self::Request) -> ResponseResult;
 
-    /// Invoked for every incoming `RpcMethodCall`
+    /// Invoked for every incoming [`RpcMethodCall`]. Notifications are adapted to method calls
+    /// with an [`anvil_rpc::request::Id::Null`] identifier, and their responses are discarded.
     ///
     /// This will attempt to deserialize a `{ "method" : "<name>", "params": "<params>" }` message
     /// into the `Request` type of this handler. If a `Request` instance was deserialized

--- a/crates/anvil/server/src/pubsub.rs
+++ b/crates/anvil/server/src/pubsub.rs
@@ -265,10 +265,16 @@ mod tests {
         request::{RequestParams, RpcCall, RpcNotification, Version},
         response::RpcResponse,
     };
-    use std::{pin::pin, task::Waker};
+    use std::{
+        pin::pin,
+        sync::atomic::{AtomicUsize, Ordering},
+        task::Waker,
+    };
 
-    #[derive(Clone)]
-    struct TestHandler;
+    #[derive(Clone, Default)]
+    struct TestHandler {
+        requests: Arc<AtomicUsize>,
+    }
 
     #[async_trait::async_trait]
     impl PubSubRpcHandler for TestHandler {
@@ -281,6 +287,7 @@ mod tests {
             _request: Self::Request,
             _cx: PubSubContext<Self>,
         ) -> ResponseResult {
+            self.requests.fetch_add(1, Ordering::Relaxed);
             ResponseResult::success(serde_json::Value::Null)
         }
     }
@@ -305,7 +312,7 @@ mod tests {
 
     #[test]
     fn process_request_keeps_empty_batch_invalid() {
-        let mut connection = PubSubConnection::new((), TestHandler);
+        let mut connection = PubSubConnection::new((), TestHandler::default());
         connection.process_request(Ok(Request::Batch(vec![])));
 
         let response = run_ready(connection.processing.pop().unwrap());
@@ -316,11 +323,13 @@ mod tests {
     }
 
     #[test]
-    fn process_request_skips_notification_only_batch_response() {
-        let mut connection = PubSubConnection::new((), TestHandler);
+    fn process_request_executes_notification_without_response() {
+        let handler = TestHandler::default();
+        let mut connection = PubSubConnection::new((), handler.clone());
         connection.process_request(Ok(Request::Batch(vec![notification()])));
 
         let response = run_ready(connection.processing.pop().unwrap());
         assert_eq!(response, None);
+        assert_eq!(handler.requests.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -19,6 +19,28 @@ use revm::{
 use serde_json::{Value, json};
 use std::str::FromStr;
 
+#[tokio::test(flavor = "multi_thread")]
+async fn executes_rpc_notification_without_response() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let account = address!("0000000000000000000000000000000000000001");
+    let balance = U256::from(42);
+
+    let response = reqwest::Client::new()
+        .post(handle.http_endpoint())
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "method": "anvil_setBalance",
+            "params": [account, balance],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::NO_CONTENT);
+    assert!(response.bytes().await.unwrap().is_empty());
+    assert_eq!(handle.http_provider().get_balance(account).await.unwrap(), balance);
+}
+
 async fn state_without_block_history() -> (Value, Address, U256, u64) {
     let account = address!("0000000000000000000000000000000000010363");
     let balance = U256::from(10363);


### PR DESCRIPTION
Anvil previously ignored JSON-RPC notifications entirely. This change executes notifications through the normal RPC handler while continuing to suppress their responses, as required by JSON-RPC 2.0. It applies consistently across HTTP, WebSocket, and IPC transports.