### PR TITLE
fix(mutation): filter fixed-bytes unary ops

### DIFF
--- a/.changelog/mutation-fixed-bytes-unary.md
+++ b/.changelog/mutation-fixed-bytes-unary.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Stopped mutation testing from generating invalid negation and increment replacements for fixed-bytes operands.

--- a/crates/forge/src/mutation/type_analysis.rs
+++ b/crates/forge/src/mutation/type_analysis.rs
@@ -141,10 +141,26 @@ impl<'hir> Visit<'hir> for MutationExclusionCollector<'hir> {
             self.collect_comparison(expr, left, op.kind, right);
         }
         if let ExprKind::Unary(_, operand) = &expr.kind
-            && is_unsigned(self.gcx, operand)
+            && let Some(kind) = unary_operand_kind(self.gcx, operand)
             && let Some(span) = self.local_span(expr.span)
         {
-            self.mutations.insert(MutationExclusion::unary(span, UnOpKind::Neg));
+            match kind {
+                UnaryOperandKind::SignedInteger => {}
+                UnaryOperandKind::UnsignedInteger => {
+                    self.mutations.insert(MutationExclusion::unary(span, UnOpKind::Neg));
+                }
+                UnaryOperandKind::FixedBytes => {
+                    for op in [
+                        UnOpKind::PreInc,
+                        UnOpKind::PreDec,
+                        UnOpKind::PostInc,
+                        UnOpKind::PostDec,
+                        UnOpKind::Neg,
+                    ] {
+                        self.mutations.insert(MutationExclusion::unary(span, op));
+                    }
+                }
+            }
         }
         if let ExprKind::Unary(_, operand) = &expr.kind
             && is_non_storage_push_call(self.gcx, operand)
@@ -294,10 +310,21 @@ fn comparison_operand_kind(
     }
 }
 
-fn is_unsigned(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> bool {
-    gcx.type_of_expr(expr.peel_parens().id).is_some_and(|ty| {
-        matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::UInt(_)))
-    })
+#[derive(Clone, Copy)]
+enum UnaryOperandKind {
+    SignedInteger,
+    UnsignedInteger,
+    FixedBytes,
+}
+
+fn unary_operand_kind(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> Option<UnaryOperandKind> {
+    let ty = gcx.type_of_expr(expr.peel_parens().id)?;
+    match ty.peel_refs().kind {
+        TyKind::Elementary(ElementaryType::Int(_)) => Some(UnaryOperandKind::SignedInteger),
+        TyKind::Elementary(ElementaryType::UInt(_)) => Some(UnaryOperandKind::UnsignedInteger),
+        TyKind::Elementary(ElementaryType::FixedBytes(_)) => Some(UnaryOperandKind::FixedBytes),
+        _ => None,
+    }
 }
 
 fn is_non_storage_push_call(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> bool {
@@ -560,6 +587,62 @@ contract Test {
 
         for op in [UnOpKind::PreInc, UnOpKind::PreDec, UnOpKind::PostInc, UnOpKind::PostDec] {
             assert!(!mutations.contains(&unary_mutation(source, "-values.push()", op)));
+        }
+    }
+
+    #[test]
+    fn excludes_invalid_fixed_bytes_unary_mutations() {
+        let source = r#"
+contract Test {
+    function check(bytes32 word) external pure returns (bytes32) {
+        return ~word;
+    }
+
+    function checkNumber(uint256 number) external pure returns (uint256) {
+        return ~number;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        for op in [
+            UnOpKind::PreInc,
+            UnOpKind::PreDec,
+            UnOpKind::PostInc,
+            UnOpKind::PostDec,
+            UnOpKind::Neg,
+        ] {
+            assert!(mutations.contains(&unary_mutation(source, "~word", op)));
+        }
+        assert!(!mutations.contains(&unary_mutation(source, "~word", UnOpKind::BitNot)));
+
+        for op in [UnOpKind::PreInc, UnOpKind::PreDec, UnOpKind::PostInc, UnOpKind::PostDec] {
+            assert!(!mutations.contains(&unary_mutation(source, "~number", op)));
+        }
+        assert!(mutations.contains(&unary_mutation(source, "~number", UnOpKind::Neg)));
+    }
+
+    #[test]
+    fn excludes_invalid_fixed_bytes_storage_push_mutations() {
+        let source = r#"
+contract Test {
+    bytes32[] values;
+
+    function check() external returns (bytes32) {
+        return ~values.push();
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        for op in [
+            UnOpKind::PreInc,
+            UnOpKind::PreDec,
+            UnOpKind::PostInc,
+            UnOpKind::PostDec,
+            UnOpKind::Neg,
+        ] {
+            assert!(mutations.contains(&unary_mutation(source, "~values.push()", op)));
         }
     }
 

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -235,6 +235,73 @@ exclude_operators = [
     assert_eq!(summary["skipped"], 0);
 });
 
+forgetest_init!(mutation_testing_filters_invalid_fixed_bytes_unary_mutants, |prj, cmd| {
+    prj.add_source(
+        "TypedUnary.sol",
+        r#"
+pragma solidity ^0.8.13;
+
+contract TypedUnary {
+    function complementWord(bytes32 word) public pure returns (bytes32) {
+        return ~word;
+    }
+
+    function complementNumber(uint256 number) public pure returns (uint256) {
+        return ~number;
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "TypedUnary.t.sol",
+        r#"
+pragma solidity ^0.8.13;
+
+import "../src/TypedUnary.sol";
+
+contract TypedUnaryTest {
+    TypedUnary private target = new TypedUnary();
+
+    function testComplementWord() public view {
+        assert(target.complementWord(bytes32(uint256(3))) == ~bytes32(uint256(3)));
+    }
+
+    function testComplementNumber() public view {
+        assert(target.complementNumber(3) == ~uint256(3));
+    }
+}
+"#,
+    );
+
+    fs::write(
+        prj.root().join("foundry.toml"),
+        r#"
+[mutation]
+exclude_operators = [
+    "assembly",
+    "assignment",
+    "binary-op",
+    "delete-expression",
+    "elim-delegate",
+    "require",
+]
+"#,
+    )
+    .unwrap();
+
+    let output = cmd
+        .args(["test", "--mutate", "src/TypedUnary.sol", "--mutation-jobs", "1", "--json"])
+        .assert_success();
+    let summary = mutation_summary(&output.get_output().stdout_lossy());
+
+    assert_eq!(summary["total"], 4);
+    assert_eq!(summary["killed"], 4);
+    assert_eq!(summary["survived"], 0);
+    assert_eq!(summary["invalid"], 0);
+    assert_eq!(summary["skipped"], 0);
+});
+
 forgetest_init!(mutation_testing_comparison_type_matrix, |prj, cmd| {
     prj.add_source(
         "Comparisons.sol",


### PR DESCRIPTION
The unary mutator generated negation and increment or decrement replacements for fixed-bytes operands, even though fixed bytes support bitwise complement but not those replacement operators. These candidates always failed compilation.

This classifies resolved elementary operand types and records replacement-specific exclusions for fixed bytes. It preserves bitwise complement, valid unsigned increment and decrement mutations, storage `push()` behavior, and the existing fail-open handling for unresolved or overloaded user-defined value types.

Implementation was assisted by Codex
