### PR TITLE
fix(evm): honor explicit fork network

### DIFF
--- a/.changelog/explicit-fork-network-override.md
+++ b/.changelog/explicit-fork-network-override.md
@@ -1,0 +1,8 @@
+---
+anvil: patch
+cast: patch
+chisel: patch
+forge: patch
+---
+
+Preserved explicit execution-network selections when resolving fork endpoints without authoritative network metadata.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1524,9 +1524,7 @@ impl NodeConfig {
     ) -> Result<ForkEndpointIdentity> {
         let Some(node_info) = node_info_probe.request(provider).await? else {
             let source_chain_id = source_chain_id_override.unwrap_or(fallback_execution_chain_id);
-            let explicit_fallback = self
-                .has_explicit_network_selection()
-                .then(|| self.networks.canonical_execution_profile());
+            let explicit_fallback = self.has_explicit_network_selection().then_some(self.networks);
             let network_profile = NetworkConfigs::from_rpc_identity_profile_with_fallback(
                 source_chain_id,
                 None,
@@ -1574,9 +1572,7 @@ impl NodeConfig {
         };
         let identity_chain_id =
             if node_info.network.is_some() { execution_chain_id } else { source_chain_id };
-        let explicit_fallback = self
-            .has_explicit_network_selection()
-            .then(|| self.networks.canonical_execution_profile());
+        let explicit_fallback = self.has_explicit_network_selection().then_some(self.networks);
         let network_profile = NetworkConfigs::from_rpc_identity_profile_with_fallback(
             identity_chain_id,
             Some(node_info.network.as_deref()),

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -396,7 +396,7 @@ impl EvmOpts {
 
     fn endpoint_network_fallback(&self) -> NetworkConfigs {
         if self.networks.has_network_selection() && !self.fork_network_is_inferred {
-            self.networks.canonical_execution_profile()
+            self.networks
         } else {
             NetworkConfigs::default()
         }
@@ -1575,6 +1575,17 @@ mod tests {
         assert_eq!(description, "provider example.com");
         assert!(!description.contains("secret"));
         assert!(!description.contains("private-api-key"));
+    }
+
+    #[test]
+    fn endpoint_network_fallback_preserves_explicit_selection() {
+        let default = EvmOpts::default().endpoint_network_fallback();
+        assert!(!default.has_network_selection());
+
+        let explicit = EvmOpts { networks: NetworkConfigs::with_ethereum(), ..Default::default() }
+            .endpoint_network_fallback();
+        assert!(explicit.has_network_selection());
+        assert_eq!(explicit.execution_network(), NetworkVariant::Ethereum);
     }
 
     #[test]

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -672,9 +672,10 @@ impl NetworkConfigs {
 
     /// Resolves an RPC endpoint's complete execution profile.
     ///
-    /// Explicit metadata is authoritative. Legacy Anvil responses and ordinary RPC endpoints
-    /// recover Celo only from a canonical Celo chain ID; a caller-supplied fallback handles custom
-    /// chain IDs when the profile was selected explicitly.
+    /// Explicit metadata is authoritative. When metadata is absent or omits the profile, a
+    /// caller-supplied explicit profile takes precedence over chain-ID inference. Otherwise,
+    /// legacy Anvil responses and ordinary RPC endpoints recover Celo from a canonical Celo chain
+    /// ID and preserve the historical behavior for custom chain IDs.
     pub fn from_rpc_identity_profile_with_fallback(
         chain_id: ChainId,
         node_info_profile: Option<Option<&str>>,
@@ -685,11 +686,19 @@ impl NetworkConfigs {
                 network.map(|network| Self::default().with_rpc_identity(network, chain_id))
             })
         };
+        let fallback_is_explicit =
+            unknown_fallback.is_some_and(|fallback| fallback.has_network_selection());
         let fallback = unknown_fallback.map(Self::canonical_execution_profile);
+        if let Some(Some(profile)) = node_info_profile {
+            return Self::from_node_info_profile(profile).map(Some);
+        }
+        if fallback_is_explicit && let Some(fallback) = fallback {
+            return Ok(Some(fallback));
+        }
         match node_info_profile {
-            Some(Some(profile)) => Self::from_node_info_profile(profile).map(Some),
             Some(None) => Ok(known_profile()?.or(fallback).or(Some(Self::default()))),
             None => Ok(known_profile()?.or(fallback)),
+            Some(Some(_)) => unreachable!(),
         }
     }
 
@@ -1087,6 +1096,80 @@ mod tests {
 
         assert_eq!(profile, NetworkConfigs::default());
         assert!(profile.bypass_prevrandao(NamedChain::Moonbeam as u64));
+    }
+
+    #[test]
+    fn default_fallback_still_infers_known_execution_profile() {
+        for node_info in [None, Some(None)] {
+            assert_eq!(
+                NetworkConfigs::from_rpc_identity_profile_with_fallback(
+                    NamedChain::Tempo as u64,
+                    node_info,
+                    Some(NetworkConfigs::default()),
+                )
+                .unwrap(),
+                Some(NetworkConfigs::with_tempo())
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_ethereum_overrides_known_execution_profile() {
+        for node_info in [None, Some(None)] {
+            assert_eq!(
+                NetworkConfigs::from_rpc_identity_profile_with_fallback(
+                    NamedChain::Tempo as u64,
+                    node_info,
+                    Some(NetworkConfigs::with_ethereum()),
+                )
+                .unwrap(),
+                Some(NetworkConfigs::default())
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(not(feature = "monad"))]
+    fn explicit_ethereum_overrides_disabled_monad_without_node_info() {
+        assert_eq!(
+            NetworkConfigs::from_rpc_identity_profile_with_fallback(
+                NamedChain::Monad as u64,
+                None,
+                Some(NetworkConfigs::with_ethereum()),
+            )
+            .unwrap(),
+            Some(NetworkConfigs::default())
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "monad"))]
+    fn explicit_ethereum_overrides_disabled_monad_with_legacy_node_info() {
+        assert_eq!(
+            NetworkConfigs::from_rpc_identity_profile_with_fallback(
+                NamedChain::Monad as u64,
+                Some(None),
+                Some(NetworkConfigs::with_ethereum()),
+            )
+            .unwrap(),
+            Some(NetworkConfigs::default())
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "monad"))]
+    fn disabled_monad_without_explicit_profile_still_errors() {
+        for node_info in [None, Some(None)] {
+            assert_eq!(
+                NetworkConfigs::from_rpc_identity_profile_with_fallback(
+                    NamedChain::Monad as u64,
+                    node_info,
+                    None,
+                )
+                .unwrap_err(),
+                "network family `monad` is not enabled in this build"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

#15343 Monad follow-up.

Prefer an explicit caller-selected execution profile before chain-ID inference when fork metadata is absent or legacy. This prevents disabled known network families from overriding an explicit Ethereum selection.
