### PR TITLE
feat(crates/cheatcodes): add secp256k1 EC arithmetic

### DIFF
--- a/.changelog/add-secp256k1-ec-arithmetic.md
+++ b/.changelog/add-secp256k1-ec-arithmetic.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added cheatcodes for secp256k1 point addition and scalar multiplication in affine and projective coordinates.

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -52,7 +52,7 @@ dialoguer.workspace = true
 eyre.workspace = true
 itertools.workspace = true
 jsonpath_lib.workspace = true
-k256.workspace = true
+k256 = { workspace = true, features = ["expose-field"] }
 memchr.workspace = true
 p256 = "0.13"
 ed25519-consensus = "2.1"

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4447,7 +4447,7 @@
     {
       "func": {
         "id": "ecMulAffine",
-        "description": "Multiplies the secp256k1 affine point `(pointX, pointY)` by `scalar`.\nThe point at infinity is represented as `(0, 0)`.",
+        "description": "Multiplies the secp256k1 affine point `(pointX, pointY)` by `scalar`.\nThe scalar is reduced modulo the secp256k1 group order.\nThe point at infinity is represented as `(0, 0)`.",
         "declaration": "function ecMulAffine(uint256 pointX, uint256 pointY, uint256 scalar) external pure returns (uint256 resultX, uint256 resultY);",
         "visibility": "external",
         "mutability": "pure",
@@ -4467,7 +4467,7 @@
     {
       "func": {
         "id": "ecMulProjective",
-        "description": "Multiplies the secp256k1 projective point `(pointX, pointY, pointZ)` by `scalar`.\nThe point at infinity is accepted as `(0, y, 0)` for any non-zero `y` and returned as\n`(0, 1, 0)`. Any other result is normalized to `(x, y, 1)`.",
+        "description": "Multiplies the secp256k1 projective point `(pointX, pointY, pointZ)` by `scalar`.\nThe scalar is reduced modulo the secp256k1 group order.\nThe point at infinity is accepted as `(0, y, 0)` for any non-zero `y` and returned as\n`(0, 1, 0)`. Any other result is normalized to `(x, y, 1)`.",
         "declaration": "function ecMulProjective(uint256 pointX, uint256 pointY, uint256 pointZ, uint256 scalar) external pure returns (uint256 resultX, uint256 resultY, uint256 resultZ);",
         "visibility": "external",
         "mutability": "pure",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4406,6 +4406,86 @@
     },
     {
       "func": {
+        "id": "ecAddAffine",
+        "description": "Adds the secp256k1 affine points `point1 = (pointX1, pointY1)` and\n`point2 = (pointX2, pointY2)`.\nThe point at infinity is represented as `(0, 0)`.",
+        "declaration": "function ecAddAffine(uint256 pointX1, uint256 pointY1, uint256 pointX2, uint256 pointY2) external pure returns (uint256 resultX, uint256 resultY);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "ecAddAffine(uint256,uint256,uint256,uint256)",
+        "selector": "0x1af9eefc",
+        "selectorBytes": [
+          26,
+          249,
+          238,
+          252
+        ]
+      },
+      "group": "crypto",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "ecAddProjective",
+        "description": "Adds the secp256k1 projective points `point1 = (pointX1, pointY1, pointZ1)` and\n`point2 = (pointX2, pointY2, pointZ2)`.\nThe point at infinity is accepted as `(0, y, 0)` for any non-zero `y` and returned as\n`(0, 1, 0)`. Any other result is normalized to `(x, y, 1)`.",
+        "declaration": "function ecAddProjective(uint256 pointX1, uint256 pointY1, uint256 pointZ1, uint256 pointX2, uint256 pointY2, uint256 pointZ2) external pure returns (uint256 resultX, uint256 resultY, uint256 resultZ);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "ecAddProjective(uint256,uint256,uint256,uint256,uint256,uint256)",
+        "selector": "0x45b12879",
+        "selectorBytes": [
+          69,
+          177,
+          40,
+          121
+        ]
+      },
+      "group": "crypto",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "ecMulAffine",
+        "description": "Multiplies the secp256k1 affine point `(pointX, pointY)` by `scalar`.\nThe point at infinity is represented as `(0, 0)`.",
+        "declaration": "function ecMulAffine(uint256 pointX, uint256 pointY, uint256 scalar) external pure returns (uint256 resultX, uint256 resultY);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "ecMulAffine(uint256,uint256,uint256)",
+        "selector": "0xc74ca094",
+        "selectorBytes": [
+          199,
+          76,
+          160,
+          148
+        ]
+      },
+      "group": "crypto",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "ecMulProjective",
+        "description": "Multiplies the secp256k1 projective point `(pointX, pointY, pointZ)` by `scalar`.\nThe point at infinity is accepted as `(0, y, 0)` for any non-zero `y` and returned as\n`(0, 1, 0)`. Any other result is normalized to `(x, y, 1)`.",
+        "declaration": "function ecMulProjective(uint256 pointX, uint256 pointY, uint256 pointZ, uint256 scalar) external pure returns (uint256 resultX, uint256 resultY, uint256 resultZ);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "ecMulProjective(uint256,uint256,uint256,uint256)",
+        "selector": "0x031661fc",
+        "selectorBytes": [
+          3,
+          22,
+          97,
+          252
+        ]
+      },
+      "group": "crypto",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "eip712HashStruct_0",
         "description": "Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.\nSupports 2 different inputs:\n 1. Name of the type (i.e. \"PermitSingle\"):\n    * requires previous binding generation with `forge bind-json`.\n    * bindings will be retrieved from the path configured in `foundry.toml`.\n 2. String representation of the type (i.e. \"Foo(Bar bar) Bar(uint256 baz)\").\n    * Note: the cheatcode will use the canonical type even if the input is malformed\n            with the wrong order of elements or with extra whitespaces.",
         "declaration": "function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2987,6 +2987,49 @@ interface Vm {
     #[cheatcode(group = Crypto)]
     function publicKeyP256(uint256 privateKey) external pure returns (uint256 publicKeyX, uint256 publicKeyY);
 
+    /// Adds the secp256k1 affine points `point1 = (pointX1, pointY1)` and
+    /// `point2 = (pointX2, pointY2)`.
+    /// The point at infinity is represented as `(0, 0)`.
+    #[cheatcode(group = Crypto)]
+    function ecAddAffine(uint256 pointX1, uint256 pointY1, uint256 pointX2, uint256 pointY2)
+        external
+        pure
+        returns (uint256 resultX, uint256 resultY);
+
+    /// Adds the secp256k1 projective points `point1 = (pointX1, pointY1, pointZ1)` and
+    /// `point2 = (pointX2, pointY2, pointZ2)`.
+    /// The point at infinity is accepted as `(0, y, 0)` for any non-zero `y` and returned as
+    /// `(0, 1, 0)`. Any other result is normalized to `(x, y, 1)`.
+    #[cheatcode(group = Crypto)]
+    function ecAddProjective(
+        uint256 pointX1,
+        uint256 pointY1,
+        uint256 pointZ1,
+        uint256 pointX2,
+        uint256 pointY2,
+        uint256 pointZ2
+    )
+        external
+        pure
+        returns (uint256 resultX, uint256 resultY, uint256 resultZ);
+
+    /// Multiplies the secp256k1 affine point `(pointX, pointY)` by `scalar`.
+    /// The point at infinity is represented as `(0, 0)`.
+    #[cheatcode(group = Crypto)]
+    function ecMulAffine(uint256 pointX, uint256 pointY, uint256 scalar)
+        external
+        pure
+        returns (uint256 resultX, uint256 resultY);
+
+    /// Multiplies the secp256k1 projective point `(pointX, pointY, pointZ)` by `scalar`.
+    /// The point at infinity is accepted as `(0, y, 0)` for any non-zero `y` and returned as
+    /// `(0, 1, 0)`. Any other result is normalized to `(x, y, 1)`.
+    #[cheatcode(group = Crypto)]
+    function ecMulProjective(uint256 pointX, uint256 pointY, uint256 pointZ, uint256 scalar)
+        external
+        pure
+        returns (uint256 resultX, uint256 resultY, uint256 resultZ);
+
     /// Generates an Ed25519 key pair from a deterministic salt.
     /// Returns (publicKey, privateKey) as 32-byte values.
     #[cheatcode(group = Crypto, safety = Safe)]

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -3014,6 +3014,7 @@ interface Vm {
         returns (uint256 resultX, uint256 resultY, uint256 resultZ);
 
     /// Multiplies the secp256k1 affine point `(pointX, pointY)` by `scalar`.
+    /// The scalar is reduced modulo the secp256k1 group order.
     /// The point at infinity is represented as `(0, 0)`.
     #[cheatcode(group = Crypto)]
     function ecMulAffine(uint256 pointX, uint256 pointY, uint256 scalar)
@@ -3022,6 +3023,7 @@ interface Vm {
         returns (uint256 resultX, uint256 resultY);
 
     /// Multiplies the secp256k1 projective point `(pointX, pointY, pointZ)` by `scalar`.
+    /// The scalar is reduced modulo the secp256k1 group order.
     /// The point at infinity is accepted as `(0, y, 0)` for any non-zero `y` and returned as
     /// `(0, 1, 0)`. Any other result is normalized to `(x, y, 1)`.
     #[cheatcode(group = Crypto)]

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -17,9 +17,9 @@ use k256::{
     AffinePoint, EncodedPoint, FieldBytes, FieldElement, ProjectivePoint, Scalar,
     ecdsa::{SigningKey, hazmat},
     elliptic_curve::{
-        PrimeField,
-        bigint::ArrayEncoding,
+        bigint::{ArrayEncoding, U256 as K256U256},
         group::Group,
+        ops::Reduce,
         sec1::{FromEncodedPoint, ToEncodedPoint},
     },
 };
@@ -262,7 +262,7 @@ impl Cheatcode for ecMulAffineCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
         let Self { pointX, pointY, scalar } = self;
         let point = parse_affine_point(pointX, pointY, "point")?;
-        let scalar = parse_ec_scalar(scalar)?;
+        let scalar = reduce_ec_scalar(scalar);
         encode_affine_point(ProjectivePoint::from(point) * scalar)
     }
 }
@@ -271,7 +271,7 @@ impl Cheatcode for ecMulProjectiveCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
         let Self { pointX, pointY, pointZ, scalar } = self;
         let point = parse_projective_point(pointX, pointY, pointZ, "point")?;
-        let scalar = parse_ec_scalar(scalar)?;
+        let scalar = reduce_ec_scalar(scalar);
         encode_projective_point(point * scalar)
     }
 }
@@ -545,10 +545,8 @@ fn parse_field_element(value: &U256, name: &str) -> Result<FieldElement> {
         .ok_or_else(|| fmt_err!("invalid secp256k1 {name}"))
 }
 
-fn parse_ec_scalar(scalar: &U256) -> Result<Scalar> {
-    Scalar::from_repr(scalar.to_be_bytes().into())
-        .into_option()
-        .ok_or_else(|| fmt_err!("invalid secp256k1 scalar"))
+fn reduce_ec_scalar(scalar: &U256) -> Scalar {
+    <Scalar as Reduce<K256U256>>::reduce_bytes(&scalar.to_be_bytes().into())
 }
 
 fn encode_affine_point(point: ProjectivePoint) -> Result {

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -14,9 +14,14 @@ use alloy_sol_types::SolValue;
 use foundry_common::wallet::{derive_private_key, derive_private_key_with_language};
 use foundry_evm_core::evm::FoundryEvmNetwork;
 use k256::{
-    FieldBytes, Scalar,
+    AffinePoint, EncodedPoint, FieldBytes, FieldElement, ProjectivePoint, Scalar,
     ecdsa::{SigningKey, hazmat},
-    elliptic_curve::{bigint::ArrayEncoding, sec1::ToEncodedPoint},
+    elliptic_curve::{
+        PrimeField,
+        bigint::ArrayEncoding,
+        group::Group,
+        sec1::{FromEncodedPoint, ToEncodedPoint},
+    },
 };
 
 use p256::ecdsa::{
@@ -232,6 +237,42 @@ impl Cheatcode for publicKeyP256Call {
         let pub_key_y = U256::from_be_bytes((*pub_key.y().unwrap()).into());
 
         Ok((pub_key_x, pub_key_y).abi_encode())
+    }
+}
+
+impl Cheatcode for ecAddAffineCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { pointX1, pointY1, pointX2, pointY2 } = self;
+        let lhs = parse_affine_point(pointX1, pointY1, "first point")?;
+        let rhs = parse_affine_point(pointX2, pointY2, "second point")?;
+        encode_affine_point(ProjectivePoint::from(lhs) + rhs)
+    }
+}
+
+impl Cheatcode for ecAddProjectiveCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { pointX1, pointY1, pointZ1, pointX2, pointY2, pointZ2 } = self;
+        let lhs = parse_projective_point(pointX1, pointY1, pointZ1, "first point")?;
+        let rhs = parse_projective_point(pointX2, pointY2, pointZ2, "second point")?;
+        encode_projective_point(lhs + rhs)
+    }
+}
+
+impl Cheatcode for ecMulAffineCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { pointX, pointY, scalar } = self;
+        let point = parse_affine_point(pointX, pointY, "point")?;
+        let scalar = parse_ec_scalar(scalar)?;
+        encode_affine_point(ProjectivePoint::from(point) * scalar)
+    }
+}
+
+impl Cheatcode for ecMulProjectiveCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { pointX, pointY, pointZ, scalar } = self;
+        let point = parse_projective_point(pointX, pointY, pointZ, "point")?;
+        let scalar = parse_ec_scalar(scalar)?;
+        encode_projective_point(point * scalar)
     }
 }
 
@@ -461,6 +502,77 @@ fn sign_p256(private_key: &U256, digest: &B256) -> Result {
     let s_bytes: [u8; 32] = signature.s().to_bytes().into();
 
     Ok((r_bytes, s_bytes).abi_encode())
+}
+
+fn parse_affine_point(x: &U256, y: &U256, name: &str) -> Result<AffinePoint> {
+    if x.is_zero() && y.is_zero() {
+        return Ok(AffinePoint::IDENTITY);
+    }
+
+    let encoded = EncodedPoint::from_affine_coordinates(
+        &FieldBytes::from(x.to_be_bytes()),
+        &FieldBytes::from(y.to_be_bytes()),
+        false,
+    );
+    AffinePoint::from_encoded_point(&encoded)
+        .into_option()
+        .ok_or_else(|| fmt_err!("invalid secp256k1 {name}"))
+}
+
+fn parse_projective_point(x: &U256, y: &U256, z: &U256, name: &str) -> Result<ProjectivePoint> {
+    let x_field = parse_field_element(x, name)?;
+    let y_field = parse_field_element(y, name)?;
+    let z_field = parse_field_element(z, name)?;
+
+    if bool::from(z_field.is_zero()) {
+        ensure!(
+            bool::from(x_field.is_zero()) && !bool::from(y_field.is_zero()),
+            "invalid secp256k1 {name}"
+        );
+        return Ok(ProjectivePoint::IDENTITY);
+    }
+
+    let z_inv = z_field.invert().expect("non-zero field element is invertible");
+    let affine_x = U256::from_be_slice(&(x_field * z_inv).to_bytes());
+    let affine_y = U256::from_be_slice(&(y_field * z_inv).to_bytes());
+
+    Ok(ProjectivePoint::from(parse_affine_point(&affine_x, &affine_y, name)?))
+}
+
+fn parse_field_element(value: &U256, name: &str) -> Result<FieldElement> {
+    FieldElement::from_bytes(&FieldBytes::from(value.to_be_bytes()))
+        .into_option()
+        .ok_or_else(|| fmt_err!("invalid secp256k1 {name}"))
+}
+
+fn parse_ec_scalar(scalar: &U256) -> Result<Scalar> {
+    Scalar::from_repr(scalar.to_be_bytes().into())
+        .into_option()
+        .ok_or_else(|| fmt_err!("invalid secp256k1 scalar"))
+}
+
+fn encode_affine_point(point: ProjectivePoint) -> Result {
+    if bool::from(point.is_identity()) {
+        return Ok((U256::ZERO, U256::ZERO).abi_encode());
+    }
+
+    let encoded = point.to_affine().to_encoded_point(false);
+    let x = U256::from_be_slice(encoded.x().expect("non-identity point has x coordinate"));
+    let y = U256::from_be_slice(encoded.y().expect("non-identity point has y coordinate"));
+
+    Ok((x, y).abi_encode())
+}
+
+fn encode_projective_point(point: ProjectivePoint) -> Result {
+    if bool::from(point.is_identity()) {
+        return Ok((U256::ZERO, U256::from(1), U256::ZERO).abi_encode());
+    }
+
+    let encoded = point.to_affine().to_encoded_point(false);
+    let x = U256::from_be_slice(encoded.x().expect("non-identity point has x coordinate"));
+    let y = U256::from_be_slice(encoded.y().expect("non-identity point has y coordinate"));
+
+    Ok((x, y, U256::from(1)).abi_encode())
 }
 
 fn validate_private_key<C: ecdsa::PrimeCurve>(private_key: &U256) -> Result<()> {

--- a/testdata/default/cheats/Ec.t.sol
+++ b/testdata/default/cheats/Ec.t.sol
@@ -5,6 +5,7 @@ import "utils/Test.sol";
 
 contract EcTest is Test {
     uint256 internal constant P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
+    uint256 internal constant N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141;
     uint256 internal constant GX = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
     uint256 internal constant GY = 0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8;
 
@@ -19,6 +20,10 @@ contract EcTest is Test {
         (x, y) = vm.ecAddAffine(GX, GY, GX, GY);
         assertEq(x, wallet2.publicKeyX);
         assertEq(y, wallet2.publicKeyY);
+
+        (x, y) = vm.ecAddAffine(GX, GY, GX, P - GY);
+        assertEq(x, 0);
+        assertEq(y, 0);
     }
 
     function testEcAddProjective() public {
@@ -28,8 +33,14 @@ contract EcTest is Test {
         (uint256 x, uint256 y, uint256 z) = vm.ecAddProjective(0, 1, 0, GX, GY, 1);
         _assertProjectivePoint(x, y, z, wallet1);
 
-        (x, y, z) = vm.ecAddProjective(GX, GY, 1, GX, GY, 1);
+        uint256 inputZ = 2;
+        (x, y, z) = vm.ecAddProjective(mulmod(GX, inputZ, P), mulmod(GY, inputZ, P), inputZ, GX, GY, 1);
         _assertProjectivePoint(x, y, z, wallet2);
+
+        (x, y, z) = vm.ecAddProjective(GX, GY, 1, GX, P - GY, 1);
+        assertEq(x, 0);
+        assertEq(y, 1);
+        assertEq(z, 0);
     }
 
     function testEcMulAffine() public {
@@ -43,6 +54,18 @@ contract EcTest is Test {
         (x, y) = vm.ecMulAffine(GX, GY, 2);
         assertEq(x, wallet2.publicKeyX);
         assertEq(y, wallet2.publicKeyY);
+
+        (x, y) = vm.ecMulAffine(GX, GY, 0);
+        assertEq(x, 0);
+        assertEq(y, 0);
+
+        (x, y) = vm.ecMulAffine(GX, GY, N);
+        assertEq(x, 0);
+        assertEq(y, 0);
+
+        (x, y) = vm.ecMulAffine(GX, GY, N + 1);
+        assertEq(x, wallet1.publicKeyX);
+        assertEq(y, wallet1.publicKeyY);
     }
 
     function testEcMulProjective() public {
@@ -54,9 +77,38 @@ contract EcTest is Test {
 
         (x, y, z) = vm.ecMulProjective(GX, GY, 1, 2);
         _assertProjectivePoint(x, y, z, wallet2);
+
+        (x, y, z) = vm.ecMulProjective(GX, GY, 1, 0);
+        assertEq(x, 0);
+        assertEq(y, 1);
+        assertEq(z, 0);
+
+        (x, y, z) = vm.ecMulProjective(GX, GY, 1, N);
+        assertEq(x, 0);
+        assertEq(y, 1);
+        assertEq(z, 0);
+
+        (x, y, z) = vm.ecMulProjective(GX, GY, 1, N + 1);
+        _assertProjectivePoint(x, y, z, wallet1);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testEcRejectsInvalidPoints() public {
+        vm.expectRevert("vm.ecAddAffine: invalid secp256k1 first point");
+        vm.ecAddAffine(1, 1, GX, GY);
+
+        vm.expectRevert("vm.ecAddProjective: invalid secp256k1 first point");
+        vm.ecAddProjective(1, 1, 0, GX, GY, 1);
+
+        vm.expectRevert("vm.ecMulAffine: invalid secp256k1 point");
+        vm.ecMulAffine(1, 1, 1);
+
+        vm.expectRevert("vm.ecMulProjective: invalid secp256k1 point");
+        vm.ecMulProjective(GX, GY, P, 1);
     }
 
     function _assertProjectivePoint(uint256 x, uint256 y, uint256 z, Vm.Wallet memory wallet) internal {
+        assertEq(z, 1);
         assertEq(x, mulmod(wallet.publicKeyX, z, P));
         assertEq(y, mulmod(wallet.publicKeyY, z, P));
     }

--- a/testdata/default/cheats/Ec.t.sol
+++ b/testdata/default/cheats/Ec.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "utils/Test.sol";
+
+contract EcTest is Test {
+    uint256 internal constant P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
+    uint256 internal constant GX = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
+    uint256 internal constant GY = 0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8;
+
+    function testEcAddAffine() public {
+        Vm.Wallet memory wallet1 = vm.createWallet(1);
+        Vm.Wallet memory wallet2 = vm.createWallet(2);
+
+        (uint256 x, uint256 y) = vm.ecAddAffine(0, 0, GX, GY);
+        assertEq(x, wallet1.publicKeyX);
+        assertEq(y, wallet1.publicKeyY);
+
+        (x, y) = vm.ecAddAffine(GX, GY, GX, GY);
+        assertEq(x, wallet2.publicKeyX);
+        assertEq(y, wallet2.publicKeyY);
+    }
+
+    function testEcAddProjective() public {
+        Vm.Wallet memory wallet1 = vm.createWallet(1);
+        Vm.Wallet memory wallet2 = vm.createWallet(2);
+
+        (uint256 x, uint256 y, uint256 z) = vm.ecAddProjective(0, 1, 0, GX, GY, 1);
+        _assertProjectivePoint(x, y, z, wallet1);
+
+        (x, y, z) = vm.ecAddProjective(GX, GY, 1, GX, GY, 1);
+        _assertProjectivePoint(x, y, z, wallet2);
+    }
+
+    function testEcMulAffine() public {
+        Vm.Wallet memory wallet1 = vm.createWallet(1);
+        Vm.Wallet memory wallet2 = vm.createWallet(2);
+
+        (uint256 x, uint256 y) = vm.ecMulAffine(GX, GY, 1);
+        assertEq(x, wallet1.publicKeyX);
+        assertEq(y, wallet1.publicKeyY);
+
+        (x, y) = vm.ecMulAffine(GX, GY, 2);
+        assertEq(x, wallet2.publicKeyX);
+        assertEq(y, wallet2.publicKeyY);
+    }
+
+    function testEcMulProjective() public {
+        Vm.Wallet memory wallet1 = vm.createWallet(1);
+        Vm.Wallet memory wallet2 = vm.createWallet(2);
+
+        (uint256 x, uint256 y, uint256 z) = vm.ecMulProjective(GX, GY, 1, 1);
+        _assertProjectivePoint(x, y, z, wallet1);
+
+        (x, y, z) = vm.ecMulProjective(GX, GY, 1, 2);
+        _assertProjectivePoint(x, y, z, wallet2);
+    }
+
+    function _assertProjectivePoint(uint256 x, uint256 y, uint256 z, Vm.Wallet memory wallet) internal {
+        assertEq(x, mulmod(wallet.publicKeyX, z, P));
+        assertEq(y, mulmod(wallet.publicKeyY, z, P));
+    }
+}

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -213,6 +213,10 @@ interface Vm {
     function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index, string calldata language) external pure returns (uint256 privateKey);
     function difficulty(uint256 newDifficulty) external;
     function dumpState(string calldata pathToStateJson) external;
+    function ecAddAffine(uint256 pointX1, uint256 pointY1, uint256 pointX2, uint256 pointY2) external pure returns (uint256 resultX, uint256 resultY);
+    function ecAddProjective(uint256 pointX1, uint256 pointY1, uint256 pointZ1, uint256 pointX2, uint256 pointY2, uint256 pointZ2) external pure returns (uint256 resultX, uint256 resultY, uint256 resultZ);
+    function ecMulAffine(uint256 pointX, uint256 pointY, uint256 scalar) external pure returns (uint256 resultX, uint256 resultY);
+    function ecMulProjective(uint256 pointX, uint256 pointY, uint256 pointZ, uint256 scalar) external pure returns (uint256 resultX, uint256 resultY, uint256 resultZ);
     function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
     function eip712HashStruct(string calldata bindingsPath, string calldata typeName, bytes calldata abiEncodedData) external pure returns (bytes32 typeHash);
     function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);


### PR DESCRIPTION
## Motivation

Ref #10868

Foundry currently exposes secp256k1 key generation but does not provide generic elliptic-curve arithmetic. This makes testing protocols that use Schnorr signatures, threshold cryptography, ECDH, or stealth addresses unnecessarily difficult.

## Solution

Add `vm.ecAddAffine`, `vm.ecAddProjective`, `vm.ecMulAffine`, and `vm.ecMulProjective` cheatcodes backed by RustCrypto’s `k256` implementation.

The cheatcodes support affine and homogeneous projective coordinates, including canonical point-at-infinity representations. Inputs are validated using `k256` field and curve types.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes