### PR TITLE
fix: restore OP support in releases

### DIFF
--- a/.changelog/anvil-release-optimism-feature.md
+++ b/.changelog/anvil-release-optimism-feature.md
@@ -1,0 +1,8 @@
+---
+anvil: patch
+cast: patch
+chisel: patch
+forge: patch
+---
+
+Restored OP Stack support in release and nightly builds.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ env:
 
   # Keep the base features in sync with `release.yml`.
   RUST_PROFILE: dist
-  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer,monad
+  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer,monad,optimism
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ env:
   # Keep the base features in sync with `docker-publish.yml`.
   # Platform-specific release features are added in the build step.
   RUST_PROFILE: dist
-  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer,monad
+  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer,monad,optimism
 
 jobs:
   prepare:

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ CARGO_TARGET_DIR ?= target
 # List of features to use when building. Can be overridden via the environment.
 # No jemalloc on Windows
 ifeq ($(OS),Windows_NT)
-    FEATURES ?= aws-kms gcp-kms turnkey cli asm-keccak monad
+    FEATURES ?= aws-kms gcp-kms turnkey cli asm-keccak monad optimism
 else
-    FEATURES ?= jemalloc aws-kms gcp-kms turnkey cli asm-keccak monad
+    FEATURES ?= jemalloc aws-kms gcp-kms turnkey cli asm-keccak monad optimism
 endif
 
 ##@ Help


### PR DESCRIPTION
Restores OP Stack support in nightly, release, and Docker builds by explicitly enabling the feature alongside Monad. Fixes #16180.