### PR TITLE
fix(networks): make Monad-only lint clean

### DIFF
--- a/.changelog/monad-only-network-clippy.md
+++ b/.changelog/monad-only-network-clippy.md
@@ -1,0 +1,5 @@
+---
+foundry-evm-networks: patch
+---
+
+Fixed linting for Monad-only builds of Foundry's EVM network package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,10 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features --locked
         env:
           RUSTFLAGS: -Dwarnings
+      - name: Lint Monad-only network support
+        run: cargo clippy -p foundry-evm-networks --no-default-features --features monad --tests --locked
+        env:
+          RUSTFLAGS: -Dwarnings
 
   rustfmt:
     runs-on: depot-ubuntu-latest

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -895,14 +895,14 @@ mod tests {
     #[test]
     #[cfg(feature = "monad")]
     fn fork_sources_only_isolate_monad() {
-        let mut non_monad = vec![
+        let non_monad = [
             NetworkConfigs::default(),
             NetworkConfigs::with_ethereum(),
             NetworkConfigs::with_celo(),
             NetworkConfigs::with_tempo(),
+            #[cfg(feature = "optimism")]
+            NetworkConfigs::with_optimism(),
         ];
-        #[cfg(feature = "optimism")]
-        non_monad.push(NetworkConfigs::with_optimism());
 
         for execution in &non_monad {
             for source in &non_monad {


### PR DESCRIPTION
Fixes #16146.

The Monad-only feature combination compiled a test fixture with a mutable vector whose only mutation was gated by Optimism, so strict Clippy failed when default features were disabled. This builds the fixture directly from cfg-gated array elements and adds the isolated feature combination to CI so supported profiles remain warning-free.
