### PR TITLE
fix(mutation): filter compound negation

### DIFF
--- a/.changelog/mutation-compound-assignment-types.md
+++ b/.changelog/mutation-compound-assignment-types.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Stopped mutation testing from generating type-invalid negations for compound-assignment values.

--- a/crates/forge/src/mutation/type_analysis.rs
+++ b/crates/forge/src/mutation/type_analysis.rs
@@ -15,7 +15,7 @@ use foundry_cli::opts::configure_pcx_from_compile_output;
 use foundry_compilers::{ProjectCompileOutput, compilers::multi::MultiCompiler};
 use foundry_config::Config;
 use solar::{
-    ast::{BinOpKind, UnOpKind},
+    ast::{BinOpKind, LitKind, UnOpKind},
     interface::{Session, source_map::FileName},
     sema::{
         Compiler, CompilerRef, Gcx,
@@ -130,10 +130,14 @@ impl<'hir> Visit<'hir> for MutationExclusionCollector<'hir> {
     }
 
     fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
-        if let ExprKind::Assign(destination, None, value) = &expr.kind
+        if let ExprKind::Assign(destination, op, value) = &expr.kind
             && let Some(ty) = self.gcx.type_of_expr(destination.id)
         {
-            self.collect_assignment(value, ty);
+            if let Some(op) = op {
+                self.collect_compound_assignment(value, ty, op.kind);
+            } else {
+                self.collect_assignment(value, ty);
+            }
         }
         if let ExprKind::Binary(left, op, right) = &expr.kind
             && (op.kind.is_cmp() || matches!(op.kind, BinOpKind::And | BinOpKind::Or))
@@ -174,6 +178,25 @@ impl MutationExclusionCollector<'_> {
             self.mutations.insert(MutationExclusion::assignment(span, AssignmentReplacement::Zero));
         }
         if !kind.accepts_negation() {
+            self.mutations
+                .insert(MutationExclusion::assignment(span, AssignmentReplacement::Negate));
+        }
+    }
+
+    fn collect_compound_assignment(
+        &mut self,
+        value: &hir::Expr<'_>,
+        destination: solar::sema::ty::Ty<'_>,
+        op: BinOpKind,
+    ) {
+        let Some(span) = self.local_span(value.span) else { return };
+        let Some(destination) = assignment_destination_kind(destination) else { return };
+        let Some(value_accepts_negation) = assignment_value_accepts_negation(self.gcx, value)
+        else {
+            return;
+        };
+
+        if op.is_shift() || !destination.accepts_negation() || !value_accepts_negation {
             self.mutations
                 .insert(MutationExclusion::assignment(span, AssignmentReplacement::Negate));
         }
@@ -244,6 +267,23 @@ fn assignment_destination_kind(ty: solar::sema::ty::Ty<'_>) -> Option<Assignment
         }
         TyKind::Udvt(..) | TyKind::Err(_) => None,
         _ => Some(AssignmentDestinationKind::Other),
+    }
+}
+
+fn assignment_value_accepts_negation(gcx: Gcx<'_>, value: &hir::Expr<'_>) -> Option<bool> {
+    if matches!(&value.peel_parens().kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Number(_)))
+    {
+        return Some(true);
+    }
+
+    let ty = gcx.type_of_expr(value.peel_parens().id)?;
+    match ty.peel_refs().kind {
+        TyKind::Elementary(ElementaryType::Int(_) | ElementaryType::Fixed(..)) => Some(true),
+        TyKind::Elementary(
+            ElementaryType::UInt(_) | ElementaryType::UFixed(..) | ElementaryType::FixedBytes(_),
+        ) => Some(false),
+        TyKind::Udvt(..) | TyKind::Err(_) => None,
+        _ => Some(false),
     }
 }
 
@@ -429,6 +469,68 @@ contract Test {
                 source,
                 value,
                 AssignmentReplacement::Negate,
+            )));
+        }
+    }
+
+    #[test]
+    fn excludes_invalid_compound_assignment_negation() {
+        let source = r#"
+contract Test {
+    uint256 unsignedTotal;
+    int256 signedTotal;
+    bytes32 word;
+
+    function check(
+        uint256 unsignedAmount,
+        int256 signedAmount,
+        bytes32 mask,
+        uint8 shift
+    ) external {
+        unsignedTotal += unsignedAmount;
+        signedTotal += signedAmount;
+        word &= mask;
+        signedTotal <<= shift;
+        signedTotal += 11;
+        signedTotal &= 12;
+        signedTotal <<= 13;
+        signedTotal >>= 14;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        for value in ["unsignedAmount", "mask", "shift"] {
+            assert!(mutations.contains(&assignment_mutation(
+                source,
+                value,
+                AssignmentReplacement::Negate,
+            )));
+        }
+        assert!(!mutations.contains(&assignment_mutation(
+            source,
+            "signedAmount",
+            AssignmentReplacement::Negate,
+        )));
+        for value in ["11", "12"] {
+            assert!(!mutations.contains(&assignment_mutation(
+                source,
+                value,
+                AssignmentReplacement::Negate,
+            )));
+        }
+        for value in ["13", "14"] {
+            assert!(mutations.contains(&assignment_mutation(
+                source,
+                value,
+                AssignmentReplacement::Negate,
+            )));
+        }
+        for value in ["unsignedAmount", "signedAmount", "mask", "shift"] {
+            assert!(!mutations.contains(&assignment_mutation(
+                source,
+                value,
+                AssignmentReplacement::Zero,
             )));
         }
     }

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -1947,16 +1947,16 @@ MUTATION TESTING RESULTS
 ╭──────────┬───────────┬────────────╮
 │ Status   ┆ # Mutants ┆ % of Total │
 ╞══════════╪═══════════╪════════════╡
-│ Survived ┆ 3         ┆ 5.6%       │
+│ Survived ┆ 3         ┆ 5.7%       │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Killed   ┆ 49        ┆ 90.7%      │
+│ Killed   ┆ 48        ┆ 90.6%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Invalid  ┆ 1         ┆ 1.9%       │
+│ Invalid  ┆ 0         ┆ 0.0%       │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Skipped  ┆ 1         ┆ 1.9%       │
+│ Skipped  ┆ 2         ┆ 3.8%       │
 ╰──────────┴───────────┴────────────╯
 ...
-Mutation Score: 94.2% (49/52 mutants killed); [ELAPSED]
+Mutation Score: 94.1% (48/51 mutants killed); [ELAPSED]
 ...
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -235,6 +235,95 @@ exclude_operators = [
     assert_eq!(summary["skipped"], 0);
 });
 
+forgetest_init!(mutation_testing_filters_invalid_compound_assignments, |prj, cmd| {
+    prj.add_source(
+        "CompoundAssignments.sol",
+        r#"
+pragma solidity ^0.8.13;
+
+contract CompoundAssignments {
+    uint256 public unsignedTotal;
+    int256 public signedTotal;
+
+    function update(uint256 unsignedAmount, int256 signedAmount) public {
+        unsignedTotal += unsignedAmount;
+        signedTotal += signedAmount;
+    }
+
+    function shift(int256 value, uint8 amount) public pure returns (int256) {
+        value <<= amount;
+        return value;
+    }
+
+    function shiftLeftLiteral(int256 value) public pure returns (int256) {
+        value <<= 2;
+        return value;
+    }
+
+    function shiftRightLiteral(int256 value) public pure returns (int256) {
+        value >>= 3;
+        return value;
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "CompoundAssignments.t.sol",
+        r#"
+pragma solidity ^0.8.13;
+
+import "../src/CompoundAssignments.sol";
+
+contract CompoundAssignmentsTest {
+    CompoundAssignments private target = new CompoundAssignments();
+
+    function testUpdate() public {
+        target.update(3, 4);
+        assert(target.unsignedTotal() == 3);
+        assert(target.signedTotal() == 4);
+    }
+
+    function testShift() public view {
+        assert(target.shift(1, 2) == 4);
+    }
+
+    function testShiftLiterals() public view {
+        assert(target.shiftLeftLiteral(32) == 128);
+        assert(target.shiftRightLiteral(32) == 4);
+    }
+}
+"#,
+    );
+
+    fs::write(
+        prj.root().join("foundry.toml"),
+        r#"
+[mutation]
+exclude_operators = [
+    "assembly",
+    "binary-op",
+    "delete-expression",
+    "elim-delegate",
+    "require",
+    "unary-op",
+]
+"#,
+    )
+    .unwrap();
+
+    let output = cmd
+        .args(["test", "--mutate", "src/CompoundAssignments.sol", "--mutation-jobs", "1", "--json"])
+        .assert_success();
+    let summary = mutation_summary(&output.get_output().stdout_lossy());
+
+    assert_eq!(summary["total"], 6);
+    assert_eq!(summary["killed"], 6);
+    assert_eq!(summary["survived"], 0);
+    assert_eq!(summary["invalid"], 0);
+    assert_eq!(summary["skipped"], 0);
+});
+
 forgetest_init!(mutation_testing_comparison_type_matrix, |prj, cmd| {
     prj.add_source(
         "Comparisons.sol",


### PR DESCRIPTION
Assignment mutation also applies to compound assignments, but semantic filtering previously covered only plain assignments. This allowed mutation testing to negate unsigned or fixed-bytes right-hand operands and shift amounts, producing mutants that cannot compile.

This extends the HIR analysis to compound assignments and excludes only type-invalid negations based on the operator and resolved operand types. Signed non-shift operands and valid numeric-literal replacements remain available, while unresolved types and user-defined value types continue to fail open.

Implementation was assisted by Codex
