### PR TITLE
fix(monad): refresh reserve policy on transitions

### DIFF
--- a/.changelog/monad-reserve-policy-transition.md
+++ b/.changelog/monad-reserve-policy-transition.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-evm: patch
+foundry-evm-core: patch
+---
+
+Kept Monad reserve-balance policy synchronized with runtime hardfork transitions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "monad-revm"
 version = "0.6.0"
-source = "git+https://github.com/category-labs/monad-revm?rev=8ba4a51b221357105465cbe6d410906d3f12baeb#8ba4a51b221357105465cbe6d410906d3f12baeb"
+source = "git+https://github.com/category-labs/monad-revm?rev=bc471693e85f9aa800325e2783b465225005dc57#bc471693e85f9aa800325e2783b465225005dc57"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -565,7 +565,7 @@ solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e2
 
 ## monad
 alloy-monad-evm = { git = "https://github.com/category-labs/alloy-monad-evm", rev = "334bda1826996118d40872af35c27316a01889a2" }
-monad-revm = { git = "https://github.com/category-labs/monad-revm", rev = "8ba4a51b221357105465cbe6d410906d3f12baeb" }
+monad-revm = { git = "https://github.com/category-labs/monad-revm", rev = "bc471693e85f9aa800325e2783b465225005dc57" }
 
 ## foundry-core
 foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "d61ff900ecd69272ab810f4fc5ca478e10af7ecf" }

--- a/testdata/default/cheats/MonadReserveBalance.t.sol
+++ b/testdata/default/cheats/MonadReserveBalance.t.sol
@@ -11,19 +11,33 @@ contract PayableChild {
     constructor() payable {}
 }
 
+contract SelfDestructOnCreate {
+    constructor() payable {
+        selfdestruct(payable(address(0xBEEF)));
+    }
+}
+
 /// forge-config: default.sender = "0x0000000000000000000000000000000000001234"
 contract MonadReserveBalanceTest is Test {
     IReserveBalance constant RESERVE_BALANCE = IReserveBalance(address(0x1001));
     address constant SPENDER = address(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38);
     address payable constant RECIPIENT = payable(address(0xCAFE));
+    bytes32 constant SELFDESTRUCT_SALT = keccak256("monad-reserve-policy-transition");
     uint256 constant INITIAL_BALANCE = type(uint96).max;
+
+    address selfDestructDestination;
 
     function setUp() public {
         (bool ok, bytes memory output) =
-            address(RESERVE_BALANCE).call(abi.encodeCall(IReserveBalance.dippedIntoReserve, ()));
-        if (!ok || output.length != 32) {
-            vm.skip(true, "Monad reserve balance is only available with --network monad");
+            address(0x1000).call(abi.encodeWithSignature("getEpoch()"));
+        if (!ok || output.length < 64) {
+            vm.skip(true, "Monad staking is only available with --network monad");
         }
+
+        selfDestructDestination = vm.computeCreate2Address(
+            SELFDESTRUCT_SALT, keccak256(type(SelfDestructOnCreate).creationCode), address(this)
+        );
+        vm.deal(selfDestructDestination, 12 ether);
     }
 
     function test_nested_deployment_updates_tracker() public {
@@ -44,6 +58,35 @@ contract MonadReserveBalanceTest is Test {
         assertTrue(vm.revertToState(snapshot));
         assertEq(SPENDER.balance, INITIAL_BALANCE);
         assertTrue(!_dippedIntoReserve());
+    }
+
+    function test_monad_nine_exempts_init_selfdestruct() public {
+        _deploySelfDestructOnCreate();
+        assertTrue(!_dippedIntoReserve());
+    }
+
+    /// forge-config: default.hardfork = "monad:MonadEight"
+    function test_set_evm_version_reconfigures_reserve_policy() public {
+        vm.setEvmVersion("MonadNine");
+        _deploySelfDestructOnCreate();
+        assertTrue(!_dippedIntoReserve());
+    }
+
+    function test_set_evm_version_round_trip_reconfigures_reserve_policy() public {
+        vm.setEvmVersion("MonadEight");
+        vm.setEvmVersion("MonadNine");
+        _deploySelfDestructOnCreate();
+        assertTrue(!_dippedIntoReserve());
+    }
+
+    function _deploySelfDestructOnCreate() internal {
+        assertEq(selfDestructDestination.balance, 12 ether);
+
+        SelfDestructOnCreate deployed =
+            new SelfDestructOnCreate{salt: SELFDESTRUCT_SALT}();
+        assertEq(address(deployed), selfDestructDestination);
+        assertEq(selfDestructDestination.balance, 0);
+        assertEq(selfDestructDestination.code.length, 0);
     }
 
     function _dippedIntoReserve() internal returns (bool) {


### PR DESCRIPTION
Fixes #16143.

`vm.setEvmVersion` can select a different Monad hardfork for a nested frame. The reserve tracker previously cached hardfork-derived behavior at transaction initialization, so a frame could execute one hardfork's instructions and precompiles while enforcing another hardfork's created-and-selfdestructed-account rule.

This pins category-labs/monad-revm#45, which models reserve behavior as a typed policy and retains exact Monad hardfork identity for every materialized frame instead of reconstructing it from Ethereum `SpecId`. The Forge regression covers direct MonadNine execution, MonadEight→MonadNine, and Nine→Eight→Nine transitions with a real CREATE2 constructor selfdestruct.

This PR depends on category-labs/monad-revm#45 and should remain draft until that dependency is merged.
