### PR TITLE
chore(deps): bump Tempo revision

### DIFF
--- a/.changelog/tempo-t11.md
+++ b/.changelog/tempo-t11.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Updated Tempo dependencies so Cast recognizes the T11 hardfork.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=d7bf697983d51bb369bc996ce35525c53d412b9c#d7bf697983d51bb369bc996ce35525c53d412b9c"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=63171c2#63171c2ad2161829fa787e798603d2fc8feaf2e3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3243,7 +3243,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.19",
  "which",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3402,7 +3402,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4627,7 +4627,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4934,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=41861a3188696c93288d8451342ce5cfd4b0d651#41861a3188696c93288d8451342ce5cfd4b0d651"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=6f1ce6d#6f1ce6d62fe1e8af84f7066d0e0a3e27f9caa5ef"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7357,7 +7357,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=d7bf697983d51bb369bc996ce35525c53d412b9c#d7bf697983d51bb369bc996ce35525c53d412b9c"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=63171c2#63171c2ad2161829fa787e798603d2fc8feaf2e3"
 dependencies = [
  "alloy",
  "async-stream",
@@ -8190,7 +8190,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9617,7 +9617,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11002,7 +11002,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11061,7 +11061,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12469,13 +12469,13 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12515,7 +12515,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12538,7 +12538,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12550,7 +12550,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12562,7 +12562,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12593,7 +12593,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12605,7 +12605,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12628,7 +12628,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12639,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12667,7 +12667,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
+source = "git+https://github.com/tempoxyz/tempo?rev=0f87fa6b42c86665142432337865d1adc04238e7#0f87fa6b42c86665142432337865d1adc04238e7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12693,7 +12693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13862,7 +13862,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14010,7 +14010,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "41861a3188696c93288d8451342ce5cfd4b0d651", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "6f1ce6d", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -512,30 +512,30 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "d7bf697983d51bb369bc996ce35525c53d412b9c", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "63171c2", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "d7bf697983d51bb369bc996ce35525c53d412b9c", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "63171c2", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7" }
 
 # Monad
 alloy-monad-evm = { version = "0.5.0", default-features = false, features = [
@@ -629,9 +629,9 @@ op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "56
 alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -231,8 +231,8 @@ use tempo_primitives::{
     },
 };
 use tempo_revm::{
-    TempoBatchCallEnv, TempoBlockEnv, TempoHaltReason, TempoTxEnv, evm::TempoContext,
-    gas_params::tempo_gas_params,
+    ExecutionContext, TempoBatchCallEnv, TempoBlockEnv, TempoHaltReason, TempoTxEnv,
+    evm::TempoContext, gas_params::tempo_gas_params,
 };
 use tokio::{sync::RwLock as AsyncRwLock, task::JoinSet};
 
@@ -3391,6 +3391,7 @@ impl<N: Network> Backend<N> {
         let tx_env = TempoTxEnv {
             fee_token: request.fee_token,
             is_system_tx: false,
+            execution_context: ExecutionContext::Simulation,
             unique_tx_identifier: Some(TEMPO_RPC_SIMULATION_CONTEXT),
             fee_payer,
             tempo_tx_env: Some(Box::new(TempoBatchCallEnv {

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -3783,11 +3783,6 @@ struct AnvilNodeInfo {
     network: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-struct TempoForkSchedule {
-    active: String,
-}
-
 pub(crate) async fn is_tempo_hardfork_active<P>(
     provider: &P,
     hardfork: TempoHardfork,
@@ -3795,9 +3790,8 @@ pub(crate) async fn is_tempo_hardfork_active<P>(
 where
     P: Provider<TempoNetwork>,
 {
-    match provider.raw_request::<_, TempoForkSchedule>("tempo_forkSchedule".into(), ()).await {
-        Ok(schedule) => active_tempo_hardfork(&schedule.active, hardfork)
-            .ok_or_else(|| eyre::eyre!("unknown Tempo hardfork: {}", schedule.active)),
+    match provider.is_hardfork_active(hardfork).await {
+        Ok(active) => Ok(active),
         Err(err) if is_rpc_method_not_found(&err) => {
             match anvil_tempo_hardfork_active(provider, hardfork).await {
                 Ok(Some(active)) => Ok(active),
@@ -3845,29 +3839,9 @@ fn active_from_anvil_node_info(info: &AnvilNodeInfo, hardfork: TempoHardfork) ->
     (info.network.as_deref() == Some("tempo")).then(|| {
         info.hard_fork
             .as_deref()
-            .and_then(|active_hardfork| active_tempo_hardfork(active_hardfork, hardfork))
-            .unwrap_or(false)
+            .and_then(|active_hardfork| active_hardfork.parse::<TempoHardfork>().ok())
+            .is_some_and(|active_hardfork| active_hardfork >= hardfork)
     })
-}
-
-fn active_tempo_hardfork(active: &str, hardfork: TempoHardfork) -> Option<bool> {
-    if let Ok(active) = active.parse::<TempoHardfork>() {
-        return Some(active >= hardfork);
-    }
-
-    let active_number = active.strip_prefix('T')?.parse::<u64>().ok()?;
-    let hardfork_name = hardfork.to_string();
-    if hardfork_name == "Genesis" {
-        return Some(true);
-    }
-    let hardfork_number = hardfork_name
-        .strip_prefix('T')?
-        .chars()
-        .take_while(char::is_ascii_digit)
-        .collect::<String>()
-        .parse::<u64>()
-        .ok()?;
-    Some(active_number >= hardfork_number)
 }
 
 fn is_rpc_method_not_found(err: &TransportError) -> bool {
@@ -4510,8 +4484,7 @@ mod tests {
             network: Some("tempo".to_string()),
             hard_fork: Some("T11".to_string()),
         };
-        assert_eq!(active_from_anvil_node_info(&tempo_t11, TempoHardfork::T3), Some(true));
-        assert_eq!(active_from_anvil_node_info(&tempo_t11, TempoHardfork::T10), Some(true));
+        assert_eq!(active_from_anvil_node_info(&tempo_t11, TempoHardfork::T11), Some(true));
 
         let ethereum_t3 = AnvilNodeInfo {
             network: Some("ethereum".to_string()),

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -3783,6 +3783,11 @@ struct AnvilNodeInfo {
     network: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct TempoForkSchedule {
+    active: String,
+}
+
 pub(crate) async fn is_tempo_hardfork_active<P>(
     provider: &P,
     hardfork: TempoHardfork,
@@ -3790,8 +3795,9 @@ pub(crate) async fn is_tempo_hardfork_active<P>(
 where
     P: Provider<TempoNetwork>,
 {
-    match provider.is_hardfork_active(hardfork).await {
-        Ok(active) => Ok(active),
+    match provider.raw_request::<_, TempoForkSchedule>("tempo_forkSchedule".into(), ()).await {
+        Ok(schedule) => active_tempo_hardfork(&schedule.active, hardfork)
+            .ok_or_else(|| eyre::eyre!("unknown Tempo hardfork: {}", schedule.active)),
         Err(err) if is_rpc_method_not_found(&err) => {
             match anvil_tempo_hardfork_active(provider, hardfork).await {
                 Ok(Some(active)) => Ok(active),
@@ -3839,9 +3845,29 @@ fn active_from_anvil_node_info(info: &AnvilNodeInfo, hardfork: TempoHardfork) ->
     (info.network.as_deref() == Some("tempo")).then(|| {
         info.hard_fork
             .as_deref()
-            .and_then(|active_hardfork| active_hardfork.parse::<TempoHardfork>().ok())
-            .is_some_and(|active_hardfork| active_hardfork >= hardfork)
+            .and_then(|active_hardfork| active_tempo_hardfork(active_hardfork, hardfork))
+            .unwrap_or(false)
     })
+}
+
+fn active_tempo_hardfork(active: &str, hardfork: TempoHardfork) -> Option<bool> {
+    if let Ok(active) = active.parse::<TempoHardfork>() {
+        return Some(active >= hardfork);
+    }
+
+    let active_number = active.strip_prefix('T')?.parse::<u64>().ok()?;
+    let hardfork_name = hardfork.to_string();
+    if hardfork_name == "Genesis" {
+        return Some(true);
+    }
+    let hardfork_number = hardfork_name
+        .strip_prefix('T')?
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse::<u64>()
+        .ok()?;
+    Some(active_number >= hardfork_number)
 }
 
 fn is_rpc_method_not_found(err: &TransportError) -> bool {
@@ -4479,6 +4505,13 @@ mod tests {
         assert_eq!(active_from_anvil_node_info(&tempo_t3, TempoHardfork::T2), Some(true));
         assert_eq!(active_from_anvil_node_info(&tempo_t3, TempoHardfork::T3), Some(true));
         assert_eq!(active_from_anvil_node_info(&tempo_t3, TempoHardfork::T4), Some(false));
+
+        let tempo_t11 = AnvilNodeInfo {
+            network: Some("tempo".to_string()),
+            hard_fork: Some("T11".to_string()),
+        };
+        assert_eq!(active_from_anvil_node_info(&tempo_t11, TempoHardfork::T3), Some(true));
+        assert_eq!(active_from_anvil_node_info(&tempo_t11, TempoHardfork::T10), Some(true));
 
         let ethereum_t3 = AnvilNodeInfo {
             network: Some("ethereum".to_string()),


### PR DESCRIPTION
## Summary

- bump all Tempo dependencies from `c93d08a9` to `0f87fa6b`, adding T11 hardfork awareness
- align the transitive `foundry-wallets` and MPP Tempo revisions to avoid duplicate `tempo-alloy` types
- set the new `TempoTxEnv.execution_context` field for Anvil RPC simulations
- add coverage that Cast recognizes T11 from `anvil_nodeInfo`

## Context

A T11 Tempo devnet caused `cast keychain authorize` to treat T3 as inactive because Foundry’s pinned `TempoHardfork` enum only knew through T10. Cast then encoded the legacy pre-T3 `authorizeKey` selector, which the node rejected with `LegacyAuthorizeKeySelectorChanged`.

## Dependency PRs

- foundry-rs/foundry-core#160
- tempoxyz/mpp-rs#384

The Foundry branch temporarily pins the commits from those draft PRs so the full dependency graph resolves to one Tempo revision.

## Validation

- `cargo test -p cast@1.8.0 test_active_from_anvil_node_info_requires_tempo_network`
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p cast@1.8.0 --locked --all-targets -- -D warnings`

This PR was authored by OpenAI Codex with human direction and review requested.

Prompted by: @0xrusowsky