### PR TITLE
refactor(ci): make Touch ID checks leaner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,21 +72,14 @@ jobs:
       - run: cargo build --workspace --no-default-features --locked
 
   touch-id-link:
-    name: touch-id link (${{ matrix.target }})
-    runs-on: macos-latest
+    name: touch-id link (macOS)
+    if: github.event_name == 'push'
+    runs-on: depot-macos-latest
     timeout-minutes: 45
     permissions:
       contents: read
     env:
       MACOSX_DEPLOYMENT_TARGET: "11.0"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-apple-darwin
-            run_tests: true
-          - target: aarch64-apple-darwin
-            run_tests: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -94,15 +87,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
-          targets: ${{ matrix.target }}
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-      - run: cargo test --manifest-path crates/cast/Cargo.toml --test cli --features touch-id --target "${{ matrix.target }}" --locked --no-run
-      - run: cargo build --manifest-path crates/forge/Cargo.toml --features touch-id --target "${{ matrix.target }}" --locked
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: false
+          prefix-key: v1-rust-touch-id-macos
       - name: Run native Touch ID regressions
-        if: matrix.run_tests
         run: |
-          cargo test --manifest-path crates/cast/Cargo.toml --lib --features touch-id --locked cmd::wallet::tests
-          cargo test --manifest-path crates/cast/Cargo.toml --test cli --features touch-id --locked wallet_change_password
+          cargo test --manifest-path crates/cast/Cargo.toml --lib --features touch-id --target aarch64-apple-darwin --locked cmd::wallet::tests
+          cargo test --manifest-path crates/cast/Cargo.toml --test cli --features touch-id --target aarch64-apple-darwin --locked wallet_change_password
+      - name: Check Intel Touch ID linking
+        run: |
+          cargo test --manifest-path crates/cast/Cargo.toml --test cli --features touch-id --target x86_64-apple-darwin --locked --no-run
+          cargo build --manifest-path crates/forge/Cargo.toml --features touch-id --target x86_64-apple-darwin --locked
+      - run: cargo build --manifest-path crates/forge/Cargo.toml --features touch-id --target aarch64-apple-darwin --locked
 
   monad-check:
     runs-on: depot-ubuntu-latest
@@ -375,4 +374,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
+          allowed-skips: touch-id-link
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This moves downstream Touch ID coverage out of pull requests and into a single macOS job on pushes to `master`. The Apple Silicon runner executes the native ARM Cast regressions and Forge build while also cross-checking Intel Cast and Forge linking, with persistent Rust and sccache state and explicit target directories reused across commands.

This removes macOS runner consumption from pull requests while retaining post-merge integration coverage. The daily ARM release remains the production-artifact backstop, and `foundry-core` continues to provide broader platform, Swift, and Xcode coverage.

Prepared with AI assistance.
