### PR TITLE
fix: resolve Rust 1.96 clippy warnings

### DIFF
--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -277,8 +277,9 @@ pub(crate) async fn send_tip20_transaction(
     }
 
     let timeout = send_tx.timeout.unwrap_or(config.transaction_timeout);
+    // Box the larger branch-specific build futures to keep the parent async frame small.
     if let Some(browser) = send_tx.browser.run::<TempoNetwork>().await? {
-        let (mut tx, _) = builder.with_browser_wallet().build(browser.address()).await?;
+        let (mut tx, _) = Box::pin(builder.with_browser_wallet().build(browser.address())).await?;
         maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
         if let Some(sponsor) = &tempo_sponsor {
             attach_sponsor(
@@ -304,7 +305,7 @@ pub(crate) async fn send_tip20_transaction(
             .print_tx_result(tx_hash, send_tx.cast_async, send_tx.confirmations, timeout)
             .await?;
     } else if let Some(ak) = access_key {
-        let (mut tx, _, prepared) = builder.build_with_tempo_wallet(&ak).await?;
+        let (mut tx, _, prepared) = Box::pin(builder.build_with_tempo_wallet(&ak)).await?;
         maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
         if let Some(sponsor) = &tempo_sponsor {
             attach_sponsor(
@@ -346,7 +347,7 @@ pub(crate) async fn send_tip20_transaction(
     } else if let Some(sponsor_url) = sponsor_url {
         let (signer, _) = resolve_send_signer(pre_resolved_signer, &send_tx.eth).await?;
 
-        let (mut tx, _) = builder.build(&signer).await?;
+        let (mut tx, _) = Box::pin(builder.build(&signer)).await?;
         maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
         tx.set_fee_payer_signature(FEE_PAYER_SIGNATURE_MARKER);
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1167,32 +1167,27 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
                 }
             }
             OpcodeStepDispatch::General => {
-                if storage_hook_active {
-                    call_inspectors!(
-                        [
-                            // These are sorted in definition order.
-                            &mut self.printer,
-                            &mut self.revert_diag,
-                            &mut self.script_execution_inspector,
-                            &mut self.tracer,
-                        ],
-                        |inspector| (**inspector).step(interpreter, ecx),
-                    );
-                } else {
+                if !storage_hook_active {
                     call_inspectors!(
                         [
                             // These are sorted in definition order.
                             &mut self.edge_coverage,
                             &mut self.fuzzer,
                             &mut self.line_coverage,
-                            &mut self.printer,
-                            &mut self.revert_diag,
-                            &mut self.script_execution_inspector,
-                            &mut self.tracer,
                         ],
                         |inspector| (**inspector).step(interpreter, ecx),
                     );
                 }
+                call_inspectors!(
+                    [
+                        // These are sorted in definition order.
+                        &mut self.printer,
+                        &mut self.revert_diag,
+                        &mut self.script_execution_inspector,
+                        &mut self.tracer,
+                    ],
+                    |inspector| (**inspector).step(interpreter, ecx),
+                );
             }
         }
 


### PR DESCRIPTION
Rust 1.96 reports `branches_sharing_code` in the EVM inspector stack and `large_stack_frames` in TIP-20 transaction handling.

This moves the common inspector dispatch outside the storage-hook conditional while preserving inspector order. It also boxes only the branch-specific transaction build futures that cause `send_tip20_transaction` to exceed the configured 512 KB stack-frame threshold. The ordinary signer path remains allocation-free.

This is a maintenance-only change without user-facing behavior changes, so a maintainer should apply `L-ignore`.

AI assistance was used to investigate the warnings, implement the changes, and validate the result.
