### PR TITLE
fix(ci): stage nightly releases

### DIFF
--- a/.github/scripts/finalize-release.py
+++ b/.github/scripts/finalize-release.py
@@ -77,16 +77,6 @@ def exact_release(all_releases, tag):
     return matches[0]
 
 
-def tag_exists(commands, repo, tag):
-    result = commands.run(["gh", "api", f"repos/{repo}/git/ref/tags/{tag}"], check=False)
-    if result.returncode == 0:
-        return True
-    detail = result.stderr or result.stdout
-    if "HTTP 404" in detail:
-        return False
-    raise ReleaseError(f"could not determine whether Git tag {tag} exists: {detail.strip()}")
-
-
 def tag_commit(commands, repo, tag):
     raw = commands.output(["gh", "api", f"repos/{repo}/git/ref/tags/{tag}", "--jq", ".object"])
     try:
@@ -108,6 +98,21 @@ def tag_commit(commands, repo, tag):
     if target.get("type") != "commit" or not isinstance(sha, str) or not re.fullmatch(r"[0-9a-f]{40}", sha):
         raise ReleaseError(f"Git tag {tag} does not resolve to a full commit SHA")
     return sha
+
+
+def create_or_verify_tag(commands, repo, tag, commit):
+    args = [
+        "gh", "api", "--method", "POST", f"repos/{repo}/git/refs",
+        "-f", f"ref=refs/tags/{tag}", "-f", f"sha={commit}",
+    ]
+    result = commands.run(args, check=False)
+    try:
+        actual = tag_commit(commands, repo, tag)
+    except ReleaseError as error:
+        detail = (result.stderr or result.stdout).strip()
+        raise ReleaseError(f"could not create or verify Git tag {tag}: {detail}") from error
+    if actual != commit:
+        raise ReleaseError(f"Git tag {tag} resolves to {actual}, expected {commit}")
 
 
 def stable_aliases(candidate, all_releases):
@@ -243,6 +248,8 @@ def nightly_eligible(commands, image, candidate_sha):
 
 def finalize_nightly(commands, repo, image, tag, release_tag, expected=None):
     _, sha = parse_tag(tag, "nightly")
+    if release_tag != f"staging-release-{sha}":
+        raise ReleaseError(f"staging release tag does not match nightly commit: {release_tag}")
     digest = verify_exact(commands, image, tag, expected)
     all_releases = releases(commands, repo)
     final = [release for release in all_releases if release.get("tag_name") == tag]
@@ -265,16 +272,16 @@ def finalize_nightly(commands, repo, image, tag, release_tag, expected=None):
         raise ReleaseError(f"expected final release {tag} or staging release {release_tag}")
     if not state.get("prerelease"):
         raise ReleaseError(f"release {tag} has unexpected state/classification")
-    if staging:
-        if tag_exists(commands, repo, tag):
-            raise ReleaseError(f"final nightly tag {tag} already exists without its published release")
-        publish_staged(commands, release_tag, tag, sha)
-    if tag_commit(commands, repo, tag) != sha:
+    if final and tag_commit(commands, repo, tag) != sha:
         raise ReleaseError(f"release tag {tag} does not resolve to its encoded commit")
-    if nightly_eligible(commands, image, sha):
-        promote(commands, image, digest, "nightly")
-    else:
-        print(f"Not moving nightly: {tag} is not a descendant of the current nightly image.")
+    if not nightly_eligible(commands, image, sha):
+        print(f"Not publishing nightly: {tag} is not a descendant of the current nightly image.")
+        return
+    if staging:
+        create_or_verify_tag(commands, repo, tag, sha)
+    promote(commands, image, digest, "nightly")
+    if staging:
+        publish_staged(commands, release_tag, tag, sha)
 
 
 def main():

--- a/.github/scripts/finalize-release.py
+++ b/.github/scripts/finalize-release.py
@@ -77,6 +77,39 @@ def exact_release(all_releases, tag):
     return matches[0]
 
 
+def tag_exists(commands, repo, tag):
+    result = commands.run(["gh", "api", f"repos/{repo}/git/ref/tags/{tag}"], check=False)
+    if result.returncode == 0:
+        return True
+    detail = result.stderr or result.stdout
+    if "HTTP 404" in detail:
+        return False
+    raise ReleaseError(f"could not determine whether Git tag {tag} exists: {detail.strip()}")
+
+
+def tag_commit(commands, repo, tag):
+    raw = commands.output(["gh", "api", f"repos/{repo}/git/ref/tags/{tag}", "--jq", ".object"])
+    try:
+        target = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ReleaseError(f"could not parse Git tag {tag}: {raw}") from error
+    seen = set()
+    while target.get("type") == "tag":
+        sha = target.get("sha")
+        if sha in seen:
+            raise ReleaseError(f"Git tag {tag} contains a tag-object cycle")
+        seen.add(sha)
+        raw = commands.output(["gh", "api", f"repos/{repo}/git/tags/{sha}", "--jq", ".object"])
+        try:
+            target = json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise ReleaseError(f"could not parse Git tag object {sha}: {raw}") from error
+    sha = target.get("sha")
+    if target.get("type") != "commit" or not isinstance(sha, str) or not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise ReleaseError(f"Git tag {tag} does not resolve to a full commit SHA")
+    return sha
+
+
 def stable_aliases(candidate, all_releases):
     version = tuple(int(value) for value in STABLE.fullmatch(candidate).groups())
     versions = [version]
@@ -131,6 +164,13 @@ def publish(commands, tag, prerelease, latest):
         "gh", "release", "edit", tag, "--draft=false",
         f"--prerelease={'true' if prerelease else 'false'}",
         f"--latest={'true' if latest else 'false'}",
+    ])
+
+
+def publish_staged(commands, release_tag, tag, commit):
+    commands.run([
+        "gh", "release", "edit", release_tag, "--tag", tag, "--target", commit, "--draft=false",
+        "--prerelease=true", "--latest=false",
     ])
 
 
@@ -201,15 +241,36 @@ def nightly_eligible(commands, image, candidate_sha):
     raise ReleaseError(f"could not compare nightly history {current}..{candidate_sha}: {(result.stderr or result.stdout).strip()}")
 
 
-def finalize_nightly(commands, repo, image, tag, expected=None):
+def finalize_nightly(commands, repo, image, tag, release_tag, expected=None):
     _, sha = parse_tag(tag, "nightly")
     digest = verify_exact(commands, image, tag, expected)
-    state = exact_release(releases(commands, repo), tag)
-    commit = commands.output(["git", "rev-parse", f"{tag}^{{commit}}"])
-    if commit != sha or not state.get("prerelease"):
+    all_releases = releases(commands, repo)
+    final = [release for release in all_releases if release.get("tag_name") == tag]
+    staging = [release for release in all_releases if release.get("tag_name") == release_tag]
+    if len(final) > 1 or len(staging) > 1:
+        raise ReleaseError("found duplicate final or staging nightly releases")
+    if final and staging:
+        raise ReleaseError(f"both final release {tag} and staging release {release_tag} exist")
+    if final:
+        state = final[0]
+        if state.get("draft"):
+            raise ReleaseError(f"final nightly release {tag} unexpectedly exists as a draft")
+    elif staging:
+        state = staging[0]
+        if not state.get("draft"):
+            raise ReleaseError(f"staging nightly release {release_tag} is already published")
+        if state.get("target_commitish") != sha:
+            raise ReleaseError(f"staging nightly release {release_tag} targets an unexpected commit")
+    else:
+        raise ReleaseError(f"expected final release {tag} or staging release {release_tag}")
+    if not state.get("prerelease"):
         raise ReleaseError(f"release {tag} has unexpected state/classification")
-    if state.get("draft"):
-        publish(commands, tag, True, False)
+    if staging:
+        if tag_exists(commands, repo, tag):
+            raise ReleaseError(f"final nightly tag {tag} already exists without its published release")
+        publish_staged(commands, release_tag, tag, sha)
+    if tag_commit(commands, repo, tag) != sha:
+        raise ReleaseError(f"release tag {tag} does not resolve to its encoded commit")
     if nightly_eligible(commands, image, sha):
         promote(commands, image, digest, "nightly")
     else:
@@ -220,6 +281,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("mode", choices=("stable", "nightly"))
     parser.add_argument("--tag", required=True)
+    parser.add_argument("--release-tag")
     parser.add_argument("--digest")
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"))
     parser.add_argument("--image")
@@ -231,7 +293,9 @@ def main():
         if args.mode == "stable":
             finalize_stable(Commands(), args.repo, image, args.tag)
         else:
-            finalize_nightly(Commands(), args.repo, image, args.tag, args.digest)
+            if not args.release_tag:
+                parser.error("--release-tag is required for nightly releases")
+            finalize_nightly(Commands(), args.repo, image, args.tag, args.release_tag, args.digest)
     except ReleaseError as error:
         print(f"error: {error}", file=sys.stderr)
         return 1

--- a/.github/scripts/tests/test_finalize_release.py
+++ b/.github/scripts/tests/test_finalize_release.py
@@ -76,8 +76,11 @@ def tag_command(tag):
     return ("gh", "api", f"repos/r/git/ref/tags/{tag}", "--jq", ".object")
 
 
-def tag_exists_command(tag):
-    return ("gh", "api", f"repos/r/git/ref/tags/{tag}")
+def create_tag_command(tag, commit):
+    return (
+        "gh", "api", "--method", "POST", "repos/r/git/refs",
+        "-f", f"ref=refs/tags/{tag}", "-f", f"sha={commit}",
+    )
 
 
 class ParsingTests(unittest.TestCase):
@@ -217,7 +220,7 @@ class NightlyTests(unittest.TestCase):
                 inspect: completed(inspect, stdout=self.image_data("a" * 40, "b" * 40)),
             }), "image", candidate)
 
-    def test_draft_is_published_before_current_alias_is_promoted(self):
+    def test_current_alias_is_promoted_before_draft_is_published(self):
         candidate = "b" * 40
         tag = f"nightly-{candidate}"
         release_tag = f"staging-release-{candidate}"
@@ -231,15 +234,42 @@ class NightlyTests(unittest.TestCase):
             RELEASES_COMMAND: release_pages(
                 release(release_tag, draft=True, prerelease=True, target_commitish=candidate),
             ),
-            tag_exists_command(tag): completed(tag_exists_command(tag), code=1, stderr="gh: Not Found (HTTP 404)"),
-            publish: 0,
-            tag_command(tag): json.dumps({"type": "commit", "sha": candidate}),
             self.inspect_command(): completed(self.inspect_command(), stdout=self.image_data(candidate, candidate)),
+            create_tag_command(tag, candidate): 0,
+            tag_command(tag): json.dumps({"type": "commit", "sha": candidate}),
+            publish: 0,
             promote: 0,
             digest_command("image:nightly"): f'"{DIGEST}"',
         })
         MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
-        self.assertLess(commands.calls.index(publish), commands.calls.index(promote))
+        self.assertLess(commands.calls.index(self.inspect_command()), commands.calls.index(publish))
+        self.assertLess(commands.calls.index(promote), commands.calls.index(publish))
+
+    def test_existing_exact_final_tag_allows_publication_retry(self):
+        candidate = "b" * 40
+        tag = f"nightly-{candidate}"
+        release_tag = f"staging-release-{candidate}"
+        publish = (
+            "gh", "release", "edit", release_tag, "--tag", tag, "--target", candidate, "--draft=false",
+            "--prerelease=true", "--latest=false",
+        )
+        promote = ("docker", "buildx", "imagetools", "create", "--tag", "image:nightly", f"image@{DIGEST}")
+        create = create_tag_command(tag, candidate)
+        commands = FakeCommands({
+            digest_command(f"image:{tag}"): f'"{DIGEST}"',
+            RELEASES_COMMAND: release_pages(
+                release(release_tag, draft=True, prerelease=True, target_commitish=candidate),
+            ),
+            self.inspect_command(): completed(self.inspect_command(), stdout=self.image_data(candidate, candidate)),
+            create: completed(create, code=1, stderr="gh: Reference already exists (HTTP 422)"),
+            tag_command(tag): json.dumps({"type": "commit", "sha": candidate}),
+            publish: 0,
+            promote: 0,
+            digest_command("image:nightly"): f'"{DIGEST}"',
+        })
+        MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
+        self.assertLess(commands.calls.index(promote), commands.calls.index(publish))
+        self.assertIn(publish, commands.calls)
 
     def test_published_nightly_retry_still_promotes_alias(self):
         candidate = "b" * 40
@@ -289,6 +319,24 @@ class NightlyTests(unittest.TestCase):
                 with self.assertRaisesRegex(MODULE.ReleaseError, message):
                     MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
 
+    def test_stale_nightly_is_not_published(self):
+        candidate = "b" * 40
+        current = "c" * 40
+        tag = f"nightly-{candidate}"
+        release_tag = f"staging-release-{candidate}"
+        ancestry = ("git", "merge-base", "--is-ancestor", current, candidate)
+        commands = FakeCommands({
+            digest_command(f"image:{tag}"): f'"{DIGEST}"',
+            RELEASES_COMMAND: release_pages(
+                release(release_tag, draft=True, prerelease=True, target_commitish=candidate),
+            ),
+            self.inspect_command(): completed(self.inspect_command(), stdout=self.image_data(current, current)),
+            ancestry: 1,
+        })
+        MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
+        self.assertFalse(any(call[:3] == ("gh", "release", "edit") for call in commands.calls))
+        self.assertFalse(any(call[:4] == ("gh", "api", "--method", "POST") for call in commands.calls))
+
     def test_legacy_final_draft_fails(self):
         candidate = "b" * 40
         tag = f"nightly-{candidate}"
@@ -300,19 +348,29 @@ class NightlyTests(unittest.TestCase):
         with self.assertRaisesRegex(MODULE.ReleaseError, "unexpectedly exists as a draft"):
             MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
 
-    def test_existing_final_tag_blocks_staging_publication(self):
+    def test_existing_wrong_final_tag_blocks_staging_publication(self):
         candidate = "b" * 40
         tag = f"nightly-{candidate}"
         release_tag = f"staging-release-{candidate}"
+        create = create_tag_command(tag, candidate)
         commands = FakeCommands({
             digest_command(f"image:{tag}"): f'"{DIGEST}"',
             RELEASES_COMMAND: release_pages(
                 release(release_tag, draft=True, prerelease=True, target_commitish=candidate),
             ),
-            tag_exists_command(tag): completed(tag_exists_command(tag)),
+            self.inspect_command(): completed(self.inspect_command(), stdout=self.image_data(candidate, candidate)),
+            create: completed(create, code=1, stderr="gh: Reference already exists (HTTP 422)"),
+            tag_command(tag): json.dumps({"type": "commit", "sha": "a" * 40}),
         })
-        with self.assertRaisesRegex(MODULE.ReleaseError, "already exists"):
+        with self.assertRaisesRegex(MODULE.ReleaseError, "resolves to .* expected"):
             MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
+
+    def test_unrelated_staging_tag_fails_before_external_checks(self):
+        candidate = "b" * 40
+        with self.assertRaisesRegex(MODULE.ReleaseError, "does not match nightly commit"):
+            MODULE.finalize_nightly(
+                FakeCommands(), "r", "image", f"nightly-{candidate}", "staging-release-unrelated", DIGEST,
+            )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_finalize_release.py
+++ b/.github/scripts/tests/test_finalize_release.py
@@ -54,8 +54,11 @@ def completed(args, code=0, stdout="", stderr=""):
     return subprocess.CompletedProcess(args, code, stdout, stderr)
 
 
-def release(tag, draft=False, prerelease=False):
-    return {"tag_name": tag, "draft": draft, "prerelease": prerelease}
+def release(tag, draft=False, prerelease=False, target_commitish=None):
+    value = {"tag_name": tag, "draft": draft, "prerelease": prerelease}
+    if target_commitish is not None:
+        value["target_commitish"] = target_commitish
+    return value
 
 
 def release_pages(*values):
@@ -67,6 +70,14 @@ def digest_command(reference):
         "docker", "buildx", "imagetools", "inspect", reference,
         "--format", "{{json .Manifest.Digest}}",
     )
+
+
+def tag_command(tag):
+    return ("gh", "api", f"repos/r/git/ref/tags/{tag}", "--jq", ".object")
+
+
+def tag_exists_command(tag):
+    return ("gh", "api", f"repos/r/git/ref/tags/{tag}")
 
 
 class ParsingTests(unittest.TestCase):
@@ -209,35 +220,99 @@ class NightlyTests(unittest.TestCase):
     def test_draft_is_published_before_current_alias_is_promoted(self):
         candidate = "b" * 40
         tag = f"nightly-{candidate}"
-        publish = ("gh", "release", "edit", tag, "--draft=false", "--prerelease=true", "--latest=false")
+        release_tag = f"staging-release-{candidate}"
+        publish = (
+            "gh", "release", "edit", release_tag, "--tag", tag, "--target", candidate, "--draft=false",
+            "--prerelease=true", "--latest=false",
+        )
         promote = ("docker", "buildx", "imagetools", "create", "--tag", "image:nightly", f"image@{DIGEST}")
         commands = FakeCommands({
             digest_command(f"image:{tag}"): f'"{DIGEST}"',
-            RELEASES_COMMAND: release_pages(release(tag, draft=True, prerelease=True)),
-            ("git", "rev-parse", f"{tag}^{{commit}}"): candidate,
+            RELEASES_COMMAND: release_pages(
+                release(release_tag, draft=True, prerelease=True, target_commitish=candidate),
+            ),
+            tag_exists_command(tag): completed(tag_exists_command(tag), code=1, stderr="gh: Not Found (HTTP 404)"),
             publish: 0,
+            tag_command(tag): json.dumps({"type": "commit", "sha": candidate}),
             self.inspect_command(): completed(self.inspect_command(), stdout=self.image_data(candidate, candidate)),
             promote: 0,
             digest_command("image:nightly"): f'"{DIGEST}"',
         })
-        MODULE.finalize_nightly(commands, "r", "image", tag, DIGEST)
+        MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
         self.assertLess(commands.calls.index(publish), commands.calls.index(promote))
 
     def test_published_nightly_retry_still_promotes_alias(self):
         candidate = "b" * 40
         tag = f"nightly-{candidate}"
+        release_tag = f"staging-release-{candidate}"
         promote = ("docker", "buildx", "imagetools", "create", "--tag", "image:nightly", f"image@{DIGEST}")
         commands = FakeCommands({
             digest_command(f"image:{tag}"): f'"{DIGEST}"',
             RELEASES_COMMAND: release_pages(release(tag, prerelease=True)),
-            ("git", "rev-parse", f"{tag}^{{commit}}"): candidate,
+            tag_command(tag): json.dumps({"type": "commit", "sha": candidate}),
             self.inspect_command(): completed(self.inspect_command(), stdout=self.image_data(candidate, candidate)),
             promote: 0,
             digest_command("image:nightly"): f'"{DIGEST}"',
         })
-        MODULE.finalize_nightly(commands, "r", "image", tag, DIGEST)
+        MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
         self.assertFalse(any(call[:3] == ("gh", "release", "edit") for call in commands.calls))
         self.assertIn(promote, commands.calls)
+
+    def test_conflicting_final_and_staging_releases_fail(self):
+        candidate = "b" * 40
+        tag = f"nightly-{candidate}"
+        release_tag = f"staging-release-{candidate}"
+        commands = FakeCommands({
+            digest_command(f"image:{tag}"): f'"{DIGEST}"',
+            RELEASES_COMMAND: release_pages(
+                release(tag, prerelease=True),
+                release(release_tag, draft=True, prerelease=True, target_commitish=candidate),
+            ),
+        })
+        with self.assertRaisesRegex(MODULE.ReleaseError, "both final release"):
+            MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
+
+    def test_invalid_staging_release_states_fail(self):
+        candidate = "b" * 40
+        tag = f"nightly-{candidate}"
+        release_tag = f"staging-release-{candidate}"
+        cases = (
+            (release(release_tag, prerelease=True, target_commitish=candidate), "already published"),
+            (release(release_tag, draft=True, prerelease=True, target_commitish="a" * 40), "unexpected commit"),
+        )
+        for state, message in cases:
+            with self.subTest(message=message):
+                commands = FakeCommands({
+                    digest_command(f"image:{tag}"): f'"{DIGEST}"',
+                    RELEASES_COMMAND: release_pages(state),
+                })
+                with self.assertRaisesRegex(MODULE.ReleaseError, message):
+                    MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
+
+    def test_legacy_final_draft_fails(self):
+        candidate = "b" * 40
+        tag = f"nightly-{candidate}"
+        release_tag = f"staging-release-{candidate}"
+        commands = FakeCommands({
+            digest_command(f"image:{tag}"): f'"{DIGEST}"',
+            RELEASES_COMMAND: release_pages(release(tag, draft=True, prerelease=True)),
+        })
+        with self.assertRaisesRegex(MODULE.ReleaseError, "unexpectedly exists as a draft"):
+            MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
+
+    def test_existing_final_tag_blocks_staging_publication(self):
+        candidate = "b" * 40
+        tag = f"nightly-{candidate}"
+        release_tag = f"staging-release-{candidate}"
+        commands = FakeCommands({
+            digest_command(f"image:{tag}"): f'"{DIGEST}"',
+            RELEASES_COMMAND: release_pages(
+                release(release_tag, draft=True, prerelease=True, target_commitish=candidate),
+            ),
+            tag_exists_command(tag): completed(tag_exists_command(tag)),
+        })
+        with self.assertRaisesRegex(MODULE.ReleaseError, "already exists"):
+            MODULE.finalize_nightly(commands, "r", "image", tag, release_tag, DIGEST)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
           RELEASE_TAG_NAME: ${{ steps.release_info.outputs.release_tag_name }}
+          EXPECTED_SHA: ${{ github.sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -162,9 +163,12 @@ jobs:
           fi
           if (( final_count == 0 )); then
             tag_error="$(mktemp)"
-            if gh api "repos/$GH_REPO/git/ref/tags/$TAG_NAME" > /dev/null 2>"$tag_error"; then
-              echo "::error::Final nightly tag $TAG_NAME exists without its published release."
-              exit 1
+            if final_ref="$(gh api "repos/$GH_REPO/git/ref/tags/$TAG_NAME" 2>"$tag_error")"; then
+              if [[ "$(jq -r '.object.type' <<< "$final_ref")" != "commit" || "$(jq -r '.object.sha' <<< "$final_ref")" != "$EXPECTED_SHA" ]]; then
+                echo "::error::Final nightly tag $TAG_NAME does not point to $EXPECTED_SHA."
+                exit 1
+              fi
+              echo "Final nightly tag $TAG_NAME already points to $EXPECTED_SHA; allowing publication retry."
             elif ! grep -q 'HTTP 404' "$tag_error"; then
               cat "$tag_error" >&2
               echo "::error::Could not determine whether final nightly tag $TAG_NAME exists."
@@ -189,6 +193,10 @@ jobs:
             fi
             if [[ "$(jq -r '.[0].prerelease' <<< "$staging")" != "true" ]]; then
               echo "::error::Staging nightly release $RELEASE_TAG_NAME is not a prerelease."
+              exit 1
+            fi
+            if [[ "$(jq -r '.[0].target_commitish' <<< "$staging")" != "$EXPECTED_SHA" ]]; then
+              echo "::error::Staging nightly release $RELEASE_TAG_NAME does not target $EXPECTED_SHA."
               exit 1
             fi
             echo "Draft nightly release $RELEASE_TAG_NAME already exists; continuing so assets can be uploaded."
@@ -227,11 +235,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if release_state="$(gh release view "$TAG_NAME" --json isDraft,isPrerelease --jq '[.isDraft, .isPrerelease] | @tsv' 2>/dev/null)"; then
-            read -r is_draft is_prerelease <<< "$release_state"
+          if release_state="$(gh release view "$TAG_NAME" --json isDraft,isPrerelease,targetCommitish --jq '[.isDraft, .isPrerelease, .targetCommitish] | @tsv' 2>/dev/null)"; then
+            read -r is_draft is_prerelease target_commitish <<< "$release_state"
             if [[ "$is_draft" == "true" ]]; then
               if [[ "$is_prerelease" != "$EXPECTED_PRERELEASE" ]]; then
                 echo "::error::Draft release $TAG_NAME has prerelease=$is_prerelease; expected $EXPECTED_PRERELEASE."
+                exit 1
+              fi
+              if [[ "$TAG_NAME" != "$FINAL_TAG_NAME" && "$target_commitish" != "$GITHUB_SHA" ]]; then
+                echo "::error::Draft release $TAG_NAME targets $target_commitish; expected $GITHUB_SHA."
                 exit 1
               fi
               echo "Draft release $TAG_NAME already exists; reusing it."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
       pull-requests: read
     outputs:
       tag_name: ${{ steps.release_info.outputs.tag_name }}
+      release_tag_name: ${{ steps.release_info.outputs.release_tag_name }}
       release_name: ${{ steps.release_info.outputs.release_name }}
       changelog: ${{ steps.build_changelog.outputs.changelog }}
       skip_assets: ${{ steps.existing_release.outputs.skip_assets || 'false' }}
@@ -79,6 +80,7 @@ jobs:
 
           if [[ ${IS_NIGHTLY} == 'true' ]]; then
             tag_name="nightly-${GITHUB_SHA}"
+            release_tag_name="staging-release-${GITHUB_SHA}"
             release_name="Nightly ($(date '+%Y-%m-%d'))"
             is_prerelease=true
             # Find the previous nightly tag for changelog generation,
@@ -87,6 +89,7 @@ jobs:
               --format='%(refname:strip=2)' 'refs/tags/nightly-*')
           else
             tag_name="$GITHUB_REF_NAME"
+            release_tag_name="$tag_name"
             release_name="$GITHUB_REF_NAME"
 
             if [[ "$GITHUB_REF_NAME" =~ $stable_pattern ]]; then
@@ -125,6 +128,7 @@ jobs:
           fi
           {
             printf 'tag_name=%s\n' "$tag_name"
+            printf 'release_tag_name=%s\n' "$release_tag_name"
             printf 'release_name=%s\n' "$release_name"
             printf 'is_prerelease=%s\n' "$is_prerelease"
             printf 'from_tag=%s\n' "$from_tag"
@@ -137,33 +141,59 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
+          RELEASE_TAG_NAME: ${{ steps.release_info.outputs.release_tag_name }}
         shell: bash
         run: |
           set -euo pipefail
           skip_assets=false
-          if is_draft="$(gh release view "$TAG_NAME" --json isDraft --jq .isDraft 2>/dev/null)"; then
-            if [[ "$is_draft" == "true" ]]; then
-              echo "Draft nightly release $TAG_NAME already exists; continuing so assets can be uploaded."
-            else
-              echo "Published nightly release $TAG_NAME already exists; skipping assets and retrying finalization."
-              skip_assets=true
+          releases="$(gh api --paginate --slurp "repos/$GH_REPO/releases?per_page=100" | jq 'add')"
+          final="$(jq -c --arg tag "$TAG_NAME" '[.[] | select(.tag_name == $tag)]' <<< "$releases")"
+          staging="$(jq -c --arg tag "$RELEASE_TAG_NAME" '[.[] | select(.tag_name == $tag)]' <<< "$releases")"
+          final_count="$(jq 'length' <<< "$final")"
+          staging_count="$(jq 'length' <<< "$staging")"
+
+          if (( final_count > 1 || staging_count > 1 )); then
+            echo "::error::Found duplicate final or staging nightly releases."
+            exit 1
+          fi
+          if (( final_count == 1 && staging_count == 1 )); then
+            echo "::error::Both final release $TAG_NAME and staging release $RELEASE_TAG_NAME exist."
+            exit 1
+          fi
+          if (( final_count == 0 )); then
+            tag_error="$(mktemp)"
+            if gh api "repos/$GH_REPO/git/ref/tags/$TAG_NAME" > /dev/null 2>"$tag_error"; then
+              echo "::error::Final nightly tag $TAG_NAME exists without its published release."
+              exit 1
+            elif ! grep -q 'HTTP 404' "$tag_error"; then
+              cat "$tag_error" >&2
+              echo "::error::Could not determine whether final nightly tag $TAG_NAME exists."
+              exit 1
             fi
           fi
+          if (( final_count == 1 )); then
+            if [[ "$(jq -r '.[0].draft' <<< "$final")" == "true" ]]; then
+              echo "::error::Final nightly release $TAG_NAME unexpectedly exists as a draft."
+              exit 1
+            fi
+            if [[ "$(jq -r '.[0].prerelease' <<< "$final")" != "true" ]]; then
+              echo "::error::Final nightly release $TAG_NAME is not a prerelease."
+              exit 1
+            fi
+            echo "Published nightly release $TAG_NAME already exists; skipping assets and retrying finalization."
+            skip_assets=true
+          elif (( staging_count == 1 )); then
+            if [[ "$(jq -r '.[0].draft' <<< "$staging")" != "true" ]]; then
+              echo "::error::Staging nightly release $RELEASE_TAG_NAME is already published."
+              exit 1
+            fi
+            if [[ "$(jq -r '.[0].prerelease' <<< "$staging")" != "true" ]]; then
+              echo "::error::Staging nightly release $RELEASE_TAG_NAME is not a prerelease."
+              exit 1
+            fi
+            echo "Draft nightly release $RELEASE_TAG_NAME already exists; continuing so assets can be uploaded."
+          fi
           printf 'skip_assets=%s\n' "$skip_assets" >> "$GITHUB_OUTPUT"
-
-      # Creates a `nightly-SHA` tag for this specific nightly
-      # This tag is used for this specific nightly version's release
-      # which allows users to roll back. It is also used to build
-      # the changelog.
-      - name: Create build-specific nightly tag
-        if: ${{ env.IS_NIGHTLY == 'true' && steps.existing_release.outputs.skip_assets != 'true' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
-        with:
-          script: |
-            const createTag = require('./.github/scripts/create-tag.js')
-            await createTag({ github, context }, process.env.TAG_NAME)
 
       - name: Build changelog
         id: build_changelog
@@ -172,7 +202,9 @@ jobs:
         with:
           configuration: "./.github/changelog.json"
           fromTag: ${{ steps.release_info.outputs.from_tag || '' }}
-          toTag: ${{ steps.release_info.outputs.tag_name }}
+          # The canonical nightly tag is created only when the complete release
+          # is published, so use its commit directly while building the notes.
+          toTag: ${{ (env.IS_NIGHTLY == 'true' && github.sha) || steps.release_info.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -187,7 +219,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
+          TAG_NAME: ${{ steps.release_info.outputs.release_tag_name }}
+          FINAL_TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
           RELEASE_NAME: ${{ steps.release_info.outputs.release_name }}
           CHANGELOG: ${{ steps.build_changelog.outputs.changelog }}
           EXPECTED_PRERELEASE: ${{ steps.release_info.outputs.is_prerelease }}
@@ -209,7 +242,12 @@ jobs:
           fi
           notes_file="$(mktemp)"
           printf '%s' "$CHANGELOG" > "$notes_file"
-          flags=(--draft --verify-tag --title "$RELEASE_NAME" --notes-file "$notes_file")
+          flags=(--draft --title "$RELEASE_NAME" --notes-file "$notes_file")
+          if [[ "$TAG_NAME" == "$FINAL_TAG_NAME" ]]; then
+            flags+=(--verify-tag)
+          else
+            flags+=(--target "$GITHUB_SHA")
+          fi
           if [[ "$EXPECTED_PRERELEASE" == "true" ]]; then
             flags+=(--prerelease)
           fi
@@ -521,7 +559,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
+          TAG_NAME: ${{ needs.prepare.outputs.release_tag_name }}
           FILE_NAME: ${{ steps.artifacts.outputs.file_name }}
           FOUNDRY_ATTESTATION: ${{ steps.artifacts.outputs.foundry_attestation }}
           FOUNDRY_SBOM: ${{ steps.artifacts.outputs.foundry_sbom }}
@@ -572,9 +610,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
+          RELEASE_TAG_NAME: ${{ needs.prepare.outputs.release_tag_name }}
           DIGEST: ${{ needs.release-docker.outputs.digest }}
         shell: bash
-        run: python3 .github/scripts/finalize-release.py nightly --tag "$TAG_NAME" --digest "$DIGEST"
+        run: python3 .github/scripts/finalize-release.py nightly --tag "$TAG_NAME" --release-tag "$RELEASE_TAG_NAME" --digest "$DIGEST"
 
   # If any of the jobs fail, this will create a high-priority issue to signal so.
   issue:


### PR DESCRIPTION
Stages nightly assets under a temporary release identity, then creates and publishes `nightly-<sha>` only after every build completes. This prevents Atom consumers from discovering incomplete nightlies whose assets return 404.