### PR TITLE
test(forge): stabilize multi-version bytecode

### DIFF
--- a/testdata/foundry.toml
+++ b/testdata/foundry.toml
@@ -22,10 +22,14 @@ extra_output = ["storageLayout"]
 additional_compiler_profiles = [
     # paris - EVM version paris for testing profile selection
     { name = "paris", evm_version = "paris" },
+    # no-metadata - stable bytecode for cross-platform multi-version tests
+    { name = "no-metadata", bytecode_hash = "None" },
 ]
 compilation_restrictions = [
     # paris - files in paris/ directory use paris EVM version
     { paths = "paris/**", evm_version = "paris" },
+    # Keep multi-version bytecode stable across platforms while preserving the encoded solc version.
+    { paths = "multi-version/**", bytecode_hash = "None" },
 ]
 
 ffi = true


### PR DESCRIPTION
The multi-version `vm.getCode` fixtures currently include IPFS metadata whose source hash can vary with platform-specific source paths. That makes byte-for-byte comparisons against `type(Counter).creationCode` fail on macOS and Windows even though the executable bytecode is identical.

This adds a compiler profile restricted to `multi-version/**` that disables the metadata hash. The solc version remains encoded in the metadata, preserving the tests' 0.8.17 versus 0.8.18 selection coverage without changing bytecode for other testdata fixtures.

This maintenance-only change needs the `L-ignore` label rather than a release changelog entry.

This PR was written primarily by Centaur AI.

Prompted by: @grandizzy
