### PR TITLE
feat(script): add gas estimate buffer

### DIFF
--- a/.changelog/forge-script-gas-buffer.md
+++ b/.changelog/forge-script-gas-buffer.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added `forge script --gas-buffer` to apply a fixed gas overhead after the estimate multiplier.

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -4,9 +4,11 @@ use crate::{
     constants::TEMPLATE_CONTRACT,
     utils::{assert_debug_dump_identifies_contract, generate_large_runtime_contract},
 };
+use alloy_consensus::Transaction as _;
 use alloy_hardforks::EthereumHardfork;
 use alloy_network::Ethereum;
 use alloy_primitives::{Address, Bytes, U256, address, hex};
+use alloy_provider::Provider as _;
 use anvil::{NodeConfig, spawn};
 use axum::{Router, body::Bytes as BodyBytes};
 use forge_script_sequence::ScriptSequence;
@@ -906,6 +908,64 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 
 "#]]);
+});
+
+forgetest_async!(can_add_fixed_buffer_to_script_gas_estimate, |prj, cmd| {
+    const GAS_BUFFER: u64 = 12_345;
+    const SIMPLE_TRANSFER_GAS: u64 = 21_000;
+
+    foundry_test_utils::util::initialize(prj.root());
+    let script = prj.add_script(
+        "GasBuffer.s.sol",
+        r#"
+import "forge-std/Script.sol";
+
+contract GasBufferScript is Script {
+    function run() external {
+        vm.broadcast();
+        (bool success,) = address(0xbeef).call("");
+        require(success, "call failed");
+    }
+}
+"#,
+    );
+    let gas_buffer = GAS_BUFFER.to_string();
+
+    for skip_simulation in [false, true] {
+        let (_api, handle) = spawn(NodeConfig::test()).await;
+        let target = format!("{}:GasBufferScript", script.display());
+        let endpoint = handle.http_endpoint();
+        let forge = cmd.forge_fuse().args([
+            "script",
+            &target,
+            "--fork-url",
+            &endpoint,
+            "--broadcast",
+            "--slow",
+            "--non-interactive",
+            "--gas-estimate-multiplier",
+            "100",
+            "--gas-buffer",
+            &gas_buffer,
+            "--private-key",
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        ]);
+        if skip_simulation {
+            forge.arg("--skip-simulation");
+        }
+        forge.assert_success();
+
+        let block =
+            handle.http_provider().get_block_by_number(1.into()).full().await.unwrap().unwrap();
+        let transactions = block.transactions.as_transactions().unwrap();
+        assert_eq!(transactions.len(), 1);
+        let gas_limit = transactions[0].gas_limit();
+        if skip_simulation {
+            assert_eq!(gas_limit, SIMPLE_TRANSFER_GAS + GAS_BUFFER);
+        } else {
+            assert!(gas_limit >= SIMPLE_TRANSFER_GAS + GAS_BUFFER);
+        }
+    }
 });
 
 forgetest_async!(can_deploy_script_without_lib, |prj, cmd| {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, num::NonZeroU64, sync::Arc, time::Duration};
 
 use crate::{
-    ScriptArgs, ScriptConfig,
+    ScriptArgs, ScriptConfig, adjusted_gas_limit,
     build::LinkedBuildData,
     progress::ScriptProgress,
     sequence::ScriptSequenceKind,
@@ -58,6 +58,7 @@ pub async fn estimate_gas<N: Network, P: Provider<N>>(
     tx: &mut N::TransactionRequest,
     provider: &P,
     estimate_multiplier: u64,
+    estimate_buffer: u64,
     tempo_browser: bool,
 ) -> Result<()>
 where
@@ -69,11 +70,9 @@ where
 
     let request =
         if tempo_browser { tx.browser_wallet_gas_estimation_request() } else { tx.clone() };
-    tx.set_gas_limit(
-        provider.estimate_gas(request).await.wrap_err("Failed to estimate gas for tx")?
-            * estimate_multiplier
-            / 100,
-    );
+    let estimate =
+        provider.estimate_gas(request).await.wrap_err("Failed to estimate gas for tx")?;
+    tx.set_gas_limit(adjusted_gas_limit(estimate, estimate_multiplier, estimate_buffer));
     Ok(())
 }
 
@@ -139,6 +138,7 @@ where
         is_fixed_gas_limit: bool,
         estimate_via_rpc: bool,
         estimate_multiplier: u64,
+        estimate_buffer: u64,
         tempo_sponsor: Option<&TempoSponsor>,
         chain: Option<Chain>,
     ) -> Result<()> {
@@ -201,7 +201,7 @@ where
         // Chains which use `eth_estimateGas` are being sent sequentially and require their
         // gas to be re-estimated right before broadcasting.
         if !is_fixed_gas_limit && estimate_via_rpc {
-            estimate_gas(tx, provider, estimate_multiplier, tempo_browser).await?;
+            estimate_gas(tx, provider, estimate_multiplier, estimate_buffer, tempo_browser).await?;
         }
 
         if let Some(sponsor) = tempo_sponsor {
@@ -271,6 +271,7 @@ where
         is_fixed_gas_limit: bool,
         estimate_via_rpc: bool,
         estimate_multiplier: u64,
+        estimate_buffer: u64,
         tempo_sponsor: Option<&TempoSponsor>,
         chain: Option<Chain>,
     ) -> Result<TxHash> {
@@ -280,6 +281,7 @@ where
             is_fixed_gas_limit,
             estimate_via_rpc,
             estimate_multiplier,
+            estimate_buffer,
             tempo_sponsor,
             chain,
         )
@@ -655,6 +657,7 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                                             *is_fixed_gas_limit,
                                             estimate_via_rpc,
                                             self.args.gas_estimate_multiplier,
+                                            self.args.gas_buffer,
                                             tempo_sponsor.as_deref(),
                                             Some(sequence_chain.into()),
                                         )
@@ -701,6 +704,7 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
                                             is_fixed_gas_limit,
                                             estimate_via_rpc,
                                             self.args.gas_estimate_multiplier,
+                                            self.args.gas_buffer,
                                             tempo_sponsor.as_deref(),
                                             Some(sequence_chain.into()),
                                         )
@@ -1205,8 +1209,14 @@ impl BundledState<TempoEvmNetwork> {
         }
 
         // Estimate gas for the batch transaction
-        estimate_gas(&mut batch_tx, provider.as_ref(), self.args.gas_estimate_multiplier, false)
-            .await?;
+        estimate_gas(
+            &mut batch_tx,
+            provider.as_ref(),
+            self.args.gas_estimate_multiplier,
+            self.args.gas_buffer,
+            false,
+        )
+        .await?;
 
         sh_println!("Estimated gas: {}", batch_tx.inner.gas.unwrap_or(0))?;
 
@@ -1580,6 +1590,7 @@ mod tests {
                 true,
                 false,
                 100,
+                0,
                 None,
                 Some(Chain::from_named(NamedChain::Mainnet)),
             )

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -92,6 +92,10 @@ foundry_config::merge_impl_figment_convert!(ScriptArgs, build, evm);
 
 const DEFAULT_CONFIRMATIONS: u64 = 1;
 
+pub(crate) const fn adjusted_gas_limit(estimate: u64, multiplier: u64, buffer: u64) -> u64 {
+    estimate * multiplier / 100 + buffer
+}
+
 /// CLI arguments for `forge script`.
 #[derive(Clone, Debug, Default, Parser)]
 pub struct ScriptArgs {
@@ -169,6 +173,10 @@ pub struct ScriptArgs {
     /// Relative percentage to multiply gas estimates by.
     #[arg(long, short, default_value = "130")]
     pub gas_estimate_multiplier: u64,
+
+    /// Fixed amount to add to gas estimates after applying the multiplier.
+    #[arg(long, default_value = "0")]
+    pub gas_buffer: u64,
 
     /// Override the sender's initial nonce for script execution and transaction generation.
     #[arg(
@@ -1088,6 +1096,11 @@ mod tests {
                 || message.contains("unknown block"),
             "unexpected orphaned block lookup error: {error:#}"
         );
+    }
+
+    #[test]
+    fn adjusts_gas_limit_with_multiplier_and_buffer() {
+        assert_eq!(adjusted_gas_limit(21_000, 130, 10_000), 37_300);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -165,6 +165,7 @@ impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
                     .with_execution_result(
                         &result,
                         self.args.gas_estimate_multiplier,
+                        self.args.gas_buffer,
                         &self.build_data,
                     )
                     .build();
@@ -342,6 +343,7 @@ impl<FEN: FoundryEvmNetwork> FilledTransactionsState<FEN> {
                             tx,
                             &provider_info.provider,
                             self.args.gas_estimate_multiplier,
+                            self.args.gas_buffer,
                             false,
                         )
                         .await

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -1,4 +1,4 @@
-use super::ScriptResult;
+use super::{ScriptResult, adjusted_gas_limit};
 use crate::build::LinkedBuildData;
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_network::{Network, TransactionBuilder};
@@ -150,6 +150,7 @@ impl<N: Network> ScriptTransactionBuilder<N> {
         mut self,
         result: &ScriptResult<N>,
         gas_estimate_multiplier: u64,
+        gas_buffer: u64,
         linked_build_data: &LinkedBuildData,
     ) -> Self {
         let mut created_contracts =
@@ -166,8 +167,11 @@ impl<N: Network> ScriptTransactionBuilder<N> {
         if !self.transaction.is_fixed_gas_limit
             && let Some(unsigned) = self.transaction.transaction.as_unsigned_mut()
         {
-            // We inflate the gas used by the user specified percentage
-            unsigned.set_gas_limit(result.gas_used * gas_estimate_multiplier / 100);
+            unsigned.set_gas_limit(adjusted_gas_limit(
+                result.gas_used,
+                gas_estimate_multiplier,
+                gas_buffer,
+            ));
         }
 
         self


### PR DESCRIPTION
`forge script` currently supports percentage-based gas estimate inflation, but that cannot account for fixed overhead charged outside the EVM on Cosmos-integrated chains. This adds `--gas-buffer <GAS>` and applies it after the existing multiplier to both simulation-derived and RPC-derived estimates, including retries and Tempo batch broadcasts. Explicit gas limits remain unchanged, and the zero default preserves existing behavior.

Closes #10352.

AI disclosure: This pull request was authored with Codex.
