### PR TITLE
feat(forge): cover empty special functions

### DIFF
--- a/.changelog/coverage-empty-special-functions.md
+++ b/.changelog/coverage-empty-special-functions.md
@@ -1,0 +1,6 @@
+---
+forge: minor
+foundry-evm-coverage: minor
+---
+
+Report coverage hits for empty constructors, receive functions, and fallbacks.

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -45,6 +45,7 @@ struct SourceVisitorCheckpoint {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum EmptySpecialFunctionKind {
+    Constructor,
     Receive,
     Fallback,
 }
@@ -74,11 +75,19 @@ fn resolve_empty_special_functions(
     for contract_id in gcx.hir.contract_ids() {
         let contract = gcx.hir.contract(contract_id);
         let Some(&contract_source_id) = hir_source_ids.get(&contract.source) else { continue };
-        for (function_id, kind) in [
+        let constructors = contract.linearized_bases.iter().filter_map(|&base_id| {
+            gcx.hir
+                .contract(base_id)
+                .ctor
+                .map(|function_id| (function_id, EmptySpecialFunctionKind::Constructor))
+        });
+        let runtime_functions = [
             (contract.receive, EmptySpecialFunctionKind::Receive),
             (contract.fallback, EmptySpecialFunctionKind::Fallback),
-        ] {
-            let Some(function_id) = function_id else { continue };
+        ]
+        .into_iter()
+        .filter_map(|(function_id, kind)| function_id.map(|function_id| (function_id, kind)));
+        for (function_id, kind) in constructors.chain(runtime_functions) {
             let function = gcx.hir.function(function_id);
             if !function.body.is_some_and(|body| body.is_empty()) {
                 continue;

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -43,6 +43,63 @@ struct SourceVisitorCheckpoint {
     function_calls: usize,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EmptySpecialFunctionKind {
+    Receive,
+    Fallback,
+}
+
+struct ResolvedEmptySpecialFunction {
+    contract_source_id: u32,
+    contract_name: Arc<str>,
+    function_source_id: u32,
+    function_contract_name: Arc<str>,
+    function_bytes: Range<u32>,
+    kind: EmptySpecialFunctionKind,
+}
+
+fn resolve_empty_special_functions(
+    gcx: Gcx<'_>,
+    data: &SourceFiles,
+) -> Vec<ResolvedEmptySpecialFunction> {
+    let hir_source_ids = data
+        .sources
+        .iter()
+        .map(|(&source_id, path)| {
+            let (hir_source_id, _) = gcx.get_hir_source(path).unwrap();
+            (hir_source_id, source_id)
+        })
+        .collect::<HashMap<_, _>>();
+    let mut resolved = Vec::new();
+    for contract_id in gcx.hir.contract_ids() {
+        let contract = gcx.hir.contract(contract_id);
+        let Some(&contract_source_id) = hir_source_ids.get(&contract.source) else { continue };
+        for (function_id, kind) in [
+            (contract.receive, EmptySpecialFunctionKind::Receive),
+            (contract.fallback, EmptySpecialFunctionKind::Fallback),
+        ] {
+            let Some(function_id) = function_id else { continue };
+            let function = gcx.hir.function(function_id);
+            if !function.body.is_some_and(|body| body.is_empty()) {
+                continue;
+            }
+            let Some(&function_source_id) = hir_source_ids.get(&function.source) else { continue };
+            let Some(function_contract_id) = function.contract else { continue };
+            let function_contract = gcx.hir.contract(function_contract_id);
+            let function_bytes = gcx.sess.source_map().span_to_source(function.span).unwrap().data;
+            resolved.push(ResolvedEmptySpecialFunction {
+                contract_source_id,
+                contract_name: contract.name.as_str().into(),
+                function_source_id,
+                function_contract_name: function_contract.name.as_str().into(),
+                function_bytes: function_bytes.start as u32..function_bytes.end as u32,
+                kind,
+            });
+        }
+    }
+    resolved
+}
+
 impl<'gcx> SourceVisitor<'gcx> {
     fn new(source_id: u32, gcx: Gcx<'gcx>) -> Self {
         Self {
@@ -209,9 +266,9 @@ impl<'ast> ast::Visit<'ast> for SourceVisitor<'_> {
     fn visit_item(&mut self, item: &'ast ast::Item<'ast>) -> ControlFlow<Self::BreakValue> {
         match &item.kind {
             ItemKind::Function(func) => {
-                // TODO: We currently can only detect empty bodies in normal functions, not any of
-                // the other kinds: https://github.com/foundry-rs/foundry/issues/9458
-                if func.kind != ast::FunctionKind::Function && !has_statements(func.body.as_ref()) {
+                // Empty modifiers have no bytecode of their own to anchor. Empty constructors,
+                // receive functions, and fallbacks are handled separately.
+                if func.kind == ast::FunctionKind::Modifier && !has_statements(func.body.as_ref()) {
                     return ControlFlow::Continue(());
                 }
 
@@ -461,6 +518,10 @@ pub struct SourceAnalysis {
     all_items: Vec<CoverageItem>,
     /// Source ID to `(offset, len)` into `all_items`.
     map: Vec<(u32, u32)>,
+    /// Empty receive and fallback items keyed by coverage item ID.
+    empty_special_functions: HashMap<u32, EmptySpecialFunctionKind>,
+    /// Empty receive and fallback item IDs resolved for each contract, including inheritance.
+    contract_empty_special_functions: HashMap<u32, HashMap<Arc<str>, Vec<u32>>>,
 }
 
 impl SourceAnalysis {
@@ -478,7 +539,10 @@ impl SourceAnalysis {
     /// also include the compiler build ID.
     #[instrument(name = "SourceAnalysis::new", skip_all)]
     pub fn new(data: &SourceFiles, output: &ProjectCompileOutput) -> eyre::Result<Self> {
+        let mut resolved_empty_special_functions = Vec::new();
         let mut sourced_items = output.parser().solc().compiler().enter(|compiler| {
+            resolved_empty_special_functions =
+                resolve_empty_special_functions(compiler.gcx(), data);
             data.sources
                 .par_iter()
                 .map(|(&source_id, path)| {
@@ -536,7 +600,31 @@ impl SourceAnalysis {
             all_items.extend(items);
         }
 
-        Ok(Self { all_items, map })
+        let mut empty_special_functions = HashMap::default();
+        let mut contract_empty_special_functions =
+            HashMap::<u32, HashMap<Arc<str>, Vec<u32>>>::default();
+        for resolved in resolved_empty_special_functions {
+            let item_ids = all_items
+                .iter()
+                .enumerate()
+                .filter(|(_, item)| {
+                    item.loc.source_id == resolved.function_source_id as usize
+                        && item.loc.contract_name == resolved.function_contract_name
+                        && item.loc.bytes == resolved.function_bytes
+                })
+                .map(|(item_id, _)| item_id as u32)
+                .collect::<Vec<_>>();
+            empty_special_functions
+                .extend(item_ids.iter().map(|&item_id| (item_id, resolved.kind)));
+            contract_empty_special_functions
+                .entry(resolved.contract_source_id)
+                .or_default()
+                .entry(resolved.contract_name)
+                .or_default()
+                .extend(item_ids);
+        }
+
+        Ok(Self { all_items, map, empty_special_functions, contract_empty_special_functions })
     }
 
     /// Returns all the coverage items.
@@ -571,6 +659,26 @@ impl SourceAnalysis {
     #[inline]
     pub fn get(&self, item_id: u32) -> Option<&CoverageItem> {
         self.all_items.get(item_id as usize)
+    }
+
+    pub(crate) fn empty_special_function_kind(
+        &self,
+        item_id: u32,
+    ) -> Option<EmptySpecialFunctionKind> {
+        self.empty_special_functions.get(&item_id).copied()
+    }
+
+    pub(crate) fn empty_special_function_ids(
+        &self,
+        source_id: u32,
+        contract_name: &str,
+    ) -> impl Iterator<Item = u32> + '_ {
+        self.contract_empty_special_functions
+            .get(&source_id)
+            .and_then(|contracts| contracts.get(contract_name))
+            .into_iter()
+            .flatten()
+            .copied()
     }
 }
 

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -1,4 +1,4 @@
-use super::{CallAnchor, CallAnchorKind, CoverageItemKind, ItemAnchor, SourceLocation};
+use super::{CoverageItemKind, ExecutionAnchor, ExecutionAnchorKind, ItemAnchor, SourceLocation};
 use crate::analysis::{EmptySpecialFunctionKind, SourceAnalysis};
 use alloy_primitives::map::rustc_hash::FxHashSet;
 use eyre::ensure;
@@ -55,20 +55,22 @@ pub fn find_anchors(
         .collect()
 }
 
-/// Finds call-based anchors for empty receive and fallback functions in a contract.
-pub fn find_call_anchors(
+/// Finds execution-based anchors for empty constructors, receive functions, and fallbacks in a
+/// contract.
+pub fn find_execution_anchors(
     source_id: u32,
     contract_name: &str,
     analysis: &SourceAnalysis,
-) -> Vec<CallAnchor> {
+) -> Vec<ExecutionAnchor> {
     analysis
         .empty_special_function_ids(source_id, contract_name)
         .filter_map(|item_id| {
-            analysis.empty_special_function_kind(item_id).map(|kind| CallAnchor {
+            analysis.empty_special_function_kind(item_id).map(|kind| ExecutionAnchor {
                 item_id,
                 kind: match kind {
-                    EmptySpecialFunctionKind::Receive => CallAnchorKind::Receive,
-                    EmptySpecialFunctionKind::Fallback => CallAnchorKind::Fallback,
+                    EmptySpecialFunctionKind::Constructor => ExecutionAnchorKind::Constructor,
+                    EmptySpecialFunctionKind::Receive => ExecutionAnchorKind::Receive,
+                    EmptySpecialFunctionKind::Fallback => ExecutionAnchorKind::Fallback,
                 },
             })
         })

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -1,5 +1,5 @@
-use super::{CoverageItemKind, ItemAnchor, SourceLocation};
-use crate::analysis::SourceAnalysis;
+use super::{CallAnchor, CallAnchorKind, CoverageItemKind, ItemAnchor, SourceLocation};
+use crate::analysis::{EmptySpecialFunctionKind, SourceAnalysis};
 use alloy_primitives::map::rustc_hash::FxHashSet;
 use eyre::ensure;
 use foundry_compilers::artifacts::sourcemap::{SourceElement, SourceMap};
@@ -20,6 +20,9 @@ pub fn find_anchors(
         .filter(|&source| seen_sources.insert(source))
         .flat_map(|source| analysis.items_for_source_enumerated(source))
         .filter_map(|(item_id, item)| {
+            if analysis.empty_special_function_kind(item_id).is_some() {
+                return None;
+            }
             let anchor_loc = item.anchor_loc.as_ref().unwrap_or(&item.loc);
             match item.kind {
                 CoverageItemKind::Branch { path_id, is_first_opcode: true, .. }
@@ -48,6 +51,26 @@ pub fn find_anchors(
             }
             .inspect_err(|err| warn!(%item, %err, "could not find anchor"))
             .ok()
+        })
+        .collect()
+}
+
+/// Finds call-based anchors for empty receive and fallback functions in a contract.
+pub fn find_call_anchors(
+    source_id: u32,
+    contract_name: &str,
+    analysis: &SourceAnalysis,
+) -> Vec<CallAnchor> {
+    analysis
+        .empty_special_function_ids(source_id, contract_name)
+        .filter_map(|item_id| {
+            analysis.empty_special_function_kind(item_id).map(|kind| CallAnchor {
+                item_id,
+                kind: match kind {
+                    EmptySpecialFunctionKind::Receive => CallAnchorKind::Receive,
+                    EmptySpecialFunctionKind::Fallback => CallAnchorKind::Fallback,
+                },
+            })
         })
         .collect()
 }

--- a/crates/evm/coverage/src/inspector.rs
+++ b/crates/evm/coverage/src/inspector.rs
@@ -35,8 +35,13 @@ impl Default for LineCoverageCollector {
 impl<CTX> Inspector<CTX> for LineCoverageCollector {
     fn initialize_interp(&mut self, interpreter: &mut Interpreter, _context: &mut CTX) {
         let call = interpreter.input.bytecode_address.is_some().then(|| {
-            let input = interpreter.input.input.as_bytes_memory(&interpreter.memory);
-            (CallData::new(&input), !interpreter.input.call_value.is_zero())
+            let calldata = if interpreter.input.input.is_empty() {
+                CallData::Empty
+            } else {
+                let input = interpreter.input.input.as_bytes_memory(&interpreter.memory);
+                CallData::new(&input)
+            };
+            (calldata, !interpreter.input.call_value.is_zero())
         });
         let map = self.get_or_insert_map(interpreter);
         if let Some((call, with_value)) = call {

--- a/crates/evm/coverage/src/inspector.rs
+++ b/crates/evm/coverage/src/inspector.rs
@@ -2,7 +2,7 @@ use crate::{CallData, HitMap, HitMaps};
 use alloy_primitives::B256;
 use revm::{
     Inspector,
-    interpreter::{Interpreter, interpreter_types::Jumps},
+    interpreter::{CreateInputs, CreateOutcome, Interpreter, interpreter_types::Jumps},
 };
 use std::ptr::NonNull;
 
@@ -34,12 +34,14 @@ impl Default for LineCoverageCollector {
 
 impl<CTX> Inspector<CTX> for LineCoverageCollector {
     fn initialize_interp(&mut self, interpreter: &mut Interpreter, _context: &mut CTX) {
-        let call = {
+        let call = interpreter.input.bytecode_address.is_some().then(|| {
             let input = interpreter.input.input.as_bytes_memory(&interpreter.memory);
-            CallData::new(&input)
-        };
+            (CallData::new(&input), !interpreter.input.call_value.is_zero())
+        });
         let map = self.get_or_insert_map(interpreter);
-        map.call(call);
+        if let Some((call, with_value)) = call {
+            map.call(call, with_value);
+        }
         // Reserve some space early to avoid reallocating too often.
         map.reserve(8192.min(interpreter.bytecode.len()));
     }
@@ -47,6 +49,19 @@ impl<CTX> Inspector<CTX> for LineCoverageCollector {
     fn step(&mut self, interpreter: &mut Interpreter, _context: &mut CTX) {
         let map = self.get_or_insert_map(interpreter);
         map.hit(interpreter.bytecode.pc() as u32);
+    }
+
+    fn create_end(
+        &mut self,
+        _context: &mut CTX,
+        inputs: &CreateInputs,
+        outcome: &mut CreateOutcome,
+    ) {
+        if outcome.result.result.is_ok()
+            && let Some(map) = self.maps.get_mut(&inputs.init_code_hash())
+        {
+            map.creation();
+        }
     }
 }
 

--- a/crates/evm/coverage/src/inspector.rs
+++ b/crates/evm/coverage/src/inspector.rs
@@ -1,4 +1,4 @@
-use crate::{HitMap, HitMaps};
+use crate::{CallData, HitMap, HitMaps};
 use alloy_primitives::B256;
 use revm::{
     Inspector,
@@ -34,7 +34,12 @@ impl Default for LineCoverageCollector {
 
 impl<CTX> Inspector<CTX> for LineCoverageCollector {
     fn initialize_interp(&mut self, interpreter: &mut Interpreter, _context: &mut CTX) {
+        let call = {
+            let input = interpreter.input.input.as_bytes_memory(&interpreter.memory);
+            CallData::new(&input)
+        };
         let map = self.get_or_insert_map(interpreter);
+        map.call(call);
         // Reserve some space early to avoid reallocating too often.
         map.reserve(8192.min(interpreter.bytecode.len()));
     }

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -50,8 +50,8 @@ pub struct CoverageReport {
     ///
     /// `(id, (creation, runtime))`
     pub anchors: HashMap<ContractId, (Vec<ItemAnchor>, Vec<ItemAnchor>)>,
-    /// Call-based anchors for compiler-generated runtime paths.
-    call_anchors: HashMap<ContractId, ContractCallAnchors>,
+    /// Execution-based anchors for coverage items without source-mapped bytecode.
+    execution_anchors: HashMap<ContractId, ContractExecutionAnchors>,
     /// All the bytecode hits for the codebase.
     pub bytecode_hits: HashMap<ContractId, HitMap>,
     /// The bytecode -> source mappings.
@@ -98,23 +98,25 @@ impl CoverageReport {
         self.anchors.extend(anchors);
     }
 
-    /// Adds call-based anchors for a contract.
-    pub fn add_call_anchors(
+    /// Adds execution-based anchors for a contract.
+    pub fn add_execution_anchors(
         &mut self,
         contract_id: ContractId,
-        anchors: Vec<CallAnchor>,
+        anchors: Vec<ExecutionAnchor>,
         function_selectors: impl IntoIterator<Item = [u8; 4]>,
         has_receive: bool,
+        fallback_payable: bool,
     ) {
         if anchors.is_empty() {
             return;
         }
-        self.call_anchors.insert(
+        self.execution_anchors.insert(
             contract_id,
-            ContractCallAnchors {
+            ContractExecutionAnchors {
                 anchors,
                 function_selectors: function_selectors.into_iter().collect(),
                 has_receive,
+                fallback_payable,
             },
         );
     }
@@ -176,9 +178,9 @@ impl CoverageReport {
                 }
             }
         }
-        if is_deployed_code && let Some(anchors) = self.call_anchors.get(contract_id) {
+        if let Some(anchors) = self.execution_anchors.get(contract_id) {
             for anchor in &anchors.anchors {
-                let hits = anchors.hits(hit_map, anchor.kind);
+                let hits = anchors.hits(hit_map, anchor.kind, is_deployed_code);
                 self.analyses
                     .get_mut(&contract_id.build_id)
                     .and_then(|items| items.all_items_mut().get_mut(anchor.item_id as usize))
@@ -206,9 +208,9 @@ impl CoverageReport {
                 *hits_by_item.entry(anchor.item_id).or_default() += hits.get();
             }
         }
-        if is_deployed_code && let Some(anchors) = self.call_anchors.get(contract_id) {
+        if let Some(anchors) = self.execution_anchors.get(contract_id) {
             for anchor in &anchors.anchors {
-                let hits = anchors.hits(hit_map, anchor.kind);
+                let hits = anchors.hits(hit_map, anchor.kind, is_deployed_code);
                 if hits > 0 {
                     *hits_by_item.entry(anchor.item_id).or_default() += hits;
                 }
@@ -309,6 +311,31 @@ impl CallData {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct CallHits {
+    without_value: u32,
+    with_value: u32,
+}
+
+impl CallHits {
+    const fn hit(&mut self, with_value: bool) {
+        if with_value {
+            self.with_value += 1;
+        } else {
+            self.without_value += 1;
+        }
+    }
+
+    const fn merge(&mut self, other: Self) {
+        self.without_value += other.without_value;
+        self.with_value += other.with_value;
+    }
+
+    const fn total(self, payable: bool) -> u32 {
+        self.without_value + if payable { self.with_value } else { 0 }
+    }
+}
+
 /// Hit data for an address.
 ///
 /// Contains low-level data about hit counters for the instructions in the bytecode of a contract.
@@ -316,9 +343,10 @@ impl CallData {
 pub struct HitMap {
     hits: FxHashMap<u32, u32>,
     bytecode: Bytes,
-    empty_calls: u32,
-    short_calls: u32,
-    selector_calls: FxHashMap<[u8; 4], u32>,
+    creations: u32,
+    empty_calls: CallHits,
+    short_calls: CallHits,
+    selector_calls: FxHashMap<[u8; 4], CallHits>,
 }
 
 impl HitMap {
@@ -328,8 +356,9 @@ impl HitMap {
         Self {
             bytecode,
             hits: HashMap::with_capacity_and_hasher(1024, Default::default()),
-            empty_calls: 0,
-            short_calls: 0,
+            creations: 0,
+            empty_calls: Default::default(),
+            short_calls: Default::default(),
             selector_calls: Default::default(),
         }
     }
@@ -358,12 +387,17 @@ impl HitMap {
         *self.hits.entry(pc).or_default() += hits;
     }
 
-    fn call(&mut self, call: CallData) {
-        match call {
-            CallData::Empty => self.empty_calls += 1,
-            CallData::Short => self.short_calls += 1,
-            CallData::Selector(selector) => *self.selector_calls.entry(selector).or_default() += 1,
-        }
+    fn call(&mut self, call: CallData, with_value: bool) {
+        let hits = match call {
+            CallData::Empty => &mut self.empty_calls,
+            CallData::Short => &mut self.short_calls,
+            CallData::Selector(selector) => self.selector_calls.entry(selector).or_default(),
+        };
+        hits.hit(with_value);
+    }
+
+    const fn creation(&mut self) {
+        self.creations += 1;
     }
 
     /// Reserve space for additional hits.
@@ -378,10 +412,11 @@ impl HitMap {
         for (pc, hits) in other.iter() {
             self.hits(pc, hits);
         }
-        self.empty_calls += other.empty_calls;
-        self.short_calls += other.short_calls;
+        self.creations += other.creations;
+        self.empty_calls.merge(other.empty_calls);
+        self.short_calls.merge(other.short_calls);
         for (&selector, &hits) in &other.selector_calls {
-            *self.selector_calls.entry(selector).or_default() += hits;
+            self.selector_calls.entry(selector).or_default().merge(hits);
         }
     }
 
@@ -438,18 +473,20 @@ impl fmt::Display for ItemAnchor {
     }
 }
 
-/// A call-based anchor for coverage items without source-mapped bytecode.
+/// An execution-based anchor for a coverage item without source-mapped bytecode.
 #[derive(Clone, Copy, Debug)]
-pub struct CallAnchor {
+pub struct ExecutionAnchor {
     /// The item ID this anchor points to.
     pub item_id: u32,
-    /// The call path that marks the item as covered.
-    pub kind: CallAnchorKind,
+    /// The execution path that marks the item as covered.
+    pub kind: ExecutionAnchorKind,
 }
 
-/// The compiler-generated call path associated with a call-based anchor.
+/// The execution path associated with an execution-based anchor.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CallAnchorKind {
+pub enum ExecutionAnchorKind {
+    /// A successful contract creation.
+    Constructor,
     /// An empty calldata call routed to `receive`.
     Receive,
     /// A call routed to `fallback`.
@@ -457,27 +494,34 @@ pub enum CallAnchorKind {
 }
 
 #[derive(Clone, Debug)]
-struct ContractCallAnchors {
-    anchors: Vec<CallAnchor>,
+struct ContractExecutionAnchors {
+    anchors: Vec<ExecutionAnchor>,
     function_selectors: FxHashSet<[u8; 4]>,
     has_receive: bool,
+    fallback_payable: bool,
 }
 
-impl ContractCallAnchors {
-    fn hits(&self, hit_map: &HitMap, kind: CallAnchorKind) -> u32 {
-        match kind {
-            CallAnchorKind::Receive => hit_map.empty_calls,
-            CallAnchorKind::Fallback => {
-                let empty_calls = if self.has_receive { 0 } else { hit_map.empty_calls };
+impl ContractExecutionAnchors {
+    fn hits(&self, hit_map: &HitMap, kind: ExecutionAnchorKind, is_deployed_code: bool) -> u32 {
+        match (kind, is_deployed_code) {
+            (ExecutionAnchorKind::Constructor, false) => hit_map.creations,
+            (ExecutionAnchorKind::Receive, true) => hit_map.empty_calls.total(true),
+            (ExecutionAnchorKind::Fallback, true) => {
+                let empty_calls = if self.has_receive {
+                    0
+                } else {
+                    hit_map.empty_calls.total(self.fallback_payable)
+                };
                 empty_calls
-                    + hit_map.short_calls
+                    + hit_map.short_calls.total(self.fallback_payable)
                     + hit_map
                         .selector_calls
                         .iter()
                         .filter(|(selector, _)| !self.function_selectors.contains(*selector))
-                        .map(|(_, hits)| hits)
+                        .map(|(_, hits)| hits.total(self.fallback_payable))
                         .sum::<u32>()
             }
+            _ => 0,
         }
     }
 }

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -10,7 +10,10 @@ extern crate tracing;
 
 use alloy_primitives::{
     Bytes,
-    map::{B256HashMap, HashMap, rustc_hash::FxHashMap},
+    map::{
+        B256HashMap, HashMap,
+        rustc_hash::{FxHashMap, FxHashSet},
+    },
 };
 use analysis::SourceAnalysis;
 use eyre::Result;
@@ -47,6 +50,8 @@ pub struct CoverageReport {
     ///
     /// `(id, (creation, runtime))`
     pub anchors: HashMap<ContractId, (Vec<ItemAnchor>, Vec<ItemAnchor>)>,
+    /// Call-based anchors for compiler-generated runtime paths.
+    call_anchors: HashMap<ContractId, ContractCallAnchors>,
     /// All the bytecode hits for the codebase.
     pub bytecode_hits: HashMap<ContractId, HitMap>,
     /// The bytecode -> source mappings.
@@ -91,6 +96,27 @@ impl CoverageReport {
         anchors: impl IntoIterator<Item = (ContractId, (Vec<ItemAnchor>, Vec<ItemAnchor>))>,
     ) {
         self.anchors.extend(anchors);
+    }
+
+    /// Adds call-based anchors for a contract.
+    pub fn add_call_anchors(
+        &mut self,
+        contract_id: ContractId,
+        anchors: Vec<CallAnchor>,
+        function_selectors: impl IntoIterator<Item = [u8; 4]>,
+        has_receive: bool,
+    ) {
+        if anchors.is_empty() {
+            return;
+        }
+        self.call_anchors.insert(
+            contract_id,
+            ContractCallAnchors {
+                anchors,
+                function_selectors: function_selectors.into_iter().collect(),
+                has_receive,
+            },
+        );
     }
 
     /// Returns an iterator over coverage summaries by source file path.
@@ -150,6 +176,16 @@ impl CoverageReport {
                 }
             }
         }
+        if is_deployed_code && let Some(anchors) = self.call_anchors.get(contract_id) {
+            for anchor in &anchors.anchors {
+                let hits = anchors.hits(hit_map, anchor.kind);
+                self.analyses
+                    .get_mut(&contract_id.build_id)
+                    .and_then(|items| items.all_items_mut().get_mut(anchor.item_id as usize))
+                    .expect("Anchor refers to non-existent coverage item")
+                    .hits += hits;
+            }
+        }
 
         Ok(())
     }
@@ -168,6 +204,14 @@ impl CoverageReport {
         for anchor in anchors {
             if let Some(hits) = hit_map.get(anchor.instruction) {
                 *hits_by_item.entry(anchor.item_id).or_default() += hits.get();
+            }
+        }
+        if is_deployed_code && let Some(anchors) = self.call_anchors.get(contract_id) {
+            for anchor in &anchors.anchors {
+                let hits = anchors.hits(hit_map, anchor.kind);
+                if hits > 0 {
+                    *hits_by_item.entry(anchor.item_id).or_default() += hits;
+                }
             }
         }
 
@@ -246,6 +290,25 @@ impl DerefMut for HitMaps {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+enum CallData {
+    Empty,
+    Short,
+    Selector([u8; 4]),
+}
+
+impl CallData {
+    fn new(input: &[u8]) -> Self {
+        if input.is_empty() {
+            Self::Empty
+        } else if let Some(selector) = input.get(..4) {
+            Self::Selector(selector.try_into().unwrap())
+        } else {
+            Self::Short
+        }
+    }
+}
+
 /// Hit data for an address.
 ///
 /// Contains low-level data about hit counters for the instructions in the bytecode of a contract.
@@ -253,13 +316,22 @@ impl DerefMut for HitMaps {
 pub struct HitMap {
     hits: FxHashMap<u32, u32>,
     bytecode: Bytes,
+    empty_calls: u32,
+    short_calls: u32,
+    selector_calls: FxHashMap<[u8; 4], u32>,
 }
 
 impl HitMap {
     /// Create a new hitmap with the given bytecode.
     #[inline]
     pub fn new(bytecode: Bytes) -> Self {
-        Self { bytecode, hits: HashMap::with_capacity_and_hasher(1024, Default::default()) }
+        Self {
+            bytecode,
+            hits: HashMap::with_capacity_and_hasher(1024, Default::default()),
+            empty_calls: 0,
+            short_calls: 0,
+            selector_calls: Default::default(),
+        }
     }
 
     /// Returns the bytecode.
@@ -286,6 +358,14 @@ impl HitMap {
         *self.hits.entry(pc).or_default() += hits;
     }
 
+    fn call(&mut self, call: CallData) {
+        match call {
+            CallData::Empty => self.empty_calls += 1,
+            CallData::Short => self.short_calls += 1,
+            CallData::Selector(selector) => *self.selector_calls.entry(selector).or_default() += 1,
+        }
+    }
+
     /// Reserve space for additional hits.
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
@@ -297,6 +377,11 @@ impl HitMap {
         self.reserve(other.len());
         for (pc, hits) in other.iter() {
             self.hits(pc, hits);
+        }
+        self.empty_calls += other.empty_calls;
+        self.short_calls += other.short_calls;
+        for (&selector, &hits) in &other.selector_calls {
+            *self.selector_calls.entry(selector).or_default() += hits;
         }
     }
 
@@ -350,6 +435,50 @@ pub struct ItemAnchor {
 impl fmt::Display for ItemAnchor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "IC {} -> Item {}", self.instruction, self.item_id)
+    }
+}
+
+/// A call-based anchor for coverage items without source-mapped bytecode.
+#[derive(Clone, Copy, Debug)]
+pub struct CallAnchor {
+    /// The item ID this anchor points to.
+    pub item_id: u32,
+    /// The call path that marks the item as covered.
+    pub kind: CallAnchorKind,
+}
+
+/// The compiler-generated call path associated with a call-based anchor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CallAnchorKind {
+    /// An empty calldata call routed to `receive`.
+    Receive,
+    /// A call routed to `fallback`.
+    Fallback,
+}
+
+#[derive(Clone, Debug)]
+struct ContractCallAnchors {
+    anchors: Vec<CallAnchor>,
+    function_selectors: FxHashSet<[u8; 4]>,
+    has_receive: bool,
+}
+
+impl ContractCallAnchors {
+    fn hits(&self, hit_map: &HitMap, kind: CallAnchorKind) -> u32 {
+        match kind {
+            CallAnchorKind::Receive => hit_map.empty_calls,
+            CallAnchorKind::Fallback => {
+                let empty_calls = if self.has_receive { 0 } else { hit_map.empty_calls };
+                empty_calls
+                    + hit_map.short_calls
+                    + hit_map
+                        .selector_calls
+                        .iter()
+                        .filter(|(selector, _)| !self.function_selectors.contains(*selector))
+                        .map(|(_, hits)| hits)
+                        .sum::<u32>()
+            }
+        }
     }
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -854,7 +854,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         let result = outcome.result.result;
         call_inspectors!(
             #[ret]
-            [&mut self.tracer, &mut self.cheatcodes, &mut self.printer],
+            [&mut self.line_coverage, &mut self.tracer, &mut self.cheatcodes, &mut self.printer],
             |inspector| {
                 let previous_output = outcome.output().clone();
                 inspector.create_end(ecx, call, outcome);

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -8,7 +8,7 @@ use crate::coverage::{
     CoverageSummaryReporter, DebugReporter, ItemAnchor, LcovReporter, ResolvedHitMap,
     ResolvedHitMaps,
     analysis::{SourceAnalysis, SourceFiles},
-    anchors::find_anchors,
+    anchors::{find_anchors, find_call_anchors},
 };
 use alloy_primitives::{Address, Bytes, U256, map::HashMap};
 use clap::{Parser, ValueHint};
@@ -353,6 +353,21 @@ impl CoverageArgs {
                 })
                 .collect_vec_list();
             report.add_anchors(anchors.into_iter().flatten());
+            for artifact in
+                artifacts.iter().filter(|artifact| artifact.contract_id.build_id == *build_id)
+            {
+                let call_anchors = find_call_anchors(
+                    artifact.contract_id.source_id as u32,
+                    &artifact.contract_id.contract_name,
+                    &source_analysis,
+                );
+                report.add_call_anchors(
+                    artifact.contract_id.clone(),
+                    call_anchors,
+                    artifact.function_selectors.iter().copied(),
+                    artifact.has_receive,
+                );
+            }
             report.add_analysis(build_id.clone(), source_analysis);
         }
 
@@ -526,10 +541,18 @@ pub struct ArtifactData {
     pub contract_id: ContractId,
     pub creation: BytecodeData,
     pub deployed: BytecodeData,
+    pub function_selectors: Vec<[u8; 4]>,
+    pub has_receive: bool,
 }
 
 impl ArtifactData {
     pub fn new(id: &ArtifactId, source_id: usize, artifact: &impl Artifact) -> Option<Self> {
+        let abi = artifact.get_abi();
+        let function_selectors = abi
+            .as_ref()
+            .map(|abi| abi.functions().map(|function| function.selector().into()).collect())
+            .unwrap_or_default();
+        let has_receive = abi.as_ref().is_some_and(|abi| abi.receive.is_some());
         Some(Self {
             contract_id: ContractId {
                 version: id.version.clone(),
@@ -549,6 +572,8 @@ impl ArtifactData {
                     .get_deployed_bytecode()
                     .and_then(|bytecode| dummy_link_deployed_bytecode(bytecode.into_owned()))?,
             ),
+            function_selectors,
+            has_receive,
         })
     }
 }

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -8,8 +8,9 @@ use crate::coverage::{
     CoverageSummaryReporter, DebugReporter, ItemAnchor, LcovReporter, ResolvedHitMap,
     ResolvedHitMaps,
     analysis::{SourceAnalysis, SourceFiles},
-    anchors::{find_anchors, find_call_anchors},
+    anchors::{find_anchors, find_execution_anchors},
 };
+use alloy_json_abi::StateMutability;
 use alloy_primitives::{Address, Bytes, U256, map::HashMap};
 use clap::{Parser, ValueHint};
 use eyre::Result;
@@ -356,16 +357,17 @@ impl CoverageArgs {
             for artifact in
                 artifacts.iter().filter(|artifact| artifact.contract_id.build_id == *build_id)
             {
-                let call_anchors = find_call_anchors(
+                let execution_anchors = find_execution_anchors(
                     artifact.contract_id.source_id as u32,
                     &artifact.contract_id.contract_name,
                     &source_analysis,
                 );
-                report.add_call_anchors(
+                report.add_execution_anchors(
                     artifact.contract_id.clone(),
-                    call_anchors,
+                    execution_anchors,
                     artifact.function_selectors.iter().copied(),
                     artifact.has_receive,
+                    artifact.fallback_payable,
                 );
             }
             report.add_analysis(build_id.clone(), source_analysis);
@@ -543,6 +545,7 @@ pub struct ArtifactData {
     pub deployed: BytecodeData,
     pub function_selectors: Vec<[u8; 4]>,
     pub has_receive: bool,
+    pub fallback_payable: bool,
 }
 
 impl ArtifactData {
@@ -553,6 +556,10 @@ impl ArtifactData {
             .map(|abi| abi.functions().map(|function| function.selector().into()).collect())
             .unwrap_or_default();
         let has_receive = abi.as_ref().is_some_and(|abi| abi.receive.is_some());
+        let fallback_payable = abi
+            .as_ref()
+            .and_then(|abi| abi.fallback)
+            .is_some_and(|fallback| fallback.state_mutability == StateMutability::Payable);
         Some(Self {
             contract_id: ContractId {
                 version: id.version.clone(),
@@ -574,6 +581,7 @@ impl ArtifactData {
             ),
             function_selectors,
             has_receive,
+            fallback_payable,
         })
     }
 }

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1948,6 +1948,58 @@ end_of_record
 "#]]);
 });
 
+// Test empty shared-memory calldata used by nested calls with isolation disabled.
+forgetest!(empty_shared_calldata, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract AContract {
+    receive() external payable {}
+}
+    "#,
+    );
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import "./AContract.sol";
+
+contract AContractTest is DSTest {
+    address internal target;
+
+    function setUp() public {
+        target = address(new AContract());
+    }
+
+    function test_receive() public {
+        (bool success,) = target.call{gas: 100_000}("");
+        require(success);
+    }
+}
+    "#,
+    );
+
+    let expected = str![[r#"
+TN:
+SF:src/AContract.sol
+DA:5,1
+FN:5,AContract.receive
+FNDA:1,AContract.receive
+FNF:1
+FNH:1
+LF:1
+LH:1
+BRF:0
+BRH:0
+end_of_record
+
+"#]];
+    assert_lcov(cmd.arg("coverage").arg("--no-isolate"), expected.clone());
+    assert_lcov(cmd.forge_fuse().arg("coverage").args(["--no-isolate", "--ir-minimum"]), expected);
+});
+
 // Test that inherited empty constructors, receive functions, and fallbacks have distinct anchors.
 forgetest!(empty_special_functions_are_distinct, |prj, cmd| {
     prj.insert_ds_test();

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1867,10 +1867,10 @@ contract AContractTest is DSTest {
 "#]]);
 });
 
-// https://github.com/foundry-rs/foundry/issues/9270, https://github.com/foundry-rs/foundry/issues/9444
-// Test that special functions with no statements are not counted.
-// TODO: We should support this, but for now just ignore them.
-// See TODO in `visit_function_definition`: https://github.com/foundry-rs/foundry/issues/9458
+// https://github.com/foundry-rs/foundry/issues/9270,
+// https://github.com/foundry-rs/foundry/issues/9444,
+// https://github.com/foundry-rs/foundry/issues/9458
+// Test coverage for functions with no statements.
 forgetest!(empty_functions, |prj, cmd| {
     prj.insert_ds_test();
     prj.add_source(
@@ -1880,6 +1880,8 @@ contract AContract {
     constructor() {}
 
     receive() external payable {}
+
+    fallback() external {}
 
     function increment() public {}
 }
@@ -1898,6 +1900,8 @@ contract AContractTest is DSTest {
         a.increment();
         (bool success,) = address(a).call{value: 1}("");
         require(success);
+        (success,) = address(a).call(hex"deadbeef");
+        require(success);
     }
 }
     "#,
@@ -1908,9 +1912,142 @@ contract AContractTest is DSTest {
         str![[r#"
 TN:
 SF:src/AContract.sol
+DA:5,1
+FN:5,AContract.constructor
+FNDA:1,AContract.constructor
+DA:7,1
+FN:7,AContract.receive
+FNDA:1,AContract.receive
 DA:9,1
-FN:9,AContract.increment
+FN:9,AContract.fallback
+FNDA:1,AContract.fallback
+DA:11,1
+FN:11,AContract.increment
 FNDA:1,AContract.increment
+FNF:4
+FNH:4
+LF:4
+LH:4
+BRF:0
+BRH:0
+end_of_record
+
+"#]],
+    );
+
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
+...
+╭-------------------+---------------+--------------+------------+---------------╮
+| File              | % Lines       | % Statements | % Branches | % Funcs       |
++===============================================================================+
+| src/AContract.sol | 100.00% (4/4) | N/A (0/0)    | N/A (0/0)  | 100.00% (4/4) |
+|-------------------+---------------+--------------+------------+---------------|
+| Total             | 100.00% (4/4) | N/A (0/0)    | N/A (0/0)  | 100.00% (4/4) |
+╰-------------------+---------------+--------------+------------+---------------╯
+
+"#]]);
+});
+
+// Test that inherited empty receive and fallback functions have distinct coverage anchors.
+forgetest!(empty_special_functions_are_distinct, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract Base {
+    receive() external payable {}
+
+    fallback() external {}
+
+    function increment() public {}
+}
+
+contract AContract is Base {}
+    "#,
+    );
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import "./AContract.sol";
+
+contract AContractTest is DSTest {
+    function test_receive() public {
+        AContract a = new AContract();
+        (bool success,) = address(a).call{value: 1}("");
+        require(success);
+    }
+}
+    "#,
+    );
+
+    assert_lcov(
+        cmd.arg("coverage"),
+        str![[r#"
+TN:
+SF:src/AContract.sol
+DA:5,1
+FN:5,Base.receive
+FNDA:1,Base.receive
+DA:7,0
+FN:7,Base.fallback
+FNDA:0,Base.fallback
+DA:9,0
+FN:9,Base.increment
+FNDA:0,Base.increment
+FNF:3
+FNH:1
+LF:3
+LH:1
+BRF:0
+BRH:0
+end_of_record
+
+"#]],
+    );
+});
+
+// Test that a fallback without a receive uses the same anchor for empty and non-empty calldata.
+forgetest!(empty_fallback_without_receive, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract AContract {
+    fallback() external {}
+}
+    "#,
+    );
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import "./AContract.sol";
+
+contract AContractTest is DSTest {
+    function test_fallback() public {
+        AContract a = new AContract();
+        (bool success,) = address(a).call("");
+        require(success);
+        (success,) = address(a).call(hex"01");
+        require(success);
+        (success,) = address(a).call(hex"deadbeef");
+        require(success);
+    }
+}
+    "#,
+    );
+
+    assert_lcov(
+        cmd.arg("coverage"),
+        str![[r#"
+TN:
+SF:src/AContract.sol
+DA:5,3
+FN:5,AContract.fallback
+FNDA:3,AContract.fallback
 FNF:1
 FNH:1
 LF:1
@@ -1921,19 +2058,6 @@ end_of_record
 
 "#]],
     );
-
-    // Assert there's only one function (`increment`) reported.
-    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
-...
-╭-------------------+---------------+--------------+------------+---------------╮
-| File              | % Lines       | % Statements | % Branches | % Funcs       |
-+===============================================================================+
-| src/AContract.sol | 100.00% (1/1) | N/A (0/0)    | N/A (0/0)  | 100.00% (1/1) |
-|-------------------+---------------+--------------+------------+---------------|
-| Total             | 100.00% (1/1) | N/A (0/0)    | N/A (0/0)  | 100.00% (1/1) |
-╰-------------------+---------------+--------------+------------+---------------╯
-
-"#]]);
 });
 
 // Test coverage for `receive` functions.
@@ -1952,6 +2076,8 @@ contract AContract {
     receive() external payable {
         counter = msg.value;
     }
+
+    fallback() external {}
 }
     "#,
     );
@@ -1973,7 +2099,7 @@ contract AContractTest is DSTest {
     "#,
     );
 
-    // Assert both constructor and receive functions coverage reported and appear in LCOV.
+    // Assert the constructor and receive are covered while the empty fallback is not.
     assert_lcov(
         cmd.arg("coverage"),
         str![[r#"
@@ -1987,9 +2113,12 @@ DA:11,1
 FN:11,AContract.receive
 FNDA:1,AContract.receive
 DA:12,1
-FNF:2
+DA:15,0
+FN:15,AContract.fallback
+FNDA:0,AContract.fallback
+FNF:3
 FNH:2
-LF:4
+LF:5
 LH:4
 BRF:0
 BRH:0
@@ -2000,13 +2129,13 @@ end_of_record
 
     cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
-╭-------------------+---------------+---------------+------------+---------------╮
-| File              | % Lines       | % Statements  | % Branches | % Funcs       |
-+================================================================================+
-| src/AContract.sol | 100.00% (4/4) | 100.00% (2/2) | N/A (0/0)  | 100.00% (2/2) |
-|-------------------+---------------+---------------+------------+---------------|
-| Total             | 100.00% (4/4) | 100.00% (2/2) | N/A (0/0)  | 100.00% (2/2) |
-╰-------------------+---------------+---------------+------------+---------------╯
+╭-------------------+--------------+---------------+------------+--------------╮
+| File              | % Lines      | % Statements  | % Branches | % Funcs      |
++==============================================================================+
+| src/AContract.sol | 80.00% (4/5) | 100.00% (2/2) | N/A (0/0)  | 66.67% (2/3) |
+|-------------------+--------------+---------------+------------+--------------|
+| Total             | 80.00% (4/5) | 100.00% (2/2) | N/A (0/0)  | 66.67% (2/3) |
+╰-------------------+--------------+---------------+------------+--------------╯
 
 "#]]);
 });

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1948,13 +1948,15 @@ end_of_record
 "#]]);
 });
 
-// Test that inherited empty receive and fallback functions have distinct coverage anchors.
+// Test that inherited empty constructors, receive functions, and fallbacks have distinct anchors.
 forgetest!(empty_special_functions_are_distinct, |prj, cmd| {
     prj.insert_ds_test();
     prj.add_source(
         "AContract.sol",
         r#"
 contract Base {
+    constructor() {}
+
     receive() external payable {}
 
     fallback() external {}
@@ -1988,18 +1990,21 @@ contract AContractTest is DSTest {
 TN:
 SF:src/AContract.sol
 DA:5,1
-FN:5,Base.receive
+FN:5,Base.constructor
+FNDA:1,Base.constructor
+DA:7,1
+FN:7,Base.receive
 FNDA:1,Base.receive
-DA:7,0
-FN:7,Base.fallback
-FNDA:0,Base.fallback
 DA:9,0
-FN:9,Base.increment
+FN:9,Base.fallback
+FNDA:0,Base.fallback
+DA:11,0
+FN:11,Base.increment
 FNDA:0,Base.increment
-FNF:3
-FNH:1
-LF:3
-LH:1
+FNF:4
+FNH:2
+LF:4
+LH:2
 BRF:0
 BRH:0
 end_of_record
@@ -2015,7 +2020,7 @@ forgetest!(empty_fallback_without_receive, |prj, cmd| {
         "AContract.sol",
         r#"
 contract AContract {
-    fallback() external {}
+    fallback() external payable {}
 }
     "#,
     );
@@ -2029,7 +2034,7 @@ import "./AContract.sol";
 contract AContractTest is DSTest {
     function test_fallback() public {
         AContract a = new AContract();
-        (bool success,) = address(a).call("");
+        (bool success,) = address(a).call{value: 1}("");
         require(success);
         (success,) = address(a).call(hex"01");
         require(success);
@@ -2052,6 +2057,54 @@ FNF:1
 FNH:1
 LF:1
 LH:1
+BRF:0
+BRH:0
+end_of_record
+
+"#]],
+    );
+});
+
+// Test that a nonpayable fallback is not covered by a rejected value-bearing call.
+forgetest!(empty_nonpayable_fallback_rejects_value, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract AContract {
+    fallback() external {}
+}
+    "#,
+    );
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import "./AContract.sol";
+
+contract AContractTest is DSTest {
+    function test_rejected_fallback() public {
+        AContract a = new AContract();
+        (bool success,) = address(a).call{value: 1}(hex"deadbeef");
+        require(!success);
+    }
+}
+    "#,
+    );
+
+    assert_lcov(
+        cmd.arg("coverage"),
+        str![[r#"
+TN:
+SF:src/AContract.sol
+DA:5,0
+FN:5,AContract.fallback
+FNDA:0,AContract.fallback
+FNF:1
+FNH:0
+LF:1
+LH:0
 BRF:0
 BRH:0
 end_of_record
@@ -2138,6 +2191,52 @@ end_of_record
 ╰-------------------+--------------+---------------+------------+--------------╯
 
 "#]]);
+});
+
+// Test empty constructor coverage when via-IR source maps contain no matching span.
+forgetest!(empty_constructor_ir_minimum, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract AContract {
+    constructor() {}
+}
+    "#,
+    );
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import "./AContract.sol";
+
+contract AContractTest is DSTest {
+    function test_constructor() public {
+        new AContract();
+    }
+}
+    "#,
+    );
+
+    assert_lcov(
+        cmd.arg("coverage").arg("--ir-minimum"),
+        str![[r#"
+TN:
+SF:src/AContract.sol
+DA:5,1
+FN:5,AContract.constructor
+FNDA:1,AContract.constructor
+FNF:1
+FNH:1
+LF:1
+LH:1
+BRF:0
+BRH:0
+end_of_record
+
+"#]],
+    );
 });
 
 // https://github.com/foundry-rs/foundry/issues/9322


### PR DESCRIPTION
Empty constructors, receive functions, and fallbacks had no reliable source-mapped opcode, so coverage either omitted them or could not tell receive and fallback apart. This records call routing alongside instruction hits, then uses artifact ABI selectors and Solar's resolved inheritance data to attribute those calls without conflating receive, fallback, or named functions.

Closes #9458.

AI assistance was used for implementation and verification.