### PR TITLE
fix(cast): reject disabled networks in da-estimate

### DIFF
--- a/.changelog/cast-da-estimate-known-networks.md
+++ b/.changelog/cast-da-estimate-known-networks.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fixed `cast da-estimate` silently using Ethereum data availability semantics for a known chain whose network family is not enabled in the build.

--- a/crates/cast/src/cmd/da_estimate.rs
+++ b/crates/cast/src/cmd/da_estimate.rs
@@ -33,7 +33,7 @@ impl DAEstimateArgs {
             Some(n) => n,
             None => {
                 let provider = ProviderBuilder::<AnyNetwork>::from_config(&config)?.build()?;
-                provider.get_chain_id().await?.into()
+                infer_network(provider.get_chain_id().await?)?
             }
         };
         match network {
@@ -44,6 +44,17 @@ impl DAEstimateArgs {
             NetworkVariant::Tempo => unsupported_da_estimation("Tempo"),
         }
     }
+}
+
+/// Infers the network family from an endpoint's chain ID.
+///
+/// A known chain that belongs to a family this build does not support is rejected instead of
+/// silently estimating with Ethereum semantics. Only genuinely unknown chain IDs fall back to
+/// Ethereum.
+fn infer_network(chain_id: u64) -> Result<NetworkVariant> {
+    NetworkVariant::from_known_chain_id(chain_id)
+        .map(|network| network.unwrap_or(NetworkVariant::Ethereum))
+        .map_err(|error| eyre::eyre!("cannot infer network from chain ID {chain_id}: {error}"))
 }
 
 fn unsupported_da_estimation(network: &str) -> Result<()> {
@@ -70,9 +81,44 @@ pub async fn da_estimate<N: Network>(config: &Config, block_id: BlockId) -> Resu
     Ok(())
 }
 
-#[cfg(all(test, feature = "monad"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_chains::NamedChain;
+
+    #[test]
+    fn infers_ethereum_for_unknown_chain() {
+        assert_eq!(infer_network(98_765_432).unwrap(), NetworkVariant::Ethereum);
+    }
+
+    #[test]
+    fn infers_ethereum_for_mainnet() {
+        assert_eq!(infer_network(NamedChain::Mainnet as u64).unwrap(), NetworkVariant::Ethereum);
+    }
+
+    #[test]
+    #[cfg(feature = "optimism")]
+    fn infers_optimism_for_op_mainnet() {
+        assert_eq!(infer_network(NamedChain::Optimism as u64).unwrap(), NetworkVariant::Optimism);
+    }
+
+    #[test]
+    #[cfg(feature = "monad")]
+    fn infers_monad_for_monad_chains() {
+        for chain in [NamedChain::Monad, NamedChain::MonadTestnet] {
+            assert_eq!(infer_network(chain as u64).unwrap(), NetworkVariant::Monad);
+        }
+    }
+
+    #[test]
+    #[cfg(not(feature = "monad"))]
+    fn rejects_monad_chains_when_feature_is_disabled() {
+        for chain in [NamedChain::Monad, NamedChain::MonadTestnet] {
+            let err = infer_network(chain as u64).unwrap_err().to_string();
+            assert!(err.contains(&format!("chain ID {}", chain as u64)), "{err}");
+            assert!(err.contains("network family `monad` is not enabled"), "{err}");
+        }
+    }
 
     #[tokio::test]
     #[cfg(feature = "monad")]


### PR DESCRIPTION
`cast da-estimate` inferred its network family from the RPC chain ID through the infallible `From<ChainId>` conversion, which deliberately swallows the classifier's error and defaults to Ethereum. A known chain belonging to a family the build does not support therefore resolved to Ethereum instead of being rejected: a stock build (which enables `optimism` but not `monad`) pointed at chain ID 143 silently produced an Ethereum DA estimate for a Monad endpoint. The other network-inference paths added in #15343 use the fallible classifier precisely to prevent this.

This resolves the chain ID through `NetworkVariant::from_known_chain_id`, propagates its unavailable-family error, and falls back to Ethereum only when the classifier returns `Ok(None)` for a genuinely unknown chain. An explicit `--network` selection still short-circuits before any RPC call, so it remains authoritative.

The test module was gated behind the non-default `monad` feature and so never compiled in a default build. It is now ungated, with only the Monad-specific cases feature-gated, and covers an unknown chain ID, Ethereum mainnet, OP mainnet, and the Monad IDs both with and without the feature.

Fixes #16145

Written with assistance from Claude Code, per CONTRIBUTING.md. Note that I was unable to compile locally — the dependency fetch did not complete in my environment — so this change is unverified beyond review; CI is the first real check.
