### PR TITLE
fix(foundryup): clarify install status

### DIFF
--- a/.changelog/foundryup-install-status.md
+++ b/.changelog/foundryup-install-status.md
@@ -1,0 +1,8 @@
+---
+anvil: patch
+cast: patch
+chisel: patch
+forge: patch
+---
+
+Clarified why Foundryup downloads fresh binaries without reporting an integrity failure unless an installed binary actually has a mismatched hash.

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -7,7 +7,7 @@ set -eo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-FOUNDRYUP_INSTALLER_VERSION="1.9.2"
+FOUNDRYUP_INSTALLER_VERSION="1.9.3"
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
@@ -226,49 +226,27 @@ main() {
         # Check if the binaries are already installed and match the expected hashes.
         # If they do, skip the download.
         version_dir="$FOUNDRY_VERSIONS_DIR/$FOUNDRYUP_TAG"
-        all_match=true
-        for bin in "${BINS[@]}"; do
-          expected=""
-          for i in "${!HASH_NAMES[@]}"; do
-            if [ "${HASH_NAMES[$i]}" = "$bin" ] || [ "${HASH_NAMES[$i]}" = "$bin.exe" ]; then
-              expected="${HASH_VALUES[$i]}"
-              break
-            fi
-          done
-
-          path="$version_dir/$bin"
-
-          if [ -z "$expected" ]; then
-            if is_missing_optional_bin "$bin" "$expected" "$path"; then
-              continue
-            fi
-            all_match=false
-            break
-          fi
-
-          if [ ! -x "$path" ]; then
-            all_match=false
-            break
-          fi
-
-          actual=$(compute_sha256 "$path")
-          if [ "$actual" != "$expected" ]; then
-            all_match=false
-            break
-          fi
-        done
-
-        if $all_match; then
-          say "version $FOUNDRYUP_TAG already installed and verified, activating..."
-          FOUNDRYUP_VERSION=$FOUNDRYUP_TAG
-          use
-          say "done!"
-          exit 0
+        if [ ! -d "$version_dir" ]; then
+          installed_status=not-installed
+        else
+          installed_status=$(installed_bins_status "$version_dir")
         fi
+        case "$installed_status" in
+          verified)
+            say "version $FOUNDRYUP_TAG already installed and verified, activating..."
+            FOUNDRYUP_VERSION=$FOUNDRYUP_TAG
+            use
+            say "done!"
+            exit 0
+            ;;
+          hash-error:*)
+            err "$(installed_bins_message "$installed_status" "$FOUNDRYUP_TAG")"
+            ;;
+          *)
+            say "$(installed_bins_message "$installed_status" "$FOUNDRYUP_TAG")"
+            ;;
+        esac
       fi
-
-      # If we reach here, we need to download the binaries.
-      say "binaries not found or do not match expected hashes, downloading new binaries"
     fi
 
     # Download and extract the binaries archive
@@ -337,7 +315,7 @@ main() {
             continue
           fi
 
-          actual=$(compute_sha256 "$path")
+          actual=$(compute_downloaded_sha256 "$bin" "$path")
           if [ "$actual" != "$expected" ]; then
             say "$bin hash verification failed:"
             say "  expected: $expected"
@@ -606,6 +584,85 @@ compute_sha256() {
   else
     shasum -a 256 "$1" | awk '{print $1}'
   fi
+}
+
+compute_downloaded_sha256() {
+  local bin="$1" path="$2" actual
+  if ! actual=$(compute_sha256 "$path" 2>/dev/null); then
+    err "could not calculate SHA-256 hash for downloaded $bin, aborting installation"
+  fi
+  printf '%s\n' "$actual"
+}
+
+installed_bins_status() {
+  local version_dir="$1" bin expected path actual i
+  for bin in "${BINS[@]}"; do
+    expected=""
+    for i in "${!HASH_NAMES[@]}"; do
+      if [ "${HASH_NAMES[$i]}" = "$bin" ] || [ "${HASH_NAMES[$i]}" = "$bin.exe" ]; then
+        expected="${HASH_VALUES[$i]}"
+        break
+      fi
+    done
+
+    path="$version_dir/$bin"
+    if is_missing_optional_bin "$bin" "$expected" "$path"; then
+      continue
+    fi
+    if [ ! -e "$path" ]; then
+      printf 'missing:%s\n' "$bin"
+      return
+    fi
+    if [ ! -f "$path" ] || [ ! -x "$path" ]; then
+      printf 'not-executable:%s\n' "$bin"
+      return
+    fi
+    if [ -z "$expected" ]; then
+      printf 'unverifiable:%s\n' "$bin"
+      return
+    fi
+    if ! actual=$(compute_sha256 "$path" 2>/dev/null); then
+      printf 'hash-error:%s\n' "$bin"
+      return
+    fi
+    if [ "$actual" != "$expected" ]; then
+      printf 'mismatch:%s\n' "$bin"
+      return
+    fi
+  done
+  printf 'verified\n'
+}
+
+installed_bins_message() {
+  local status="$1" tag="$2"
+  case "$status" in
+    not-installed)
+      printf 'version %s is not installed, downloading binaries\n' "$tag"
+      ;;
+    missing:*)
+      printf 'installed version %s is incomplete (missing %s), downloading and verifying a fresh copy\n' \
+        "$tag" "${status#missing:}"
+      ;;
+    not-executable:*)
+      printf 'installed version %s is incomplete (%s is not executable), downloading and verifying a fresh copy\n' \
+        "$tag" "${status#not-executable:}"
+      ;;
+    unverifiable:*)
+      printf 'installed version %s cannot be verified (no expected hash for %s), downloading a fresh copy\n' \
+        "$tag" "${status#unverifiable:}"
+      ;;
+    hash-error:*)
+      printf 'installed version %s cannot be verified (could not calculate a hash for %s), aborting installation\n' \
+        "$tag" "${status#hash-error:}"
+      ;;
+    mismatch:*)
+      printf 'installed version %s did not match the expected SHA-256 hash (%s), downloading and verifying a fresh copy\n' \
+        "$tag" "${status#mismatch:}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 need_cmd() {

--- a/foundryup/test.sh
+++ b/foundryup/test.sh
@@ -127,6 +127,71 @@ touch "$optional_path"
 check_eq "present optional binary without hash is rejected" \
   "1" "$(is_missing_optional_bin solar "" "$optional_path"; echo $?)"
 
+status_tmp="$selector_tmp/status"
+mkdir -p "$status_tmp"
+BINS=(forge)
+HASH_NAMES=()
+HASH_VALUES=()
+check_eq "missing installed binary is reported without implying a hash mismatch" \
+  "missing:forge" "$(installed_bins_status "$status_tmp")"
+printf 'forge' > "$status_tmp/forge"
+check_eq "non-executable installed binary is reported explicitly" \
+  "not-executable:forge" "$(installed_bins_status "$status_tmp")"
+chmod +x "$status_tmp/forge"
+check_eq "installed binary without an expected hash is unverifiable" \
+  "unverifiable:forge" "$(installed_bins_status "$status_tmp")"
+HASH_NAMES=(forge)
+HASH_VALUES=(expected)
+rm -f "$status_tmp/forge"
+mkdir "$status_tmp/forge"
+check_eq "non-file installed binary is reported as non-executable" \
+  "not-executable:forge" "$(installed_bins_status "$status_tmp")"
+rm -rf "$status_tmp/forge"
+printf 'changed' > "$status_tmp/forge"
+chmod +x "$status_tmp/forge"
+check_eq "installed binary hash mismatch is reported explicitly" \
+  "mismatch:forge" "$(installed_bins_status "$status_tmp")"
+HASH_VALUES=("$(compute_sha256 "$status_tmp/forge")")
+check_eq "installed binary with expected hash is verified" \
+  "verified" "$(installed_bins_status "$status_tmp")"
+original_compute_sha256=$(declare -f compute_sha256)
+compute_sha256() { return 1; }
+check_eq "hash computation failure is not reported as a mismatch" \
+  "hash-error:forge" "$(installed_bins_status "$status_tmp")"
+say() { printf 'foundryup: %s\n' "$1"; }
+if downloaded_hash_output=$(compute_downloaded_sha256 forge "$status_tmp/forge" 2>&1); then
+  downloaded_hash_status=0
+else
+  downloaded_hash_status=$?
+fi
+check_eq "downloaded binary hash computation failure aborts with context" \
+  "1" "$downloaded_hash_status"
+check_eq "downloaded binary hash computation failure identifies the binary" \
+  "foundryup: could not calculate SHA-256 hash for downloaded forge, aborting installation" \
+  "$downloaded_hash_output"
+say() { :; }
+eval "$original_compute_sha256"
+
+check_eq "first install message does not imply a hash mismatch" \
+  "version nightly is not installed, downloading binaries" \
+  "$(installed_bins_message not-installed nightly)"
+check_eq "incomplete install message identifies a missing binary" \
+  "installed version nightly is incomplete (missing forge), downloading and verifying a fresh copy" \
+  "$(installed_bins_message missing:forge nightly)"
+check_eq "incomplete install message identifies a non-executable binary" \
+  "installed version nightly is incomplete (forge is not executable), downloading and verifying a fresh copy" \
+  "$(installed_bins_message not-executable:forge nightly)"
+check_eq "unverifiable install message identifies a missing expected hash" \
+  "installed version nightly cannot be verified (no expected hash for forge), downloading a fresh copy" \
+  "$(installed_bins_message unverifiable:forge nightly)"
+check_eq "hash computation failure message does not imply a mismatch" \
+  "installed version nightly cannot be verified (could not calculate a hash for forge), aborting installation" \
+  "$(installed_bins_message hash-error:forge nightly)"
+check_eq "hash mismatch message is limited to a genuine mismatch" \
+  "installed version nightly did not match the expected SHA-256 hash (forge), downloading and verifying a fresh copy" \
+  "$(installed_bins_message mismatch:forge nightly)"
+BINS=(forge cast anvil chisel solar)
+
 version_tmp="$selector_tmp/version"
 mkdir -p "$version_tmp"
 touch "$version_tmp/solar" "$version_tmp/solar.exe" "$version_tmp/unrelated"


### PR DESCRIPTION
Foundryup previously used the same message for a normal first install and an installed binary that failed hash verification, making routine downloads look like integrity failures. This change reports the specific cache state and reserves SHA-256 mismatch language for an actual mismatch, while aborting clearly if a hash cannot be calculated.
