### PR TITLE
fix(cast): omit wallet new stdout record on interactive terminals

### DIFF
--- a/.changelog/cast-wallet-new-tty-stdout-record.md
+++ b/.changelog/cast-wallet-new-tty-stdout-record.md
@@ -1,0 +1,6 @@
+---
+cast: patch
+foundry-common: patch
+---
+
+`cast wallet new` no longer repeats the address and private key as a tab-separated stdout record in interactive terminals; the machine-readable record is still emitted when stdout is piped or redirected.

--- a/.changelog/cast-wallet-new-tty-stdout-record.md
+++ b/.changelog/cast-wallet-new-tty-stdout-record.md
@@ -3,4 +3,4 @@ cast: patch
 foundry-common: patch
 ---
 
-`cast wallet new` no longer repeats the address and private key as a tab-separated stdout record in interactive terminals; the machine-readable record is still emitted when stdout is piped or redirected.
+`cast wallet new` and `cast create2` no longer repeat the generated values as a tab-separated stdout record in interactive terminals; the machine-readable record is still emitted when stdout is piped or redirected.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,6 +2990,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.4",
  "revm",
+ "rexpect",
  "rpassword",
  "semver 1.0.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,6 +476,9 @@ ratatui = { version = "0.30", default-features = false }
 rayon = "1"
 regex = { version = "1", default-features = false }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+# PTY-based CLI tests.
+# https://github.com/rust-cli/rexpect/pull/106
+rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6a85bedbae71a01cc578958fc" }
 ron = "0.12"
 rustls = "0.23"
 semver = "1"

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -108,8 +108,7 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [target.'cfg(unix)'.dev-dependencies]
-# Keep this aligned with the Chisel PTY test dependency.
-rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6a85bedbae71a01cc578958fc" }
+rexpect.workspace = true
 
 [dev-dependencies]
 alloy-hardforks.workspace = true

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -107,6 +107,10 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Threading",
 ] }
 
+[target.'cfg(unix)'.dev-dependencies]
+# Keep this aligned with the Chisel PTY test dependency.
+rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6a85bedbae71a01cc578958fc" }
+
 [dev-dependencies]
 alloy-hardforks.workspace = true
 alloy-serde.workspace = true

--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -7,7 +7,7 @@ use foundry_cli::{
     opts::BuildOpts,
     utils::{LoadConfig, find_contract_artifacts, parse_constructor_args},
 };
-use foundry_common::compile;
+use foundry_common::{compile, shell};
 use foundry_compilers::{info::ContractInfo, utils::canonicalize};
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use regex::RegexSetBuilder;
@@ -301,7 +301,11 @@ impl Create2Args {
         sh_status!("Successfully found contract address in {:?}", timer.elapsed())?;
         sh_status!("Address: {address}")?;
         sh_status!("Salt: {salt} ({})", U256::from_be_bytes(salt.0))?;
-        sh_println!("{address}\t{salt}")?;
+        // The machine-readable stdout record duplicates the prose above when stdout is an
+        // interactive terminal.
+        if !shell::is_out_tty() {
+            sh_println!("{address}\t{salt}")?;
+        }
 
         Ok(Create2Output { address, salt })
     }

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -547,7 +547,11 @@ impl WalletSubcommands {
                                         hex::encode(wallet.public_key())
                                     )?;
                                 }
-                                sh_println!("{}", wallet.address().to_checksum(None))?;
+                                // The machine-readable stdout record duplicates the prose above
+                                // when stdout is an interactive terminal.
+                                if !shell::is_out_tty() {
+                                    sh_println!("{}", wallet.address().to_checksum(None))?;
+                                }
                             }
                         }
                     }
@@ -574,11 +578,15 @@ impl WalletSubcommands {
                                     "Private key: 0x{}",
                                     hex::encode(wallet.credential().to_bytes())
                                 )?;
-                                sh_println!(
-                                    "{}\t0x{}",
-                                    wallet.address().to_checksum(None),
-                                    hex::encode(wallet.credential().to_bytes())
-                                )?;
+                                // The machine-readable stdout record duplicates the prose above
+                                // when stdout is an interactive terminal.
+                                if !shell::is_out_tty() {
+                                    sh_println!(
+                                        "{}\t0x{}",
+                                        wallet.address().to_checksum(None),
+                                        hex::encode(wallet.credential().to_bytes())
+                                    )?;
+                                }
                             }
                         }
                     }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3459,6 +3459,44 @@ casttest!(create2_output_channels, |_prj, cmd| {
 "#]]);
 });
 
+// tests that the machine-readable stdout record is omitted on an interactive terminal, where it
+// would duplicate the stderr prose
+casttest!(
+    #[cfg(unix)]
+    create2_tty_omits_stdout_record,
+    |_prj, _cmd| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_cast"));
+        command.env("NO_COLOR", "1").env("TERM", "dumb").args([
+            "create2",
+            "--starts-with",
+            "cc",
+            "--init-code-hash",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+        ]);
+
+        let mut session = spawn_with_options(
+            command,
+            Options {
+                timeout_ms: Some(30_000),
+                strip_ansi_escape_codes: true,
+                encoding: Encoding::UTF8,
+            },
+        )
+        .unwrap();
+
+        session.exp_string("Successfully found contract address").unwrap();
+        session.exp_string("Address: 0x").unwrap();
+        session.exp_string("Salt: 0x").unwrap();
+        // Only the salt value and its decimal representation may follow; the `address\tsalt`
+        // record must not be printed to a tty.
+        let rest = session.exp_eof().unwrap();
+        assert!(
+            !rest.contains("0x") && !rest.contains('\t'),
+            "unexpected stdout record on tty: {rest:?}"
+        );
+    }
+);
+
 // tests that `cast create2 --salt` writes `address\tsalt` to stdout
 casttest!(create2_fixed_salt_output_channels, |_prj, cmd| {
     cmd.args([

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -27,6 +27,8 @@ use foundry_test_utils::{
     str,
     util::OutputExt,
 };
+#[cfg(unix)]
+use rexpect::{Encoding, reader::Options, spawn_with_options};
 use serde_json::json;
 use std::{fs, io::ErrorKind, net::TcpListener, path::Path, process::Command, str::FromStr};
 use tempo_contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
@@ -376,6 +378,38 @@ Successfully created new keypair.
 
 "#]]);
 });
+
+// tests that the machine-readable stdout record is omitted on an interactive terminal, where it
+// would duplicate the stderr prose
+casttest!(
+    #[cfg(unix)]
+    new_wallet_tty_omits_stdout_record,
+    |_prj, _cmd| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_cast"));
+        command.env("NO_COLOR", "1").env("TERM", "dumb").args(["wallet", "new"]);
+
+        let mut session = spawn_with_options(
+            command,
+            Options {
+                timeout_ms: Some(30_000),
+                strip_ansi_escape_codes: true,
+                encoding: Encoding::UTF8,
+            },
+        )
+        .unwrap();
+
+        session.exp_string("Successfully created new keypair.").unwrap();
+        session.exp_string("Address:").unwrap();
+        session.exp_string("Private key: 0x").unwrap();
+        // Only the private key value may follow; the `address\tprivate_key` record must not be
+        // printed to a tty.
+        let rest = session.exp_eof().unwrap();
+        assert!(
+            !rest.contains("0x") && !rest.contains('\t'),
+            "unexpected stdout record on tty: {rest:?}"
+        );
+    }
+);
 
 // tests that we can create a new wallet with json output
 casttest!(new_wallet_json, |_prj, cmd| {

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -63,8 +63,7 @@ tracing-subscriber.workspace = true
 # REPL tests only work on Unix.
 [target.'cfg(unix)'.dev-dependencies]
 foundry-test-utils.workspace = true
-# https://github.com/rust-cli/rexpect/pull/106
-rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6a85bedbae71a01cc578958fc" }
+rexpect.workspace = true
 
 [features]
 default = ["jemalloc", "asm-keccak", "optimism"]

--- a/crates/common/src/io/shell.rs
+++ b/crates/common/src/io/shell.rs
@@ -45,6 +45,14 @@ pub fn is_err_tty() -> bool {
     Shell::get().is_err_tty()
 }
 
+/// Returns whether stdout is a terminal (tty).
+///
+/// Used to gate machine-readable stdout records that would duplicate the status prose
+/// already shown on stderr in interactive sessions.
+pub fn is_out_tty() -> bool {
+    Shell::get().is_out_tty()
+}
+
 /// Returns whether the output format is [`OutputFormat::Json`].
 pub fn is_json() -> bool {
     Shell::get().is_json()
@@ -152,6 +160,7 @@ enum ShellOut {
     Stream {
         stdout: AutoStream<std::io::Stdout>,
         stderr: AutoStream<std::io::Stderr>,
+        stdout_tty: bool,
         stderr_tty: bool,
         color_choice: ColorChoice,
     },
@@ -203,6 +212,7 @@ impl Shell {
                 stdout: AutoStream::new(std::io::stdout(), color.to_anstream_color_choice()),
                 stderr: AutoStream::new(std::io::stderr(), color.to_anstream_color_choice()),
                 color_choice: color,
+                stdout_tty: std::io::stdout().is_terminal(),
                 stderr_tty: std::io::stderr().is_terminal(),
             },
             output_format: format,
@@ -343,6 +353,14 @@ impl Shell {
     pub const fn is_err_tty(&self) -> bool {
         match self.output {
             ShellOut::Stream { stderr_tty, .. } => stderr_tty,
+            ShellOut::Empty(_) | ShellOut::Captured { .. } => false,
+        }
+    }
+
+    /// Returns `true` if stdout is a tty.
+    pub const fn is_out_tty(&self) -> bool {
+        match self.output {
+            ShellOut::Stream { stdout_tty, .. } => stdout_tty,
             ShellOut::Empty(_) | ShellOut::Captured { .. } => false,
         }
     }

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -121,8 +121,7 @@ tempfile.workspace = true
 alloy-signer-local.workspace = true
 
 [target.'cfg(unix)'.dev-dependencies]
-# Keep this aligned with the Chisel PTY test dependency.
-rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6a85bedbae71a01cc578958fc" }
+rexpect.workspace = true
 
 [features]
 default = ["jemalloc", "asm-keccak", "optimism"]

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -103,7 +103,7 @@ Each row's status is one of:
 | `cast logs`            | Pretty-printed logs                                  | JSON array                                                     | migrated |
 | `cast run`             | Trace / decoded output                               | JSON                                                           | migrated |
 | `cast trace`           | Trace                                                | JSON trace                                                     | migrated |
-| `cast wallet new`      | One record per wallet: `address` (keystore) or `address\tprivate_key` (no keystore) | JSON array of `{ address, public_key, path }` (keystore) or `{ address, public_key, private_key }` (no keystore) | migrated |
+| `cast wallet new`      | One record per wallet: `address` (keystore) or `address\tprivate_key` (no keystore); omitted when stdout is a tty, where the stderr prose already shows the values | JSON array of `{ address, public_key, path }` (keystore) or `{ address, public_key, private_key }` (no keystore) | migrated |
 | `cast wallet sign`     | Signature                                            | JSON                                                           | migrated |
 | `cast wallet sign-auth`| Signed authorization RLP                             | JSON                                                           | migrated |
 | `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | migrated |

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -107,7 +107,7 @@ Each row's status is one of:
 | `cast wallet sign`     | Signature                                            | JSON                                                           | migrated |
 | `cast wallet sign-auth`| Signed authorization RLP                             | JSON                                                           | migrated |
 | `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | migrated |
-| `cast create2`         | `address\tsalt` (tab-separated)                      | n/a                                                            | migrated |
+| `cast create2`         | `address\tsalt` (tab-separated); when mining, omitted when stdout is a tty, where the stderr prose already shows the values | n/a                                                            | migrated |
 | `cast access-list`     | Access list                                          | JSON                                                           | migrated |
 | `cast interface`       | Solidity interface source                            | JSON ABI array                                                 | migrated |
 | `cast artifact`        | JSON artifact                                        | n/a                                                            | migrated |


### PR DESCRIPTION
Since #15001, `cast wallet new` prints the keypair twice in an interactive terminal: the labeled prose on stderr, followed by the machine-readable `address\tprivate_key` stdout record, which shows up as a confusing unlabeled tab-separated line right below it. `cast create2` vanity mining has the same duplication with its `address\tsalt` record.

The stdout record is now only emitted when stdout is not a tty, via a new `shell::is_out_tty()` mirroring the existing `is_err_tty()`. Scripts and pipes still receive the documented record (`cast wallet new 2>/dev/null` is unchanged), while interactive sessions only see the prose. The keystore variant's bare address record is gated the same way, and `create2 --salt` is unchanged since it prints no prose. `docs/dev/output-channels.md` reflects the behavior. Adds PTY-based tests asserting the records are not printed on a terminal, and moves the pinned `rexpect` test dependency to the workspace now that forge, chisel, and cast all use it.

Written with AI assistance.
