### PR TITLE
fix(ci): stop nightlies overwriting latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -109,7 +109,8 @@ jobs:
             VERGEN_GIT_SHA=${{ github.sha }}
           project: 8gkbxxjrpw
           context: .
-          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
+          # Depot implicitly tags an untagged multi-platform output as `latest` when merging.
+          outputs: type=image,name=ghcr.io/${{ github.repository }}:build-staging,push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           no-cache: true


### PR DESCRIPTION
Depot normalizes an untagged multi-platform image output to `:latest`, causing nightly builds to overwrite the stable Docker alias before promotion. Publish the merged image under the internal `:build-staging` tag instead, while retaining the existing digest-based signing, attestation, and promotion flow.

This addresses the Docker regression reported in #16181