### PR TITLE
fix(config): resolve external remapping contexts

### DIFF
--- a/.changelog/external-remapping-contexts.md
+++ b/.changelog/external-remapping-contexts.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-config: patch
+---
+
+Fixed contextual remapping resolution for dependencies outside the project root.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,7 +2737,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3225,7 +3225,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.19",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3384,7 +3384,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4609,7 +4609,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4916,7 +4916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5517,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5759,7 +5759,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5769,7 +5769,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.13.0",
+ "itertools 0.15.0",
  "path-slash",
  "rand 0.10.2",
  "rayon",
@@ -5790,7 +5790,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5799,7 +5799,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5819,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5832,7 +5832,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6164,7 +6164,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6270,7 +6270,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=94b10d5c0108da0a4e58eb05fefe24b717a5c8f0#94b10d5c0108da0a4e58eb05fefe24b717a5c8f0"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -6515,8 +6515,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -6970,7 +6970,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7330,7 +7330,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8151,7 +8151,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9426,7 +9426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9578,7 +9578,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10963,7 +10963,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11022,7 +11022,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11916,7 +11916,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11962,7 +11962,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -12430,7 +12430,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12654,7 +12654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13823,7 +13823,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13971,7 +13971,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "94b10d5c0108da0a4e58eb05fefe24b717a5c8f0", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "d61ff900ecd69272ab810f4fc5ca478e10af7ecf", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -553,9 +553,9 @@ solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e22
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e2267c549555a980aef6b0b1f249eb" }
 
 ## foundry-core
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "94b10d5c0108da0a4e58eb05fefe24b717a5c8f0" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "94b10d5c0108da0a4e58eb05fefe24b717a5c8f0" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "94b10d5c0108da0a4e58eb05fefe24b717a5c8f0" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "d61ff900ecd69272ab810f4fc5ca478e10af7ecf" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "d61ff900ecd69272ab810f4fc5ca478e10af7ecf" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "d61ff900ecd69272ab810f4fc5ca478e10af7ecf" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1550,7 +1550,7 @@ impl Config {
             .scripts(&self.script)
             .artifacts(&self.out)
             .libs(self.libs.iter())
-            .remappings(self.get_all_remappings())
+            .remappings(self.project_remappings())
             .allowed_path(&self.root)
             .allowed_paths(&self.libs)
             .allowed_paths(&self.allow_paths)
@@ -1604,6 +1604,42 @@ impl Config {
     /// Returns all configured remappings.
     pub fn get_all_remappings(&self) -> impl Iterator<Item = Remapping> + '_ {
         self.remappings.iter().map(|m| m.clone().into())
+    }
+
+    /// Returns project remappings with absolute aliases for relative filesystem contexts.
+    fn project_remappings(&self) -> Vec<Remapping> {
+        let remappings = self.get_all_remappings().collect::<Vec<_>>();
+        let mut adjusted = Vec::with_capacity(remappings.len());
+
+        // External source unit names remain absolute in the compiler input, while configured
+        // contexts are root-relative. Preserve the configured order and add an equivalent absolute
+        // context immediately after each relative form so both the project resolver and compiler
+        // select the same mapping.
+        for remapping in &remappings {
+            adjusted.push(remapping.clone());
+
+            let Some(context) = remapping.context.as_deref() else { continue };
+            if Path::new(context).is_absolute() {
+                continue;
+            }
+            let Ok(context_path) = foundry_compilers::utils::normalize_solidity_import_path(
+                &self.root,
+                Path::new(context),
+            ) else {
+                continue;
+            };
+            let mut context_path = context_path.display().to_string();
+            if context.ends_with(['/', '\\']) && !context_path.ends_with(['/', '\\']) {
+                context_path.push(std::path::MAIN_SEPARATOR);
+            }
+
+            let mut absolute = remapping.clone();
+            absolute.context = Some(context_path);
+            if !remappings.contains(&absolute) && !adjusted.contains(&absolute) {
+                adjusted.push(absolute);
+            }
+        }
+        adjusted
     }
 
     /// Returns the configured rpc jwt secret
@@ -3248,6 +3284,66 @@ mod tests {
     fn mark_serialized_invariant_provenance(config: &mut Config) {
         config.invariant.corpus_random_sequence_weight_configured = true;
         config.invariant.workers_configured = true;
+    }
+
+    #[test]
+    fn project_remappings_alias_relative_filesystem_contexts_in_place() {
+        let root = tempdir().unwrap();
+        let dependency = root.path().join("dependency");
+        let absolute_dependency = root.path().join("absolute-dependency");
+        fs::create_dir(&dependency).unwrap();
+        fs::create_dir(&absolute_dependency).unwrap();
+
+        let global_before = Remapping {
+            context: None,
+            name: "global-before/".into(),
+            path: "lib/global-before/".into(),
+        };
+        let relative = Remapping {
+            context: Some(format!("dependency{}", std::path::MAIN_SEPARATOR)),
+            name: "relative/".into(),
+            path: "lib/relative/".into(),
+        };
+        let absolute = Remapping {
+            context: Some(format!(
+                "{}{}",
+                absolute_dependency.display(),
+                std::path::MAIN_SEPARATOR
+            )),
+            name: "absolute/".into(),
+            path: "lib/absolute/".into(),
+        };
+        let missing = Remapping {
+            context: Some(format!("missing{}", std::path::MAIN_SEPARATOR)),
+            name: "missing/".into(),
+            path: "lib/missing/".into(),
+        };
+        let global_after = Remapping {
+            context: None,
+            name: "global-after/".into(),
+            path: "lib/global-after/".into(),
+        };
+        let mut config = Config::with_root(root.path());
+        config.remappings = [
+            global_before.clone(),
+            relative.clone(),
+            absolute.clone(),
+            missing.clone(),
+            global_after.clone(),
+        ]
+        .map(Into::into)
+        .into();
+
+        let mut absolute_alias = relative.clone();
+        absolute_alias.context = Some(format!(
+            "{}{}",
+            config.root.join("dependency").display(),
+            std::path::MAIN_SEPARATOR
+        ));
+        assert_eq!(
+            config.project_remappings(),
+            vec![global_before, relative, absolute_alias, absolute, missing, global_after]
+        );
     }
 
     #[test]

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1195,6 +1195,91 @@ outer/=lib/outer/src/
     cmd.forge_fuse().arg("lint").assert_success();
 });
 
+forgetest!(external_dependency_uses_contextual_remapping, |prj, cmd| {
+    let project = prj.root().join("utils");
+    let dependency = prj.root().join("node_modules/dependency");
+    let library = prj.root().join("node_modules/library/src");
+    pretty_err(&project, fs::create_dir_all(project.join("src")));
+    pretty_err(&dependency, fs::create_dir_all(dependency.join("src/internal")));
+    pretty_err(&library, fs::create_dir_all(&library));
+    pretty_err(
+        &project,
+        fs::write(
+            project.join("foundry.toml"),
+            r#"
+[profile.default]
+src = "src"
+allow_paths = ["../"]
+auto_detect_remappings = false
+remappings = [
+    "dependency/=../node_modules/dependency/src/",
+    "../node_modules/dependency/:library/=../node_modules/library/src/",
+    "library/=../node_modules/library/",
+]
+"#,
+        ),
+    );
+    pretty_err(
+        &project,
+        fs::write(
+            project.join("src/Root.sol"),
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import {Dep} from "dependency/Dep.sol";
+import {RootLibrary} from "library/src/RootLibrary.sol";
+
+contract Root is Dep, RootLibrary {}
+"#,
+        ),
+    );
+    pretty_err(
+        &dependency,
+        fs::write(
+            dependency.join("src/Dep.sol"),
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import {Core} from "./internal/Core.sol";
+
+contract Dep is Core {}
+"#,
+        ),
+    );
+    pretty_err(
+        &dependency,
+        fs::write(
+            dependency.join("src/internal/Core.sol"),
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import {DependencyLibrary} from "library/DependencyLibrary.sol";
+
+contract Core is DependencyLibrary {}
+"#,
+        ),
+    );
+    pretty_err(
+        &library,
+        fs::write(
+            library.join("RootLibrary.sol"),
+            "// SPDX-License-Identifier: UNLICENSED\npragma solidity >=0.8.0;\ncontract RootLibrary {}\n",
+        ),
+    );
+    pretty_err(
+        &library,
+        fs::write(
+            library.join("DependencyLibrary.sol"),
+            "// SPDX-License-Identifier: UNLICENSED\npragma solidity >=0.8.0;\ncontract DependencyLibrary {}\n",
+        ),
+    );
+
+    cmd.args(["build", "--no-lint", "--root", project.to_str().unwrap()]).assert_success();
+});
+
 forgetest!(cli_preserves_explicit_contextual_remapping_pair, |prj, cmd| {
     let dependency = prj.paths().libraries[0].join("dep");
     pretty_err(&dependency, fs::create_dir_all(dependency.join("src")));


### PR DESCRIPTION
## Description

Closes #11587.

Contextual remappings for dependencies outside the project root could be skipped when external source units were canonicalized while their configured contexts remained root-relative. This updates the `foundry-core` pin to include foundry-rs/foundry-core#149 and adds equivalent absolute aliases for relative filesystem contexts while preserving the configured remapping order.

This keeps project resolution and compiler input aligned, allowing contextual remappings to handle conflicting dependency layouts such as the OpenZeppelin upgrades and `forge-std` conflict reported in #11587.