### PR TITLE
chore(deps): bump alloy-hardforks to 0.4.8

### DIFF
--- a/.changelog/bump-alloy-hardforks-0.4.8.md
+++ b/.changelog/bump-alloy-hardforks-0.4.8.md
@@ -1,0 +1,8 @@
+---
+forge: patch
+cast: patch
+anvil: patch
+chisel: patch
+---
+
+Updated the named Ethereum hardfork definitions to alloy-hardforks 0.4.8.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
+checksum = "865371fb677c005f7cb0ea9c2847a1ba4fdb042caf6428b1769fee20368bbfc7"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,7 +378,7 @@ alloy-transport = { version = "2.4.0", default-features = false }
 alloy-transport-http = { version = "2.4.0", default-features = false }
 alloy-transport-ipc = { version = "2.4.0", default-features = false }
 alloy-transport-ws = { version = "2.4.0", default-features = false }
-alloy-hardforks = { version = "0.4.7", default-features = false }
+alloy-hardforks = { version = "0.4.8", default-features = false }
 alloy-op-hardforks = { version = "0.5.0", default-features = false }
 
 ## alloy-core


### PR DESCRIPTION
Updates `alloy-hardforks` from 0.4.7 to 0.4.8 so Foundry includes the latest named Ethereum hardfork definitions. The lockfile update is limited to the corresponding crate version and checksum.

AI disclosure: This dependency update and PR were prepared with OpenAI Codex.
