### PR TITLE
fix(anvil): close IPC connections on shutdown

### DIFF
--- a/.changelog/close-ipc-connections-on-shutdown.md
+++ b/.changelog/close-ipc-connections-on-shutdown.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Close established IPC connections when their Anvil node shuts down.

--- a/crates/anvil/src/server/mod.rs
+++ b/crates/anvil/src/server/mod.rs
@@ -8,7 +8,7 @@ use foundry_primitives::FoundryNetwork;
 use futures::StreamExt;
 use rpc_handlers::{HttpEthRpcHandler, PubSubEthRpcHandler};
 use std::{io, net::SocketAddr, pin::pin};
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, task::JoinSet};
 
 mod beacon;
 mod rpc_handlers;
@@ -69,9 +69,20 @@ pub fn try_spawn_ipc(api: EthApi<FoundryNetwork>, path: String) -> io::Result<Ip
 
     let task = tokio::task::spawn(async move {
         let mut incoming = pin!(incoming);
-        while let Some(stream) = incoming.next().await {
-            trace!(target: "ipc", "new ipc connection");
-            tokio::task::spawn(stream);
+        let mut connections = JoinSet::new();
+        loop {
+            tokio::select! {
+                stream = incoming.next() => {
+                    let Some(stream) = stream else { break };
+                    trace!(target: "ipc", "new ipc connection");
+                    connections.spawn(stream);
+                }
+                result = connections.join_next(), if !connections.is_empty() => {
+                    if let Some(Err(err)) = result {
+                        warn!(target: "ipc", %err, "IPC connection task failed");
+                    }
+                }
+            }
         }
     });
 

--- a/crates/anvil/tests/it/ipc.rs
+++ b/crates/anvil/tests/it/ipc.rs
@@ -1,10 +1,11 @@
 //! IPC tests
 
 use crate::{init_tracing, utils::connect_pubsub};
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use anvil::{NodeConfig, spawn};
 use futures::StreamExt;
+use std::time::Duration;
 use tempfile::TempDir;
 
 fn ipc_config() -> (Option<TempDir>, NodeConfig) {
@@ -36,6 +37,25 @@ async fn can_get_block_number_ipc() {
 
     let num = provider.get_block_number().await.unwrap();
     assert_eq!(num, block_num.to::<u64>());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dropping_handle_closes_ipc_connections() {
+    let (_dir, config) = ipc_config();
+    let (_api, handle) = spawn(config).await;
+    let provider = handle.ipc_provider().unwrap();
+
+    provider.get_balance(Address::ZERO).await.unwrap();
+    drop(handle);
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while let Ok(Ok(_)) =
+            tokio::time::timeout(Duration::from_millis(500), provider.get_balance(Address::ZERO))
+                .await
+        {}
+    })
+    .await
+    .expect("IPC connection continued serving requests after node shutdown");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Dropping `NodeHandle` stopped the IPC listener, but connections that had already been accepted were running as detached tasks and continued serving RPC requests. This allowed existing IPC clients to retain access to the node backend after Anvil was expected to have shut down.

This change tracks accepted connections under the listener task so shutting down the node also closes its active IPC connections. Completed connection tasks are cleaned up during normal operation, and the regression test accounts for Alloy’s automatic IPC reconnection behavior.