### PR TITLE
feat(anvil): add debug_executionWitness endpoint

### DIFF
--- a/.changelog/anvil-debug-execution-witness.md
+++ b/.changelog/anvil-debug-execution-witness.md
@@ -1,0 +1,5 @@
+---
+anvil: minor
+---
+
+Added support for the `debug_executionWitness` RPC endpoint, returning a best-effort witness built from the full parent state of the requested block. Not supported while forking.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ checksum = "88813dc63f261e25d158f07063a71e926f36b3ee8076c1e6d8396348452c5f69"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -51,7 +51,7 @@ alloy-signer = { workspace = true, features = ["eip712"] }
 alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 alloy-sol-types = { workspace = true, features = ["std"] }
 alloy-dyn-abi = { workspace = true, features = ["std", "eip712"] }
-alloy-rpc-types = { workspace = true, features = ["anvil", "trace", "txpool"] }
+alloy-rpc-types = { workspace = true, features = ["anvil", "debug", "trace", "txpool"] }
 alloy-rpc-types-beacon.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-mev.workspace = true

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -409,6 +409,10 @@ pub enum EthRequest {
     #[serde(rename = "debug_accountInfoAt")]
     DebugAccountInfoAt(BlockId, Index, Address),
 
+    /// reth's `debug_executionWitness` endpoint.
+    #[serde(rename = "debug_executionWitness", with = "sequence")]
+    DebugExecutionWitness(BlockNumber),
+
     /// geth's `debug_traceBlock` endpoint.
     #[serde(rename = "debug_traceBlock")]
     DebugTraceBlock(Bytes, #[serde(default)] GethDebugTracingOptions),
@@ -1883,6 +1887,17 @@ true}]}"#;
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
         let s = r#"{"method": "debug_accountInfoAt", "params": [{"blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"}, 0, "0xd84de507f3fada7df80908082d3239466db55a71"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_debug_execution_witness() {
+        let s = r#"{"method": "debug_executionWitness", "params": ["0x1"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "debug_executionWitness", "params": ["latest"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -64,6 +64,7 @@ use alloy_rpc_types::{
     anvil::{
         ForkedNetwork, Forking, Metadata, MineOptions, NodeEnvironment, NodeForkConfig, NodeInfo,
     },
+    debug::ExecutionWitness,
     erc4337::TransactionConditional,
     pubsub::TransactionReceiptsParams,
     request::TransactionRequest,
@@ -1622,6 +1623,16 @@ impl EthApi<FoundryNetwork> {
         self.backend.debug_account_info_at(block_id, tx_index, address).await
     }
 
+    /// Returns a best-effort execution witness for the given block, built from the full parent
+    /// state. See [`crate::eth::backend::mem::Backend::debug_execution_witness`] for the exact
+    /// contents and limitations.
+    ///
+    /// Handler for RPC call: `debug_executionWitness`.
+    pub async fn debug_execution_witness(&self, block: BlockNumber) -> Result<ExecutionWitness> {
+        node_info!("debug_executionWitness");
+        self.backend.debug_execution_witness(block).await
+    }
+
     /// Returns opcode gas usage for a transaction.
     ///
     /// Handler for RPC call: `trace_transactionOpcodeGas`.
@@ -2117,6 +2128,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::DebugFreeOsMemory(()) => self.debug_free_os_memory().to_rpc_result(),
             EthRequest::DebugAccountInfoAt(block_id, tx_index, address) => {
                 self.debug_account_info_at(block_id, tx_index, address).await.to_rpc_result()
+            }
+            EthRequest::DebugExecutionWitness(block) => {
+                self.debug_execution_witness(block).await.to_rpc_result()
             }
             EthRequest::DebugTraceBlock(rlp_block, opts) => {
                 self.debug_trace_block(rlp_block, opts).await.to_rpc_result()

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -11,7 +11,9 @@ use crate::{
     eth::{
         backend::{
             cheats::{CheatEcrecover, CheatsManager},
-            db::{AnvilCacheDB, Db, MaybeFullDatabase, SerializableState, StateDb},
+            db::{
+                AnvilCacheDB, BLOCKHASH_HISTORY, Db, MaybeFullDatabase, SerializableState, StateDb,
+            },
             executor::{
                 AnvilBlockExecutor, BlockExecutionKind, EthereumBlockTransitions,
                 ExecutedPoolTransactions, FoundryReceiptBuilder, PoolTransactionHooks,
@@ -22,7 +24,7 @@ use crate::{
             fork::{ClientFork, ForkEndpointIdentity},
             genesis::GenesisConfig,
             mem::{
-                state::{state_root, storage_root, trie_accounts},
+                state::{state_root, state_trie_witness, storage_root, trie_accounts},
                 storage::MinedTransactionReceipt,
             },
             notifications::{ChainNotification, ChainNotifications, NewBlockNotification},
@@ -86,7 +88,7 @@ use alloy_network::{
 use alloy_op_evm::{OpEvmContext, OpEvmFactory, OpTx};
 use alloy_primitives::{
     Address, B256, Bloom, Bytes, Signature, TxHash, TxKind, U64, U256, address, hex, keccak256,
-    map::{AddressMap, HashMap, HashSet},
+    map::{AddressMap, B256Set, HashMap, HashSet},
 };
 use alloy_rlp::Decodable;
 use alloy_rpc_types::{
@@ -95,6 +97,7 @@ use alloy_rpc_types::{
     EIP1186StorageProof as StorageProof, Filter, Header as AlloyHeader, Index, Log, Transaction,
     TransactionReceipt,
     anvil::Forking,
+    debug::ExecutionWitness,
     request::TransactionRequest,
     serde_helpers::JsonStorageKey,
     simulate::{
@@ -7031,6 +7034,79 @@ where
         };
 
         Ok(BlockOpcodeGas { block_hash, block_number: block.header.number(), transactions })
+    }
+
+    /// Returns a best-effort execution witness for the given block, in the same format as reth's
+    /// `debug_executionWitness`.
+    ///
+    /// Anvil does not track which state a block's execution actually touched, so this returns a
+    /// witness for the entire parent state instead: the RLP encoding of every node of the parent
+    /// state trie (including all storage tries), all contract codes, and the preimages of all
+    /// account addresses and storage slots. This is a strict superset of the minimal witness, so
+    /// stateless re-execution of the block against it works, but the witness size grows with the
+    /// total state instead of the state accessed by the block.
+    ///
+    /// Limitations:
+    /// - Not supported while forking: only remotely accessed accounts are known locally, and the
+    ///   locally computed state roots do not match the remote chain's roots.
+    /// - The parent block's state must still be available in the state history, i.e. it must not
+    ///   have been discarded via `--prune-history`.
+    /// - The genesis block has no witness since it has no parent state.
+    /// - `headers` contains the ancestor headers within the 256 block `BLOCKHASH` window that are
+    ///   known locally, which may be fewer than 256.
+    pub async fn debug_execution_witness(
+        &self,
+        block: BlockNumber,
+    ) -> Result<ExecutionWitness, BlockchainError> {
+        let number = self.convert_block_number(Some(block));
+        let best = self.best_number();
+        if number > best {
+            return Err(BlockchainError::BlockOutOfRange(best, number));
+        }
+        let Some(parent) = number.checked_sub(1) else {
+            return Err(BlockchainError::Message(
+                "genesis block has no parent state to build a witness from".to_string(),
+            ));
+        };
+
+        let mut headers = Vec::new();
+        for ancestor in (number.saturating_sub(BLOCKHASH_HISTORY)..number).rev() {
+            let Some(block) = self.get_block(ancestor) else { break };
+            headers.push(alloy_rlp::encode(&block.header).into());
+        }
+
+        self.with_database_at(Some(BlockRequest::Number(parent)), |state, _| {
+            let Some(accounts) = state.maybe_full_db() else {
+                return Err(BlockchainError::Message(
+                    "debug_executionWitness is not supported while forking".to_string(),
+                ));
+            };
+
+            let (_, nodes) = state_trie_witness(&accounts);
+            let mut codes = Vec::new();
+            let mut seen_codes = B256Set::default();
+            let mut keys = Vec::new();
+            for (address, account) in &accounts {
+                keys.push(Bytes::copy_from_slice(address.as_slice()));
+                for slot in account.storage.keys() {
+                    keys.push(Bytes::copy_from_slice(&slot.to_be_bytes::<32>()));
+                }
+                if account.info.code_hash != KECCAK_EMPTY
+                    && seen_codes.insert(account.info.code_hash)
+                {
+                    let code = match &account.info.code {
+                        Some(code) => code.original_bytes(),
+                        None => state.code_by_hash_ref(account.info.code_hash)?.original_bytes(),
+                    };
+                    codes.push(code);
+                }
+            }
+            keys.sort_unstable();
+            keys.dedup();
+
+            Ok(ExecutionWitness { state: nodes, codes, keys, headers })
+        })
+        .await?
     }
 
     /// Returns account information after replaying a block through the transaction at `tx_index`.

--- a/crates/anvil/src/eth/backend/mem/state.rs
+++ b/crates/anvil/src/eth/backend/mem/state.rs
@@ -1,7 +1,7 @@
 //! Support for generating the state root for memdb storage
 
 use alloy_primitives::{
-    B256, U256, keccak256,
+    B256, Bytes, U256, keccak256,
     map::{AddressMap, B256Map, HashSet, U256Map},
 };
 use alloy_rlp::Encodable;
@@ -344,6 +344,13 @@ impl TrieNode {
             return Some(rlp.clone());
         }
 
+        let rlp = self.encode(out)?;
+        self.rlp = Some(rlp.clone());
+        Some(rlp)
+    }
+
+    /// Encodes this node into `out`, returning its RLP reference without consulting the cache.
+    fn encode(&mut self, out: &mut Vec<u8>) -> Option<RlpNode> {
         let rlp = match &mut self.kind {
             TrieNodeKind::Empty => return None,
             TrieNodeKind::Leaf { path, value } => {
@@ -370,9 +377,43 @@ impl TrieNode {
                 BranchNodeRef::new(&stack[..stack_len], state_mask).rlp(out)
             }
         };
-        self.rlp = Some(rlp.clone());
         Some(rlp)
     }
+
+    /// Appends the RLP encoding of this node and all of its descendants to `nodes`.
+    fn collect_nodes(&mut self, rlp_buf: &mut Vec<u8>, nodes: &mut Vec<Bytes>) {
+        match &mut self.kind {
+            TrieNodeKind::Empty => return,
+            TrieNodeKind::Leaf { .. } => {}
+            TrieNodeKind::Extension { child, .. } => child.collect_nodes(rlp_buf, nodes),
+            TrieNodeKind::Branch { children } => {
+                for child in children.iter_mut().flatten() {
+                    child.collect_nodes(rlp_buf, nodes);
+                }
+            }
+        }
+        self.encode(rlp_buf);
+        nodes.push(Bytes::copy_from_slice(rlp_buf));
+    }
+}
+
+/// Builds the state trie for the given accounts and returns its root together with the RLP
+/// encoding of every node of the account trie and all storage tries.
+///
+/// The node set is a witness for any execution against this state: it is a strict superset of
+/// the nodes touched by any particular block.
+pub fn state_trie_witness(accounts: &AddressMap<DbAccount>) -> (B256, Vec<Bytes>) {
+    let mut rlp_buf = Vec::new();
+    let mut trie = IncrementalStateTrie::from_accounts(accounts, &mut rlp_buf);
+    let mut nodes = Vec::new();
+    for storage_trie in trie.storage.values_mut() {
+        storage_trie.root.collect_nodes(&mut rlp_buf, &mut nodes);
+    }
+    trie.accounts.root.collect_nodes(&mut rlp_buf, &mut nodes);
+    let root = trie.root(&mut rlp_buf);
+    nodes.sort_unstable();
+    nodes.dedup();
+    (root, nodes)
 }
 
 pub fn build_root(values: impl IntoIterator<Item = (Nibbles, Vec<u8>)>) -> B256 {

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -13,13 +13,13 @@ use alloy_network::{
     TxSignerSync,
 };
 use alloy_primitives::{
-    Address, B256, ChainId, Keccak256, U256, b256, bytes,
+    Address, B256, ChainId, Keccak256, U256, b256, bytes, keccak256,
     map::{AddressHashMap, B256HashMap, HashMap},
 };
 use alloy_provider::{PendingTransactionConfig, Provider};
 use alloy_rpc_types::{
-    BlockId, BlockNumberOrTag, BlockOverrides, BlockTransactions, erc4337::TransactionConditional,
-    request::TransactionRequest, state::AccountOverride,
+    BlockId, BlockNumberOrTag, BlockOverrides, BlockTransactions, debug::ExecutionWitness,
+    erc4337::TransactionConditional, request::TransactionRequest, state::AccountOverride,
 };
 use alloy_rpc_types_eth::{Bundle, EthCallResponse};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse};
@@ -1173,4 +1173,64 @@ async fn test_send_transaction_uses_valid_fallback_gas_on_osaka() {
 
     let receipt = api.send_transaction_sync(WithOtherFields::new(tx_req)).await.unwrap();
     assert!(!receipt.status(), "transaction should preserve send-path revert semantics");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_execution_witness() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    let accounts: Vec<_> = handle.dev_wallets().collect();
+    let signer: EthereumWallet = accounts[0].clone().into();
+    let from = accounts[0].address();
+    let to = accounts[1].address();
+
+    let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
+
+    // Deploy a contract so the witness contains code and storage.
+    let contract = SimpleStorage::deploy(&provider, "initial".to_string()).await.unwrap();
+    let receipt = contract
+        .setValue("updated".to_string())
+        .from(from)
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let number = receipt.block_number.unwrap();
+
+    // No witness exists for the genesis block since it has no parent state.
+    api.debug_execution_witness(BlockNumberOrTag::Number(0)).await.unwrap_err();
+
+    let witness: ExecutionWitness = provider
+        .client()
+        .request("debug_executionWitness", (BlockNumberOrTag::Number(number),))
+        .await
+        .unwrap();
+
+    // The witness contains the full parent state trie, so the parent state root must be among the
+    // collected nodes.
+    let parent = provider.get_block(BlockId::number(number - 1)).await.unwrap().unwrap();
+    assert!(witness.state.iter().any(|node| keccak256(node) == parent.header.state_root));
+
+    // Preimages of the touched account addresses and the deployed code are included.
+    assert!(witness.keys.iter().any(|key| key.as_ref() == from.as_slice()));
+    assert!(witness.keys.iter().any(|key| key.as_ref() == to.as_slice()));
+    assert!(witness.keys.iter().any(|key| key.len() == 32));
+    assert!(!witness.codes.is_empty());
+
+    // Ancestor headers start at the parent block.
+    assert_eq!(witness.headers.len(), number as usize);
+    assert_eq!(keccak256(&witness.headers[0]), parent.header.hash);
+
+    let tx = TransactionRequest::default().with_from(from).with_to(to).with_value(U256::from(1));
+    provider.send_transaction(WithOtherFields::new(tx)).await.unwrap().get_receipt().await.unwrap();
+
+    // Witnesses for older blocks are served from the state history.
+    let historical: ExecutionWitness = provider
+        .client()
+        .request("debug_executionWitness", (BlockNumberOrTag::Number(number),))
+        .await
+        .unwrap();
+    assert_eq!(historical, witness);
 }


### PR DESCRIPTION
Adds support for reth's `debug_executionWitness` endpoint to anvil, as a best-effort implementation.

Anvil does not track which state a block's execution actually touched, so instead of the minimal witness reth produces, the endpoint returns a witness for the entire parent state: the RLP encoding of every node of the parent state trie and all storage tries (rebuilt via the incremental trie from the parent's flat state snapshot), all contract codes, the preimages of all account addresses and storage slots, and the locally known ancestor headers within the 256 block `BLOCKHASH` window. Since this is a strict superset of the touched nodes, stateless re-execution of the block against the witness works, at the cost of witness size growing with total state rather than accessed state, which is acceptable for the small states of a dev node.

Limitations, also documented on the backend method: the endpoint errors while forking, because only remotely accessed accounts are known locally and anvil's computed state roots do not match the remote chain's; the parent block's state must still be available in the state history (`--prune-history` discards it); and the genesis block has no witness since it has no parent state.

The trie change in `mem/state.rs` splits the cached `TrieNode::rlp` into a cache wrapper plus an unconditional `encode`, and adds a walk that collects every node's encoding, so witness collection stays O(state) and reuses the existing incremental trie types.

AI assisted.
