### PR TITLE
fix(anvil): preserve fork endpoint identity

### DIFF
--- a/.changelog/anvil-fork-endpoint-identity.md
+++ b/.changelog/anvil-fork-endpoint-identity.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Kept fork endpoint identity validation strict and atomic during resets and RPC URL replacement.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1604,26 +1604,6 @@ impl NodeConfig {
         })
     }
 
-    fn offline_fork_identity(&self, chain_id: u64) -> Result<ForkEndpointIdentity> {
-        ensure_fork_network_supported(chain_id)?;
-        let network_profile = if self.networks.has_network_selection() {
-            Some(self.networks.canonical_execution_profile())
-        } else {
-            NetworkConfigs::from_rpc_identity_profile_with_fallback(chain_id, None, None)
-                .map_err(eyre::Report::msg)?
-        };
-        Ok(ForkEndpointIdentity {
-            execution_chain_id: chain_id,
-            source_chain_id: chain_id,
-            network: network_profile.map(|profile| profile.execution_network()),
-            network_profile,
-            hardfork: None,
-            instance_id: None,
-            source_fork_block_number: None,
-            source_fork_block_hash: None,
-        })
-    }
-
     async fn resolved_fork_endpoint_identity(
         &self,
         provider: &RetryProvider,
@@ -1644,22 +1624,46 @@ impl NodeConfig {
         Ok(identity)
     }
 
-    pub(crate) async fn stable_fork_provider(
+    pub(crate) async fn replacement_fork_provider(
         &self,
         eth_rpc_url: &str,
-    ) -> Result<Arc<RetryProvider>> {
+        expected: ForkEndpointIdentity,
+        block_number: u64,
+        block_hash: B256,
+        serving_instance_id: B256,
+    ) -> Result<(Arc<RetryProvider>, ForkEndpointIdentity)> {
         let provider = Arc::new(self.fork_provider(eth_rpc_url)?);
         let mut node_info_probe = AnvilNodeInfoProbe::default();
         for _ in 0..3 {
             let before =
                 self.resolved_fork_endpoint_identity(&provider, &mut node_info_probe).await?;
+            eyre::ensure!(
+                before.instance_id != Some(serving_instance_id),
+                "cannot set Anvil's fork provider to its own RPC endpoint"
+            );
+            let block = provider
+                .get_block(BlockNumberOrTag::Number(block_number).into())
+                .await
+                .wrap_err("failed to confirm active fork block on replacement endpoint")?;
             let after =
                 self.resolved_fork_endpoint_identity(&provider, &mut node_info_probe).await?;
-            if before == after {
-                return Ok(provider);
+            if before != after {
+                continue;
             }
+            if !before.context_eq(expected) {
+                eyre::bail!("replacement fork endpoint has an incompatible execution context");
+            }
+            let actual_hash = block.map(|block| block.header.hash);
+            if actual_hash != Some(block_hash) {
+                eyre::bail!(
+                    "replacement fork endpoint does not contain active fork block {block_number} with hash {block_hash}"
+                );
+            }
+            return Ok((provider, before));
         }
-        eyre::bail!("fork endpoint changed while its identity was being resolved");
+        eyre::bail!(
+            "fork endpoint changed while its identity and active fork block were being resolved"
+        );
     }
 
     async fn stable_fork_snapshot(
@@ -1782,21 +1786,6 @@ impl NodeConfig {
         endpoint_identity.is_authoritative() || self.fork_urls.len() > 1
     }
 
-    pub(crate) async fn detect_fork_network(&self, eth_rpc_url: &str) -> Result<NetworkConfigs> {
-        if let Some(chain_id) = self.fork_chain_id {
-            let identity = self.offline_fork_identity(chain_id.to())?;
-            return Ok(identity.network_profile.unwrap_or_default());
-        }
-
-        let provider = self.fork_provider(eth_rpc_url)?;
-        let mut node_info_probe = AnvilNodeInfoProbe::default();
-        let identity =
-            self.resolved_fork_endpoint_identity(&provider, &mut node_info_probe).await?;
-        // Preserve Foundry's historical behavior for custom EVM chains that do not expose Anvil
-        // metadata. Authoritative metadata still wins when present.
-        Ok(identity.network_profile.unwrap_or_default())
-    }
-
     /// Configures everything related to forking based on the passed `eth_rpc_url`:
     ///  - returning a tuple of a [ForkedDatabase] and [ClientForkConfig] which can be used to build
     ///    a [ClientFork] to fork from.
@@ -1855,7 +1844,7 @@ impl NodeConfig {
             && !self.networks.supports_fork_source(&target_profile)
         {
             eyre::bail!(
-                "cannot reset Anvil across execution profiles ({} -> {}); start a new instance \
+                "cannot reset Anvil across network families ({} -> {}); start a new instance \
                  with matching network configuration",
                 self.networks.execution_profile_name(),
                 target_profile.execution_profile_name()
@@ -2633,25 +2622,5 @@ mod tests {
 
         assert_eq!(config.get_chain_id(), 1);
         assert_eq!(config.get_hardfork(), FoundryHardfork::Monad(MonadHardfork::MonadEight));
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "monad")]
-    async fn fork_chain_id_network_detection_is_offline() {
-        let config =
-            NodeConfig::test().with_fork_chain_id(Some(U256::from(NamedChain::Monad as u64)));
-
-        let networks = config.detect_fork_network("http://127.0.0.1:1").await.unwrap();
-
-        assert!(networks.is_monad());
-    }
-
-    #[tokio::test]
-    async fn unknown_fork_chain_id_defaults_to_ethereum_offline() {
-        let config = NodeConfig::test().with_fork_chain_id(Some(U256::from(98_765_432u64)));
-
-        let networks = config.detect_fork_network("http://127.0.0.1:1").await.unwrap();
-
-        assert_eq!(networks, NetworkConfigs::default());
     }
 }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -5063,10 +5063,13 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn set_rpc_url_installs_context_equivalent_identity_with_new_instance() {
-        let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+        let genesis_timestamp = 1_700_000_000u64;
+        let (_origin_api, origin_handle) =
+            spawn(NodeConfig::test().with_genesis_timestamp(Some(genesis_timestamp))).await;
         let (api, _handle) =
             spawn(NodeConfig::test().with_eth_rpc_url(Some(origin_handle.http_endpoint()))).await;
-        let (target_api, target_handle) = spawn(NodeConfig::test()).await;
+        let (target_api, target_handle) =
+            spawn(NodeConfig::test().with_genesis_timestamp(Some(genesis_timestamp))).await;
         let target_url = target_handle.http_endpoint();
         let fork = api.backend.get_fork().unwrap();
         let identity_before = fork.config.read().endpoint_identity;

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -609,11 +609,23 @@ impl<N: Network> EthApi<N> {
         let _reset = self.reset_lock.lock().await;
         let staged_fork = if let Some(fork) = self.backend.get_fork() {
             let mut validation_config = self.backend.node_config.read().await.clone();
+            let (expected_identity, block_number, block_hash) = {
+                let config = fork.config.read();
+                (config.endpoint_identity, config.block_number, config.block_hash)
+            };
             // A new URL replaces an offline discovery hint. Resolve the actual source identity so
             // unsupported networks cannot be hidden behind the previous endpoint's hint.
             validation_config.fork_chain_id = None;
-            let provider = validation_config.stable_fork_provider(&url).await?;
-            Some((fork, provider))
+            let (provider, endpoint_identity) = validation_config
+                .replacement_fork_provider(
+                    &url,
+                    expected_identity,
+                    block_number,
+                    block_hash,
+                    self.instance_id(),
+                )
+                .await?;
+            Some((fork, provider, endpoint_identity))
         } else {
             None
         };
@@ -621,12 +633,13 @@ impl<N: Network> EthApi<N> {
         let _lifecycle = self.lifecycle_lock.write().await;
         let _mining = self.backend.lock_mining().await;
         let mut node_config = self.backend.node_config.write().await;
-        if let Some((fork, provider)) = staged_fork {
+        if let Some((fork, provider, endpoint_identity)) = staged_fork {
             let mut config = fork.config.write();
             trace!(target: "backend", "Updated fork rpc from \"{}\" to \"{}\"", config.eth_rpc_url().unwrap_or("none"), url);
             config.provider = provider;
             config.fork_urls = vec![url.clone()];
             config.fork_chain_id = None;
+            config.endpoint_identity = endpoint_identity;
         }
         // Keep node_config in sync so a subsequent URL-less fork reset uses the updated endpoint.
         node_config.fork_urls = vec![url];
@@ -5047,6 +5060,26 @@ fn merge_pre_fork_fee_history(
 mod tests {
     use super::*;
     use crate::{NodeConfig, spawn};
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_rpc_url_installs_context_equivalent_identity_with_new_instance() {
+        let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+        let (api, _handle) =
+            spawn(NodeConfig::test().with_eth_rpc_url(Some(origin_handle.http_endpoint()))).await;
+        let (target_api, target_handle) = spawn(NodeConfig::test()).await;
+        let target_url = target_handle.http_endpoint();
+        let fork = api.backend.get_fork().unwrap();
+        let identity_before = fork.config.read().endpoint_identity;
+
+        api.anvil_set_rpc_url(target_url.clone()).await.unwrap();
+
+        let fork = api.backend.get_fork().unwrap();
+        let config = fork.config.read();
+        assert!(config.endpoint_identity.context_eq(identity_before));
+        assert_ne!(config.endpoint_identity.instance_id, identity_before.instance_id);
+        assert_eq!(config.endpoint_identity.instance_id, Some(target_api.instance_id()));
+        assert_eq!(config.eth_rpc_url(), Some(target_url.as_str()));
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn memory_reset_stages_live_fees_after_active_mining() {

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -64,6 +64,17 @@ impl ForkEndpointIdentity {
     pub(crate) const fn is_authoritative(self) -> bool {
         self.hardfork.is_some()
     }
+
+    /// Returns whether two endpoints expose the same fork execution context.
+    pub(crate) fn context_eq(self, other: Self) -> bool {
+        self.execution_chain_id == other.execution_chain_id
+            && self.source_chain_id == other.source_chain_id
+            && self.network == other.network
+            && self.network_profile == other.network_profile
+            && self.hardfork == other.hardfork
+            && self.source_fork_block_number == other.source_fork_block_number
+            && self.source_fork_block_hash == other.source_fork_block_hash
+    }
 }
 
 /// Ensures the fork network can be executed by Anvil's EVM backend.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4642,13 +4642,7 @@ impl<N: Network> Backend<N> {
                     )
                 })?
         };
-        let target_rpc_url = target_rpc_urls.first().ok_or_else(|| {
-            RpcError::invalid_params(
-                "Forking not enabled and RPC URL not provided to start forking",
-            )
-        })?;
         let flush_old_cache = previous_fork.is_some();
-        self.ensure_reset_network(target_rpc_url).await?;
         if flush_old_cache {
             // Staging opens a separate BlockchainDb from disk. Persist the live remote cache first
             // so an unchanged source and block can reuse it without copying locally modified state.
@@ -4743,7 +4737,7 @@ impl<N: Network> Backend<N> {
                 && !self.networks.supports_fork_source(&target_networks)
             {
                 return Err(RpcError::invalid_params(format!(
-                    "cannot reset Anvil across execution profiles ({} -> {}); start a new \
+                    "cannot reset Anvil across network families ({} -> {}); start a new \
                      instance with matching network configuration",
                     self.execution_profile_name(),
                     target_networks.execution_profile_name()
@@ -4911,24 +4905,6 @@ impl<N: Network> Backend<N> {
         self.cheats.clear_next_block_prevrandao();
 
         trace!(target: "backend", "reset fork");
-        Ok(())
-    }
-
-    async fn ensure_reset_network(&self, fork_url: &str) -> Result<(), BlockchainError> {
-        let node_config = self.node_config.read().await.clone();
-        if node_config.has_explicit_network_selection() {
-            return Ok(());
-        }
-
-        let target_networks = node_config.detect_fork_network(fork_url).await?;
-        let current = self.networks.execution_profile_name();
-        let target = target_networks.execution_profile_name();
-        if !self.networks.supports_fork_source(&target_networks) {
-            return Err(RpcError::invalid_params(format!(
-                "cannot reset Anvil across network families ({current} -> {target}); start a new instance with matching network configuration"
-            ))
-            .into());
-        }
         Ok(())
     }
 

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -114,6 +114,27 @@ async fn test_fork_rejects_node_info_failure_after_anvil_identification() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_keeps_node_info_probe_strict_after_identification_during_staging() {
+    let (_initial_api, initial_origin) = spawn(NodeConfig::test()).await;
+    let (api, _handle) =
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(initial_origin.http_endpoint()))).await;
+    let (_target_api, target_origin) = spawn(NodeConfig::test()).await;
+    let fork_url =
+        spawn_rpc_proxy_rejecting_method_after(target_origin.http_endpoint(), "anvil_nodeInfo", 1)
+            .await;
+
+    let error = api
+        .anvil_reset(Some(Forking { json_rpc_url: Some(fork_url), block_number: None }))
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("failed to determine network family from fork endpoint"),
+        "{error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fork_retries_when_anvil_node_info_becomes_available() {
     let (_api, origin) = spawn(NodeConfig::test()).await;
     let fork_url =
@@ -3567,6 +3588,30 @@ async fn test_anvil_reset_rejects_self_reference_without_mutation() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_set_rpc_url_rejects_self_reference_without_mutation() {
+    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let origin_url = origin_handle.http_endpoint();
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_url.clone()))
+            .with_fork_block_number(Some(0u64)),
+    )
+    .await;
+    let fork = api.backend.get_fork().unwrap();
+    let config_before = fork.config.read().clone();
+
+    let error = api.anvil_set_rpc_url(handle.http_endpoint()).await.unwrap_err();
+
+    assert!(error.to_string().contains("own RPC endpoint"), "{error}");
+    let config = fork.config.read();
+    assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
+    assert_eq!(config.fork_urls, config_before.fork_urls);
+    drop(config);
+    api.anvil_reset(Some(Forking::default())).await.unwrap();
+    assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_anvil_set_rpc_url_rejects_zksync_source_atomically() {
     let (_origin_api, origin_handle) =
         spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
@@ -3596,6 +3641,87 @@ async fn test_anvil_set_rpc_url_rejects_zksync_source_atomically() {
         assert_eq!(config.execution_chain_id, config_before.execution_chain_id);
     }
 
+    api.anvil_reset(Some(Forking::default())).await.unwrap();
+    assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_set_rpc_url_rejects_different_chain_atomically() {
+    let (_origin_api, origin_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
+    let origin_url = origin_handle.http_endpoint();
+    let (api, _handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_url.clone()))
+            .with_fork_block_number(Some(0u64)),
+    )
+    .await;
+    let fork = api.backend.get_fork().unwrap();
+    let config_before = fork.config.read().clone();
+    let (_target_api, target_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Sepolia as u64))).await;
+
+    api.anvil_set_rpc_url(target_handle.http_endpoint()).await.unwrap_err();
+
+    let config = fork.config.read();
+    assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
+    assert_eq!(config.fork_urls, config_before.fork_urls);
+    drop(config);
+    api.anvil_reset(Some(Forking::default())).await.unwrap();
+    assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_set_rpc_url_rejects_mismatched_pinned_block_atomically() {
+    let (origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    origin_api.mine_one().await.unwrap();
+    let origin_url = origin_handle.http_endpoint();
+    let (api, _handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_url.clone()))
+            .with_fork_block_number(Some(1u64)),
+    )
+    .await;
+    let fork = api.backend.get_fork().unwrap();
+    let config_before = fork.config.read().clone();
+    let (target_api, target_handle) = spawn(NodeConfig::test()).await;
+    target_api.anvil_set_balance(Address::random(), U256::from(1)).await.unwrap();
+    target_api.mine_one().await.unwrap();
+
+    api.anvil_set_rpc_url(target_handle.http_endpoint()).await.unwrap_err();
+
+    let config = fork.config.read();
+    assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
+    assert_eq!(config.fork_urls, config_before.fork_urls);
+    drop(config);
+    api.anvil_reset(Some(Forking::default())).await.unwrap();
+    assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_set_rpc_url_keeps_node_info_strict_without_mutation() {
+    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let origin_url = origin_handle.http_endpoint();
+    let (api, _handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_url.clone()))
+            .with_fork_block_number(Some(0u64)),
+    )
+    .await;
+    let fork = api.backend.get_fork().unwrap();
+    let config_before = fork.config.read().clone();
+    let (_target_api, target_handle) = spawn(NodeConfig::test()).await;
+    let target_url =
+        spawn_rpc_proxy_rejecting_method_after(target_handle.http_endpoint(), "anvil_nodeInfo", 1)
+            .await;
+
+    let error = api.anvil_set_rpc_url(target_url).await.unwrap_err();
+
+    assert!(error.to_string().contains("failed to determine network family"), "{error}");
+    let config = fork.config.read();
+    assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
+    assert_eq!(config.fork_urls, config_before.fork_urls);
+    drop(config);
     api.anvil_reset(Some(Forking::default())).await.unwrap();
     assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
 }

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -3521,7 +3521,9 @@ async fn test_config_with_osaka_hardfork_with_precompile_factory() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_anvil_set_rpc_url_syncs_fork_config() {
     // Spawn an origin node and fork off it
-    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let genesis_timestamp = 1_700_000_000u64;
+    let (_origin_api, origin_handle) =
+        spawn(NodeConfig::test().with_genesis_timestamp(Some(genesis_timestamp))).await;
     let origin_url = origin_handle.http_endpoint();
 
     let (api, handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(origin_url.clone()))).await;
@@ -3532,7 +3534,8 @@ async fn test_anvil_set_rpc_url_syncs_fork_config() {
     let metadata_before = api.anvil_metadata().await.unwrap();
 
     // Spawn a second origin to use as the new URL
-    let (_origin2_api, origin2_handle) = spawn(NodeConfig::test()).await;
+    let (_origin2_api, origin2_handle) =
+        spawn(NodeConfig::test().with_genesis_timestamp(Some(genesis_timestamp))).await;
     let new_url = origin2_handle.http_endpoint();
 
     // Set RPC URL through the RPC dispatcher to cover its lifecycle-lock path.
@@ -3603,10 +3606,11 @@ async fn test_anvil_set_rpc_url_rejects_self_reference_without_mutation() {
     let error = api.anvil_set_rpc_url(handle.http_endpoint()).await.unwrap_err();
 
     assert!(error.to_string().contains("own RPC endpoint"), "{error}");
-    let config = fork.config.read();
-    assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
-    assert_eq!(config.fork_urls, config_before.fork_urls);
-    drop(config);
+    {
+        let config = fork.config.read();
+        assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
+        assert_eq!(config.fork_urls, config_before.fork_urls);
+    }
     api.anvil_reset(Some(Forking::default())).await.unwrap();
     assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
 }
@@ -3663,10 +3667,11 @@ async fn test_anvil_set_rpc_url_rejects_different_chain_atomically() {
 
     api.anvil_set_rpc_url(target_handle.http_endpoint()).await.unwrap_err();
 
-    let config = fork.config.read();
-    assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
-    assert_eq!(config.fork_urls, config_before.fork_urls);
-    drop(config);
+    {
+        let config = fork.config.read();
+        assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
+        assert_eq!(config.fork_urls, config_before.fork_urls);
+    }
     api.anvil_reset(Some(Forking::default())).await.unwrap();
     assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
 }
@@ -3690,10 +3695,11 @@ async fn test_anvil_set_rpc_url_rejects_mismatched_pinned_block_atomically() {
 
     api.anvil_set_rpc_url(target_handle.http_endpoint()).await.unwrap_err();
 
-    let config = fork.config.read();
-    assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
-    assert_eq!(config.fork_urls, config_before.fork_urls);
-    drop(config);
+    {
+        let config = fork.config.read();
+        assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
+        assert_eq!(config.fork_urls, config_before.fork_urls);
+    }
     api.anvil_reset(Some(Forking::default())).await.unwrap();
     assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
 }
@@ -3718,10 +3724,11 @@ async fn test_anvil_set_rpc_url_keeps_node_info_strict_without_mutation() {
     let error = api.anvil_set_rpc_url(target_url).await.unwrap_err();
 
     assert!(error.to_string().contains("failed to determine network family"), "{error}");
-    let config = fork.config.read();
-    assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
-    assert_eq!(config.fork_urls, config_before.fork_urls);
-    drop(config);
+    {
+        let config = fork.config.read();
+        assert!(Arc::ptr_eq(&config.provider, &config_before.provider));
+        assert_eq!(config.fork_urls, config_before.fork_urls);
+    }
     api.anvil_reset(Some(Forking::default())).await.unwrap();
     assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
 }

--- a/crates/anvil/tests/it/monad.rs
+++ b/crates/anvil/tests/it/monad.rs
@@ -1967,7 +1967,7 @@ async fn plain_anvil_rejects_monad_reset_hidden_by_fork_chain_id() {
         .unwrap_err()
         .to_string();
 
-    assert!(err.contains("cannot reset Anvil across execution profiles (ethereum -> monad)"));
+    assert!(err.contains("cannot reset Anvil across network families (ethereum -> monad)"));
     assert_eq!(provider.get_balance(marker).await.unwrap(), balance);
     assert_eq!(api.anvil_metadata().await.unwrap().instance_id, instance_id);
     assert_eq!(api.anvil_node_info().await.unwrap().network.as_deref(), Some("ethereum"));


### PR DESCRIPTION
## Motivation

#15343 Monad follow-up

Carry authoritative endpoint identity through RPC URL replacement and use reset staging as the single network validation transaction. This keeps NodeInfo failures strict after identification and prevents stale fork identity metadata.