### PR TITLE
chore(deps): use released Monad crates

### DIFF
--- a/.changelog/use-released-monad-crates.md
+++ b/.changelog/use-released-monad-crates.md
@@ -1,0 +1,8 @@
+---
+forge: patch
+cast: patch
+anvil: patch
+chisel: patch
+---
+
+Updated the Monad EVM dependencies to their crates.io releases.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,8 +403,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-monad-evm"
-version = "0.5.0"
-source = "git+https://github.com/category-labs/alloy-monad-evm?rev=334bda1826996118d40872af35c27316a01889a2#334bda1826996118d40872af35c27316a01889a2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b488e1dd0352b471aecfc903657c5505125490442ecbb63494c885ed1c0188d6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7993,7 +7994,8 @@ dependencies = [
 [[package]]
 name = "monad-revm"
 version = "0.6.0"
-source = "git+https://github.com/category-labs/monad-revm?rev=8ba4a51b221357105465cbe6d410906d3f12baeb#8ba4a51b221357105465cbe6d410906d3f12baeb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b640502c0bcc1ac08d9eb2555467ba47fb9071715b0c53592d64f8a5fade2a41"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -538,7 +538,7 @@ tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42
 tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7" }
 
 # Monad
-alloy-monad-evm = { version = "0.5.0", default-features = false, features = [
+alloy-monad-evm = { version = "0.6.0", default-features = false, features = [
     "std",
     "memory_limit",
 ] }
@@ -562,10 +562,6 @@ idna_adapter = "=1.1.0"
 solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e2267c549555a980aef6b0b1f249eb" }
 solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e2267c549555a980aef6b0b1f249eb" }
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e2267c549555a980aef6b0b1f249eb" }
-
-## monad
-alloy-monad-evm = { git = "https://github.com/category-labs/alloy-monad-evm", rev = "334bda1826996118d40872af35c27316a01889a2" }
-monad-revm = { git = "https://github.com/category-labs/monad-revm", rev = "8ba4a51b221357105465cbe6d410906d3f12baeb" }
 
 ## foundry-core
 foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b3ea9453789ba0d9d8ebf0fc4ee0fed9e4add8f" }

--- a/deny.toml
+++ b/deny.toml
@@ -114,9 +114,6 @@ allow-git = [
     # Tempo
     "https://github.com/tempoxyz/tempo",
     "https://github.com/tempoxyz/mpp-rs",
-    # Monad
-    "https://github.com/category-labs/alloy-monad-evm",
-    "https://github.com/category-labs/monad-revm",
     # Transitive dependency of Tempo
     "https://github.com/commonwarexyz/monorepo",
     "https://github.com/paradigmxyz/reth",


### PR DESCRIPTION
Replaces the temporary git patches for `monad-revm` and `alloy-monad-evm` with their published 0.6.0 crates.io releases.