### PR TITLE
refactor(evm): isolate Monad context state

### DIFF
--- a/.changelog/isolate-monad-context-state.md
+++ b/.changelog/isolate-monad-context-state.md
@@ -1,0 +1,10 @@
+---
+anvil: patch
+cast: patch
+forge-verify: patch
+foundry-cheatcodes: patch
+foundry-evm: patch
+foundry-evm-core: patch
+---
+
+Kept Monad chain context and reserve-balance tracking isolated from shared EVM context state.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -129,7 +129,7 @@ use eyre::{Context, Result};
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 #[cfg(feature = "monad")]
 use foundry_evm::core::{
-    FoundryContextExt, FromAnyRpcTransaction, MonadContextAux,
+    FromAnyRpcTransaction,
     evm::{
         FoundryEvmFactory, MonadBlockParticipants,
         monad_block_participants as collect_monad_block_participants,
@@ -456,7 +456,7 @@ impl<D> Drop for StagedForkDbUser<D> {
 }
 
 #[cfg(feature = "monad")]
-pub(crate) type MonadReplayContext = MonadContextAux;
+pub(crate) type MonadReplayContext = MonadChainContext;
 // Opaque stand-in that keeps feature-independent replay context plumbing type-stable.
 #[cfg(not(feature = "monad"))]
 #[derive(Clone)]
@@ -505,7 +505,7 @@ impl<'a> EnvelopeExecution<'a> {
 
 #[cfg(feature = "monad")]
 struct PreparedMonadExecution {
-    context: Option<MonadContextAux>,
+    context: Option<MonadChainContext>,
     kind: EnvelopeExecutionKind,
     hardfork: MonadHardfork,
 }
@@ -521,7 +521,7 @@ fn exact_monad_context_at(
     current_tx_index: usize,
 ) -> MonadExecutionContext<'static> {
     let mut context = context.clone();
-    context.chain.current_tx_index = current_tx_index;
+    context.current_tx_index = current_tx_index;
     exact_monad_context(context)
 }
 
@@ -574,11 +574,11 @@ fn prepare_monad_transaction<DB: alloy_evm::Database>(
 fn resolve_monad_execution_context(
     context: Option<MonadExecutionContext<'_>>,
     tx: &TxEnv,
-) -> Option<MonadContextAux> {
+) -> Option<MonadChainContext> {
     match context {
         Some(MonadExecutionContext::Exact(context)) => Some(*context),
         Some(MonadExecutionContext::Next(context)) => {
-            append_monad_transaction(&mut context.chain, tx);
+            append_monad_transaction(context, tx);
             Some(context.clone())
         }
         None => None,
@@ -586,19 +586,18 @@ fn resolve_monad_execution_context(
 }
 
 #[cfg(feature = "monad")]
-fn advance_monad_block(context: &mut MonadContextAux) {
+fn advance_monad_block(context: &mut MonadChainContext) {
     let current = context
-        .chain
         .current_block_senders
         .iter()
         .copied()
-        .chain(context.chain.current_block_authorities.iter().flatten().copied())
+        .chain(context.current_block_authorities.iter().flatten().copied())
         .collect();
-    context.chain.grandparent_senders_and_authorities =
-        std::mem::replace(&mut context.chain.parent_senders_and_authorities, current);
-    context.chain.current_block_senders.clear();
-    context.chain.current_block_authorities.clear();
-    context.chain.current_tx_index = 0;
+    context.grandparent_senders_and_authorities =
+        std::mem::replace(&mut context.parent_senders_and_authorities, current);
+    context.current_block_senders.clear();
+    context.current_block_authorities.clear();
+    context.current_tx_index = 0;
 }
 
 /// Removes a candidate transaction that failed before block inclusion.
@@ -1503,7 +1502,7 @@ impl<N: Network> Backend<N> {
     fn monad_context_for_child_of(
         &self,
         parent_hash: B256,
-    ) -> Result<MonadContextAux, BlockchainError> {
+    ) -> Result<MonadChainContext, BlockchainError> {
         self.monad_context_for_child_of_in_storage(&self.blockchain.storage.read(), parent_hash)
     }
 
@@ -1513,7 +1512,7 @@ impl<N: Network> Backend<N> {
         &self,
         storage: &BlockchainStorage<N>,
         parent_hash: B256,
-    ) -> Result<MonadContextAux, BlockchainError> {
+    ) -> Result<MonadChainContext, BlockchainError> {
         let (_, grandparent_hash, parent) =
             self.monad_block_participants_from_storage(storage, parent_hash)?;
         let grandparent = if grandparent_hash.is_zero() {
@@ -1529,7 +1528,7 @@ impl<N: Network> Backend<N> {
     async fn monad_context_for_child_of_block_number(
         &self,
         block_number: u64,
-    ) -> Result<MonadContextAux, BlockchainError> {
+    ) -> Result<MonadChainContext, BlockchainError> {
         let block = self
             .block_by_number_full(BlockNumber::Number(block_number))
             .await?
@@ -1546,7 +1545,7 @@ impl<N: Network> Backend<N> {
     async fn monad_context_for_child_of_block_hash(
         &self,
         block_hash: B256,
-    ) -> Result<MonadContextAux, BlockchainError> {
+    ) -> Result<MonadChainContext, BlockchainError> {
         let block =
             self.block_by_hash_full(block_hash).await?.ok_or(BlockchainError::BlockNotFound)?;
         let parent_hash = block.header().parent_hash();
@@ -1561,7 +1560,7 @@ impl<N: Network> Backend<N> {
     fn monad_context_for_mined_block(
         &self,
         block: &Block,
-    ) -> Result<MonadContextAux, BlockchainError> {
+    ) -> Result<MonadChainContext, BlockchainError> {
         let current = self.monad_tx_envs_from_storage(
             &self.blockchain.storage.read(),
             &block.body.transactions,
@@ -1582,7 +1581,7 @@ impl<N: Network> Backend<N> {
         &self,
         block: &Block,
         current_tx_index: usize,
-    ) -> Result<MonadContextAux, BlockchainError> {
+    ) -> Result<MonadChainContext, BlockchainError> {
         let current = self.monad_tx_envs_from_storage(
             &self.blockchain.storage.read(),
             &block.body.transactions,
@@ -2923,9 +2922,16 @@ impl<N: Network> Backend<N> {
             evm_env.block_env.clone(),
         );
         let factory = MonadEvmFactory::default();
-        let context = execution.context.unwrap_or_else(|| factory.context_for_transaction(&tx_env));
+        let context = execution.context.unwrap_or_else(|| {
+            monad_context_from_participants(
+                Default::default(),
+                Default::default(),
+                std::slice::from_ref(&tx_env),
+                0,
+            )
+        });
         let mut evm = factory.create_evm_with_inspector(WrapDatabaseRef(db), monad_env, inspector);
-        evm.ctx_mut().set_aux_state(context);
+        evm.ctx_mut().chain = context;
         self.inject_precompiles(evm.precompiles_mut(), evm_env);
         match execution.kind {
             EnvelopeExecutionKind::Transaction => Ok(evm.transact(tx_env)?),
@@ -3037,10 +3043,10 @@ impl<N: Network> Backend<N> {
             );
             let mut evm =
                 MonadEvmFactory::default().create_evm_with_inspector(db, monad_env, inspector);
-            let context_aux = self
+            let transaction_context = self
                 .monad_context_for_child_of(parent_hash)
                 .expect("Monad ancestor context must be available before block execution");
-            evm.ctx_mut().set_aux_state(context_aux);
+            evm.ctx_mut().chain = transaction_context;
             return run!(
                 evm,
                 prepare_monad_transaction,
@@ -5672,9 +5678,9 @@ where
             );
             let mut evm =
                 MonadEvmFactory::default().create_evm_with_inspector(db, monad_env, inspector);
-            let context_aux = monad_context
+            let transaction_context = monad_context
                 .ok_or_else(|| eyre::eyre!("Monad replay ancestor context is unavailable"))?;
-            evm.ctx_mut().set_aux_state(context_aux);
+            evm.ctx_mut().chain = transaction_context;
             return run!(evm, |executor| {
                 execute_historical_replay_with(
                     executor,

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -664,7 +664,7 @@ impl CallArgs {
             context_tx.set_kind(tx_kind);
             context_tx.set_data(input.clone());
             context_tx.set_value(value);
-            let context_aux = context_for_child_transaction::<FEN, _>(
+            let chain_context = context_for_child_transaction::<FEN, _>(
                 &provider,
                 context_block_number,
                 &context_tx,
@@ -674,11 +674,11 @@ impl CallArgs {
             let trace = match tx_kind {
                 TxKind::Create => {
                     let deploy_result =
-                        executor.deploy_with_context(from, input, value, context_aux, None);
+                        executor.deploy_with_context(from, input, value, chain_context, None);
                     TraceResult::try_from(deploy_result)?
                 }
                 TxKind::Call(to) => TraceResult::from_raw(
-                    executor.transact_raw_with_context(from, to, input, value, context_aux)?,
+                    executor.transact_raw_with_context(from, to, input, value, chain_context)?,
                     TraceKind::Execution,
                 ),
             };

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -546,8 +546,8 @@ impl RunArgs {
                         continue;
                     }
 
-                    let context_aux = block_context.as_ref().map_or_else(
-                        || FEN::EvmFactory::default().context_for_transaction(&tx_env),
+                    let chain_context = block_context.as_ref().map_or_else(
+                        || factory.chain_context_for_transaction(&tx_env),
                         |context| context.transaction(index),
                     );
 
@@ -559,7 +559,7 @@ impl RunArgs {
                             .transact_protocol_system_with_env_and_context(
                                 evm_env.clone(),
                                 tx_env.clone(),
-                                context_aux,
+                                chain_context,
                             )
                             .wrap_err_with(|| {
                                 format!(
@@ -574,7 +574,7 @@ impl RunArgs {
                             .transact_with_env_and_context(
                                 evm_env.clone(),
                                 tx_env.clone(),
-                                context_aux,
+                                chain_context,
                             )
                             .wrap_err_with(|| {
                                 format!(
@@ -588,7 +588,7 @@ impl RunArgs {
                         if let Err(error) = executor.deploy_with_env_and_context(
                             evm_env.clone(),
                             tx_env.clone(),
-                            context_aux,
+                            chain_context,
                             None,
                         ) {
                             match error {
@@ -642,8 +642,8 @@ impl RunArgs {
             } else {
                 0
             };
-            let context_aux = block_context.as_ref().map_or_else(
-                || FEN::EvmFactory::default().context_for_transaction(&tx_env),
+            let chain_context = block_context.as_ref().map_or_else(
+                || factory.chain_context_for_transaction(&tx_env),
                 |context| context.transaction(target_index),
             );
 
@@ -656,21 +656,21 @@ impl RunArgs {
                 TraceResult::from(executor.transact_protocol_system_with_env_and_context(
                     evm_env,
                     tx_env,
-                    context_aux,
+                    chain_context,
                 )?)
             } else if let Some(to) = Transaction::to(&tx) {
                 trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
                 TraceResult::from(executor.transact_with_env_and_context(
                     evm_env,
                     tx_env,
-                    context_aux,
+                    chain_context,
                 )?)
             } else {
                 trace!(tx=?tx.tx_hash(), "executing create transaction");
                 TraceResult::try_from(executor.deploy_with_env_and_context(
                     evm_env,
                     tx_env,
-                    context_aux,
+                    chain_context,
                     None,
                 ))?
             }

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1088,6 +1088,7 @@ impl Cheatcode for deleteSnapshotCall {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
         ccx.state.env_overrides_snapshots.remove(snapshotId);
+        ccx.state.context_snapshots.remove(snapshotId);
         ccx.state.delete_created_accounts_snapshot(*snapshotId);
         Ok(result.abi_encode())
     }
@@ -1098,6 +1099,7 @@ impl Cheatcode for deleteStateSnapshotCall {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
         ccx.state.env_overrides_snapshots.remove(snapshotId);
+        ccx.state.context_snapshots.remove(snapshotId);
         ccx.state.delete_created_accounts_snapshot(*snapshotId);
         Ok(result.abi_encode())
     }
@@ -1109,6 +1111,7 @@ impl Cheatcode for deleteSnapshotsCall {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
         ccx.state.env_overrides_snapshots.clear();
+        ccx.state.context_snapshots.clear();
         ccx.state.clear_created_accounts_snapshots();
         Ok(Default::default())
     }
@@ -1119,6 +1122,7 @@ impl Cheatcode for deleteStateSnapshotsCall {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
         ccx.state.env_overrides_snapshots.clear();
+        ccx.state.context_snapshots.clear();
         ccx.state.clear_created_accounts_snapshots();
         Ok(Default::default())
     }
@@ -1328,7 +1332,7 @@ impl Cheatcode for executeTransactionCall {
         let sender =
             tx.recover_signer().map_err(|err| fmt_err!("failed to recover signer: {err}"))?;
         let tx_env = TxEnvFor::<FEN>::from_recovered_tx(&tx, sender);
-        let context_aux = ccx.ecx.db().context_for_synthetic_transaction(&tx_env)?;
+        let chain_context = ccx.ecx.db().chain_context_for_synthetic_transaction(&tx_env)?;
         let created_address = tx_env.kind().is_create().then(|| sender.create(tx_env.nonce()));
 
         // Save current env for restoration after execution.
@@ -1389,7 +1393,7 @@ impl Cheatcode for executeTransactionCall {
                 ccx.state,
                 db,
                 modified_evm_env,
-                context_aux,
+                chain_context,
                 &mut |evm| {
                     // SAFETY: closure is called exactly once by the executor.
                     evm.journal_inner_mut().state = cold_state.take().expect("called once");
@@ -1581,12 +1585,17 @@ fn inner_snapshot_state<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCtxt<'_, '_, FEN
             active.pre_override_blob_hashes = Some(ccx.ecx.tx().blob_versioned_hashes().to_vec());
         }
     }
-    let context_state = ccx.ecx.context_state();
-    let id = ccx.ecx.db_mut().snapshot_state(&context_state, &evm_env);
+    let journaled_state = ccx.ecx.journal_inner().clone();
+    let id = ccx.ecx.db_mut().snapshot_state(&journaled_state, &evm_env);
     // Capture the cheatcode-side env overrides alongside the backend
     // snapshot so they can be rolled back in lockstep with `EvmEnv`. See
     // `Cheatcodes::env_overrides_snapshots`.
     ccx.state.env_overrides_snapshots.insert(id, all_env_overrides);
+    let factory = FEN::EvmFactory::default();
+    ccx.state.context_snapshots.insert(
+        id,
+        (factory.capture_chain_context(ccx.ecx), factory.capture_transaction_state(ccx.ecx)),
+    );
     ccx.state.snapshot_created_accounts(id, fork_id);
     Ok(id.abi_encode())
 }
@@ -1637,15 +1646,21 @@ fn inner_revert_to_state<FEN: FoundryEvmNetwork>(
 ) -> Result {
     let mut evm_env = ccx.ecx.evm_clone();
     let caller = ccx.ecx.caller();
-    let context_state = ccx.ecx.context_state();
+    let journaled_state = ccx.ecx.journal_inner().clone();
     if let Some(restored) = ccx.ecx.db_mut().revert_state(
         snapshot_id,
-        &context_state,
+        &journaled_state,
         &mut evm_env,
         caller,
         RevertStateSnapshotAction::RevertKeep,
     ) {
-        ccx.ecx.set_context_state(restored);
+        ccx.ecx.set_journal_inner(restored);
+        if let Some((context, state)) = ccx.state.context_snapshots.get(&snapshot_id) {
+            FEN::EvmFactory::default().apply_context_transition(ccx.ecx, Some(context));
+            FEN::EvmFactory::default().restore_transaction_state(ccx.ecx, state.clone());
+        } else {
+            refresh_context_after_state_change::<FEN>(ccx.ecx);
+        }
         ccx.ecx.set_evm(evm_env);
         // `RevertKeep` keeps the backend snapshot alive for further
         // reverts, so keep our matching env-overrides copy too.
@@ -1666,15 +1681,21 @@ fn inner_revert_to_state_and_delete<FEN: FoundryEvmNetwork>(
 ) -> Result {
     let mut evm_env = ccx.ecx.evm_clone();
     let caller = ccx.ecx.caller();
-    let context_state = ccx.ecx.context_state();
+    let journaled_state = ccx.ecx.journal_inner().clone();
     if let Some(restored) = ccx.ecx.db_mut().revert_state(
         snapshot_id,
-        &context_state,
+        &journaled_state,
         &mut evm_env,
         caller,
         RevertStateSnapshotAction::RevertRemove,
     ) {
-        ccx.ecx.set_context_state(restored);
+        ccx.ecx.set_journal_inner(restored);
+        if let Some((context, state)) = ccx.state.context_snapshots.remove(&snapshot_id) {
+            FEN::EvmFactory::default().apply_context_transition(ccx.ecx, Some(&context));
+            FEN::EvmFactory::default().restore_transaction_state(ccx.ecx, state);
+        } else {
+            refresh_context_after_state_change::<FEN>(ccx.ecx);
+        }
         ccx.ecx.set_evm(evm_env);
         if let Some(snap) = ccx.state.env_overrides_snapshots.remove(&snapshot_id) {
             ccx.state.env_overrides = snap;

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -12,10 +12,10 @@ use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
 use foundry_evm_core::{
     FoundryContextExt,
-    backend::{ContextAuxUpdate, JournaledState, LocalForkId},
+    backend::{ContextUpdate, JournaledState, LocalForkId},
     evm::{
-        BlockEnvFor, ContextAuxFor, FoundryContextFor, FoundryEvmNetwork, SpecFor, TxEnvFor,
-        rebase_context_after_state_transition,
+        BlockEnvFor, ChainContextFor, FoundryContextFor, FoundryEvmNetwork, SpecFor, TxEnvFor,
+        apply_context_transition,
     },
     fork::CreateFork,
 };
@@ -434,23 +434,21 @@ fn fork_env_op<FEN: FoundryEvmNetwork, T: SolValue>(
         &mut EvmEnv<SpecFor<FEN>, BlockEnvFor<FEN>>,
         &mut TxEnvFor<FEN>,
         &mut JournaledState,
-    ) -> eyre::Result<(T, ContextAuxUpdate<ContextAuxFor<FEN>>)>,
+    ) -> eyre::Result<(T, ContextUpdate<ChainContextFor<FEN>>)>,
 ) -> Result {
     let mut evm_env = ecx.evm_clone();
     let mut tx_env = ecx.tx_clone();
-    let current_aux = ecx.aux_state();
     let (db, inner) = ecx.db_journal_inner_mut();
     let (result, context_update) = f(db, &mut evm_env, &mut tx_env, inner)?;
     ecx.set_evm(evm_env);
     ecx.set_tx(tx_env);
     match context_update {
-        ContextAuxUpdate::Unchanged => {}
-        ContextAuxUpdate::Replace(auxiliary) => {
-            rebase_context_after_state_transition::<FEN>(ecx, &current_aux, auxiliary);
+        ContextUpdate::Unchanged => {}
+        ContextUpdate::Replace(chain_context) => {
+            apply_context_transition::<FEN>(ecx, Some(&chain_context));
         }
-        ContextAuxUpdate::Rebase => {
-            let replacement = current_aux.clone();
-            rebase_context_after_state_transition::<FEN>(ecx, &current_aux, replacement);
+        ContextUpdate::Rebase => {
+            apply_context_transition::<FEN>(ecx, None);
         }
     }
     Ok(result.abi_encode())
@@ -505,17 +503,15 @@ fn transact<FEN: FoundryEvmNetwork>(
     transaction: B256,
     fork_id: Option<U256>,
 ) -> Result {
-    let current_aux = ccx.ecx.aux_state();
     let context_update = executor.transact_on_db(ccx.state, ccx.ecx, fork_id, transaction)?;
     match context_update {
-        ContextAuxUpdate::Replace(auxiliary) => {
-            rebase_context_after_state_transition::<FEN>(ccx.ecx, &current_aux, auxiliary);
+        ContextUpdate::Replace(chain_context) => {
+            apply_context_transition::<FEN>(ccx.ecx, Some(&chain_context));
         }
-        ContextAuxUpdate::Rebase => {
-            let replacement = current_aux.clone();
-            rebase_context_after_state_transition::<FEN>(ccx.ecx, &current_aux, replacement);
+        ContextUpdate::Rebase => {
+            apply_context_transition::<FEN>(ccx.ecx, None);
         }
-        ContextAuxUpdate::Unchanged => {}
+        ContextUpdate::Unchanged => {}
     }
     Ok(Default::default())
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -41,13 +41,13 @@ use foundry_common::{
 use foundry_evm_core::{
     Breakpoints, EvmEnv, FoundryTransaction, InspectorExt,
     abi::Vm::stopExpectSafeMemoryCall,
-    backend::{ContextAuxUpdate, DatabaseError, DatabaseExt, LocalForkId, RevertDiagnostic},
+    backend::{ContextUpdate, DatabaseError, DatabaseExt, LocalForkId, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
     env::FoundryContextExt,
     evm::{
-        BlockEnvFor, ContextAuxFor, EthEvmNetwork, FoundryContextFor, FoundryEvmFactory,
-        FoundryEvmNetwork, NestedEvmClosure, SpecFor, TransactionRequestFor, TxEnvFor,
-        with_cloned_context,
+        BlockEnvFor, ChainContextFor, EthEvmNetwork, FoundryContextFor, FoundryEvmFactory,
+        FoundryEvmNetwork, NestedEvmClosureFor, SpecFor, TransactionRequestFor,
+        TransactionStateFor, TxEnvFor, with_cloned_context,
     },
 };
 use foundry_evm_traces::{
@@ -95,7 +95,7 @@ pub trait CheatcodesExecutor<FEN: FoundryEvmNetwork> {
         &mut self,
         cheats: &mut Cheatcodes<FEN>,
         ecx: &mut FoundryContextFor<'_, FEN>,
-        f: NestedEvmClosure<'_, SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>, ContextAuxFor<FEN>>,
+        f: NestedEvmClosureFor<'_, FEN>,
     ) -> Result<(), EVMError<DatabaseError>>;
 
     /// Replays a historical transaction on the database. Inspector is assembled internally.
@@ -105,7 +105,7 @@ pub trait CheatcodesExecutor<FEN: FoundryEvmNetwork> {
         ecx: &mut FoundryContextFor<'_, FEN>,
         fork_id: Option<U256>,
         transaction: B256,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>>;
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>>;
 
     /// Executes a `TransactionRequest` on the database. Inspector is assembled internally.
     fn transact_from_tx_on_db(
@@ -125,8 +125,8 @@ pub trait CheatcodesExecutor<FEN: FoundryEvmNetwork> {
         cheats: &mut Cheatcodes<FEN>,
         db: &mut <FoundryContextFor<'_, FEN> as ContextTr>::Db,
         evm_env: EvmEnv<SpecFor<FEN>, BlockEnvFor<FEN>>,
-        context_aux: ContextAuxFor<FEN>,
-        f: NestedEvmClosure<'_, SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>, ContextAuxFor<FEN>>,
+        chain_context: ChainContextFor<FEN>,
+        f: NestedEvmClosureFor<'_, FEN>,
     ) -> Result<EvmEnv<SpecFor<FEN>, BlockEnvFor<FEN>>, EVMError<DatabaseError>>;
 
     /// Simulates `console.log` invocation.
@@ -180,22 +180,33 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
         &mut self,
         cheats: &mut Cheatcodes<FEN>,
         ecx: &mut FoundryContextFor<'_, FEN>,
-        f: NestedEvmClosure<'_, SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>, ContextAuxFor<FEN>>,
+        f: NestedEvmClosureFor<'_, FEN>,
     ) -> Result<(), EVMError<DatabaseError>> {
-        with_cloned_context(ecx, |db, evm_env, context_state| {
-            let context_aux = context_state.auxiliary.clone();
-            let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
-                db,
-                evm_env,
-                context_aux,
-                cheats,
-            );
-            evm.set_context_state(context_state);
+        let factory = FEN::EvmFactory::default();
+        let chain_context = factory.capture_chain_context(ecx);
+        let state = factory.capture_transaction_state(ecx);
+        let mut nested_chain_context = None;
+        let mut transaction_state = None;
+        with_cloned_context(ecx, |db, evm_env, journaled_state| {
+            let mut evm = factory.create_foundry_nested_evm(db, evm_env, chain_context, cheats);
+            *evm.journal_inner_mut() = journaled_state;
+            evm.restore_transaction_state(state);
             f(&mut *evm)?;
-            let sub_state = evm.context_state();
+            nested_chain_context = Some(evm.capture_chain_context());
+            transaction_state = Some(evm.capture_transaction_state());
+            let sub_inner = evm.journal_inner_mut().clone();
             let sub_evm_env = evm.to_evm_env();
-            Ok((sub_evm_env, sub_state))
-        })
+            Ok((sub_evm_env, sub_inner))
+        })?;
+        factory.apply_context_transition(
+            ecx,
+            Some(&nested_chain_context.expect("nested EVM chain context was captured")),
+        );
+        factory.restore_transaction_state(
+            ecx,
+            transaction_state.expect("nested EVM state was captured"),
+        );
+        Ok(())
     }
 
     fn with_fresh_nested_evm(
@@ -203,11 +214,15 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
         cheats: &mut Cheatcodes<FEN>,
         db: &mut <FoundryContextFor<'_, FEN> as ContextTr>::Db,
         evm_env: EvmEnv<SpecFor<FEN>, BlockEnvFor<FEN>>,
-        context_aux: ContextAuxFor<FEN>,
-        f: NestedEvmClosure<'_, SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>, ContextAuxFor<FEN>>,
+        chain_context: ChainContextFor<FEN>,
+        f: NestedEvmClosureFor<'_, FEN>,
     ) -> Result<EvmEnv<SpecFor<FEN>, BlockEnvFor<FEN>>, EVMError<DatabaseError>> {
-        let mut evm =
-            FEN::EvmFactory::default().create_foundry_nested_evm(db, evm_env, context_aux, cheats);
+        let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
+            db,
+            evm_env,
+            chain_context,
+            cheats,
+        );
         f(&mut *evm)?;
         Ok(evm.to_evm_env())
     }
@@ -218,7 +233,7 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
         ecx: &mut FoundryContextFor<'_, FEN>,
         fork_id: Option<U256>,
         transaction: B256,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         let evm_env = ecx.evm_clone();
         let outer_tx_env = ecx.tx_clone();
         let (db, inner) = ecx.db_journal_inner_mut();
@@ -863,6 +878,10 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// the post-snapshot value even though `EvmEnv` was rolled back.
     pub env_overrides_snapshots: HashMap<U256, HashMap<Option<LocalForkId>, EnvOverrides>>,
 
+    /// Transaction-position context and family-owned execution state captured atomically alongside
+    /// state snapshots.
+    pub context_snapshots: HashMap<U256, (ChainContextFor<FEN>, TransactionStateFor<FEN>)>,
+
     /// Whether we are currently executing inside an isolation context, i.e.
     /// the synthetic inner transaction wrapped by
     /// `InspectorStackRefMut::transact_inner` (used by `--gas-report` and
@@ -949,6 +968,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             execution_evm_version: None,
             env_overrides: Default::default(),
             env_overrides_snapshots: Default::default(),
+            context_snapshots: Default::default(),
             in_isolation_context: false,
         }
     }

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -25,7 +25,7 @@ use revm::context::{ContextTr, JournalTr};
 pub use Vm::ForgeContext;
 pub use config::CheatsConfig;
 pub use error::{Error, ErrorKind, Result};
-pub use foundry_evm_core::evm::NestedEvmClosure;
+pub use foundry_evm_core::evm::NestedEvmClosureFor;
 pub use inspector::{
     BroadcastableTransaction, BroadcastableTransactions, Cheatcodes, CheatcodesExecutor,
 };

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -2,13 +2,13 @@
 
 use super::BackendError;
 use crate::{
-    FoundryContextState, FoundryInspectorExt,
+    FoundryInspectorExt,
     backend::{
-        Backend, ContextAuxUpdate, DatabaseExt, JournaledState, LocalForkId,
+        Backend, ContextUpdate, DatabaseExt, JournaledState, LocalForkId,
         RevertStateSnapshotAction, diagnostic::RevertDiagnostic,
     },
     evm::{
-        ContextAuxFor, EvmEnvFor, FoundryContextFor, FoundryEvmFactory, FoundryEvmNetwork,
+        ChainContextFor, EvmEnvFor, FoundryContextFor, FoundryEvmFactory, FoundryEvmNetwork,
         HaltReasonFor, SpecFor, TxEnvFor,
     },
     fork::{CreateFork, ForkId},
@@ -87,8 +87,8 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         tx_env: &mut TxEnvFor<FEN>,
         inspector: I,
     ) -> eyre::Result<ResultAndState<HaltReasonFor<FEN>>> {
-        let context_aux = self.context_for_synthetic_transaction(tx_env)?;
-        self.inspect_with_context(evm_env, tx_env, context_aux, inspector)
+        let chain_context = self.chain_context_for_synthetic_transaction(tx_env)?;
+        self.inspect_with_context(evm_env, tx_env, chain_context, inspector)
     }
 
     /// Executes the configured transaction with explicit network-specific context.
@@ -97,7 +97,7 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         &mut self,
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &mut TxEnvFor<FEN>,
-        context_aux: ContextAuxFor<FEN>,
+        chain_context: ChainContextFor<FEN>,
         inspector: I,
     ) -> eyre::Result<ResultAndState<HaltReasonFor<FEN>>> {
         // this is a new call to inspect with a new env, so even if we've cloned the backend
@@ -108,7 +108,7 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         let mut evm = factory.create_foundry_evm_with_inspector(
             self,
             evm_env.clone(),
-            context_aux,
+            chain_context,
             inspector,
         );
 
@@ -128,7 +128,7 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         &mut self,
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &mut TxEnvFor<FEN>,
-        context_aux: ContextAuxFor<FEN>,
+        chain_context: ChainContextFor<FEN>,
         inspector: I,
     ) -> eyre::Result<ResultAndState<HaltReasonFor<FEN>>> {
         self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind()));
@@ -138,7 +138,7 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         let mut evm = factory.create_foundry_evm_with_inspector(
             self,
             evm_env.clone(),
-            context_aux,
+            chain_context,
             inspector,
         );
         let result = factory.transact_foundry_replay(&mut evm, tx_env.clone())?;
@@ -180,30 +180,30 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
 }
 
 impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN> {
-    fn context_for_synthetic_transaction(
+    fn chain_context_for_synthetic_transaction(
         &self,
         tx: &TxEnvFor<FEN>,
-    ) -> eyre::Result<ContextAuxFor<FEN>> {
-        self.backend.context_for_synthetic_transaction(tx)
+    ) -> eyre::Result<ChainContextFor<FEN>> {
+        self.backend.chain_context_for_synthetic_transaction(tx)
     }
 
     fn snapshot_state(
         &mut self,
-        context_state: &FoundryContextState<ContextAuxFor<FEN>>,
+        journaled_state: &JournaledState,
         evm_env: &EvmEnvFor<FEN>,
     ) -> U256 {
-        self.backend_mut().snapshot_state(context_state, evm_env)
+        self.backend_mut().snapshot_state(journaled_state, evm_env)
     }
 
     fn revert_state(
         &mut self,
         id: U256,
-        context_state: &FoundryContextState<ContextAuxFor<FEN>>,
+        journaled_state: &JournaledState,
         evm_env: &mut EvmEnvFor<FEN>,
         caller: Address,
         action: RevertStateSnapshotAction,
-    ) -> Option<FoundryContextState<ContextAuxFor<FEN>>> {
-        self.backend_mut().revert_state(id, context_state, evm_env, caller, action)
+    ) -> Option<JournaledState> {
+        self.backend_mut().revert_state(id, journaled_state, evm_env, caller, action)
     }
 
     fn delete_state_snapshot(&mut self, id: U256) -> bool {
@@ -238,7 +238,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &mut TxEnvFor<FEN>,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         self.backend_mut().select_fork(id, evm_env, tx_env, journaled_state)
     }
 
@@ -249,7 +249,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &TxEnvFor<FEN>,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         self.backend_mut().roll_fork(id, block_number, evm_env, tx_env, journaled_state)
     }
 
@@ -260,7 +260,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &TxEnvFor<FEN>,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         self.backend_mut().roll_fork_to_transaction(
             id,
             transaction,
@@ -280,7 +280,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN
         inspector: &mut dyn for<'db> FoundryInspectorExt<
             <FEN::EvmFactory as FoundryEvmFactory>::FoundryContext<'db>,
         >,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         self.backend_mut().transact(
             id,
             transaction,

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1,11 +1,10 @@
 //! Foundry's main executor backend abstraction and implementation.
 
 use crate::{
-    FoundryBlock, FoundryContextState, FoundryInspectorExt, FoundryTransaction,
-    FromAnyRpcTransaction,
+    FoundryBlock, FoundryInspectorExt, FoundryTransaction, FromAnyRpcTransaction,
     constants::{CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, TEST_CONTRACT_ADDRESS},
     evm::{
-        BlockContext, BlockEnvFor, ContextAuxFor, EthEvmNetwork, EvmEnvFor, FoundryContextFor,
+        BlockContext, BlockEnvFor, ChainContextFor, EthEvmNetwork, EvmEnvFor, FoundryContextFor,
         FoundryEvmFactory, FoundryEvmNetwork, HaltReasonFor, SpecFor, TxEnvFor,
         execute_replay_transaction,
     },
@@ -66,12 +65,12 @@ type ForkDB<N, B> = CacheDB<SharedBackend<N, B>>;
 /// block` which can be reused by multiple tests, whereas the `LocalForkId` is unique within a test
 pub type LocalForkId = U256;
 
-/// Auxiliary-context update required after a fork operation.
-pub enum ContextAuxUpdate<AUX> {
+/// Transaction-context update required after a fork operation.
+pub enum ContextUpdate<C> {
     /// The operation did not change the active chain cursor or outer journal state.
     Unchanged,
     /// The active fork cursor changed and provides replacement chain context.
-    Replace(AUX),
+    Replace(C),
     /// The outer journal changed while the active chain context remained unchanged.
     Rebase,
 }
@@ -84,7 +83,7 @@ type ForkLookupIndex = usize;
 struct TransactionInputs<FEN: FoundryEvmNetwork> {
     evm_env: EvmEnvFor<FEN>,
     tx_env: TxEnvFor<FEN>,
-    context_aux: ContextAuxFor<FEN>,
+    chain_context: ChainContextFor<FEN>,
 }
 
 /// Block data required to execute or position a fork at a transaction.
@@ -170,7 +169,7 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
     /// [RevertStateSnapshotAction], it will keep the snapshot alive or delete it.
     fn snapshot_state(
         &mut self,
-        context_state: &FoundryContextState<F::ContextAux>,
+        journaled_state: &JournaledState,
         evm_env: &EvmEnv<F::Spec, F::BlockEnv>,
     ) -> U256;
 
@@ -189,11 +188,11 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
     fn revert_state(
         &mut self,
         id: U256,
-        context_state: &FoundryContextState<F::ContextAux>,
+        journaled_state: &JournaledState,
         evm_env: &mut EvmEnv<F::Spec, F::BlockEnv>,
         caller: Address,
         action: RevertStateSnapshotAction,
-    ) -> Option<FoundryContextState<F::ContextAux>>;
+    ) -> Option<JournaledState>;
 
     /// Deletes the state snapshot with the given `id`
     ///
@@ -213,10 +212,10 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
         evm_env: &mut EvmEnv<F::Spec, F::BlockEnv>,
         tx_env: &mut F::Tx,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<(LocalForkId, ContextAuxUpdate<F::ContextAux>)> {
+    ) -> eyre::Result<(LocalForkId, ContextUpdate<F::ChainContext>)> {
         let id = self.create_fork(fork)?;
-        let context_aux = self.select_fork(id, evm_env, tx_env, journaled_state)?;
-        Ok((id, context_aux))
+        let context = self.select_fork(id, evm_env, tx_env, journaled_state)?;
+        Ok((id, context))
     }
 
     /// Creates and also selects a new fork
@@ -229,10 +228,10 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
         tx_env: &mut F::Tx,
         journaled_state: &mut JournaledState,
         transaction: B256,
-    ) -> eyre::Result<(LocalForkId, ContextAuxUpdate<F::ContextAux>)> {
+    ) -> eyre::Result<(LocalForkId, ContextUpdate<F::ChainContext>)> {
         let id = self.create_fork_at_transaction(fork, transaction)?;
-        let context_aux = self.select_fork(id, evm_env, tx_env, journaled_state)?;
-        Ok((id, context_aux))
+        let context = self.select_fork(id, evm_env, tx_env, journaled_state)?;
+        Ok((id, context))
     }
 
     /// Creates a new fork but does _not_ select it
@@ -260,7 +259,7 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
         evm_env: &mut EvmEnv<F::Spec, F::BlockEnv>,
         tx_env: &mut F::Tx,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<F::ContextAux>>;
+    ) -> eyre::Result<ContextUpdate<F::ChainContext>>;
 
     /// Updates the fork to given block number.
     ///
@@ -276,7 +275,7 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
         evm_env: &mut EvmEnv<F::Spec, F::BlockEnv>,
         tx_env: &F::Tx,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<F::ContextAux>>;
+    ) -> eyre::Result<ContextUpdate<F::ChainContext>>;
 
     /// Updates the fork to given transaction hash
     ///
@@ -293,7 +292,7 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
         evm_env: &mut EvmEnv<F::Spec, F::BlockEnv>,
         tx_env: &F::Tx,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<F::ContextAux>>;
+    ) -> eyre::Result<ContextUpdate<F::ChainContext>>;
 
     /// Fetches the given transaction for the fork and executes it, committing the state in the DB
     fn transact(
@@ -304,7 +303,7 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
         outer_tx_env: &F::Tx,
         journaled_state: &mut JournaledState,
         inspector: &mut dyn for<'db> FoundryInspectorExt<F::FoundryContext<'db>>,
-    ) -> eyre::Result<ContextAuxUpdate<F::ContextAux>>;
+    ) -> eyre::Result<ContextUpdate<F::ChainContext>>;
 
     /// Executes a given TransactionRequest, commits the new state to the DB
     fn transact_from_tx(
@@ -315,9 +314,9 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
         inspector: &mut dyn for<'db> FoundryInspectorExt<F::FoundryContext<'db>>,
     ) -> eyre::Result<()>;
 
-    /// Returns network-specific context for a synthetic transaction on the active database.
-    fn context_for_synthetic_transaction(&self, tx: &F::Tx) -> eyre::Result<F::ContextAux> {
-        Ok(F::default().context_for_transaction(tx))
+    /// Returns transaction-position context for a synthetic transaction on the active database.
+    fn chain_context_for_synthetic_transaction(&self, tx: &F::Tx) -> eyre::Result<F::ChainContext> {
+        Ok(F::default().chain_context_for_transaction(tx))
     }
 
     /// Returns the `ForkId` that's currently used in the database, if fork mode is on
@@ -719,7 +718,6 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
             BackendDatabaseSnapshot<AnyNetwork, BlockEnvFor<FEN>>,
             SpecFor<FEN>,
             BlockEnvFor<FEN>,
-            ContextAuxFor<FEN>,
         >,
     > {
         &self.inner.state_snapshots
@@ -919,8 +917,8 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         tx_env: &mut TxEnvFor<FEN>,
         inspector: I,
     ) -> eyre::Result<ResultAndState<HaltReasonFor<FEN>>> {
-        let context_aux = self.context_for_synthetic_transaction(tx_env)?;
-        self.inspect_with_context(evm_env, tx_env, context_aux, inspector)
+        let chain_context = self.chain_context_for_synthetic_transaction(tx_env)?;
+        self.inspect_with_context(evm_env, tx_env, chain_context, inspector)
     }
 
     /// Executes the configured test call with explicit network-specific context.
@@ -929,7 +927,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         &mut self,
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &mut TxEnvFor<FEN>,
-        context_aux: ContextAuxFor<FEN>,
+        chain_context: ChainContextFor<FEN>,
         inspector: I,
     ) -> eyre::Result<ResultAndState<HaltReasonFor<FEN>>> {
         self.initialize(evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind());
@@ -937,7 +935,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         let mut evm = factory.create_foundry_evm_with_inspector(
             self,
             evm_env.to_owned(),
-            context_aux,
+            chain_context,
             inspector,
         );
         let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
@@ -1112,12 +1110,12 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         Self::block_context_inputs_from_backend(fork.backend(), block)
     }
 
-    /// Builds fresh auxiliary context for `tx` at a known position in `block_context`.
+    /// Builds transaction context for `tx` at a known position in `block_context`.
     fn context_for_block_position(
         block_context: BlockContext<FEN>,
         position: ForkPosition,
         tx: &TxEnvFor<FEN>,
-    ) -> eyre::Result<ContextAuxFor<FEN>> {
+    ) -> eyre::Result<ChainContextFor<FEN>> {
         let cursor = match position {
             ForkPosition::AfterBlock { .. } => block_context.into_child(),
             ForkPosition::BeforeTransaction { transaction_index, .. } => {
@@ -1127,15 +1125,14 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         Ok(cursor.next_transaction(tx))
     }
 
-    /// Builds fresh auxiliary context for a synthetic transaction at a fork's current position.
+    /// Builds context for a synthetic transaction at a fork's current position.
     fn context_for_fork_synthetic_transaction(
         &self,
         id: LocalForkId,
         tx: &TxEnvFor<FEN>,
-    ) -> eyre::Result<ContextAuxFor<FEN>> {
-        let factory = FEN::EvmFactory::default();
+    ) -> eyre::Result<ChainContextFor<FEN>> {
         if !FEN::EvmFactory::NEEDS_BLOCK_CONTEXT {
-            return Ok(factory.context_for_transaction(tx));
+            return Ok(FEN::EvmFactory::default().chain_context_for_transaction(tx));
         }
 
         let fork = self.inner.get_fork_by_id(id)?;
@@ -1249,7 +1246,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         Self::populate_rolled_active_fork(fork, persistent_accounts, caller, journaled_state);
     }
 
-    /// Rolls a fork while preparing active-fork auxiliary context before publishing the new fork.
+    /// Rolls a fork while preparing active transaction context before publishing the new fork.
     fn roll_fork_with_context(
         &mut self,
         id: Option<LocalForkId>,
@@ -1257,7 +1254,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: Option<&TxEnvFor<FEN>>,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         trace!(?id, ?block_number, "roll fork");
         let id = self.ensure_fork(id)?;
         let affects_active = self.is_active_fork(id);
@@ -1265,19 +1262,18 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
             self.forks.roll_fork(self.inner.ensure_fork_id(id).cloned()?, block_number)?;
 
         let context_update = if affects_active && let Some(tx) = tx_env {
-            let factory = FEN::EvmFactory::default();
-            let context_aux = if FEN::EvmFactory::NEEDS_BLOCK_CONTEXT {
+            let chain_context = if FEN::EvmFactory::NEEDS_BLOCK_CONTEXT {
                 let block = backend.get_full_block(context.block_number).wrap_err_with(|| {
                     format!("failed to fetch rolled fork block {}", context.block_number)
                 })?;
                 let block_context = Self::block_context_inputs_from_backend(&backend, &block)?;
                 block_context.into_child().next_transaction(tx)
             } else {
-                factory.context_for_transaction(tx)
+                FEN::EvmFactory::default().chain_context_for_transaction(tx)
             };
-            ContextAuxUpdate::Replace(context_aux)
+            ContextUpdate::Replace(chain_context)
         } else {
-            ContextAuxUpdate::Unchanged
+            ContextUpdate::Unchanged
         };
 
         // Update the local mapping only after all context fetches and decoding have succeeded.
@@ -1320,7 +1316,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: Option<&TxEnvFor<FEN>>,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         if !FEN::EvmFactory::NEEDS_BLOCK_CONTEXT {
             return self.roll_fork_to_transaction_inner(
                 id,
@@ -1353,15 +1349,15 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
                 block_number: block.header().number(),
                 transaction_index,
             };
-            ContextAuxUpdate::Replace(Self::context_for_block_position(
+            ContextUpdate::Replace(Self::context_for_block_position(
                 block_context.clone(),
                 position,
                 tx,
             )?)
         } else if affects_active {
-            ContextAuxUpdate::Unchanged
+            ContextUpdate::Unchanged
         } else {
-            ContextAuxUpdate::Rebase
+            ContextUpdate::Rebase
         };
 
         let current_fork_id = self.inner.ensure_fork_id(id).cloned()?;
@@ -1438,7 +1434,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: Option<&TxEnvFor<FEN>>,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         trace!(?id, ?transaction, "roll fork to transaction");
         let id = self.ensure_fork(id)?;
         let affects_active = self.is_active_fork(id);
@@ -1464,20 +1460,20 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
             None
         };
         let context_update = if affects_active && let Some(tx) = tx_env {
-            let context_aux = if let Some(context) = &block_context {
+            let chain_context = if let Some(context) = &block_context {
                 let position = ForkPosition::BeforeTransaction {
                     block_number: block.header().number(),
                     transaction_index: transaction_index.expect("checked above"),
                 };
                 Self::context_for_block_position(context.clone(), position, tx)?
             } else {
-                FEN::EvmFactory::default().context_for_transaction(tx)
+                FEN::EvmFactory::default().chain_context_for_transaction(tx)
             };
-            ContextAuxUpdate::Replace(context_aux)
+            ContextUpdate::Replace(chain_context)
         } else if affects_active {
-            ContextAuxUpdate::Unchanged
+            ContextUpdate::Unchanged
         } else {
-            ContextAuxUpdate::Rebase
+            ContextUpdate::Rebase
         };
 
         // The parent roll must not prepare an intermediate synthetic context.
@@ -1573,9 +1569,9 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
 
             if let Some(context) = block_context {
                 for (index, tx, tx_env) in &txs_to_replay {
-                    let context_aux = context.transaction(*index);
+                    let chain_context = context.transaction(*index);
                     let mut evm =
-                        factory.create_evm_with_context(replay_db, evm_env.clone(), context_aux);
+                        factory.create_evm_with_context(replay_db, evm_env.clone(), chain_context);
                     NetworkConfigs::default().inject_chain_precompiles(
                         evm.precompiles_mut(),
                         chain_id,
@@ -1618,26 +1614,25 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
 }
 
 impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
-    fn context_for_synthetic_transaction(
+    fn chain_context_for_synthetic_transaction(
         &self,
         tx: &TxEnvFor<FEN>,
-    ) -> eyre::Result<ContextAuxFor<FEN>> {
-        let factory = FEN::EvmFactory::default();
+    ) -> eyre::Result<ChainContextFor<FEN>> {
         self.block_context_for_synthetic_transaction()?.map_or_else(
-            || Ok(factory.context_for_transaction(tx)),
+            || Ok(FEN::EvmFactory::default().chain_context_for_transaction(tx)),
             |context| Ok(context.next_transaction(tx)),
         )
     }
 
     fn snapshot_state(
         &mut self,
-        context_state: &FoundryContextState<ContextAuxFor<FEN>>,
+        journaled_state: &JournaledState,
         evm_env: &EvmEnvFor<FEN>,
     ) -> U256 {
         trace!("create snapshot");
         let id = self.inner.state_snapshots.insert(BackendStateSnapshot::new(
             self.create_db_snapshot(),
-            context_state.clone(),
+            journaled_state.clone(),
             evm_env.clone(),
         ));
         trace!(target: "backend", "Created new snapshot {}", id);
@@ -1647,11 +1642,11 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
     fn revert_state(
         &mut self,
         id: U256,
-        current_state: &FoundryContextState<ContextAuxFor<FEN>>,
+        current_state: &JournaledState,
         evm_env: &mut EvmEnvFor<FEN>,
         caller: Address,
         action: RevertStateSnapshotAction,
-    ) -> Option<FoundryContextState<ContextAuxFor<FEN>>> {
+    ) -> Option<JournaledState> {
         trace!(?id, "revert snapshot");
         if let Some(mut snapshot) = self.inner.state_snapshots.remove_at(id) {
             // Re-insert snapshot to persist it
@@ -1663,7 +1658,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
             // Check if an error occurred either during or before the snapshot.
             // DSTest contracts don't have snapshot functionality, so this slot is enough to check
             // for failure here.
-            if let Some(account) = current_state.journaled_state.state.get(&CHEATCODE_ADDRESS)
+            if let Some(account) = current_state.state.get(&CHEATCODE_ADDRESS)
                 && let Some(slot) = account.storage.get(&GLOBAL_FAIL_SLOT)
                 && !slot.present_value.is_zero()
             {
@@ -1672,7 +1667,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
 
             // merge additional logs
             snapshot.merge(current_state);
-            let BackendStateSnapshot { db, mut context_state, snap_evm_env } = snapshot;
+            let BackendStateSnapshot { db, mut journaled_state, snap_evm_env } = snapshot;
             match db {
                 BackendDatabaseSnapshot::InMemory(mem_db) => {
                     self.mem_db = mem_db;
@@ -1681,9 +1676,8 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
                     // there might be the case where the snapshot was created during `setUp` with
                     // another caller, so we need to ensure the caller account is present in the
                     // journaled state and database
-                    context_state.journaled_state.state.entry(caller).or_insert_with(|| {
+                    journaled_state.state.entry(caller).or_insert_with(|| {
                         let caller_account = current_state
-                            .journaled_state
                             .state
                             .get(&caller)
                             .map(|acc| acc.info.clone())
@@ -1703,7 +1697,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
             *evm_env = snap_evm_env;
             trace!(target: "backend", "Reverted snapshot {}", id);
 
-            Some(context_state)
+            Some(journaled_state)
         } else {
             warn!(target: "backend", "No snapshot to revert for {}", id);
             None
@@ -1766,14 +1760,14 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &mut TxEnvFor<FEN>,
         active_journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         trace!(?id, "select fork");
         if self.is_active_fork(id) {
             // nothing to do
-            return Ok(ContextAuxUpdate::Unchanged);
+            return Ok(ContextUpdate::Unchanged);
         }
 
-        let context_aux = self.context_for_fork_synthetic_transaction(id, tx_env)?;
+        let chain_context = self.context_for_fork_synthetic_transaction(id, tx_env)?;
 
         // Update block number and timestamp of active fork (if any) with current env values,
         // in order to preserve values changed by using `roll` and `warp` cheatcodes.
@@ -1893,7 +1887,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         *evm_env = fork_evm_env;
         evm_env.cfg_env.set_spec_and_mainnet_gas_params(preserved_spec);
 
-        Ok(ContextAuxUpdate::Replace(context_aux))
+        Ok(ContextUpdate::Replace(chain_context))
     }
 
     /// This is effectively the same as [`Self::create_select_fork()`] but updating an existing
@@ -1905,7 +1899,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &TxEnvFor<FEN>,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         self.roll_fork_with_context(id, block_number, evm_env, Some(tx_env), journaled_state)
     }
 
@@ -1916,7 +1910,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &TxEnvFor<FEN>,
         journaled_state: &mut JournaledState,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         self.roll_fork_to_transaction_with_context(
             id,
             transaction,
@@ -1936,7 +1930,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         inspector: &mut dyn for<'db> FoundryInspectorExt<
             <FEN::EvmFactory as FoundryEvmFactory>::FoundryContext<'db>,
         >,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         trace!(?maybe_id, ?transaction, "execute transaction");
         let persistent_accounts = self.inner.persistent_accounts.clone();
         let id = self.ensure_fork(maybe_id)?;
@@ -1955,7 +1949,6 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         update_env_block(&mut evm_env, block.header());
         self.apply_fork_tx_replay_env_changes(id, &mut evm_env)?;
 
-        let factory = FEN::EvmFactory::default();
         let current_tx_position = if FEN::EvmFactory::NEEDS_BLOCK_CONTEXT {
             let BlockTransactions::Full(transactions) = block.transactions() else {
                 eyre::bail!("block {} does not contain full transactions", block.header().number());
@@ -1977,10 +1970,10 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         } else {
             None
         };
-        let context_aux = if let Some((current_tx_index, _)) = current_tx_position {
+        let chain_context = if let Some((current_tx_index, _)) = current_tx_position {
             block_context.as_ref().expect("created above").transaction(current_tx_index)
         } else {
-            factory.context_for_transaction(&tx_env)
+            FEN::EvmFactory::default().chain_context_for_transaction(&tx_env)
         };
 
         let next_position = if let Some((current_tx_index, transaction_count)) = current_tx_position
@@ -2001,22 +1994,22 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
             None
         };
         let context_update = if affects_active {
-            ContextAuxUpdate::Replace(if let Some(context) = block_context {
+            ContextUpdate::Replace(if let Some(context) = block_context {
                 Self::context_for_block_position(
                     context,
                     next_position.expect("block context has a next position"),
                     outer_tx_env,
                 )?
             } else {
-                factory.context_for_transaction(outer_tx_env)
+                FEN::EvmFactory::default().chain_context_for_transaction(outer_tx_env)
             })
         } else {
-            ContextAuxUpdate::Rebase
+            ContextUpdate::Rebase
         };
 
         let fork = self.inner.get_fork_by_id_mut(id)?;
         commit_transaction::<FEN>(
-            TransactionInputs { evm_env, tx_env, context_aux },
+            TransactionInputs { evm_env, tx_env, chain_context },
             journaled_state,
             fork,
             &fork_id,
@@ -2046,9 +2039,9 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
             let mut db = self.clone();
             let depth = journaled_state.depth + 1;
             let factory = FEN::EvmFactory::default();
-            let context_aux = self.context_for_synthetic_transaction(&tx_env)?;
+            let chain_context = self.chain_context_for_synthetic_transaction(&tx_env)?;
             let mut evm =
-                factory.create_foundry_nested_evm(&mut db, evm_env, context_aux, inspector);
+                factory.create_foundry_nested_evm(&mut db, evm_env, chain_context, inspector);
             evm.journal_inner_mut().depth = depth;
             evm.transact_raw(tx_env)?
         };
@@ -2438,7 +2431,6 @@ pub struct BackendInner<FEN: FoundryEvmNetwork> {
             BackendDatabaseSnapshot<AnyNetwork, BlockEnvFor<FEN>>,
             SpecFor<FEN>,
             BlockEnvFor<FEN>,
-            ContextAuxFor<FEN>,
         >,
     >,
     /// Tracks whether there was a failure in a snapshot that was reverted
@@ -2887,7 +2879,7 @@ fn commit_transaction<FEN: FoundryEvmNetwork>(
         <FEN::EvmFactory as FoundryEvmFactory>::FoundryContext<'db>,
     >,
 ) -> eyre::Result<()> {
-    let TransactionInputs { evm_env, tx_env, context_aux } = transaction;
+    let TransactionInputs { evm_env, tx_env, chain_context } = transaction;
     let now = Instant::now();
     let res = {
         let fork = fork.clone();
@@ -2898,7 +2890,7 @@ fn commit_transaction<FEN: FoundryEvmNetwork>(
         let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
             &mut db,
             evm_env,
-            context_aux,
+            chain_context,
             inspector,
         );
         evm.journal_inner_mut().depth = depth + 1;

--- a/crates/evm/core/src/backend/snapshot.rs
+++ b/crates/evm/core/src/backend/snapshot.rs
@@ -1,4 +1,4 @@
-use crate::FoundryContextState;
+use crate::backend::JournaledState;
 use alloy_evm::EvmEnv;
 use alloy_primitives::{
     B256, U256,
@@ -17,22 +17,18 @@ pub struct StateSnapshot {
 
 /// Represents a state snapshot taken during evm execution
 #[derive(Clone, Debug)]
-pub struct BackendStateSnapshot<T, SPEC, BLOCK, AUX> {
+pub struct BackendStateSnapshot<T, SPEC, BLOCK> {
     pub db: T,
     /// Complete context state at a specific point.
-    pub context_state: FoundryContextState<AUX>,
+    pub journaled_state: JournaledState,
     /// Contains the evm env at the time of the snapshot
     pub snap_evm_env: EvmEnv<SPEC, BLOCK>,
 }
 
-impl<T, SPEC, BLOCK, AUX> BackendStateSnapshot<T, SPEC, BLOCK, AUX> {
+impl<T, SPEC, BLOCK> BackendStateSnapshot<T, SPEC, BLOCK> {
     /// Takes a new state snapshot.
-    pub const fn new(
-        db: T,
-        context_state: FoundryContextState<AUX>,
-        evm_env: EvmEnv<SPEC, BLOCK>,
-    ) -> Self {
-        Self { db, context_state, snap_evm_env: evm_env }
+    pub const fn new(db: T, journaled_state: JournaledState, evm_env: EvmEnv<SPEC, BLOCK>) -> Self {
+        Self { db, journaled_state, snap_evm_env: evm_env }
     }
 
     /// Called when this state snapshot is reverted.
@@ -42,8 +38,8 @@ impl<T, SPEC, BLOCK, AUX> BackendStateSnapshot<T, SPEC, BLOCK, AUX> {
     /// those logs that are missing in the snapshot's journaled_state, since the current
     /// journaled_state includes the same logs, we can simply replace use that See also
     /// `DatabaseExt::revert`.
-    pub fn merge(&mut self, current: &FoundryContextState<AUX>) {
-        self.context_state.journaled_state.logs.clone_from(&current.journaled_state.logs);
+    pub fn merge(&mut self, current: &JournaledState) {
+        self.journaled_state.logs.clone_from(&current.logs);
     }
 }
 

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -8,10 +8,7 @@ use alloy_evm::FromRecoveredTx;
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
 use alloy_primitives::{Address, B256, Bytes, U256};
 #[cfg(feature = "monad")]
-use monad_revm::{
-    MonadCfgEnv, MonadChainContext, MonadJournal, MonadJournalTr,
-    reserve_balance::tracker::ReserveBalanceTracker,
-};
+use monad_revm::{MonadCfgEnv, MonadChainContext, MonadJournal};
 #[cfg(feature = "optimism")]
 use op_revm::transaction::deposit::DEPOSIT_TRANSACTION_TYPE;
 use revm::{
@@ -28,33 +25,6 @@ use revm::{
 use tempo_revm::{TempoBlockEnv, TempoTxEnv};
 
 use crate::backend::JournaledState;
-
-/// Network-specific state stored beside the standard REVM journal.
-pub trait FoundryEvmAuxState: Clone + Debug + Default + Send + Sync + 'static {}
-
-impl FoundryEvmAuxState for () {}
-
-/// Complete EVM context state that must move through nested execution and snapshots together.
-#[derive(Clone, Debug)]
-pub struct FoundryContextState<A> {
-    /// Standard REVM journal state.
-    pub journaled_state: JournaledState,
-    /// Network-specific state stored outside [`JournaledState`].
-    pub auxiliary: A,
-}
-
-/// Monad state stored outside the standard REVM journal.
-#[cfg(feature = "monad")]
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct MonadContextAux {
-    /// Chain metadata used by reserve-balance eligibility checks.
-    pub chain: MonadChainContext,
-    /// Live reserve-balance tracker for the current transaction.
-    pub reserve_balance: ReserveBalanceTracker,
-}
-
-#[cfg(feature = "monad")]
-impl FoundryEvmAuxState for MonadContextAux {}
 
 /// Extension of [`Block`] with mutable setters, allowing EVM-agnostic mutation of block fields.
 pub trait FoundryBlock: Block {
@@ -461,9 +431,6 @@ pub trait FoundryContextExt:
     /// Bubbled-up from `ContextTr::Cfg` for convenience and simplified bounds.
     type Spec: Into<SpecId> + Copy + Debug;
 
-    /// Network-specific state stored outside the standard REVM journal.
-    type Aux: FoundryEvmAuxState;
-
     /// Mutable reference to the block environment.
     fn block_mut(&mut self) -> &mut Self::Block;
 
@@ -484,26 +451,6 @@ pub trait FoundryContextExt:
 
     /// Reference to the journal inner.
     fn journal_inner(&self) -> &JournaledState;
-
-    /// Clones the network-specific auxiliary state.
-    fn aux_state(&self) -> Self::Aux;
-
-    /// Restores the network-specific auxiliary state.
-    fn set_aux_state(&mut self, auxiliary: Self::Aux);
-
-    /// Clones all context state that must survive nested execution or snapshots.
-    fn context_state(&self) -> FoundryContextState<Self::Aux> {
-        FoundryContextState {
-            journaled_state: self.journal_inner().clone(),
-            auxiliary: self.aux_state(),
-        }
-    }
-
-    /// Restores all context state captured by [`Self::context_state`].
-    fn set_context_state(&mut self, state: FoundryContextState<Self::Aux>) {
-        self.set_journal_inner(state.journaled_state);
-        self.set_aux_state(state.auxiliary);
-    }
 
     /// Sets the spec and refreshes gas params for the concrete EVM family.
     fn set_spec_and_gas_params(&mut self, spec: Self::Spec) {
@@ -556,8 +503,6 @@ impl<
 > FoundryContextExt for Context<BLOCK, TX, CfgEnv<SPEC>, DB, Journal<DB>, C>
 {
     type Spec = <Self::Cfg as Cfg>::Spec;
-    type Aux = ();
-
     fn block_mut(&mut self) -> &mut Self::Block {
         &mut self.block
     }
@@ -585,10 +530,6 @@ impl<
     fn journal_inner(&self) -> &JournaledState {
         &self.journaled_state.inner
     }
-
-    fn aux_state(&self) -> Self::Aux {}
-
-    fn set_aux_state(&mut self, _auxiliary: Self::Aux) {}
 }
 
 #[cfg(feature = "monad")]
@@ -596,8 +537,6 @@ impl<DB: Database> FoundryContextExt
     for Context<BlockEnv, TxEnv, MonadCfgEnv, DB, MonadJournal<DB>, MonadChainContext>
 {
     type Spec = <Self::Cfg as Cfg>::Spec;
-    type Aux = MonadContextAux;
-
     fn block_mut(&mut self) -> &mut Self::Block {
         &mut self.block
     }
@@ -632,18 +571,6 @@ impl<DB: Database> FoundryContextExt
     fn journal_inner(&self) -> &JournaledState {
         let journal: &Journal<DB> = self.journaled_state.deref();
         &journal.inner
-    }
-
-    fn aux_state(&self) -> Self::Aux {
-        MonadContextAux {
-            chain: self.chain.clone(),
-            reserve_balance: self.journaled_state.reserve_balance().clone(),
-        }
-    }
-
-    fn set_aux_state(&mut self, auxiliary: Self::Aux) {
-        self.chain = auxiliary.chain;
-        *self.journaled_state.reserve_balance_mut() = auxiliary.reserve_balance;
     }
 }
 

--- a/crates/evm/core/src/evm/block_context.rs
+++ b/crates/evm/core/src/evm/block_context.rs
@@ -5,7 +5,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::{BlockNumberOrTag, BlockTransactions};
 use eyre::{Result, WrapErr};
 
-use super::{BlockResponseFor, ContextAuxFor, FoundryEvmFactory, FoundryEvmNetwork, TxEnvFor};
+use super::{BlockResponseFor, ChainContextFor, FoundryEvmFactory, FoundryEvmNetwork, TxEnvFor};
 
 /// Transaction metadata for an exact block and its two ancestors.
 #[derive(Clone, Debug)]
@@ -46,8 +46,8 @@ impl<FEN: FoundryEvmNetwork> BlockContext<FEN> {
     }
 
     /// Builds context for the transaction at `index` in the current block.
-    pub fn transaction(&self, index: usize) -> ContextAuxFor<FEN> {
-        FEN::EvmFactory::default().context_for_block(
+    pub fn transaction(&self, index: usize) -> ChainContextFor<FEN> {
+        FEN::EvmFactory::default().chain_context_for_block(
             &self.grandparent,
             &self.parent,
             &self.current,
@@ -75,11 +75,11 @@ impl<FEN: FoundryEvmNetwork> BlockContext<FEN> {
     }
 
     /// Builds context for the next transaction at the cursor's current block position.
-    pub fn next_transaction(&self, tx: &TxEnvFor<FEN>) -> ContextAuxFor<FEN> {
+    pub fn next_transaction(&self, tx: &TxEnvFor<FEN>) -> ChainContextFor<FEN> {
         let mut current = self.current.clone();
         let index = current.len();
         current.push(tx.clone());
-        FEN::EvmFactory::default().context_for_block(
+        FEN::EvmFactory::default().chain_context_for_block(
             &self.grandparent,
             &self.parent,
             &current,
@@ -99,7 +99,7 @@ impl<FEN: FoundryEvmNetwork> BlockContext<FEN> {
     }
 
     /// Builds context for a synthetic transaction in a child of the current block.
-    pub fn child(&self, tx: &TxEnvFor<FEN>) -> ContextAuxFor<FEN> {
+    pub fn child(&self, tx: &TxEnvFor<FEN>) -> ChainContextFor<FEN> {
         self.clone().into_child().next_transaction(tx)
     }
 }
@@ -109,14 +109,13 @@ pub async fn context_for_child_transaction<FEN, P>(
     provider: &P,
     block_number: u64,
     tx: &TxEnvFor<FEN>,
-) -> Result<ContextAuxFor<FEN>>
+) -> Result<ChainContextFor<FEN>>
 where
     FEN: FoundryEvmNetwork,
     P: Provider<FEN::Network>,
 {
-    let factory = FEN::EvmFactory::default();
     if !FEN::EvmFactory::NEEDS_BLOCK_CONTEXT {
-        return Ok(factory.context_for_transaction(tx));
+        return Ok(FEN::EvmFactory::default().chain_context_for_transaction(tx));
     }
 
     let block = provider

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -19,7 +19,7 @@ use revm::{
 };
 
 use crate::{
-    FoundryContextExt, FoundryContextState, FoundryInspectorExt,
+    FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
     evm::{FoundryEvmFactory, NestedEvm},
 };
@@ -35,7 +35,8 @@ pub type EthRevmEvm<'db, I> = RevmEvm<
 >;
 
 impl FoundryEvmFactory for EthEvmFactory {
-    type ContextAux = ();
+    type ChainContext = ();
+    type TransactionState = ();
     type FoundryContext<'db> = EthEvmContext<&'db mut dyn DatabaseExt<Self>>;
 
     type FoundryEvm<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>> =
@@ -45,7 +46,7 @@ impl FoundryEvmFactory for EthEvmFactory {
         &self,
         db: DB,
         evm_env: EvmEnv,
-        _context_aux: Self::ContextAux,
+        _chain_context: Self::ChainContext,
     ) -> Self::Evm<DB, revm::inspector::NoOpInspector> {
         self.create_evm(db, evm_env)
     }
@@ -54,7 +55,7 @@ impl FoundryEvmFactory for EthEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv,
-        _context_aux: Self::ContextAux,
+        _chain_context: Self::ChainContext,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I> {
         let chain_id = evm_env.cfg_env.chain_id;
@@ -71,11 +72,19 @@ impl FoundryEvmFactory for EthEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv,
-        context_aux: Self::ContextAux,
+        chain_context: Self::ChainContext,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
-    ) -> Box<dyn NestedEvm<Spec = SpecId, Block = BlockEnv, Tx = TxEnv, Aux = ()> + 'db> {
+    ) -> Box<
+        dyn NestedEvm<
+                Spec = SpecId,
+                Block = BlockEnv,
+                Tx = TxEnv,
+                ChainContext = (),
+                TransactionState = (),
+            > + 'db,
+    > {
         Box::new(
-            self.create_foundry_evm_with_inspector(db, evm_env, context_aux, inspector)
+            self.create_foundry_evm_with_inspector(db, evm_env, chain_context, inspector)
                 .into_inner(),
         )
     }
@@ -87,22 +96,10 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
     type Spec = SpecId;
     type Block = BlockEnv;
     type Tx = TxEnv;
-    type Aux = ();
-
+    type ChainContext = ();
+    type TransactionState = ();
     fn journal_inner_mut(&mut self) -> &mut JournaledState {
         &mut self.ctx_mut().journaled_state.inner
-    }
-
-    fn context_state(&self) -> FoundryContextState<Self::Aux> {
-        self.ctx_ref().context_state()
-    }
-
-    fn aux_state(&self) -> Self::Aux {
-        self.ctx_ref().aux_state()
-    }
-
-    fn set_context_state(&mut self, state: FoundryContextState<Self::Aux>) {
-        self.ctx_mut().set_context_state(state);
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -1,8 +1,8 @@
 use std::{fmt::Debug, ops::Deref};
 
 use crate::{
-    FoundryBlock, FoundryContextExt, FoundryContextState, FoundryEvmAuxState, FoundryInspectorExt,
-    FoundryTransaction, FromAnyRpcTransaction,
+    FoundryBlock, FoundryContextExt, FoundryInspectorExt, FoundryTransaction,
+    FromAnyRpcTransaction,
     backend::{DatabaseExt, JournaledState},
 };
 use alloy_consensus::{SignableTransaction, Signed, transaction::SignerRecoverable};
@@ -29,7 +29,6 @@ use revm::{
         CallInput, CallInputs, CallScheme, CallValue, CreateInputs, FrameInput, InstructionResult,
     },
     primitives::{eip3860::MAX_INITCODE_SIZE, hardfork::SpecId},
-    state::EvmState,
 };
 use serde::{Deserialize, Serialize};
 use tempo_alloy::TempoNetwork;
@@ -107,8 +106,19 @@ pub type SpecFor<FEN> = <EvmFactoryFor<FEN> as EvmFactory>::Spec;
 pub type BlockEnvFor<FEN> = <EvmFactoryFor<FEN> as EvmFactory>::BlockEnv;
 pub type PrecompilesFor<FEN> = <EvmFactoryFor<FEN> as EvmFactory>::Precompiles;
 pub type EvmEnvFor<FEN> = EvmEnv<SpecFor<FEN>, BlockEnvFor<FEN>>;
-pub type ContextAuxFor<FEN> = <EvmFactoryFor<FEN> as FoundryEvmFactory>::ContextAux;
-pub type ContextStateFor<FEN> = FoundryContextState<ContextAuxFor<FEN>>;
+pub type ChainContextFor<FEN> = <EvmFactoryFor<FEN> as FoundryEvmFactory>::ChainContext;
+pub type TransactionStateFor<FEN> = <EvmFactoryFor<FEN> as FoundryEvmFactory>::TransactionState;
+
+/// Boxed nested EVM produced by a Foundry EVM factory.
+pub type NestedEvmFor<'db, F> = Box<
+    dyn NestedEvm<
+            Spec = <F as EvmFactory>::Spec,
+            Block = <F as EvmFactory>::BlockEnv,
+            Tx = <F as EvmFactory>::Tx,
+            ChainContext = <F as FoundryEvmFactory>::ChainContext,
+            TransactionState = <F as FoundryEvmFactory>::TransactionState,
+        > + 'db,
+>;
 
 pub type NetworkFor<FEN> = <FEN as FoundryEvmNetwork>::Network;
 pub type TxEnvelopeFor<FEN> = <NetworkFor<FEN> as Network>::TxEnvelope;
@@ -116,26 +126,19 @@ pub type TransactionRequestFor<FEN> = <NetworkFor<FEN> as Network>::TransactionR
 pub type TransactionResponseFor<FEN> = <NetworkFor<FEN> as Network>::TransactionResponse;
 pub type BlockResponseFor<FEN> = <NetworkFor<FEN> as Network>::BlockResponse;
 
-/// Rebases precomputed network context after the active database or fork position changes.
-pub fn rebase_context_after_state_transition<FEN: FoundryEvmNetwork>(
+/// Applies transaction-position changes and refreshes EVM-family state after a journal transition.
+pub fn apply_context_transition<FEN: FoundryEvmNetwork>(
     ecx: &mut FoundryContextFor<'_, FEN>,
-    current: &ContextAuxFor<FEN>,
-    mut replacement: ContextAuxFor<FEN>,
+    replacement: Option<&ChainContextFor<FEN>>,
 ) {
-    {
-        let (_, inner) = ecx.db_journal_inner_mut();
-        FEN::EvmFactory::default().rebase_context_aux(current, &mut replacement, &inner.state);
-    }
-    ecx.set_aux_state(replacement);
+    FEN::EvmFactory::default().apply_context_transition(ecx, replacement);
 }
 
 /// Rebases network caches after state changes that retain the active chain cursor.
 pub fn refresh_context_after_state_change<FEN: FoundryEvmNetwork>(
     ecx: &mut FoundryContextFor<'_, FEN>,
 ) {
-    let current = ecx.aux_state();
-    let replacement = current.clone();
-    rebase_context_after_state_transition::<FEN>(ecx, &current, replacement);
+    apply_context_transition::<FEN>(ecx, None);
 }
 
 pub trait FoundryEvmFactory:
@@ -150,6 +153,12 @@ pub trait FoundryEvmFactory:
     + Default
     + 'static
 {
+    /// Chain context required to execute at an exact transaction position.
+    type ChainContext: Clone + Debug + Default + Send + Sync + 'static;
+
+    /// Family-owned state scoped to the active transaction.
+    type TransactionState: Clone + Debug + Default + Send + Sync + 'static;
+
     /// Additional network-specific cheatcode contract addresses.
     const EXTRA_CHEATCODE_ADDRESSES: &'static [Address] = &[];
 
@@ -162,15 +171,11 @@ pub trait FoundryEvmFactory:
     /// Whether canonical protocol system transactions must be included during fork replay.
     const REPLAYS_PROTOCOL_SYSTEM_TRANSACTIONS: bool = false;
 
-    /// Network-specific state stored outside the standard REVM journal.
-    type ContextAux: FoundryEvmAuxState;
-
     /// Foundry Context abstraction
     type FoundryContext<'db>: FoundryContextExt<
             Block = Self::BlockEnv,
             Tx = Self::Tx,
             Spec = Self::Spec,
-            Aux = Self::ContextAux,
             Db: DatabaseExt<Self>,
         >
     where
@@ -192,35 +197,49 @@ pub trait FoundryEvmFactory:
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        context_aux: Self::ContextAux,
+        chain_context: Self::ChainContext,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I>;
 
-    /// Returns the auxiliary state for a standalone synthetic transaction.
-    fn context_for_transaction(&self, _tx: &Self::Tx) -> Self::ContextAux {
-        Self::ContextAux::default()
+    /// Builds chain context for a standalone synthetic transaction.
+    fn chain_context_for_transaction(&self, _tx: &Self::Tx) -> Self::ChainContext {
+        Self::ChainContext::default()
     }
 
-    /// Returns the auxiliary state for a transaction at an exact position in a block.
-    fn context_for_block(
+    /// Builds chain context for a transaction at an exact block position.
+    fn chain_context_for_block(
         &self,
         _grandparent: &[Self::Tx],
         _parent: &[Self::Tx],
         _current: &[Self::Tx],
         _current_tx_index: usize,
-    ) -> Self::ContextAux {
-        Self::ContextAux::default()
+    ) -> Self::ChainContext {
+        Self::ChainContext::default()
     }
 
-    /// Rebases live auxiliary state after the underlying database or fork position changes.
-    ///
-    /// `replacement` contains context reconstructed at the new position. Implementations may
-    /// preserve transaction-scoped state from `current` while recomputing caches against `state`.
-    fn rebase_context_aux(
+    /// Captures the active transaction position from a live EVM context.
+    fn capture_chain_context(&self, _ecx: &Self::FoundryContext<'_>) -> Self::ChainContext {
+        Self::ChainContext::default()
+    }
+
+    /// Applies a new transaction position and refreshes family-owned state after journal changes.
+    fn apply_context_transition<'db>(
         &self,
-        _current: &Self::ContextAux,
-        _replacement: &mut Self::ContextAux,
-        _state: &EvmState,
+        _ecx: &mut Self::FoundryContext<'db>,
+        _replacement: Option<&Self::ChainContext>,
+    ) {
+    }
+
+    /// Captures family-owned state for the active transaction.
+    fn capture_transaction_state(&self, _ecx: &Self::FoundryContext<'_>) -> Self::TransactionState {
+        Self::TransactionState::default()
+    }
+
+    /// Restores family-owned state for the active transaction.
+    fn restore_transaction_state(
+        &self,
+        _ecx: &mut Self::FoundryContext<'_>,
+        _state: Self::TransactionState,
     ) {
     }
 
@@ -263,12 +282,12 @@ pub trait FoundryEvmFactory:
         evm.transact(tx).map_err(Into::into)
     }
 
-    /// Creates an uninspected EVM with explicit network-specific auxiliary state.
+    /// Creates an uninspected EVM with explicit transaction-position context.
     fn create_evm_with_context<DB: alloy_evm::Database>(
         &self,
         db: DB,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        context_aux: Self::ContextAux,
+        chain_context: Self::ChainContext,
     ) -> Self::Evm<DB, NoOpInspector>;
 
     /// Creates a Foundry-wrapped EVM with a dynamic inspector, returning a boxed [`NestedEvm`].
@@ -281,16 +300,9 @@ pub trait FoundryEvmFactory:
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        context_aux: Self::ContextAux,
+        chain_context: Self::ChainContext,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
-    ) -> Box<
-        dyn NestedEvm<
-                Spec = Self::Spec,
-                Block = Self::BlockEnv,
-                Tx = Self::Tx,
-                Aux = Self::ContextAux,
-            > + 'db,
-    >;
+    ) -> NestedEvmFor<'db, Self>;
 }
 
 /// Object-safe trait exposing the operations that cheatcode nested EVM closures need.
@@ -304,23 +316,28 @@ pub trait NestedEvm {
     type Block;
     /// The transaction environment type.
     type Tx;
-    /// Network-specific state stored outside the standard REVM journal.
-    type Aux: FoundryEvmAuxState;
-
+    /// Chain context identifying the active transaction position.
+    type ChainContext: Clone + Debug + Default + Send + Sync + 'static;
+    /// Family-owned state scoped to the active transaction.
+    type TransactionState: Clone + Debug + Default + Send + Sync + 'static;
     /// Returns a mutable reference to the journal inner state (`JournaledState`).
     fn journal_inner_mut(&mut self) -> &mut JournaledState;
 
-    /// Clones the complete context state.
-    fn context_state(&self) -> FoundryContextState<Self::Aux>;
+    /// Captures the active transaction position.
+    fn capture_chain_context(&self) -> Self::ChainContext {
+        Self::ChainContext::default()
+    }
 
-    /// Clones the network-specific auxiliary state.
-    fn aux_state(&self) -> Self::Aux;
+    /// Captures family-owned state for the active transaction.
+    fn capture_transaction_state(&self) -> Self::TransactionState {
+        Self::TransactionState::default()
+    }
 
-    /// Restores the complete context state.
-    fn set_context_state(&mut self, state: FoundryContextState<Self::Aux>);
+    /// Restores family-owned state for the active transaction.
+    fn restore_transaction_state(&mut self, _state: Self::TransactionState) {}
 
-    /// Preserves auxiliary state across the next synthetic transaction boundary.
-    fn preserve_aux_state_on_transaction(&mut self) {}
+    /// Preserves transaction-scoped state across the next transaction boundary.
+    fn preserve_transaction_state_on_next_transaction(&mut self) {}
 
     /// Runs a single execution frame (create or call) through the EVM handler loop.
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>>;
@@ -343,35 +360,48 @@ pub trait NestedEvm {
 }
 
 /// Closure type used by `CheatcodesExecutor` methods that run nested EVM operations.
-pub type NestedEvmClosure<'a, Spec, Block, Tx, Aux> =
+pub type NestedEvmClosure<'a, Spec, Block, Tx, ChainContext, TransactionState> =
     &'a mut dyn FnMut(
-        &mut dyn NestedEvm<Spec = Spec, Block = Block, Tx = Tx, Aux = Aux>,
+        &mut dyn NestedEvm<
+            Spec = Spec,
+            Block = Block,
+            Tx = Tx,
+            ChainContext = ChainContext,
+            TransactionState = TransactionState,
+        >,
     ) -> Result<(), EVMError<DatabaseError>>;
 
+/// Nested EVM closure for a Foundry EVM network.
+pub type NestedEvmClosureFor<'a, FEN> = NestedEvmClosure<
+    'a,
+    SpecFor<FEN>,
+    BlockEnvFor<FEN>,
+    TxEnvFor<FEN>,
+    ChainContextFor<FEN>,
+    TransactionStateFor<FEN>,
+>;
+
 /// Clones the current context (env + journal), passes the database, cloned env,
-/// and cloned context state to the callback. The callback builds whatever EVM it
-/// needs, runs its operations, and returns `(result, modified_env, modified_context)`.
+/// and cloned journal inner to the callback. The callback builds whatever EVM it
+/// needs, runs its operations, and returns `(result, modified_env, modified_journal)`.
 /// Modified state is written back after the callback returns.
 pub fn with_cloned_context<CTX: FoundryContextExt>(
     ecx: &mut CTX,
     f: impl FnOnce(
         &mut CTX::Db,
         EvmEnv<CTX::Spec, CTX::Block>,
-        FoundryContextState<CTX::Aux>,
-    ) -> Result<
-        (EvmEnv<CTX::Spec, CTX::Block>, FoundryContextState<CTX::Aux>),
-        EVMError<DatabaseError>,
-    >,
+        JournaledState,
+    )
+        -> Result<(EvmEnv<CTX::Spec, CTX::Block>, JournaledState), EVMError<DatabaseError>>,
 ) -> Result<(), EVMError<DatabaseError>> {
     let evm_env = ecx.evm_clone();
-    let context_state = ecx.context_state();
+    let (db, journal_inner) = ecx.db_journal_inner_mut();
+    let journal_inner = journal_inner.clone();
 
-    let db = ecx.db_mut();
-
-    let (sub_evm_env, sub_state) = f(db, evm_env, context_state)?;
+    let (sub_evm_env, sub_inner) = f(db, evm_env, journal_inner)?;
 
     // Write back modified state. The db borrow was released when f returned.
-    ecx.set_context_state(sub_state);
+    ecx.set_journal_inner(sub_inner);
     ecx.set_evm(sub_evm_env);
 
     Ok(())

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -4,14 +4,15 @@ use alloy_sol_types::SolCall;
 use eyre::WrapErr;
 use foundry_fork_db::DatabaseError;
 use monad_revm::{
-    MonadBuilder, MonadCfgEnv, MonadContext, MonadEvm as RevmMonadEvm, MonadHardfork,
-    MonadJournalTr,
+    MonadBuilder, MonadCfgEnv, MonadChainContext, MonadContext, MonadEvm as RevmMonadEvm,
+    MonadHardfork, MonadJournalTr,
     api::block::{
         syscall_on_epoch_change_calldata, syscall_reward_calldata, syscall_snapshot_calldata,
     },
     handler::MonadHandler,
     instructions::MonadInstructions,
     monad_context_with_db,
+    reserve_balance::tracker::ReserveBalanceTracker,
     staking::{
         STAKING_ADDRESS,
         constants::SYSTEM_ADDRESS,
@@ -30,11 +31,10 @@ use revm::{
     inspector::{InspectSystemCallEvm, Inspector, InspectorHandler},
     interpreter::{FrameInput, GasTracker, SharedMemory, interpreter_action::FrameInit},
     primitives::{Address, HashSet},
-    state::EvmState,
 };
 
 use crate::{
-    FoundryContextExt, FoundryContextState, FoundryInspectorExt, MonadContextAux,
+    FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
     constants::MONAD_CHEATCODE_ADDRESS,
     evm::{FoundryEvmFactory, NestedEvm, ProtocolSystemCall, finish_protocol_system_call},
@@ -70,21 +70,32 @@ pub fn monad_context_from_participants(
     parent_senders_and_authorities: MonadBlockParticipants,
     current: &[TxEnv],
     current_tx_index: usize,
-) -> MonadContextAux {
-    MonadContextAux {
-        chain: monad_revm::MonadChainContext {
-            grandparent_senders_and_authorities,
-            parent_senders_and_authorities,
-            current_block_senders: current.iter().map(Transaction::caller).collect(),
-            current_block_authorities: current
-                .iter()
-                .map(|tx| tx.authorization_list().filter_map(|auth| auth.authority()).collect())
-                .collect(),
-            current_tx_index,
-            ..Default::default()
-        },
+) -> MonadChainContext {
+    MonadChainContext {
+        grandparent_senders_and_authorities,
+        parent_senders_and_authorities,
+        current_block_senders: current.iter().map(Transaction::caller).collect(),
+        current_block_authorities: current
+            .iter()
+            .map(|tx| tx.authorization_list().filter_map(|auth| auth.authority()).collect())
+            .collect(),
+        current_tx_index,
         ..Default::default()
     }
+}
+
+fn set_monad_chain_context<DB: alloy_evm::Database>(
+    context: &mut MonadContext<DB>,
+    chain_context: MonadChainContext,
+) {
+    context.chain = chain_context;
+}
+
+fn rebase_monad_context<DB: alloy_evm::Database>(context: &mut MonadContext<DB>) {
+    let chain = context.chain.clone();
+    let mut tracker = std::mem::take(context.journaled_state.reserve_balance_mut());
+    tracker.rebase(&chain, &context.journaled_state.inner.state);
+    *context.journaled_state.reserve_balance_mut() = tracker;
 }
 
 fn transact_monad_replay<DB, I>(
@@ -101,7 +112,9 @@ where
     };
 
     system_call.validate_chain_id(evm.chain_id())?;
-    let context_state = evm.ctx().context_state();
+    let journal = evm.ctx().journal_inner().clone();
+    let chain = evm.ctx().chain.clone();
+    let reserve_balance = evm.ctx().journaled_state.reserve_balance().clone();
     let result = (|| {
         let (db, journal) = evm.ctx_mut().db_journal_inner_mut();
         system_call.apply_prestate(db, journal)?;
@@ -111,7 +124,9 @@ where
         finish_protocol_system_call(result)
     })();
     if result.is_err() {
-        evm.ctx_mut().set_context_state(context_state);
+        evm.ctx_mut().set_journal_inner(journal);
+        evm.ctx_mut().chain = chain;
+        *evm.ctx_mut().journaled_state.reserve_balance_mut() = reserve_balance;
     }
     result
 }
@@ -123,48 +138,47 @@ impl FoundryEvmFactory for MonadEvmFactory {
     const NEEDS_BLOCK_CONTEXT: bool = true;
     const REPLAYS_PROTOCOL_SYSTEM_TRANSACTIONS: bool = true;
 
-    type ContextAux = MonadContextAux;
+    type ChainContext = MonadChainContext;
+    type TransactionState = ReserveBalanceTracker;
+
     type FoundryContext<'db> = MonadContext<&'db mut dyn DatabaseExt<Self>>;
 
     type FoundryEvm<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>> =
         MonadEvm<&'db mut dyn DatabaseExt<Self>, I>;
 
-    fn create_evm_with_context<DB: alloy_evm::Database>(
+    fn capture_transaction_state(&self, ecx: &Self::FoundryContext<'_>) -> Self::TransactionState {
+        ecx.journaled_state.reserve_balance().clone()
+    }
+
+    fn capture_chain_context(&self, ecx: &Self::FoundryContext<'_>) -> Self::ChainContext {
+        ecx.chain.clone()
+    }
+
+    fn restore_transaction_state(
         &self,
-        db: DB,
-        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        context_aux: Self::ContextAux,
-    ) -> Self::Evm<DB, revm::inspector::NoOpInspector> {
-        let mut evm = self.create_evm(db, evm_env);
-        evm.ctx_mut().set_aux_state(context_aux);
-        evm
+        ecx: &mut Self::FoundryContext<'_>,
+        state: Self::TransactionState,
+    ) {
+        *ecx.journaled_state.reserve_balance_mut() = state;
+        rebase_monad_context(ecx);
     }
 
-    fn create_foundry_evm_with_inspector<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>>(
-        &self,
-        db: &'db mut dyn DatabaseExt<Self>,
-        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        context_aux: Self::ContextAux,
-        inspector: I,
-    ) -> Self::FoundryEvm<'db, I> {
-        let mut monad_evm = self.create_evm_with_inspector(db, evm_env, inspector);
-        monad_evm.ctx_mut().set_aux_state(context_aux);
-        monad_evm.cfg.tx_chain_id_check = true;
-        monad_evm.inspector().get_networks().inject_precompiles(monad_evm.precompiles_mut());
-        monad_evm
+    fn chain_context_for_transaction(&self, tx: &Self::Tx) -> Self::ChainContext {
+        monad_context_from_participants(
+            Default::default(),
+            Default::default(),
+            std::slice::from_ref(tx),
+            0,
+        )
     }
 
-    fn context_for_transaction(&self, tx: &Self::Tx) -> Self::ContextAux {
-        self.context_for_block(&[], &[], std::slice::from_ref(tx), 0)
-    }
-
-    fn context_for_block(
+    fn chain_context_for_block(
         &self,
         grandparent: &[Self::Tx],
         parent: &[Self::Tx],
         current: &[Self::Tx],
         current_tx_index: usize,
-    ) -> Self::ContextAux {
+    ) -> Self::ChainContext {
         monad_context_from_participants(
             monad_block_participants(grandparent),
             monad_block_participants(parent),
@@ -173,14 +187,40 @@ impl FoundryEvmFactory for MonadEvmFactory {
         )
     }
 
-    fn rebase_context_aux(
+    fn create_evm_with_context<DB: alloy_evm::Database>(
         &self,
-        current: &Self::ContextAux,
-        replacement: &mut Self::ContextAux,
-        state: &EvmState,
+        db: DB,
+        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
+        chain_context: Self::ChainContext,
+    ) -> Self::Evm<DB, revm::inspector::NoOpInspector> {
+        let mut evm = self.create_evm(db, evm_env);
+        set_monad_chain_context(evm.ctx_mut(), chain_context);
+        evm
+    }
+
+    fn create_foundry_evm_with_inspector<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>>(
+        &self,
+        db: &'db mut dyn DatabaseExt<Self>,
+        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
+        chain_context: Self::ChainContext,
+        inspector: I,
+    ) -> Self::FoundryEvm<'db, I> {
+        let mut monad_evm = self.create_evm_with_inspector(db, evm_env, inspector);
+        set_monad_chain_context(monad_evm.ctx_mut(), chain_context);
+        monad_evm.cfg.tx_chain_id_check = true;
+        monad_evm.inspector().get_networks().inject_precompiles(monad_evm.precompiles_mut());
+        monad_evm
+    }
+
+    fn apply_context_transition<'db>(
+        &self,
+        ecx: &mut Self::FoundryContext<'db>,
+        replacement: Option<&Self::ChainContext>,
     ) {
-        replacement.reserve_balance = current.reserve_balance.clone();
-        replacement.reserve_balance.rebase(&replacement.chain, state);
+        if let Some(replacement) = replacement {
+            set_monad_chain_context(ecx, replacement.clone());
+        }
+        rebase_monad_context(ecx);
     }
 
     fn protocol_system_call(&self, tx: &Self::Tx) -> eyre::Result<Option<ProtocolSystemCall>> {
@@ -323,11 +363,16 @@ impl FoundryEvmFactory for MonadEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        context_aux: Self::ContextAux,
+        chain_context: Self::ChainContext,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<
-        dyn NestedEvm<Spec = MonadHardfork, Block = BlockEnv, Tx = TxEnv, Aux = MonadContextAux>
-            + 'db,
+        dyn NestedEvm<
+                Spec = MonadHardfork,
+                Block = BlockEnv,
+                Tx = TxEnv,
+                ChainContext = MonadChainContext,
+                TransactionState = ReserveBalanceTracker,
+            > + 'db,
     > {
         let spec = evm_env.cfg_env.spec;
         let monad_cfg = MonadCfgEnv::from(evm_env.cfg_env);
@@ -337,7 +382,7 @@ impl FoundryEvmFactory for MonadEvmFactory {
             .build_monad_with_inspector(inspector)
             .with_precompiles(MonadPrecompilesMap::new_with_spec(spec));
 
-        evm.0.ctx.set_aux_state(context_aux);
+        set_monad_chain_context(&mut evm.0.ctx, chain_context);
         evm.0.ctx.cfg.tx_chain_id_check = true;
         evm.0.inspector.get_networks().inject_precompiles(&mut evm.0.precompiles);
 
@@ -351,25 +396,26 @@ impl<'db, I: FoundryInspectorExt<MonadContext<&'db mut dyn DatabaseExt<MonadEvmF
     type Spec = MonadHardfork;
     type Block = BlockEnv;
     type Tx = TxEnv;
-    type Aux = MonadContextAux;
-
+    type ChainContext = MonadChainContext;
+    type TransactionState = ReserveBalanceTracker;
     fn journal_inner_mut(&mut self) -> &mut JournaledState {
         &mut self.ctx_mut().journaled_state.inner
     }
 
-    fn context_state(&self) -> FoundryContextState<Self::Aux> {
-        self.ctx_ref().context_state()
+    fn capture_chain_context(&self) -> Self::ChainContext {
+        self.ctx_ref().chain.clone()
     }
 
-    fn aux_state(&self) -> Self::Aux {
-        self.ctx_ref().aux_state()
+    fn capture_transaction_state(&self) -> Self::TransactionState {
+        self.ctx_ref().journaled_state.reserve_balance().clone()
     }
 
-    fn set_context_state(&mut self, state: FoundryContextState<Self::Aux>) {
-        self.ctx_mut().set_context_state(state);
+    fn restore_transaction_state(&mut self, state: Self::TransactionState) {
+        *self.ctx_mut().journaled_state.reserve_balance_mut() = state;
+        rebase_monad_context(self.ctx_mut());
     }
 
-    fn preserve_aux_state_on_transaction(&mut self) {
+    fn preserve_transaction_state_on_next_transaction(&mut self) {
         self.ctx_mut().journaled_state.set_preserve_reserve_balance_tracker(true);
     }
 
@@ -408,7 +454,9 @@ impl<'db, I: FoundryInspectorExt<MonadContext<&'db mut dyn DatabaseExt<MonadEvmF
         };
 
         system_call.validate_chain_id(self.ctx_ref().cfg().chain_id())?;
-        let context_state = self.context_state();
+        let journal = self.ctx_ref().journal_inner().clone();
+        let chain = self.ctx_ref().chain.clone();
+        let reserve_balance = self.ctx_ref().journaled_state.reserve_balance().clone();
         let result = (|| {
             let (db, journal) = self.0.ctx.db_journal_inner_mut();
             system_call.apply_prestate(db, journal)?;
@@ -422,7 +470,9 @@ impl<'db, I: FoundryInspectorExt<MonadContext<&'db mut dyn DatabaseExt<MonadEvmF
             finish_protocol_system_call(result)
         })();
         if result.is_err() {
-            self.set_context_state(context_state);
+            self.ctx_mut().set_journal_inner(journal);
+            self.ctx_mut().chain = chain;
+            *self.ctx_mut().journaled_state.reserve_balance_mut() = reserve_balance;
         }
         result
     }
@@ -445,7 +495,7 @@ mod tests {
             },
         },
         primitives::{B256, U256},
-        state::{Account, AccountInfo},
+        state::{Account, AccountInfo, EvmState},
     };
 
     fn transaction(caller: Address, authority: Address) -> TxEnv {
@@ -487,10 +537,10 @@ mod tests {
     }
 
     #[test]
-    fn monad_factory_rebases_live_tracker_with_replacement_context() {
+    fn monad_context_transition_rebases_live_tracker() {
         let sender = Address::with_last_byte(1);
-        let old_chain = monad_revm::MonadChainContext::default();
-        let new_chain = monad_revm::MonadChainContext {
+        let old_chain = MonadChainContext::default();
+        let new_chain = MonadChainContext {
             parent_senders_and_authorities: [sender].into_iter().collect(),
             ..Default::default()
         };
@@ -498,8 +548,16 @@ mod tests {
             Account::from(AccountInfo { balance: U256::from(12), ..Default::default() });
         account.info.balance = U256::from(9);
 
-        let mut current = MonadContextAux { chain: old_chain.clone(), ..Default::default() };
-        current.reserve_balance.init(ReserveBalanceInit {
+        let factory = MonadEvmFactory::default();
+        let mut evm = factory.create_evm(
+            revm::database::EmptyDB::default(),
+            EvmEnv::new(
+                revm::context::CfgEnv::new_with_spec(MonadHardfork::MonadNine),
+                BlockEnv::default(),
+            ),
+        );
+        evm.ctx_mut().chain = old_chain.clone();
+        evm.ctx_mut().journaled_state.reserve_balance_mut().init(ReserveBalanceInit {
             chain: &old_chain,
             spec: MonadHardfork::MonadNine,
             sender,
@@ -508,15 +566,14 @@ mod tests {
             sender_is_delegated: false,
             sender_account: Some(&account),
         });
-        assert!(!current.reserve_balance.has_violation());
+        assert!(!evm.ctx().journaled_state.reserve_balance().has_violation());
 
-        let mut replacement = MonadContextAux { chain: new_chain.clone(), ..Default::default() };
-        let state = EvmState::from_iter([(sender, account)]);
-        MonadEvmFactory::default().rebase_context_aux(&current, &mut replacement, &state);
+        evm.ctx_mut().chain = new_chain.clone();
+        evm.ctx_mut().journaled_state.inner.state = EvmState::from_iter([(sender, account)]);
+        rebase_monad_context(evm.ctx_mut());
 
-        assert_eq!(replacement.chain, new_chain);
-        assert!(replacement.reserve_balance.has_violation());
-        assert!(!current.reserve_balance.has_violation());
+        assert_eq!(evm.ctx().chain, new_chain);
+        assert!(evm.ctx().journaled_state.reserve_balance().has_violation());
     }
 
     #[test]
@@ -678,17 +735,17 @@ mod tests {
             1,
         );
 
-        assert_eq!(context.chain.current_tx_index, 1);
-        assert_eq!(context.chain.grandparent_senders_and_authorities.len(), 2);
-        assert!(context.chain.grandparent_senders_and_authorities.contains(&grandparent_sender));
-        assert!(context.chain.grandparent_senders_and_authorities.contains(&grandparent_authority));
-        assert_eq!(context.chain.parent_senders_and_authorities.len(), 2);
-        assert!(context.chain.parent_senders_and_authorities.contains(&parent_sender));
-        assert!(context.chain.parent_senders_and_authorities.contains(&parent_authority));
-        assert_eq!(context.chain.current_block_senders, vec![current_sender, next_sender]);
-        assert_eq!(context.chain.current_block_authorities.len(), 2);
-        assert!(context.chain.current_block_authorities[0].contains(&current_authority));
-        assert!(context.chain.current_block_authorities[1].contains(&next_authority));
+        assert_eq!(context.current_tx_index, 1);
+        assert_eq!(context.grandparent_senders_and_authorities.len(), 2);
+        assert!(context.grandparent_senders_and_authorities.contains(&grandparent_sender));
+        assert!(context.grandparent_senders_and_authorities.contains(&grandparent_authority));
+        assert_eq!(context.parent_senders_and_authorities.len(), 2);
+        assert!(context.parent_senders_and_authorities.contains(&parent_sender));
+        assert!(context.parent_senders_and_authorities.contains(&parent_authority));
+        assert_eq!(context.current_block_senders, vec![current_sender, next_sender]);
+        assert_eq!(context.current_block_authorities.len(), 2);
+        assert!(context.current_block_authorities[0].contains(&current_authority));
+        assert!(context.current_block_authorities[1].contains(&next_authority));
     }
 
     #[test]
@@ -707,15 +764,15 @@ mod tests {
         )
         .child(&transaction(child_sender, child_authority));
 
-        assert_eq!(context.chain.current_tx_index, 0);
-        assert_eq!(context.chain.grandparent_senders_and_authorities.len(), 2);
-        assert!(context.chain.grandparent_senders_and_authorities.contains(&parent_sender));
-        assert!(context.chain.grandparent_senders_and_authorities.contains(&parent_authority));
-        assert_eq!(context.chain.parent_senders_and_authorities.len(), 2);
-        assert!(context.chain.parent_senders_and_authorities.contains(&current_sender));
-        assert!(context.chain.parent_senders_and_authorities.contains(&current_authority));
-        assert_eq!(context.chain.current_block_senders, vec![child_sender]);
-        assert!(context.chain.current_block_authorities[0].contains(&child_authority));
+        assert_eq!(context.current_tx_index, 0);
+        assert_eq!(context.grandparent_senders_and_authorities.len(), 2);
+        assert!(context.grandparent_senders_and_authorities.contains(&parent_sender));
+        assert!(context.grandparent_senders_and_authorities.contains(&parent_authority));
+        assert_eq!(context.parent_senders_and_authorities.len(), 2);
+        assert!(context.parent_senders_and_authorities.contains(&current_sender));
+        assert!(context.parent_senders_and_authorities.contains(&current_authority));
+        assert_eq!(context.current_block_senders, vec![child_sender]);
+        assert!(context.current_block_authorities[0].contains(&child_authority));
     }
 
     #[test]
@@ -738,10 +795,10 @@ mod tests {
         .unwrap();
         let context = cursor.next_transaction(&transaction(synthetic_sender, Address::ZERO));
 
-        assert_eq!(context.chain.current_tx_index, 1);
-        assert_eq!(context.chain.current_block_senders, vec![preceding_sender, synthetic_sender]);
-        assert!(!context.chain.current_block_senders.contains(&target_sender));
-        assert!(!context.chain.current_block_senders.contains(&future_sender));
+        assert_eq!(context.current_tx_index, 1);
+        assert_eq!(context.current_block_senders, vec![preceding_sender, synthetic_sender]);
+        assert!(!context.current_block_senders.contains(&target_sender));
+        assert!(!context.current_block_senders.contains(&future_sender));
     }
 
     #[test]
@@ -759,9 +816,9 @@ mod tests {
         cursor.record_transaction(transaction(first_sender, Address::ZERO));
         let context = cursor.next_transaction(&transaction(second_sender, Address::ZERO));
 
-        assert_eq!(context.chain.current_tx_index, 1);
-        assert_eq!(context.chain.current_block_senders, vec![first_sender, second_sender]);
-        assert!(context.chain.parent_senders_and_authorities.contains(&fork_sender));
+        assert_eq!(context.current_tx_index, 1);
+        assert_eq!(context.current_block_senders, vec![first_sender, second_sender]);
+        assert!(context.parent_senders_and_authorities.contains(&fork_sender));
     }
 
     #[test]
@@ -781,10 +838,10 @@ mod tests {
         cursor.advance_block();
         let context = cursor.next_transaction(&transaction(second_sender, Address::ZERO));
 
-        assert_eq!(context.chain.current_tx_index, 0);
-        assert_eq!(context.chain.current_block_senders, vec![second_sender]);
-        assert!(context.chain.parent_senders_and_authorities.contains(&first_sender));
-        assert!(context.chain.grandparent_senders_and_authorities.contains(&fork_sender));
-        assert!(!context.chain.grandparent_senders_and_authorities.contains(&fork_parent_sender));
+        assert_eq!(context.current_tx_index, 0);
+        assert_eq!(context.current_block_senders, vec![second_sender]);
+        assert!(context.parent_senders_and_authorities.contains(&first_sender));
+        assert!(context.grandparent_senders_and_authorities.contains(&fork_sender));
+        assert!(!context.grandparent_senders_and_authorities.contains(&fork_parent_sender));
     }
 }

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -17,7 +17,7 @@ use revm::{
 };
 
 use crate::{
-    FoundryContextExt, FoundryContextState, FoundryInspectorExt,
+    FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
     evm::{FoundryEvmFactory, FoundryEvmNetwork, IntoInstructionResult, NestedEvm},
 };
@@ -49,7 +49,8 @@ pub type OpRevmEvm<'db, I> = RevmEvm<
 >;
 
 impl FoundryEvmFactory for OpEvmFactory {
-    type ContextAux = ();
+    type ChainContext = ();
+    type TransactionState = ();
     type FoundryContext<'db> = OpEvmContext<&'db mut dyn DatabaseExt<Self>>;
 
     type FoundryEvm<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>> =
@@ -59,7 +60,7 @@ impl FoundryEvmFactory for OpEvmFactory {
         &self,
         db: DB,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        _context_aux: Self::ContextAux,
+        _chain_context: Self::ChainContext,
     ) -> Self::Evm<DB, revm::inspector::NoOpInspector> {
         self.create_evm(db, evm_env)
     }
@@ -68,7 +69,7 @@ impl FoundryEvmFactory for OpEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        _context_aux: Self::ContextAux,
+        _chain_context: Self::ChainContext,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I> {
         let mut op_evm = Self::default().create_evm_with_inspector(db, evm_env, inspector);
@@ -81,11 +82,19 @@ impl FoundryEvmFactory for OpEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        context_aux: Self::ContextAux,
+        chain_context: Self::ChainContext,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
-    ) -> Box<dyn NestedEvm<Spec = OpSpecId, Block = BlockEnv, Tx = OpTx, Aux = ()> + 'db> {
+    ) -> Box<
+        dyn NestedEvm<
+                Spec = OpSpecId,
+                Block = BlockEnv,
+                Tx = OpTx,
+                ChainContext = (),
+                TransactionState = (),
+            > + 'db,
+    > {
         Box::new(
-            self.create_foundry_evm_with_inspector(db, evm_env, context_aux, inspector)
+            self.create_foundry_evm_with_inspector(db, evm_env, chain_context, inspector)
                 .into_inner(),
         )
     }
@@ -108,22 +117,10 @@ impl<'db, I: FoundryInspectorExt<OpEvmContext<&'db mut dyn DatabaseExt<OpEvmFact
     type Spec = OpSpecId;
     type Block = BlockEnv;
     type Tx = OpTx;
-    type Aux = ();
-
+    type ChainContext = ();
+    type TransactionState = ();
     fn journal_inner_mut(&mut self) -> &mut JournaledState {
         &mut self.ctx().journaled_state.inner
-    }
-
-    fn context_state(&self) -> FoundryContextState<Self::Aux> {
-        self.ctx_ref().context_state()
-    }
-
-    fn aux_state(&self) -> Self::Aux {
-        self.ctx_ref().aux_state()
-    }
-
-    fn set_context_state(&mut self, state: FoundryContextState<Self::Aux>) {
-        self.ctx().set_context_state(state);
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {

--- a/crates/evm/core/src/evm/replay.rs
+++ b/crates/evm/core/src/evm/replay.rs
@@ -195,7 +195,7 @@ mod monad_tests {
     use alloy_monad_evm::MonadEvmFactory;
     use alloy_sol_types::{SolCall, SolEvent};
     use monad_revm::{
-        MonadContext, MonadHardfork,
+        MonadContext, MonadHardfork, MonadJournalTr,
         staking::{
             STAKING_ADDRESS,
             constants::{MON, SYSTEM_ADDRESS},
@@ -356,16 +356,18 @@ mod monad_tests {
             EvmEnv::new(CfgEnv::new_with_spec(MonadHardfork::MonadNine), BlockEnv::default());
         let mut evm =
             factory.create_evm_with_inspector(db, evm_env, ProtocolPrestateInspector::default());
-        let context_before = evm.context_state();
+        let journal_before = evm.ctx().journal_inner().clone();
+        let chain_before = evm.ctx().chain.clone();
+        let tracker_before = evm.ctx().journaled_state.reserve_balance().clone();
 
         let error = execute_replay_transaction(&factory, &mut evm, tx).unwrap_err();
 
         assert!(error.to_string().contains("reverted or halted"));
         assert!(evm.inspector().call_count > 0);
         assert_eq!(evm.inspector().staking_balance, Some(initial_staking_balance + reward));
-        let context_after = evm.context_state();
-        assert_eq!(context_after.journaled_state.state, context_before.journaled_state.state);
-        assert_eq!(context_after.auxiliary, context_before.auxiliary);
+        assert_eq!(evm.ctx().journal_inner().state, journal_before.state);
+        assert_eq!(evm.ctx().chain, chain_before);
+        assert_eq!(evm.ctx().journaled_state.reserve_balance(), &tracker_before);
         assert_eq!(evm.db_mut().basic(SYSTEM_ADDRESS).unwrap().unwrap().nonce, 11);
         assert_eq!(
             evm.db_mut().basic(STAKING_ADDRESS).unwrap().unwrap().balance,

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -23,7 +23,7 @@ use tempo_revm::{
 };
 
 use crate::{
-    FoundryContextExt, FoundryContextState, FoundryInspectorExt,
+    FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
     constants::{CALLER, TEST_CONTRACT_ADDRESS},
     evm::{FoundryEvmFactory, NestedEvm},
@@ -78,7 +78,8 @@ pub(crate) fn initialize_tempo_evm<
 }
 
 impl FoundryEvmFactory for TempoEvmFactory {
-    type ContextAux = ();
+    type ChainContext = ();
+    type TransactionState = ();
     type FoundryContext<'db> = TempoContext<&'db mut dyn DatabaseExt<Self>>;
 
     type FoundryEvm<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>> =
@@ -88,7 +89,7 @@ impl FoundryEvmFactory for TempoEvmFactory {
         &self,
         db: DB,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        _context_aux: Self::ContextAux,
+        _chain_context: Self::ChainContext,
     ) -> Self::Evm<DB, revm::inspector::NoOpInspector> {
         self.create_evm(db, evm_env)
     }
@@ -97,7 +98,7 @@ impl FoundryEvmFactory for TempoEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        _context_aux: Self::ContextAux,
+        _chain_context: Self::ChainContext,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I> {
         let is_forked = db.is_forked_mode();
@@ -129,13 +130,19 @@ impl FoundryEvmFactory for TempoEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        context_aux: Self::ContextAux,
+        chain_context: Self::ChainContext,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> Box<
-        dyn NestedEvm<Spec = TempoHardfork, Block = TempoBlockEnv, Tx = TempoTxEnv, Aux = ()> + 'db,
+        dyn NestedEvm<
+                Spec = TempoHardfork,
+                Block = TempoBlockEnv,
+                Tx = TempoTxEnv,
+                ChainContext = (),
+                TransactionState = (),
+            > + 'db,
     > {
         Box::new(
-            self.create_foundry_evm_with_inspector(db, evm_env, context_aux, inspector)
+            self.create_foundry_evm_with_inspector(db, evm_env, chain_context, inspector)
                 .into_inner(),
         )
     }
@@ -166,22 +173,10 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
     type Spec = TempoHardfork;
     type Block = TempoBlockEnv;
     type Tx = TempoTxEnv;
-    type Aux = ();
-
+    type ChainContext = ();
+    type TransactionState = ();
     fn journal_inner_mut(&mut self) -> &mut JournaledState {
         &mut self.ctx_mut().journaled_state.inner
-    }
-
-    fn context_state(&self) -> FoundryContextState<Self::Aux> {
-        self.ctx_ref().context_state()
-    }
-
-    fn aux_state(&self) -> Self::Aux {
-        self.ctx_ref().aux_state()
-    }
-
-    fn set_context_state(&mut self, state: FoundryContextState<Self::Aux>) {
-        self.ctx_mut().set_context_state(state);
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -35,7 +35,7 @@ use foundry_evm_core::{
         history_window_start,
     },
     evm::{
-        BlockContext, ContextAuxFor, EthEvmNetwork, EvmEnvFor, FoundryEvmFactory,
+        BlockContext, ChainContextFor, EthEvmNetwork, EvmEnvFor, FoundryEvmFactory,
         FoundryEvmNetwork, HaltReasonFor, IntoInstructionResult, SpecFor, TxEnvFor,
     },
     utils::StateChangeset,
@@ -264,17 +264,17 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         }
     }
 
-    fn context_for_synthetic_transaction(
+    fn chain_context_for_synthetic_transaction(
         &self,
         tx: &TxEnvFor<FEN>,
-    ) -> eyre::Result<ContextAuxFor<FEN>> {
+    ) -> eyre::Result<ChainContextFor<FEN>> {
         self.block_context.as_ref().map_or_else(
-            || self.backend().context_for_synthetic_transaction(tx),
+            || self.backend().chain_context_for_synthetic_transaction(tx),
             |context| Ok(context.next_transaction(tx)),
         )
     }
 
-    fn record_transaction_context(&mut self, tx: TxEnvFor<FEN>) {
+    fn record_block_transaction(&mut self, tx: TxEnvFor<FEN>) {
         if let Some(context) = &mut self.block_context {
             context.record_transaction(tx);
         }
@@ -506,11 +506,11 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         from: Address,
         code: Bytes,
         value: U256,
-        context_aux: ContextAuxFor<FEN>,
+        chain_context: ChainContextFor<FEN>,
         rd: Option<&RevertDecoder>,
     ) -> Result<DeployResult<FEN>, EvmError<FEN>> {
         let (evm_env, tx_env) = self.build_test_env(from, TxKind::Create, code, value);
-        self.deploy_with_env_and_context(evm_env, tx_env, context_aux, rd)
+        self.deploy_with_env_and_context(evm_env, tx_env, chain_context, rd)
     }
 
     /// Deploys a contract using the given `env` and commits the new state to the underlying
@@ -526,8 +526,8 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         tx_env: TxEnvFor<FEN>,
         rd: Option<&RevertDecoder>,
     ) -> Result<DeployResult<FEN>, EvmError<FEN>> {
-        let context_aux = self.context_for_synthetic_transaction(&tx_env)?;
-        self.deploy_with_env_and_context(evm_env, tx_env, context_aux, rd)
+        let chain_context = self.chain_context_for_synthetic_transaction(&tx_env)?;
+        self.deploy_with_env_and_context(evm_env, tx_env, chain_context, rd)
     }
 
     /// Deploys a contract with explicit network-specific context and commits its state changes.
@@ -540,7 +540,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         &mut self,
         evm_env: EvmEnvFor<FEN>,
         tx_env: TxEnvFor<FEN>,
-        context_aux: ContextAuxFor<FEN>,
+        chain_context: ChainContextFor<FEN>,
         rd: Option<&RevertDecoder>,
     ) -> Result<DeployResult<FEN>, EvmError<FEN>> {
         assert!(
@@ -550,7 +550,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         );
         trace!(sender=%tx_env.caller(), "deploying contract");
 
-        let mut result = self.transact_with_env_and_context(evm_env, tx_env, context_aux)?;
+        let mut result = self.transact_with_env_and_context(evm_env, tx_env, chain_context)?;
         result = result.into_result(rd)?;
         let Some(Output::Create(_, Some(address))) = result.out else {
             panic!("Deployment succeeded, but no address was returned: {result:#?}");
@@ -692,10 +692,10 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         to: Address,
         calldata: Bytes,
         value: U256,
-        context_aux: ContextAuxFor<FEN>,
+        chain_context: ChainContextFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
         let (evm_env, tx_env) = self.build_test_env(from, TxKind::Call(to), calldata, value);
-        self.transact_with_env_and_context(evm_env, tx_env, context_aux)
+        self.transact_with_env_and_context(evm_env, tx_env, chain_context)
     }
 
     /// Performs a raw call to an account on the current state of the VM with an EIP-7702
@@ -728,7 +728,8 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             let mut evm = FEN::EvmFactory::default().create_foundry_evm_with_inspector(
                 &mut backend,
                 evm_env.clone(),
-                Default::default(),
+                FEN::EvmFactory::default()
+                    .chain_context_for_transaction(&TxEnvFor::<FEN>::default()),
                 inspector,
             );
             let result =
@@ -753,8 +754,8 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         evm_env: EvmEnvFor<FEN>,
         tx_env: TxEnvFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
-        let context_aux = self.context_for_synthetic_transaction(&tx_env)?;
-        self.call_with_env_and_context(evm_env, tx_env, context_aux)
+        let chain_context = self.chain_context_for_synthetic_transaction(&tx_env)?;
+        self.call_with_env_and_context(evm_env, tx_env, chain_context)
     }
 
     /// Executes the transaction with explicit network-specific context without committing state.
@@ -763,7 +764,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         &self,
         mut evm_env: EvmEnvFor<FEN>,
         mut tx_env: TxEnvFor<FEN>,
-        context_aux: ContextAuxFor<FEN>,
+        chain_context: ChainContextFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
         let mut stack = self.inspector().clone();
         let sancov_edges = stack.inner.sancov_edges;
@@ -772,7 +773,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         let mut backend = CowBackend::new_borrowed(self.backend());
         let result = {
             let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
-            backend.inspect_with_context(&mut evm_env, &mut tx_env, context_aux, &mut stack)?
+            backend.inspect_with_context(&mut evm_env, &mut tx_env, chain_context, &mut stack)?
         };
         let has_state_snapshot_failure = backend.has_state_snapshot_failure();
         let fork_block_number = backend.active_fork_block_number();
@@ -801,8 +802,8 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         evm_env: EvmEnvFor<FEN>,
         tx_env: TxEnvFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
-        let context_aux = self.context_for_synthetic_transaction(&tx_env)?;
-        self.transact_with_env_and_context(evm_env, tx_env, context_aux)
+        let chain_context = self.chain_context_for_synthetic_transaction(&tx_env)?;
+        self.transact_with_env_and_context(evm_env, tx_env, chain_context)
     }
 
     /// Executes and commits the transaction with explicit network-specific context.
@@ -811,7 +812,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         &mut self,
         mut evm_env: EvmEnvFor<FEN>,
         mut tx_env: TxEnvFor<FEN>,
-        context_aux: ContextAuxFor<FEN>,
+        chain_context: ChainContextFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
         let mut stack = self.inspector().clone();
         let sancov_edges = stack.inner.sancov_edges;
@@ -820,7 +821,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         let backend = self.backend_mut();
         let result = {
             let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
-            backend.inspect_with_context(&mut evm_env, &mut tx_env, context_aux, &mut stack)?
+            backend.inspect_with_context(&mut evm_env, &mut tx_env, chain_context, &mut stack)?
         };
         let has_state_snapshot_failure = backend.has_state_snapshot_failure();
         let fork_block_number = backend.active_fork_block_number();
@@ -841,7 +842,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         }
         let committed_tx = result.tx_env.clone();
         self.commit(&mut result);
-        self.record_transaction_context(committed_tx);
+        self.record_block_transaction(committed_tx);
         Ok(result)
     }
 
@@ -851,7 +852,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         &mut self,
         mut evm_env: EvmEnvFor<FEN>,
         mut tx_env: TxEnvFor<FEN>,
-        context_aux: ContextAuxFor<FEN>,
+        chain_context: ChainContextFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
         let factory = FEN::EvmFactory::default();
         if factory.protocol_system_call(&tx_env)?.is_none() {
@@ -863,7 +864,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         let result = backend.inspect_replay_with_context(
             &mut evm_env,
             &mut tx_env,
-            context_aux,
+            chain_context,
             &mut stack,
         )?;
         let has_state_snapshot_failure = backend.has_state_snapshot_failure();
@@ -879,7 +880,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         )?;
         let committed_tx = result.tx_env.clone();
         self.commit(&mut result);
-        self.record_transaction_context(committed_tx);
+        self.record_block_transaction(committed_tx);
         Ok(result)
     }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -8,17 +8,17 @@ use alloy_primitives::{
     map::{AddressHashMap, AddressHashSet, AddressMap},
 };
 
-use foundry_cheatcodes::{CheatcodeAnalysis, CheatcodesExecutor, NestedEvmClosure, Wallets};
+use foundry_cheatcodes::{CheatcodeAnalysis, CheatcodesExecutor, NestedEvmClosureFor, Wallets};
 use foundry_common::{compile::Analysis, sh_warn};
 use foundry_config::FuzzCorpusConfig;
 use foundry_evm_core::{
     FoundryBlock, FoundryTransaction, InspectorExt,
-    backend::{ContextAuxUpdate, DatabaseError, DatabaseExt, JournaledState},
+    backend::{ContextUpdate, DatabaseError, DatabaseExt, JournaledState},
     constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH,
     env::FoundryContextExt,
     evm::{
-        BlockEnvFor, ContextAuxFor, EthEvmNetwork, EvmEnvFor, FoundryContextFor, FoundryEvmFactory,
-        FoundryEvmNetwork, SpecFor, TxEnvFor, get_create2_factory_call_inputs,
+        BlockEnvFor, ChainContextFor, EthEvmNetwork, EvmEnvFor, FoundryContextFor,
+        FoundryEvmFactory, FoundryEvmNetwork, TxEnvFor, get_create2_factory_call_inputs,
         refresh_context_after_state_change, with_cloned_context,
     },
 };
@@ -454,23 +454,35 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
         &mut self,
         cheats: &mut Cheatcodes<FEN>,
         ecx: &mut FoundryContextFor<'_, FEN>,
-        f: NestedEvmClosure<'_, SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>, ContextAuxFor<FEN>>,
+        f: NestedEvmClosureFor<'_, FEN>,
     ) -> Result<(), EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        with_cloned_context(ecx, |db, evm_env, context_state| {
-            let context_aux = context_state.auxiliary.clone();
-            let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
-                db,
-                evm_env,
-                context_aux,
-                &mut inspector,
-            );
-            evm.set_context_state(context_state);
+        let factory = FEN::EvmFactory::default();
+        let chain_context = factory.capture_chain_context(ecx);
+        let state = factory.capture_transaction_state(ecx);
+        let mut nested_chain_context = None;
+        let mut transaction_state = None;
+        with_cloned_context(ecx, |db, evm_env, journaled_state| {
+            let mut evm =
+                factory.create_foundry_nested_evm(db, evm_env, chain_context, &mut inspector);
+            *evm.journal_inner_mut() = journaled_state;
+            evm.restore_transaction_state(state);
             f(&mut *evm)?;
-            let sub_state = evm.context_state();
+            nested_chain_context = Some(evm.capture_chain_context());
+            transaction_state = Some(evm.capture_transaction_state());
+            let sub_inner = evm.journal_inner_mut().clone();
             let sub_evm_env = evm.to_evm_env();
-            Ok((sub_evm_env, sub_state))
-        })
+            Ok((sub_evm_env, sub_inner))
+        })?;
+        factory.apply_context_transition(
+            ecx,
+            Some(&nested_chain_context.expect("nested EVM chain context was captured")),
+        );
+        factory.restore_transaction_state(
+            ecx,
+            transaction_state.expect("nested EVM state was captured"),
+        );
+        Ok(())
     }
 
     fn with_fresh_nested_evm(
@@ -478,14 +490,14 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
         cheats: &mut Cheatcodes<FEN>,
         db: &mut <FoundryContextFor<'_, FEN> as ContextTr>::Db,
         evm_env: EvmEnvFor<FEN>,
-        context_aux: ContextAuxFor<FEN>,
-        f: NestedEvmClosure<'_, SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>, ContextAuxFor<FEN>>,
+        chain_context: ChainContextFor<FEN>,
+        f: NestedEvmClosureFor<'_, FEN>,
     ) -> Result<EvmEnvFor<FEN>, EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
         let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
             db,
             evm_env,
-            context_aux,
+            chain_context,
             &mut inspector,
         );
         f(&mut *evm)?;
@@ -498,7 +510,7 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
         ecx: &mut FoundryContextFor<'_, FEN>,
         fork_id: Option<U256>,
         transaction: B256,
-    ) -> eyre::Result<ContextAuxUpdate<ContextAuxFor<FEN>>> {
+    ) -> eyre::Result<ContextUpdate<ChainContextFor<FEN>>> {
         let evm_env = ecx.evm_clone();
         let outer_tx_env = ecx.tx_clone();
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
@@ -983,60 +995,65 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
 
         let evm_env = ecx.evm_clone();
         let tx_env = ecx.tx_clone();
-        let context_aux = ecx.aux_state();
+        let factory = FEN::EvmFactory::default();
+        let chain_context = factory.capture_chain_context(ecx);
 
-        let res = self.with_inspector(|mut inspector| {
-            let (res, nested_env, nested_aux) = {
-                let (db, journal) = ecx.db_journal_inner_mut();
-                let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
-                    db,
-                    evm_env,
-                    context_aux,
-                    &mut inspector,
-                );
-                evm.preserve_aux_state_on_transaction();
+        let isolated_state = {
+            let journal = ecx.journal_inner();
+            let mut state = journal.state.clone();
+            for (addr, acc_mut) in &mut state {
+                // Preserve revm's per-transaction creation flag for accounts created in
+                // the parent context in initialize_interp. A cold load in the nested
+                // context clears local flags, but keeping accounts cold preserves gas
+                // accounting for isolated calls.
+                if journal.warm_addresses.is_cold(addr) {
+                    acc_mut.mark_cold();
+                }
 
-                evm.journal_inner_mut().state = {
-                    let mut state = journal.state.clone();
+                // Mark all slots cold.
+                for slot_mut in acc_mut.storage.values_mut() {
+                    slot_mut.is_cold = true;
+                    slot_mut.original_value = slot_mut.present_value;
+                }
+            }
+            state
+        };
 
-                    for (addr, acc_mut) in &mut state {
-                        // Preserve revm's per-transaction creation flag for accounts created in
-                        // the parent context in initialize_interp. A cold load in the nested
-                        // context clears local flags, but keeping accounts cold preserves gas
-                        // accounting for isolated calls.
-                        if journal.warm_addresses.is_cold(addr) {
-                            acc_mut.mark_cold();
-                        }
-
-                        // mark all slots cold
-                        for slot_mut in acc_mut.storage.values_mut() {
-                            slot_mut.is_cold = true;
-                            slot_mut.original_value = slot_mut.present_value;
-                        }
-                    }
-
-                    state
+        let state = factory.capture_transaction_state(ecx);
+        let (res, nested_chain_context, transaction_state) =
+            self.with_inspector(|mut inspector| {
+                let (res, nested_env, chain_context, transaction_state) = {
+                    let (db, _) = ecx.db_journal_inner_mut();
+                    let mut evm = factory.create_foundry_nested_evm(
+                        db,
+                        evm_env,
+                        chain_context,
+                        &mut inspector,
+                    );
+                    evm.journal_inner_mut().state = isolated_state;
+                    evm.restore_transaction_state(state);
+                    evm.preserve_transaction_state_on_next_transaction();
+                    // Set depth to 1 to make sure traces are collected correctly.
+                    evm.journal_inner_mut().depth = 1;
+                    let res = evm.transact_raw(tx_env);
+                    (
+                        res,
+                        evm.to_evm_env(),
+                        evm.capture_chain_context(),
+                        evm.capture_transaction_state(),
+                    )
                 };
 
-                // set depth to 1 to make sure traces are collected correctly
-                evm.journal_inner_mut().depth = 1;
+                // Restore env, preserving cheatcode cfg/block changes from the nested EVM
+                // but restoring the original tx and basefee (which we zeroed for the nested call).
+                let mut restored_evm_env = nested_env;
+                restored_evm_env.block_env.set_basefee(cached_evm_env.block_env.basefee());
+                ecx.set_evm(restored_evm_env);
+                ecx.set_tx(cached_tx_env);
 
-                let res = evm.transact_raw(tx_env);
-                let nested_evm_env = evm.to_evm_env();
-                let nested_aux = evm.aux_state();
-                (res, nested_evm_env, nested_aux)
-            };
-
-            // Restore env, preserving cheatcode cfg/block changes from the nested EVM
-            // but restoring the original tx and basefee (which we zeroed for the nested call).
-            let mut restored_evm_env = nested_env;
-            restored_evm_env.block_env.set_basefee(cached_evm_env.block_env.basefee());
-            ecx.set_evm(restored_evm_env);
-            ecx.set_tx(cached_tx_env);
-            ecx.set_aux_state(nested_aux);
-
-            res
-        });
+                (res, chain_context, transaction_state)
+            });
+        factory.apply_context_transition(ecx, Some(&nested_chain_context));
 
         self.in_inner_context = false;
         self.inner_context_data = None;
@@ -1050,6 +1067,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         let mut gas = Gas::new(gas_limit);
 
         let Ok(res) = res else {
+            factory.restore_transaction_state(ecx, transaction_state);
             refresh_context_after_state_change::<FEN>(ecx);
             // Should we match, encode and propagate error as a revert reason?
             let result =
@@ -1083,6 +1101,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
                 slot_mut.is_cold &= val.is_cold;
             }
         }
+        factory.restore_transaction_state(ecx, transaction_state);
 
         let (result, address, output) = match res.result {
             ExecutionResult::Success { reason, gas: result_gas, logs: _, output } => {

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -41,7 +41,7 @@ use foundry_evm::{
     core::{
         FoundryTransaction as _,
         evm::{
-            BlockContext, ContextAuxFor, EthEvmNetwork, FoundryEvmFactory, FoundryEvmNetwork,
+            BlockContext, ChainContextFor, EthEvmNetwork, FoundryEvmFactory, FoundryEvmNetwork,
             TempoEvmNetwork, TxEnvFor,
         },
     },
@@ -785,7 +785,7 @@ impl VerifyBytecodeArgs {
 
             apply_chain_specific_tx_replay_env_changes_for_chain(&mut evm_env, chain.id());
             let factory = FEN::EvmFactory::default();
-            let mut target_context = None::<ContextAuxFor<FEN>>;
+            let mut target_context = None::<ChainContextFor<FEN>>;
             if let Some(ref block) = block {
                 let BlockTransactions::Full(txs) = block.transactions() else {
                     return Err(eyre::eyre!("Could not get block txs"));
@@ -804,7 +804,7 @@ impl VerifyBytecodeArgs {
                     txs[target_index].from(),
                 );
                 target_context = Some(block_context.as_ref().map_or_else(
-                    || factory.context_for_transaction(&target_tx_env),
+                    || factory.chain_context_for_transaction(&target_tx_env),
                     |context| context.transaction(target_index),
                 ));
 
@@ -823,8 +823,8 @@ impl VerifyBytecodeArgs {
                     {
                         continue;
                     }
-                    let context_aux = block_context.as_ref().map_or_else(
-                        || factory.context_for_transaction(&tx_env),
+                    let chain_context = block_context.as_ref().map_or_else(
+                        || factory.chain_context_for_transaction(&tx_env),
                         |context| context.transaction(index),
                     );
 
@@ -833,7 +833,7 @@ impl VerifyBytecodeArgs {
                             .transact_protocol_system_with_env_and_context(
                                 evm_env.clone(),
                                 tx_env.clone(),
-                                context_aux,
+                                chain_context,
                             )
                             .wrap_err_with(|| {
                                 format!(
@@ -847,7 +847,7 @@ impl VerifyBytecodeArgs {
                             .transact_with_env_and_context(
                                 evm_env.clone(),
                                 tx_env.clone(),
-                                context_aux,
+                                chain_context,
                             )
                             .wrap_err_with(|| {
                                 format!(
@@ -859,7 +859,7 @@ impl VerifyBytecodeArgs {
                     } else if let Err(error) = executor.deploy_with_env_and_context(
                         evm_env.clone(),
                         tx_env.clone(),
-                        context_aux,
+                        chain_context,
                         None,
                     ) {
                         match error {
@@ -888,7 +888,7 @@ impl VerifyBytecodeArgs {
                 TxEnvFor::<FEN>::from_recovered_tx(transaction.as_ref(), transaction.from());
             tx_env.set_nonce(prev_block_nonce);
             let target_context =
-                target_context.unwrap_or_else(|| factory.context_for_transaction(&tx_env));
+                target_context.unwrap_or_else(|| factory.chain_context_for_transaction(&tx_env));
 
             // Replace the `input` with local creation code in the creation tx.
             if let TxKind::Call(to) = kind {

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -29,7 +29,7 @@ use foundry_evm::{
         FoundryBlock as _,
         decode::RevertDecoder,
         evm::{
-            BlockContext, BlockEnvFor, BlockResponseFor, ContextAuxFor, EvmEnvFor,
+            BlockContext, BlockEnvFor, BlockResponseFor, ChainContextFor, EvmEnvFor,
             FoundryEvmFactory, FoundryEvmNetwork, TxEnvFor,
         },
     },
@@ -406,7 +406,7 @@ pub fn deploy_contract<FEN>(
     evm_env: &EvmEnvFor<FEN>,
     tx_env: &TxEnvFor<FEN>,
     to: TxKind,
-    context_aux: ContextAuxFor<FEN>,
+    chain_context: ChainContextFor<FEN>,
 ) -> Result<Address, eyre::ErrReport>
 where
     FEN: FoundryEvmNetwork,
@@ -417,8 +417,11 @@ where
                 "Transaction `to` address is not the default create2 deployer i.e the tx is not a contract creation tx."
             );
         }
-        let result =
-            executor.transact_with_env_and_context(evm_env.clone(), tx_env.clone(), context_aux)?;
+        let result = executor.transact_with_env_and_context(
+            evm_env.clone(),
+            tx_env.clone(),
+            chain_context,
+        )?;
 
         trace!(transact_result = ?result.exit_reason);
 
@@ -451,7 +454,7 @@ where
         let deploy_result = executor.deploy_with_env_and_context(
             evm_env.clone(),
             tx_env.clone(),
-            context_aux,
+            chain_context,
             None,
         )?;
         trace!(deploy_result = ?deploy_result.raw.exit_reason);
@@ -462,12 +465,12 @@ where
 pub fn synthetic_deployment_context<FEN>(
     block_context: Option<&BlockContext<FEN>>,
     tx_env: &TxEnvFor<FEN>,
-) -> ContextAuxFor<FEN>
+) -> ChainContextFor<FEN>
 where
     FEN: FoundryEvmNetwork,
 {
     block_context.map_or_else(
-        || FEN::EvmFactory::default().context_for_transaction(tx_env),
+        || FEN::EvmFactory::default().chain_context_for_transaction(tx_env),
         |context| context.child(tx_env),
     )
 }
@@ -728,33 +731,27 @@ contract Broken {
         );
         let synthetic_tx = monad_tx(synthetic_sender);
 
-        let auxiliary =
+        let chain_context =
             synthetic_deployment_context::<MonadEvmNetwork>(Some(&context), &synthetic_tx);
 
-        assert_eq!(
-            auxiliary.chain.grandparent_senders_and_authorities,
-            [child_grandparent].into_iter().collect()
-        );
-        assert_eq!(
-            auxiliary.chain.parent_senders_and_authorities,
-            [child_parent].into_iter().collect()
-        );
-        assert_eq!(auxiliary.chain.current_block_senders, vec![synthetic_sender]);
-        assert_eq!(auxiliary.chain.current_tx_index, 0);
+        assert!(chain_context.grandparent_senders_and_authorities.contains(&child_grandparent));
+        assert!(chain_context.parent_senders_and_authorities.contains(&child_parent));
+        assert_eq!(chain_context.current_block_senders, vec![synthetic_sender]);
+        assert_eq!(chain_context.current_tx_index, 0);
     }
 
     #[test]
     #[cfg(feature = "monad")]
-    fn synthetic_monad_deployment_without_history_uses_transaction_context() {
+    fn synthetic_monad_deployment_without_history_uses_chain_context() {
         let synthetic_sender = Address::repeat_byte(0x44);
         let synthetic_tx = monad_tx(synthetic_sender);
 
-        let auxiliary = synthetic_deployment_context::<MonadEvmNetwork>(None, &synthetic_tx);
+        let chain_context = synthetic_deployment_context::<MonadEvmNetwork>(None, &synthetic_tx);
 
-        assert!(auxiliary.chain.grandparent_senders_and_authorities.is_empty());
-        assert!(auxiliary.chain.parent_senders_and_authorities.is_empty());
-        assert_eq!(auxiliary.chain.current_block_senders, vec![synthetic_sender]);
-        assert_eq!(auxiliary.chain.current_tx_index, 0);
+        assert!(chain_context.grandparent_senders_and_authorities.is_empty());
+        assert!(chain_context.parent_senders_and_authorities.is_empty());
+        assert_eq!(chain_context.current_block_senders, vec![synthetic_sender]);
+        assert_eq!(chain_context.current_tx_index, 0);
     }
 
     #[test]

--- a/testdata/default/cheats/MonadReserveBalance.t.sol
+++ b/testdata/default/cheats/MonadReserveBalance.t.sol
@@ -49,6 +49,18 @@ contract MonadReserveBalanceTest is Test {
         assertTrue(_dippedIntoReserve());
     }
 
+    /// forge-config: default.isolate = true
+    function test_isolation_success_updates_tracker() public {
+        this.violateReserve();
+
+        assertEq(SPENDER.balance, 9 ether);
+        assertTrue(_dippedIntoReserve());
+    }
+
+    function violateReserve() external {
+        _violateReserve(SPENDER);
+    }
+
     function test_snapshot_revert_restores_tracker() public {
         uint256 snapshot = vm.snapshotState();
 
@@ -59,6 +71,19 @@ contract MonadReserveBalanceTest is Test {
         assertTrue(vm.revertToState(snapshot));
         assertEq(SPENDER.balance, INITIAL_BALANCE);
         assertTrue(!_dippedIntoReserve());
+    }
+
+    function test_snapshot_revert_and_delete_restores_tracker() public {
+        uint256 snapshot = vm.snapshotState();
+
+        vm.prank(SPENDER);
+        RECIPIENT.transfer(INITIAL_BALANCE - 9 ether);
+        assertTrue(_dippedIntoReserve());
+
+        assertTrue(vm.revertToStateAndDelete(snapshot));
+        assertEq(SPENDER.balance, INITIAL_BALANCE);
+        assertTrue(!_dippedIntoReserve());
+        assertTrue(!vm.revertToState(snapshot));
     }
 
     function test_deal_clears_violation() public {


### PR DESCRIPTION
This follows #15343 and #16161 by moving Monad execution state behind the factory boundary established by the network cleanup. Monad needs exact chain-position metadata for reserve rules and transaction-scoped reserve-balance tracking across nested EVM and snapshot boundaries, but those concerns should not be exposed through generic Foundry context APIs.

This replaces the generic auxiliary context wrapper with a factory-owned `ChainContext`, using `MonadChainContext` for Monad and `()` for other EVM families. Reserve tracking remains separate transaction-lifecycle state with explicit capture and restore hooks, while snapshots store the journal and chain context as one atomic entry so they cannot drift. The result keeps `FoundryContextExt` structural, preserves nested and isolated execution semantics, and confines Monad-specific behavior and dependencies to the `monad` feature.
