### PR TITLE
fix(forge): use project root for installs

### DIFF
--- a/.changelog/install-project-root.md
+++ b/.changelog/install-project-root.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Made `forge install` use an enclosing Foundry project when invoked from a nested Git repository without its own `foundry.toml`.

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -67,7 +67,13 @@ pub struct InstallArgs {
 impl_figment_convert_basic!(InstallArgs);
 
 impl InstallArgs {
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(mut self) -> Result<()> {
+        if self.root.is_none() {
+            self.root = std::env::current_dir()?
+                .ancestors()
+                .find(|root| root.join(Config::FILE_NAME).is_file())
+                .map(Path::to_path_buf);
+        }
         let mut config = self.load_config()?;
         self.opts.install(&mut config, self.dependencies).await
     }

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -497,6 +497,40 @@ forgetest!(can_install_empty, |prj, cmd| {
     cmd.assert_empty_stdout();
 });
 
+// <https://github.com/foundry-rs/foundry/issues/7205>
+forgetest!(install_from_nested_git_repo_uses_project_root, |prj, cmd| {
+    prj.update_config(|config| config.libs = vec![PathBuf::from("dependencies")]);
+    cmd.git_init();
+
+    let nested = prj.root().join("vendor/dependency");
+    fs::create_dir_all(&nested).unwrap();
+    Git::new(&nested).init().unwrap();
+
+    cmd.forge_fuse().current_dir(&nested).args(["install", "--no-git"]).assert_success();
+
+    assert!(prj.root().join("dependencies").is_dir());
+    assert!(!nested.join("lib").exists());
+});
+
+forgetest!(install_from_nested_foundry_project_uses_nested_root, |prj, cmd| {
+    prj.update_config(|config| config.libs = vec![PathBuf::from("outer-dependencies")]);
+    cmd.git_init();
+
+    let nested = prj.root().join("vendor/dependency");
+    fs::create_dir_all(&nested).unwrap();
+    Git::new(&nested).init().unwrap();
+    fs::write(
+        nested.join(Config::FILE_NAME),
+        "[profile.default]\nlibs = [\"nested-dependencies\"]\n",
+    )
+    .unwrap();
+
+    cmd.forge_fuse().current_dir(&nested).args(["install", "--no-git"]).assert_success();
+
+    assert!(nested.join("nested-dependencies").is_dir());
+    assert!(!prj.root().join("outer-dependencies").exists());
+});
+
 // test to check that package can be reinstalled after manually removing the directory
 forgetest!(can_reinstall_after_manual_remove, |prj, cmd| {
     cmd.git_init();


### PR DESCRIPTION
## Motivation

Closes #7205.

Running `forge install` from inside an unconfigured nested Git checkout causes project discovery to stop at that checkout. This creates another dependency directory inside the nested repository instead of respecting the enclosing Foundry project.

## Solution

When `--root` is absent, `forge install` now prefers the nearest ancestor containing `foundry.toml` before using the existing Git-root fallback. An explicit root remains authoritative, and a nested repository with its own Foundry configuration remains its own project. Regression coverage exercises both nested-repository cases.

This PR was written with Codex, which assisted with issue investigation, code generation, and testing.
