### PR TITLE
fix(symbolic): preserve call semantics

### DIFF
--- a/.changelog/fix-symbolic-call-create-semantics.md
+++ b/.changelog/fix-symbolic-call-create-semantics.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Fixed symbolic static calls, `CALLCODE` balance checks, and reverted constructor return data to match concrete EVM execution.

--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -879,40 +879,45 @@ impl SymbolicExecutor {
             }
         }
         let code_address = self.function_mock_target(state, to, &call_input)?.unwrap_or(to);
+        let call_context =
+            (!matches!(kind, CallKind::DelegateCall)).then(|| state.prank_for_next_call());
+        let transfer_to = if matches!(kind, CallKind::Call) { to } else { state.address };
+        if matches!(kind, CallKind::Call | CallKind::CallCode) {
+            let call_caller = call_context.as_ref().expect("value calls have a call context").0;
+            if !self.prepare_value_transfer(
+                executor,
+                state,
+                worklist,
+                call_caller,
+                transfer_to,
+                value.clone(),
+                out_offset.clone(),
+                &out_size,
+            )? {
+                return Ok(StepOutcome::Continue);
+            }
+        }
         if !state.call_mocks.is_empty() {
             let concrete_value = state.constrained_word(&mut self.cx, &value);
             if let Some(mock) =
                 self.take_call_mock(state, code_address, concrete_value, &call_input)?
             {
-                if !matches!(kind, CallKind::DelegateCall) {
-                    let _ = state.prank_for_next_call();
-                }
                 let (return_data, reverts) = mock.into_parts();
                 state.return_data = return_data;
+                if !reverts && let Some((call_caller, _, _)) = call_context {
+                    self.apply_call_value_transfer(executor, state, kind, to, call_caller, value);
+                }
                 state.copy_call_output_offset(&mut self.cx, out_offset, &out_size)?;
                 let success = SymExpr::constant(&mut self.cx, U256::from(!reverts));
                 state.stack.push(success)?;
                 return Ok(StepOutcome::Continue);
             }
         }
-
         if matches!(kind, CallKind::DelegateCall) && state.prank.has_active() {
             return Err(SymbolicError::Unsupported("symbolic prank delegatecall"));
         }
-        let (call_caller, call_caller_word, pranked_origin) = state.prank_for_next_call();
-        if matches!(kind, CallKind::Call | CallKind::CallCode)
-            && !self.prepare_value_transfer(
-                executor,
-                state,
-                worklist,
-                call_caller,
-                value.clone(),
-                out_offset.clone(),
-                &out_size,
-            )?
-        {
-            return Ok(StepOutcome::Continue);
-        }
+        let (call_caller, call_caller_word, pranked_origin) =
+            call_context.unwrap_or_else(|| state.prank_for_next_call());
 
         let spec_id: SpecId = executor.spec_id().into();
         if is_supported_precompile(code_address, spec_id) {
@@ -1327,6 +1332,7 @@ impl SymbolicExecutor {
         state: &mut PathState,
         worklist: &mut VecDeque<PathState>,
         from: Address,
+        to: Address,
         value: SymExpr,
         out_offset: SymExpr,
         out_size: &BoundedCopySize,
@@ -1336,8 +1342,16 @@ impl SymbolicExecutor {
         }
 
         let balance = state.world.balance_word_for_address(&mut self.cx, executor, from);
-        let can_pay = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Uge, balance, value);
-        match can_pay.as_const() {
+        let can_pay = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Uge, balance, value.clone());
+        let can_transfer = if from == to {
+            can_pay
+        } else {
+            let balance = state.world.balance_word_for_address(&mut self.cx, executor, to);
+            let sum = SymExpr::binop(&mut self.cx, SymBinOp::Add, balance.clone(), value);
+            let no_overflow = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Uge, sum, balance);
+            SymBoolExpr::and(&mut self.cx, vec![can_pay, no_overflow])
+        };
+        match can_transfer.as_const() {
             Some(true) => Ok(true),
             Some(false) => {
                 state.return_data = SymReturnData::empty(&mut self.cx);
@@ -1347,11 +1361,11 @@ impl SymbolicExecutor {
             }
             None => {
                 let mut success_constraints = state.constraints.clone();
-                success_constraints.push(can_pay.clone());
+                success_constraints.push(can_transfer.clone());
                 let success_sat = self.solver.is_sat(&mut self.cx, &success_constraints)?;
 
                 let mut failure_constraints = state.constraints.clone();
-                failure_constraints.push(can_pay.not(&mut self.cx));
+                failure_constraints.push(can_transfer.not(&mut self.cx));
                 let failure_sat = self.solver.is_sat(&mut self.cx, &failure_constraints)?;
 
                 match (success_sat, failure_sat) {
@@ -1492,22 +1506,28 @@ impl SymbolicExecutor {
             }
             let (call_caller, _, _) = branch.prank_for_next_call();
             if matches!(kind, CallKind::Call | CallKind::CallCode) {
+                let transfer_to = if matches!(kind, CallKind::Call) {
+                    branch.world.symbolic_address_slot(target)
+                } else {
+                    branch.address
+                };
                 if self.prepare_value_transfer(
                     executor,
                     &mut branch,
                     &mut parents,
                     call_caller,
+                    transfer_to,
                     value.clone(),
                     out_offset.clone(),
                     &out_size,
                 )? {
-                    let to = if matches!(kind, CallKind::Call) {
-                        let symbolic_target = target;
-                        branch.world.symbolic_address_slot(symbolic_target)
-                    } else {
-                        branch.address
-                    };
-                    branch.world.transfer(&mut self.cx, executor, call_caller, to, value.clone());
+                    branch.world.transfer(
+                        &mut self.cx,
+                        executor,
+                        call_caller,
+                        transfer_to,
+                        value.clone(),
+                    );
                     branch.return_data = SymReturnData::empty(&mut self.cx);
                     branch.copy_call_output_offset(&mut self.cx, out_offset.clone(), &out_size)?;
                     branch.stack.push(SymExpr::one(&mut self.cx))?;

--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -11,7 +11,8 @@ impl SymbolicExecutor {
     ) -> Result<StepOutcome, SymbolicError> {
         let pre_call_state = (!state.function_mocks.is_empty()
             || !state.expected_calls.is_empty()
-            || !state.call_mocks.is_empty())
+            || !state.call_mocks.is_empty()
+            || (state.is_static && matches!(kind, CallKind::Call)))
         .then(|| state.clone());
         let call_pc = state.pc.saturating_sub(1);
         let gas = state.stack.pop()?;
@@ -86,11 +87,43 @@ impl SymbolicExecutor {
             }
         };
 
-        if state.is_static
-            && !state.constrained_word(&mut self.cx, &value).is_some_and(|value| value.is_zero())
-        {
-            state.return_data = SymReturnData::empty(&mut self.cx);
-            return Ok(StepOutcome::Revert);
+        if state.is_static && matches!(kind, CallKind::Call) {
+            match state.constrained_word(&mut self.cx, &value) {
+                Some(value) if value.is_zero() => {}
+                Some(_) => {
+                    state.return_data = SymReturnData::empty(&mut self.cx);
+                    return Ok(StepOutcome::Revert);
+                }
+                None => {
+                    let zero = SymBoolExpr::eq_word_const(&mut self.cx, &value, U256::ZERO);
+                    let (zero_constraints, zero_sat) =
+                        self.constraints_with_condition(state, zero.clone())?;
+                    let nonzero = zero.not(&mut self.cx);
+                    let (nonzero_constraints, nonzero_sat) =
+                        self.constraints_with_condition(state, nonzero)?;
+                    match (zero_sat, nonzero_sat) {
+                        (true, true) => {
+                            let mut zero_state = pre_call_state
+                                .as_ref()
+                                .expect("static calls preserve pre-call state")
+                                .clone();
+                            zero_state.pc = call_pc;
+                            zero_state.constraints = zero_constraints;
+                            worklist.push_back(zero_state);
+                            state.constraints = nonzero_constraints;
+                            state.return_data = SymReturnData::empty(&mut self.cx);
+                            return Ok(StepOutcome::Revert);
+                        }
+                        (true, false) => state.constraints = zero_constraints,
+                        (false, true) => {
+                            state.constraints = nonzero_constraints;
+                            state.return_data = SymReturnData::empty(&mut self.cx);
+                            return Ok(StepOutcome::Revert);
+                        }
+                        (false, false) => return Ok(StepOutcome::AssumeRejected),
+                    }
+                }
+            }
         }
 
         let call_input = in_size.read_from_memory(&mut self.cx, &state.memory, in_offset.clone());
@@ -867,7 +900,7 @@ impl SymbolicExecutor {
             return Err(SymbolicError::Unsupported("symbolic prank delegatecall"));
         }
         let (call_caller, call_caller_word, pranked_origin) = state.prank_for_next_call();
-        if matches!(kind, CallKind::Call)
+        if matches!(kind, CallKind::Call | CallKind::CallCode)
             && !self.prepare_value_transfer(
                 executor,
                 state,
@@ -910,9 +943,7 @@ impl SymbolicExecutor {
             )? {
                 Some(return_data) => {
                     state.return_data = return_data;
-                    if matches!(kind, CallKind::Call) {
-                        state.world.transfer(&mut self.cx, executor, call_caller, to, value);
-                    }
+                    self.apply_call_value_transfer(executor, state, kind, to, call_caller, value);
                     state.copy_call_output_offset(&mut self.cx, out_offset, &out_size)?;
                     state.stack.push(SymExpr::one(&mut self.cx))?;
                 }
@@ -927,9 +958,7 @@ impl SymbolicExecutor {
 
         let child_code = state.world.extcode(&mut self.cx, executor, code_address)?;
         if child_code.is_empty() {
-            if matches!(kind, CallKind::Call) {
-                state.world.transfer(&mut self.cx, executor, call_caller, to, value);
-            }
+            self.apply_call_value_transfer(executor, state, kind, to, call_caller, value);
             state.return_data = SymReturnData::empty(&mut self.cx);
             state.copy_call_output_offset(&mut self.cx, out_offset, &out_size)?;
             state.stack.push(SymExpr::one(&mut self.cx))?;
@@ -1017,9 +1046,7 @@ impl SymbolicExecutor {
             child.origin = origin;
             child.origin_word = origin_word;
         }
-        if matches!(kind, CallKind::Call) {
-            child.world.transfer(&mut self.cx, executor, call_caller, to, value);
-        }
+        self.apply_call_value_transfer(executor, &mut child, kind, to, call_caller, value);
         child.expected_revert = None;
         child.assume_no_revert_next_call = None;
         let outcomes = self.execute_external_call(executor, child, &child_code, completed_paths)?;
@@ -1263,9 +1290,7 @@ impl SymbolicExecutor {
         match outcome {
             Some(return_data) => {
                 state.return_data = return_data;
-                if matches!(kind, CallKind::Call) {
-                    state.world.transfer(&mut self.cx, executor, call_caller, to, value);
-                }
+                self.apply_call_value_transfer(executor, state, kind, to, call_caller, value);
                 state.copy_call_output_offset(&mut self.cx, out_offset, out_size)?;
                 state.stack.push(SymExpr::one(&mut self.cx))?;
             }
@@ -1276,6 +1301,23 @@ impl SymbolicExecutor {
             }
         }
         Ok(())
+    }
+
+    fn apply_call_value_transfer<FEN: FoundryEvmNetwork>(
+        &mut self,
+        executor: &Executor<FEN>,
+        state: &mut PathState,
+        kind: CallKind,
+        to: Address,
+        from: Address,
+        value: SymExpr,
+    ) {
+        let to = match kind {
+            CallKind::Call => to,
+            CallKind::CallCode => state.address,
+            CallKind::DelegateCall | CallKind::StaticCall => return,
+        };
+        state.world.transfer(&mut self.cx, executor, from, to, value);
     }
 
     #[expect(clippy::too_many_arguments)]
@@ -1449,7 +1491,7 @@ impl SymbolicExecutor {
                 return Err(SymbolicError::Unsupported("symbolic prank delegatecall"));
             }
             let (call_caller, _, _) = branch.prank_for_next_call();
-            if matches!(kind, CallKind::Call) {
+            if matches!(kind, CallKind::Call | CallKind::CallCode) {
                 if self.prepare_value_transfer(
                     executor,
                     &mut branch,
@@ -1459,20 +1501,23 @@ impl SymbolicExecutor {
                     out_offset.clone(),
                     &out_size,
                 )? {
-                    let symbolic_target = target;
-                    let to = branch.world.symbolic_address_slot(symbolic_target);
+                    let to = if matches!(kind, CallKind::Call) {
+                        let symbolic_target = target;
+                        branch.world.symbolic_address_slot(symbolic_target)
+                    } else {
+                        branch.address
+                    };
                     branch.world.transfer(&mut self.cx, executor, call_caller, to, value.clone());
                     branch.return_data = SymReturnData::empty(&mut self.cx);
                     branch.copy_call_output_offset(&mut self.cx, out_offset.clone(), &out_size)?;
                     branch.stack.push(SymExpr::one(&mut self.cx))?;
-                    parents.push_back(branch);
                 }
             } else {
                 branch.return_data = SymReturnData::empty(&mut self.cx);
                 branch.copy_call_output_offset(&mut self.cx, out_offset.clone(), &out_size)?;
                 branch.stack.push(SymExpr::one(&mut self.cx))?;
-                parents.push_back(branch);
             }
+            parents.push_back(branch);
         }
 
         for (to, constraint) in candidates.into_iter().zip(candidate_constraints) {

--- a/crates/evm/symbolic/src/executor/create.rs
+++ b/crates/evm/symbolic/src/executor/create.rs
@@ -203,6 +203,7 @@ impl SymbolicExecutor {
                 }
                 TopLevelCallStatus::Revert => {
                     parent.world = failure_world.clone();
+                    parent.return_data = outcome.return_data.clone();
                     parent.stack.push(SymExpr::zero(&mut self.cx))?;
                 }
                 TopLevelCallStatus::Failure => {

--- a/crates/forge/tests/cli/test_cmd/symbolic_calls.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_calls.rs
@@ -1499,12 +1499,60 @@ contract SymbolicCallcodeValue is Test {
         assertEq(caller.balance, 1 - amount);
         assertEq(address(this).balance, amount);
     }
+
+    function checkPrankedCallcodeOverflow() public {
+        address caller = address(0xBEEF);
+        vm.deal(address(this), type(uint256).max);
+        vm.deal(caller, 1);
+        vm.prank(caller);
+
+        bool ok;
+        address callTarget = address(target);
+        assembly {
+            ok := callcode(gas(), callTarget, 1, 0, 0, 0, 0)
+        }
+
+        assert(!ok);
+        assertEq(caller.balance, 1);
+        assertEq(address(this).balance, type(uint256).max);
+    }
+
+    function checkMockedPrankedCallcodeValue() public {
+        address caller = address(0xBEEF);
+        bytes memory input = abi.encodeWithSelector(SymbolicCallcodeValueTarget.echoValue.selector);
+        vm.mockCall(address(target), 1, input, abi.encode(uint256(99)));
+        vm.deal(address(this), 0);
+        vm.deal(caller, 1);
+        vm.prank(caller);
+
+        uint256 echoed;
+        bool ok;
+        address callTarget = address(target);
+        assembly {
+            ok := callcode(gas(), callTarget, 1, add(input, 0x20), mload(input), 0x80, 0x20)
+            echoed := mload(0x80)
+        }
+
+        assert(ok);
+        assertEq(echoed, 99);
+        assertEq(caller.balance, 0);
+        assertEq(address(this).balance, 1);
+
+        vm.deal(caller, 0);
+        vm.prank(caller);
+        assembly {
+            ok := callcode(gas(), callTarget, 1, add(input, 0x20), mload(input), 0, 0)
+        }
+        assert(!ok);
+        assertEq(caller.balance, 0);
+        assertEq(address(this).balance, 1);
+    }
 }
 "#,
     );
 
     let stdout = cmd
-        .args(["test", "--symbolic", "--match-test", "check.*CallcodeValue"])
+        .args(["test", "--symbolic", "--match-test", "check.*Callcode"])
         .assert_success()
         .get_output()
         .stdout_lossy();
@@ -1519,6 +1567,18 @@ contract SymbolicCallcodeValue is Test {
         &stdout,
         foundry_test_utils::str![[r#"
 [PASS] checkPrankedCallcodeValue(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkPrankedCallcodeOverflow()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockedPrankedCallcodeValue()
 "#]],
     );
     assert!(!stdout.contains("symbolic CALLCODE value"), "{stdout}");

--- a/crates/forge/tests/cli/test_cmd/symbolic_calls.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_calls.rs
@@ -760,7 +760,9 @@ forgetest_init!(symbolic_external_call_with_empty_unknown_target_is_modeled, |pr
     prj.add_test(
         "SymbolicUnboundedTarget.t.sol",
         r#"
-contract SymbolicUnboundedTarget {
+import "forge-std/Test.sol";
+
+contract SymbolicUnboundedTarget is Test {
     /// forge-config: default.symbolic.symbolic_call_targets = true
     function checkUnbounded(address target) public {
         if (uint160(target) <= 9 || target == address(this)) {
@@ -771,6 +773,17 @@ contract SymbolicUnboundedTarget {
             ok := call(gas(), target, 0, 0, 0, 0, 0)
         }
         require(ok);
+    }
+
+    /// forge-config: default.symbolic.symbolic_call_targets = true
+    function checkUnboundedInsufficientValue(address target) public {
+        vm.assume(uint160(target) > 9 && target != address(this));
+        vm.deal(address(this), 0);
+        bool ok;
+        assembly {
+            ok := call(gas(), target, 1, 0, 0, 0, 0)
+        }
+        assert(!ok);
     }
 }
 "#,
@@ -786,6 +799,12 @@ contract SymbolicUnboundedTarget {
         &stdout,
         foundry_test_utils::str![[r#"
 [PASS] checkUnbounded(address)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkUnboundedInsufficientValue(address)
 "#]],
     );
     assert!(!stdout.contains("symbolic CALL target outside known contracts"), "{stdout}");
@@ -1135,6 +1154,65 @@ contract SymbolicStaticCall {
     );
 });
 
+forgetest_init!(symbolic_static_call_splits_symbolic_value, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_static_call_splits_symbolic_value because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicStaticCallValue.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract StaticValueSink {
+    receive() external payable {}
+}
+
+contract StaticValueHelper {
+    function callWithValue(address target, uint256 amount) external returns (bool ok) {
+        assembly {
+            ok := call(gas(), target, amount, 0, 0, 0, 0)
+        }
+    }
+}
+
+contract SymbolicStaticCallValue is Test {
+    StaticValueSink sink;
+    StaticValueHelper helper;
+
+    function setUp() public {
+        sink = new StaticValueSink();
+        helper = new StaticValueHelper();
+    }
+
+    function checkStaticCallValue(uint256 amount) public {
+        vm.assume(amount <= 1);
+        (bool ok,) = address(helper).staticcall(
+            abi.encodeCall(StaticValueHelper.callWithValue, (address(sink), amount))
+        );
+        assertEq(ok, amount == 0);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkStaticCallValue"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkStaticCallValue(uint256)
+"#]],
+    );
+});
+
 forgetest_init!(symbolic_delegatecall_writes_caller_storage, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(
@@ -1382,8 +1460,30 @@ contract SymbolicCallcodeValue is Test {
     }
 
     function checkSymbolicCallcodeValue(uint256 amount) public {
-        vm.assume(amount <= 7);
+        vm.assume(amount <= 8);
         vm.deal(address(this), 7);
+
+        bytes memory input = abi.encodeWithSelector(SymbolicCallcodeValueTarget.echoValue.selector);
+        uint256 echoed;
+        bool ok;
+        address callTarget = address(target);
+        assembly {
+            ok := callcode(gas(), callTarget, amount, add(input, 0x20), mload(input), 0x80, 0x20)
+            echoed := mload(0x80)
+        }
+
+        assertEq(ok, amount <= 7);
+        if (ok) {
+            assertEq(echoed, amount);
+        }
+    }
+
+    function checkPrankedCallcodeValue(uint256 amount) public {
+        vm.assume(amount <= 1);
+        address caller = address(0xBEEF);
+        vm.deal(address(this), 0);
+        vm.deal(caller, 1);
+        vm.prank(caller);
 
         bytes memory input = abi.encodeWithSelector(SymbolicCallcodeValueTarget.echoValue.selector);
         uint256 echoed;
@@ -1396,13 +1496,15 @@ contract SymbolicCallcodeValue is Test {
 
         assert(ok);
         assertEq(echoed, amount);
+        assertEq(caller.balance, 1 - amount);
+        assertEq(address(this).balance, amount);
     }
 }
 "#,
     );
 
     let stdout = cmd
-        .args(["test", "--symbolic", "--match-test", "checkSymbolicCallcodeValue"])
+        .args(["test", "--symbolic", "--match-test", "check.*CallcodeValue"])
         .assert_success()
         .get_output()
         .stdout_lossy();
@@ -1411,6 +1513,12 @@ contract SymbolicCallcodeValue is Test {
         &stdout,
         foundry_test_utils::str![[r#"
 [PASS] checkSymbolicCallcodeValue(uint256)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkPrankedCallcodeValue(uint256)
 "#]],
     );
     assert!(!stdout.contains("symbolic CALLCODE value"), "{stdout}");

--- a/crates/forge/tests/cli/test_cmd/symbolic_creates.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_creates.rs
@@ -829,12 +829,16 @@ contract SymbolicCreateRevertData {
         bytes memory initcode = hex"61123460005260206000fd";
         address created;
         uint256 size;
+        uint256 payload;
         assembly {
             created := create(0, add(initcode, 0x20), mload(initcode))
             size := returndatasize()
+            returndatacopy(0x80, 0, size)
+            payload := mload(0x80)
         }
         assert(created == address(0));
         assert(size == 32);
+        assert(payload == 0x1234);
     }
 }
 "#,

--- a/crates/forge/tests/cli/test_cmd/symbolic_creates.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_creates.rs
@@ -813,6 +813,47 @@ contract SymbolicCreateValue is Test {
     );
 });
 
+forgetest_init!(symbolic_create_preserves_revert_data, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_create_preserves_revert_data because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicCreateRevertData.t.sol",
+        r#"
+contract SymbolicCreateRevertData {
+    function checkCreateRevertData() public {
+        bytes memory initcode = hex"61123460005260206000fd";
+        address created;
+        uint256 size;
+        assembly {
+            created := create(0, add(initcode, 0x20), mload(initcode))
+            size := returndatasize()
+        }
+        assert(created == address(0));
+        assert(size == 32);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkCreateRevertData"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCreateRevertData()
+"#]],
+    );
+});
+
 forgetest_init!(symbolic_create_accepts_symbolic_value, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(


### PR DESCRIPTION
Corrects divergences between symbolic and concrete EVM execution. Static calls now preserve both feasible zero-value and reverting nonzero-value paths, while unknown symbolic targets retain insufficient-funds failures instead of silently dropping them.

`CALLCODE` now checks and transfers value from the effective caller—including pranked callers—to the current execution context, with proper rollback on revert. Reverted contract creation also exposes constructor revert data through `RETURNDATA`, matching revm behavior.