### PR TITLE
chore(deps): bump foundry-core revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5537,7 +5537,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f#8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5780,7 +5780,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f#8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5790,7 +5790,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.15.0",
+ "itertools 0.13.0",
  "path-slash",
  "rand 0.10.2",
  "rayon",
@@ -5811,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f#8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f#8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5840,7 +5840,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f#8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5853,7 +5853,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f#8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6191,7 +6191,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d61ff900ecd69272ab810f4fc5ca478e10af7ecf#d61ff900ecd69272ab810f4fc5ca478e10af7ecf"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f#8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6f1ce6d#6f1ce6d62fe1e8af84f7066d0e0a3e27f9caa5ef"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f#8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,6 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -568,6 +567,7 @@ alloy-monad-evm = { git = "https://github.com/category-labs/alloy-monad-evm", re
 monad-revm = { git = "https://github.com/category-labs/monad-revm", rev = "8ba4a51b221357105465cbe6d410906d3f12baeb" }
 
 ## foundry-core
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f", default-features = false }
 foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }
 foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "6f1ce6d", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -568,9 +568,9 @@ alloy-monad-evm = { git = "https://github.com/category-labs/alloy-monad-evm", re
 monad-revm = { git = "https://github.com/category-labs/monad-revm", rev = "8ba4a51b221357105465cbe6d410906d3f12baeb" }
 
 ## foundry-core
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "d61ff900ecd69272ab810f4fc5ca478e10af7ecf" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "d61ff900ecd69272ab810f4fc5ca478e10af7ecf" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "d61ff900ecd69272ab810f4fc5ca478e10af7ecf" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,6 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
+foundry-wallets = { version = "0.1.0", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -567,7 +568,7 @@ alloy-monad-evm = { git = "https://github.com/category-labs/alloy-monad-evm", re
 monad-revm = { git = "https://github.com/category-labs/monad-revm", rev = "8ba4a51b221357105465cbe6d410906d3f12baeb" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }
 foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }
 foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }


### PR DESCRIPTION
Updates the `foundry-core` dependencies, including `foundry-wallets`, to upstream revision `8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f` and refreshes the lockfile. This maintenance-only change should use the `L-ignore` label instead of a changelog entry.

This PR was authored with Codex assistance.

Prompted by: @DaniPopes
