### PR TITLE
feat(cheatcodes): add expectDelegateCall

### DIFF
--- a/.changelog/expect-delegate-call.md
+++ b/.changelog/expect-delegate-call.md
@@ -1,0 +1,7 @@
+---
+forge: minor
+foundry-cheatcodes: minor
+foundry-cheatcodes-spec: minor
+---
+
+Added `vm.expectDelegateCall` for asserting delegate calls separately from ordinary calls.

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -5466,6 +5466,26 @@
     },
     {
       "func": {
+        "id": "expectDelegateCall",
+        "description": "Expects a delegate call to an address with the specified calldata.\nCalldata can either be a strict or a partial match.",
+        "declaration": "function expectDelegateCall(address callee, bytes calldata data) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectDelegateCall(address,bytes)",
+        "selector": "0x3d6ac1e7",
+        "selectorBytes": [
+          61,
+          106,
+          193,
+          231
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "expectEmitAnonymous_0",
         "description": "Prepare an expected anonymous log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData.).\nCall this function, then emit an anonymous event, then call a function. Internally after the call, we check if\nlogs were emitted in the expected order with the expected topics and data (as specified by the booleans).",
         "declaration": "function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1185,6 +1185,11 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectCall(address callee, uint256 msgValue, uint64 gas, bytes calldata data, uint64 count) external;
 
+    /// Expects a delegate call to an address with the specified calldata.
+    /// Calldata can either be a strict or a partial match.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectDelegateCall(address callee, bytes calldata data) external;
+
     /// Expect a call to an address with the specified `msg.value` and calldata, and a *minimum* amount of gas.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data) external;

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1458,7 +1458,8 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             let value = call.transfer_value();
 
             // Match every partial/full calldata
-            for (calldata, (expected, actual_count)) in expected_calls_for_target {
+            for ((calldata, expected_scheme), (expected, actual_count)) in expected_calls_for_target
+            {
                 // Increment actual times seen if...
                 // The calldata is at most, as big as this call's input, and
                 if calldata.len() <= input.len() &&
@@ -1469,7 +1470,9 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                     // The gas matches, if provided
                     expected.gas.is_none_or(|gas| gas == call.gas_limit) &&
                     // The minimum gas matches, if provided
-                    expected.min_gas.is_none_or(|min_gas| min_gas <= call.gas_limit)
+                    expected.min_gas.is_none_or(|min_gas| min_gas <= call.gas_limit) &&
+                    // The call scheme matches, if provided
+                    expected_scheme.is_none_or(|scheme| scheme == call.scheme)
                 {
                     *actual_count += 1;
                 }
@@ -2672,7 +2675,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             // Match expected calls
             for (address, calldatas) in &self.expected_calls {
                 // Loop over each address, and for each address, loop over each calldata it expects.
-                for (calldata, (expected, actual_count)) in calldatas {
+                for ((calldata, scheme), (expected, actual_count)) in calldatas {
                     // Grab the values we expect to see
                     let ExpectedCallData { gas, min_gas, value, count, call_type } = expected;
 
@@ -2693,6 +2696,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                             value.as_ref().map(|v| format!("value {v}")),
                             gas.map(|g| format!("gas {g}")),
                             min_gas.map(|g| format!("minimum gas {g}")),
+                            scheme.map(|scheme| format!("call type {scheme:?}")),
                         ]
                         .into_iter()
                         .flatten()

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -17,7 +17,8 @@ use foundry_evm_traces::DecodedCallLog;
 use revm::{
     context::{ContextTr, JournalTr},
     interpreter::{
-        InstructionResult, Interpreter, InterpreterAction, interpreter_types::LoopControl,
+        CallScheme, InstructionResult, Interpreter, InterpreterAction,
+        interpreter_types::LoopControl,
     },
 };
 use tempo_contracts::precompiles::ISignatureVerifier;
@@ -26,14 +27,16 @@ use tempo_precompiles::SIGNATURE_VERIFIER_ADDRESS;
 use super::revert_handlers::RevertParameters;
 /// Tracks the expected calls per address.
 ///
-/// For each address, we track the expected calls per call data. We track it in such manner
-/// so that we don't mix together calldatas that only contain selectors and calldatas that contain
-/// selector and arguments (partial and full matches).
+/// For each address, we track the expected calls per call data and optional call scheme. We track
+/// it in such manner so that we don't mix together calldatas that only contain selectors and
+/// calldatas that contain selector and arguments (partial and full matches), or unrestricted calls
+/// and calls restricted to a specific scheme.
 ///
 /// This then allows us to customize the matching behavior for each call data on the
 /// `ExpectedCallData` struct and track how many times we've actually seen the call on the second
 /// element of the tuple.
-pub type ExpectedCallTracker = HashMap<Address, HashMap<Bytes, (ExpectedCallData, u64)>>;
+pub type ExpectedCallTracker =
+    HashMap<Address, HashMap<(Bytes, Option<CallScheme>), (ExpectedCallData, u64)>>;
 
 #[derive(Clone, Debug)]
 pub struct ExpectedCallData {
@@ -214,21 +217,31 @@ impl CreateScheme {
 impl Cheatcode for expectCall_0Call {
     fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
         let Self { callee, data } = self;
-        expect_call(state, callee, data, None, None, None, 1, ExpectedCallType::NonCount)
+        expect_call(state, callee, data, None, None, None, None, 1, ExpectedCallType::NonCount)
     }
 }
 
 impl Cheatcode for expectCall_1Call {
     fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
         let Self { callee, data, count } = self;
-        expect_call(state, callee, data, None, None, None, *count, ExpectedCallType::Count)
+        expect_call(state, callee, data, None, None, None, None, *count, ExpectedCallType::Count)
     }
 }
 
 impl Cheatcode for expectCall_2Call {
     fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
         let Self { callee, msgValue, data } = self;
-        expect_call(state, callee, data, Some(msgValue), None, None, 1, ExpectedCallType::NonCount)
+        expect_call(
+            state,
+            callee,
+            data,
+            Some(msgValue),
+            None,
+            None,
+            None,
+            1,
+            ExpectedCallType::NonCount,
+        )
     }
 }
 
@@ -240,6 +253,7 @@ impl Cheatcode for expectCall_3Call {
             callee,
             data,
             Some(msgValue),
+            None,
             None,
             None,
             *count,
@@ -258,6 +272,7 @@ impl Cheatcode for expectCall_4Call {
             Some(msgValue),
             Some(*gas),
             None,
+            None,
             1,
             ExpectedCallType::NonCount,
         )
@@ -274,8 +289,26 @@ impl Cheatcode for expectCall_5Call {
             Some(msgValue),
             Some(*gas),
             None,
+            None,
             *count,
             ExpectedCallType::Count,
+        )
+    }
+}
+
+impl Cheatcode for expectDelegateCallCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { callee, data } = self;
+        expect_call(
+            state,
+            callee,
+            data,
+            None,
+            None,
+            None,
+            Some(CallScheme::DelegateCall),
+            1,
+            ExpectedCallType::NonCount,
         )
     }
 }
@@ -290,6 +323,7 @@ impl Cheatcode for expectCallMinGas_0Call {
             Some(msgValue),
             None,
             Some(*minGas),
+            None,
             1,
             ExpectedCallType::NonCount,
         )
@@ -306,6 +340,7 @@ impl Cheatcode for expectCallMinGas_1Call {
             Some(msgValue),
             None,
             Some(*minGas),
+            None,
             *count,
             ExpectedCallType::Count,
         )
@@ -497,6 +532,7 @@ fn expect_keychain_verified<FEN: FoundryEvmNetwork>(
         state,
         &SIGNATURE_VERIFIER_ADDRESS,
         &Bytes::from(calldata),
+        None,
         None,
         None,
         None,
@@ -794,6 +830,7 @@ fn expect_call<FEN: FoundryEvmNetwork>(
     value: Option<&U256>,
     mut gas: Option<u64>,
     mut min_gas: Option<u64>,
+    scheme: Option<CallScheme>,
     count: u64,
     call_type: ExpectedCallType,
 ) -> Result {
@@ -818,19 +855,17 @@ fn expect_call<FEN: FoundryEvmNetwork>(
             // Get the expected calls for this target.
             // In this case, as we're using counted expectCalls, we should not be able to set them
             // more than once.
-            ensure!(
-                !expecteds.contains_key(calldata),
-                "counted expected calls can only bet set once"
-            );
+            let key = (calldata.clone(), scheme);
+            ensure!(!expecteds.contains_key(&key), "counted expected calls can only bet set once");
             expecteds.insert(
-                calldata.clone(),
+                key,
                 (ExpectedCallData { value: value.copied(), gas, min_gas, count, call_type }, 0),
             );
         }
         ExpectedCallType::NonCount => {
             // Check if the expected calldata exists.
             // If it does, increment the count by one as we expect to see it one more time.
-            match expecteds.entry(calldata.clone()) {
+            match expecteds.entry((calldata.clone(), scheme)) {
                 Entry::Occupied(mut entry) => {
                     let (expected, _) = entry.get_mut();
                     // Ensure we're not overwriting a counted expectCall.

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -133,10 +133,11 @@ forgetest!(expect_call_tests_should_fail, |prj, cmd| {
 [FAIL: expected call to 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f with data 0x771602f700000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001, value 0, gas 25000 to be called 1 time, but was called 0 times] testShouldFailExpectCallWithNoValueAndWrongGas() ([GAS])
 [FAIL: expected call to 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f with data 0x771602f700000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001, value 0, minimum gas 50001 to be called 1 time, but was called 0 times] testShouldFailExpectCallWithNoValueAndWrongMinGas() ([GAS])
 [FAIL: next call did not revert as expected] testShouldFailExpectCallWithRevertDisallowed() ([GAS])
+[FAIL: expected call to 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f with data 0x771602f700000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002, call type DelegateCall to be called 1 time, but was called 0 times] testShouldFailExpectDelegateCallWithCall() ([GAS])
 [FAIL: expected call to 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f with data 0x3fc7c698 to be called 1 time, but was called 0 times] testShouldFailExpectInnerCall() ([GAS])
 [FAIL: expected call to 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f with data 0x771602f700000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002 to be called 3 times, but was called 2 times] testShouldFailExpectMultipleCallsWithDataAdditive() ([GAS])
 [FAIL: expected call to 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f with data 0x771602f7 to be called 1 time, but was called 0 times] testShouldFailExpectSelectorCall() ([GAS])
-Suite result: FAILED. 0 passed; 9 failed; 0 skipped; [ELAPSED]
+Suite result: FAILED. 0 passed; 10 failed; 0 skipped; [ELAPSED]
 ...
 "#,
     );

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -2838,7 +2838,7 @@ Traces:
     │   └─ ← [Return]
     └─ ← [Stop]
 
-  [558945] PauseTracingTest::test()
+  [558957] PauseTracingTest::test()
     ├─ [0] VM::resumeTracing() [staticcall]
     │   └─ ← [Return]
     ├─ [48460] TraceGenerator::generate()

--- a/crates/forge/tests/fixtures/ExpectCallFailures.t.sol
+++ b/crates/forge/tests/fixtures/ExpectCallFailures.t.sol
@@ -80,6 +80,13 @@ contract ExpectCallFailureTest is DSTest {
         this.exposed_callTargetNTimes(target, 3, 3, 1);
     }
 
+    function testShouldFailExpectDelegateCallWithCall() public {
+        Contract target = new Contract();
+        bytes memory data = abi.encodeWithSelector(target.add.selector, 1, 2);
+        vm.expectDelegateCall(address(target), data);
+        target.add(1, 2);
+    }
+
     function testShouldFailExpectInnerCall() public {
         Contract inner = new Contract();
         NestedContract target = new NestedContract(inner);

--- a/testdata/default/cheats/ExpectCall.t.sol
+++ b/testdata/default/cheats/ExpectCall.t.sol
@@ -202,6 +202,22 @@ contract ExpectCallTest is Test {
         vm.expectCall(address(simpleCall), abi.encodeWithSignature("call()"));
         proxyWithDelegateCall.delegateCall(simpleCall);
     }
+
+    function testExpectDelegateCall() public {
+        ProxyWithDelegateCall proxyWithDelegateCall = new ProxyWithDelegateCall();
+        SimpleCall simpleCall = new SimpleCall();
+        vm.expectDelegateCall(address(simpleCall), abi.encodeWithSignature("call()"));
+        proxyWithDelegateCall.delegateCall(simpleCall);
+    }
+
+    function testExpectCallAndDelegateCallForSameCalldata() public {
+        ProxyWithDelegateCall proxyWithDelegateCall = new ProxyWithDelegateCall();
+        SimpleCall simpleCall = new SimpleCall();
+        bytes memory data = abi.encodeWithSignature("call()");
+        vm.expectCall(address(simpleCall), data);
+        vm.expectDelegateCall(address(simpleCall), data);
+        proxyWithDelegateCall.delegateCall(simpleCall);
+    }
 }
 
 contract ExpectCallCountTest is Test {

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -266,6 +266,7 @@ interface Vm {
     function expectCall(address callee, uint256 msgValue, uint64 gas, bytes calldata data, uint64 count) external;
     function expectCreate(bytes calldata bytecode, address deployer) external;
     function expectCreate2(bytes calldata bytecode, address deployer) external;
+    function expectDelegateCall(address callee, bytes calldata data) external;
     function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
     function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
     function expectEmitAnonymous() external;


### PR DESCRIPTION
Adds `vm.expectDelegateCall(address,bytes)` so tests can assert that matching calldata is executed specifically through `DELEGATECALL`. The existing expectation tracker now keys matching calldata by an optional call scheme, which preserves `expectCall`’s current any-scheme behavior and lets both expectations coexist for the same target and calldata.

Closes #8301.

This PR was written with Codex, which helped investigate the existing expectation machinery, implement the change, and test it.
