### PR TITLE
fix(ci): retry transient MPP failures

### DIFF
--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -77,13 +77,25 @@ jobs:
         env:
           MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
           MPP_ALLOW_API_KEY: "1"
-          TEMPO_HOME: ${{ runner.temp }}/tempo-mpp-moderato
+          TEMPO_HOME_BASE: ${{ runner.temp }}/tempo-mpp-moderato
           TEMPO_AUTO_FUND: "1"
           TEMPO_ROTATE_WALLET: "1"
           MPP_RPC_URL: https://rpc.mpp.moderato.tempo.xyz
           TEMPO_RPC_URL: https://rpc.moderato.tempo.xyz
           MPP_TOKEN: "0x20c0000000000000000000000000000000000000"
-        run: ./.github/scripts/tempo-mpp.sh "$(which cast | xargs dirname)"
+        run: |
+          for attempt in 1 2 3; do
+            export TEMPO_HOME="${TEMPO_HOME_BASE}-${attempt}"
+            log="${RUNNER_TEMP}/tempo-mpp-${attempt}.log"
+            if ./.github/scripts/tempo-mpp.sh "$(which cast | xargs dirname)" 2>&1 | tee "$log"; then
+              exit 0
+            fi
+            if ! grep -Eq 'HTTP error 402|replaced reusable channel|did not reuse channel' "$log"; then
+              exit 1
+            fi
+            echo "Transient MPP gateway failure on attempt ${attempt}/3"
+          done
+          exit 1
 
       - name: Run mainnet MPP e2e test
         if: |


### PR DESCRIPTION
Moderato's MPP gateway intermittently rejects valid vouchers or replaces a reusable channel, which makes the external end-to-end check flaky. Retry only those known gateway failure signatures up to three times, using a fresh Tempo home on every attempt so a failed wallet or channel store cannot affect the next run. Other failures still stop immediately.

This CI-only change needs the `L-ignore` label instead of a release changelog entry.

This PR was written with Codex.

Prompted by: @DaniPopes
