### PR TITLE
feat(cli): add gas estimate multiplier

### DIFF
--- a/.changelog/create-send-gas-estimate-multiplier.md
+++ b/.changelog/create-send-gas-estimate-multiplier.md
@@ -1,0 +1,6 @@
+---
+cast: minor
+forge: minor
+---
+
+Added `--gas-estimate-multiplier` to `cast send` and `forge create`.

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -68,6 +68,10 @@ pub struct SendTxArgs {
     #[arg(long)]
     force: bool,
 
+    /// Relative percentage to multiply the gas estimate by.
+    #[arg(long, value_name = "PERCENT", help_heading = "Transaction options")]
+    gas_estimate_multiplier: Option<u64>,
+
     #[command(flatten)]
     tx: TransactionOpts,
 
@@ -127,8 +131,19 @@ impl SendTxArgs {
         N::TransactionRequest: FoundryTransactionBuilder<N>,
         N::ReceiptResponse: UIfmt + UIfmtReceiptExt,
     {
-        let Self { to, mut sig, mut args, data, send_tx, mut tx, command, unlocked, force, path } =
-            self;
+        let Self {
+            to,
+            mut sig,
+            mut args,
+            data,
+            send_tx,
+            mut tx,
+            command,
+            unlocked,
+            force,
+            gas_estimate_multiplier,
+            path,
+        } = self;
 
         let has_session = tx.tempo.session_id()?.is_some();
         if has_session && unlocked {
@@ -231,6 +246,7 @@ impl SendTxArgs {
 
         let builder = CastTxBuilder::new(&provider, tx, &config)
             .await?
+            .with_gas_estimate_multiplier(gas_estimate_multiplier)
             .with_to(to)
             .await?
             .with_code_sig_and_args(code, sig, args)
@@ -755,6 +771,17 @@ mod tests {
         // bypass attempts that fooled the old starts_with check
         assert!(validate_sponsor_url("http://localhost.evil.com").is_err());
         assert!(validate_sponsor_url("http://127.0.0.1.evil.com").is_err());
+    }
+
+    #[test]
+    fn parses_gas_estimate_multiplier() {
+        let args = SendTxArgs::parse_from([
+            "cast-send",
+            "0x0000000000000000000000000000000000000000",
+            "--gas-estimate-multiplier",
+            "125",
+        ]);
+        assert_eq!(args.gas_estimate_multiplier, Some(125));
     }
 
     #[tokio::test]

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -856,7 +856,7 @@ where
         multiplier: Option<u64>,
     ) -> Result<u64> {
         match provider.estimate_gas(request).await {
-            Ok(estimated) => Ok(apply_gas_estimate_multiplier(estimated, multiplier)),
+            Ok(estimated) => apply_gas_estimate_multiplier(estimated, multiplier),
             Err(err) => {
                 if let TransportError::ErrorResp(payload) = &err {
                     // If execution reverted with code 3 during provider gas estimation then try

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -13,7 +13,7 @@ use clap::Args;
 use eyre::{Result, WrapErr};
 use foundry_cli::{
     opts::{CliAuthorizationList, EthereumOpts, TempoOpts, TransactionOpts},
-    utils::{self, parse_function_args},
+    utils::{self, apply_gas_estimate_multiplier, parse_function_args},
 };
 use foundry_common::{
     FoundryTransactionBuilder, TransactionReceiptWithRevertReason,
@@ -442,6 +442,8 @@ pub struct CastTxBuilder<N: Network, P, S> {
     browser: bool,
     /// The preset used when estimating EIP-1559 fees.
     eip1559_fee_estimate: Eip1559FeeEstimatePreset,
+    /// Optional percentage applied to provider gas estimates.
+    gas_estimate_multiplier: Option<u64>,
     auth: Vec<CliAuthorizationList>,
     chain: Chain,
     etherscan_api_key: Option<String>,
@@ -459,6 +461,12 @@ impl<N: Network, P, S> CastTxBuilder<N, P, S> {
     /// Marks this transaction as destined for browser wallet submission.
     pub const fn with_browser_wallet(mut self) -> Self {
         self.browser = true;
+        self
+    }
+
+    /// Applies a percentage multiplier to provider gas estimates.
+    pub const fn with_gas_estimate_multiplier(mut self, multiplier: Option<u64>) -> Self {
+        self.gas_estimate_multiplier = multiplier;
         self
     }
 
@@ -511,6 +519,7 @@ where
             fill: true,
             browser: false,
             eip1559_fee_estimate: config.eip1559_fee_estimate,
+            gas_estimate_multiplier: None,
             chain,
             etherscan_api_key,
             etherscan_api_url,
@@ -532,6 +541,7 @@ where
             fill: self.fill,
             browser: self.browser,
             eip1559_fee_estimate: self.eip1559_fee_estimate,
+            gas_estimate_multiplier: self.gas_estimate_multiplier,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
             etherscan_api_url: self.etherscan_api_url,
@@ -597,6 +607,7 @@ where
             fill: self.fill,
             browser: self.browser,
             eip1559_fee_estimate: self.eip1559_fee_estimate,
+            gas_estimate_multiplier: self.gas_estimate_multiplier,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
             etherscan_api_url: self.etherscan_api_url,
@@ -681,9 +692,13 @@ where
                 ),
                 async {
                     match gas_request {
-                        Some(request) => {
-                            Self::estimate_gas(&self.provider, request).await.map(Some)
-                        }
+                        Some(request) => Self::estimate_gas(
+                            &self.provider,
+                            request,
+                            self.gas_estimate_multiplier,
+                        )
+                        .await
+                        .map(Some),
                         None => Ok(None),
                     }
                 },
@@ -826,7 +841,8 @@ where
             } else {
                 self.tx.clone()
             };
-            let estimated = Self::estimate_gas(&self.provider, request).await?;
+            let estimated =
+                Self::estimate_gas(&self.provider, request, self.gas_estimate_multiplier).await?;
             self.tx.set_gas_limit(estimated);
         }
 
@@ -834,9 +850,13 @@ where
     }
 
     /// Estimate tx gas from provider call. Tries to decode custom error if execution reverted.
-    async fn estimate_gas(provider: &P, request: N::TransactionRequest) -> Result<u64> {
+    async fn estimate_gas(
+        provider: &P,
+        request: N::TransactionRequest,
+        multiplier: Option<u64>,
+    ) -> Result<u64> {
         match provider.estimate_gas(request).await {
-            Ok(estimated) => Ok(estimated),
+            Ok(estimated) => Ok(apply_gas_estimate_multiplier(estimated, multiplier)),
             Err(err) => {
                 if let TransportError::ErrorResp(payload) = &err {
                     // If execution reverted with code 3 during provider gas estimation then try
@@ -1008,10 +1028,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn filled_build_fetches_nonce_and_gas_concurrently_with_explicit_fees() {
+    async fn filled_build_applies_multiplier_to_concurrent_gas_estimate() {
         let asserter = Asserter::new();
         for _ in 0..2 {
-            asserter.push_success(&U64::from(1));
+            asserter.push_success(&U64::from(100));
         }
         let fill_methods = Arc::new(Mutex::new(Vec::new()));
         let transport = BarrierTransport {
@@ -1030,6 +1050,7 @@ mod tests {
         )
         .await
         .unwrap()
+        .with_gas_estimate_multiplier(Some(150))
         .with_to(Some(Address::repeat_byte(0x11).into()))
         .await
         .unwrap()
@@ -1041,9 +1062,9 @@ mod tests {
             .expect("nonce and gas requests were not in flight together")
             .unwrap();
 
-        assert_eq!(tx.nonce, Some(1));
+        assert_eq!(tx.nonce, Some(100));
         assert_eq!(tx.gas_price, Some(1));
-        assert_eq!(tx.gas, Some(1));
+        assert_eq!(tx.gas, Some(150));
         let mut fill_methods = fill_methods.lock().unwrap().clone();
         fill_methods.sort();
         assert_eq!(fill_methods, ["eth_estimateGas", "eth_getTransactionCount"]);

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -46,6 +46,14 @@ pub const STATIC_FUZZ_SEED: [u8; 32] = [
     0x5d, 0x64, 0x0b, 0x19, 0xad, 0xf0, 0xe3, 0x57, 0xb8, 0xd4, 0xbe, 0x7d, 0x49, 0xee, 0x70, 0xe6,
 ];
 
+/// Applies an optional percentage multiplier to a gas estimate.
+pub const fn apply_gas_estimate_multiplier(estimate: u64, multiplier: Option<u64>) -> u64 {
+    match multiplier {
+        Some(multiplier) => estimate * multiplier / 100,
+        None => estimate,
+    }
+}
+
 /// Regex used to parse `.gitmodules` file and capture the submodule path and branch.
 pub static SUBMODULE_BRANCH_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"\[submodule "([^"]+)"\](?:[^\[]*?branch = ([^\s]+))"#).unwrap());
@@ -1197,6 +1205,12 @@ mod tests {
     use foundry_common::fs;
     use std::{env, fs::File, io::Write};
     use tempfile::tempdir;
+
+    #[test]
+    fn applies_gas_estimate_multiplier() {
+        assert_eq!(apply_gas_estimate_multiplier(21_000, None), 21_000);
+        assert_eq!(apply_gas_estimate_multiplier(21_000, Some(150)), 31_500);
+    }
 
     #[test]
     fn parse_submodule_status() {

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -47,11 +47,10 @@ pub const STATIC_FUZZ_SEED: [u8; 32] = [
 ];
 
 /// Applies an optional percentage multiplier to a gas estimate.
-pub const fn apply_gas_estimate_multiplier(estimate: u64, multiplier: Option<u64>) -> u64 {
-    match multiplier {
-        Some(multiplier) => estimate * multiplier / 100,
-        None => estimate,
-    }
+pub fn apply_gas_estimate_multiplier(estimate: u64, multiplier: Option<u64>) -> Result<u64> {
+    let Some(multiplier) = multiplier else { return Ok(estimate) };
+    let adjusted = u128::from(estimate) * u128::from(multiplier) / 100;
+    adjusted.try_into().map_err(|_| eyre::eyre!("multiplied gas estimate exceeds u64"))
 }
 
 /// Regex used to parse `.gitmodules` file and capture the submodule path and branch.
@@ -1208,8 +1207,13 @@ mod tests {
 
     #[test]
     fn applies_gas_estimate_multiplier() {
-        assert_eq!(apply_gas_estimate_multiplier(21_000, None), 21_000);
-        assert_eq!(apply_gas_estimate_multiplier(21_000, Some(150)), 31_500);
+        assert_eq!(apply_gas_estimate_multiplier(21_000, None).unwrap(), 21_000);
+        assert_eq!(apply_gas_estimate_multiplier(21_000, Some(150)).unwrap(), 31_500);
+        assert_eq!(
+            apply_gas_estimate_multiplier(21_000, Some(1_000_000_000_000_000)).unwrap(),
+            210_000_000_000_000_000
+        );
+        assert!(apply_gas_estimate_multiplier(u64::MAX, Some(101)).is_err());
     }
 
     #[test]

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -559,7 +559,7 @@ impl CreateArgs {
             deployer.tx.set_gas_limit(apply_gas_estimate_multiplier(
                 estimated,
                 self.gas_estimate_multiplier,
-            ));
+            )?);
         }
 
         // Before we actually deploy the contract we try check if the verify settings are valid

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -14,8 +14,9 @@ use forge_verify::{RetryArgs, VerifierArgs, VerifyArgs, parse_etherscan_license_
 use foundry_cli::{
     opts::{BuildOpts, EthereumOpts, EtherscanOpts, TransactionOpts},
     utils::{
-        LoadConfig, ResolvedLane, find_contract_artifacts, maybe_print_resolved_lane,
-        parse_constructor_args, read_constructor_args_file, resolve_lane,
+        LoadConfig, ResolvedLane, apply_gas_estimate_multiplier, find_contract_artifacts,
+        maybe_print_resolved_lane, parse_constructor_args, read_constructor_args_file,
+        resolve_lane,
     },
 };
 use foundry_common::{
@@ -109,6 +110,10 @@ pub struct CreateArgs {
     /// Timeout to use for broadcasting transactions.
     #[arg(long, env = "ETH_TIMEOUT")]
     pub timeout: Option<u64>,
+
+    /// Relative percentage to multiply the gas estimate by.
+    #[arg(long, value_name = "PERCENT", help_heading = "Transaction options")]
+    gas_estimate_multiplier: Option<u64>,
 
     #[command(flatten)]
     build: BuildOpts,
@@ -551,7 +556,10 @@ impl CreateArgs {
                 deployer.tx.clone()
             };
             let estimated = provider.estimate_gas(request).await?;
-            deployer.tx.set_gas_limit(estimated);
+            deployer.tx.set_gas_limit(apply_gas_estimate_multiplier(
+                estimated,
+                self.gas_estimate_multiplier,
+            ));
         }
 
         // Before we actually deploy the contract we try check if the verify settings are valid
@@ -910,10 +918,13 @@ mod tests {
             "30",
             "--license-type",
             "13",
+            "--gas-estimate-multiplier",
+            "125",
         ]);
         assert_eq!(args.retry.retries, 10);
         assert_eq!(args.retry.delay, 30);
         assert_eq!(args.license_type.as_deref(), Some("13"));
+        assert_eq!(args.gas_estimate_multiplier, Some(125));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`forge script` supports padding provider gas estimates, but `forge create` and `cast send` do not. Closes #1803.

## Solution

Add an opt-in `--gas-estimate-multiplier <PERCENT>` to both commands. Omitting it preserves existing estimates, and explicit `--gas-limit` values remain unchanged. This change was developed with AI assistance.
