### PR TITLE
fix(ci): normalize Windows path assertions

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3347,11 +3347,10 @@ mod tests {
         .into();
 
         let mut absolute_alias = relative.clone();
-        absolute_alias.context = Some(format!(
-            "{}{}",
-            config.root.join("dependency").display(),
-            std::path::MAIN_SEPARATOR
-        ));
+        let mut absolute_context =
+            config.root.join("dependency").display().to_string().replace('\\', "/");
+        absolute_context.push(std::path::MAIN_SEPARATOR);
+        absolute_alias.context = Some(absolute_context);
         assert_eq!(
             config.project_remappings(),
             vec![global_before, relative, absolute_alias, absolute, missing, global_after]

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1277,7 +1277,7 @@ contract Core is DependencyLibrary {}
         ),
     );
 
-    cmd.args(["build", "--no-lint", "--root", project.to_str().unwrap()]).assert_success();
+    cmd.current_dir(project).args(["build", "--no-lint"]).assert_success();
 });
 
 forgetest!(cli_preserves_explicit_contextual_remapping_pair, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -534,7 +534,11 @@ contract ForgeExplicitFuzzReplayTest {{
         .arg(&missing_explicit)
         .assert_failure();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
-    assert!(stderr.contains(&missing_explicit.display().to_string()), "{stderr}");
+    let stderr = stderr.replace('\\', "/");
+    assert!(
+        stderr.contains(&missing_explicit.display().to_string().replace('\\', "/")),
+        "{stderr}"
+    );
 
     let malformed = prj.root().join("malformed-fuzz-failure.json");
     std::fs::write(&malformed, "not json").unwrap();
@@ -552,7 +556,8 @@ contract ForgeExplicitFuzzReplayTest {{
         .arg(&malformed)
         .assert_failure();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
-    assert!(stderr.contains(&malformed.display().to_string()), "{stderr}");
+    let stderr = stderr.replace('\\', "/");
+    assert!(stderr.contains(&malformed.display().to_string().replace('\\', "/")), "{stderr}");
 
     let output = cmd
         .forge_fuse()


### PR DESCRIPTION
The Windows `test all` job exposed three tests that assumed paths would always use Unix-style separators. This follows up on #16135 for contextual remappings and #16047 for explicit fuzz failure files.

This normalizes platform-dependent path comparisons while preserving the native trailing separator required by contextual remappings. The external-dependency test now runs Forge from the fixture directory, matching the workflow it covers on Windows and Unix.
