### PR TITLE
fix(ci): isolate Moonbeam RPC dependencies

### DIFF
--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -2125,7 +2125,7 @@ async fn can_override_fork_chain_id() {
 
 // <https://github.com/foundry-rs/foundry/issues/6485>
 #[tokio::test(flavor = "multi_thread")]
-async fn test_fork_reset_moonbeam() {
+async fn flaky_test_fork_reset_moonbeam() {
     crate::init_tracing();
     let (api, handle) = spawn(
         fork_config()

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -254,6 +254,31 @@ mod tests {
     }
 
     #[test]
+    fn block_normalization_sets_prevrandao_for_moonbeam() {
+        let header = AnyHeader { difficulty: U256::from(1), ..Default::default() };
+        let block = AnyRpcBlock::new(
+            Block::new(
+                AnyRpcHeader::from_sealed(header.seal(B256::ZERO)),
+                BlockTransactions::Full(Vec::new()),
+            )
+            .into(),
+        );
+        let mut evm_env = EvmEnv::new(
+            CfgEnv::<SpecId>::default(),
+            BlockEnv { prevrandao: None, ..Default::default() },
+        );
+
+        apply_chain_and_block_specific_env_changes_for_chain::<AnyNetwork, _, _>(
+            &mut evm_env,
+            &block,
+            NamedChain::Moonbeam as u64,
+            NetworkConfigs::default(),
+        );
+
+        assert!(evm_env.block_env.prevrandao.is_some());
+    }
+
+    #[test]
     fn tx_replay_env_changes_disable_priority_fee_check_only_for_arbitrum() {
         let mut evm_env = EvmEnv::new(
             revm::context::CfgEnv::<SpecId>::default(),

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -120,11 +120,11 @@ fn collect_debug_dump_storage_changes<'a>(
 /// Contracts excluded from the main `testdata` run because they depend on flaky external RPCs.
 /// These are run separately by the `flaky_testdata` test below.
 /// Format: pipe-separated regex alternation, e.g. `"Foo|Bar|Baz"`.
-const FLAKY_TESTDATA_CONTRACTS: &str = "Issue4640Test|Issue14212Test";
+const FLAKY_TESTDATA_CONTRACTS: &str = "Issue4232Test|Issue4640Test|Issue14212Test";
 
-// Issue14212Test depends on Base transaction lookups that are not reliably served by the public
-// Base RPC endpoint used in CI.
-const FLAKY_TESTDATA_RUN_CONTRACTS: &str = "Issue4640Test";
+// Issue4232Test depends on the public Moonbeam RPC, while Issue14212Test depends on Base
+// transaction lookups that are not reliably served by the public Base RPC endpoint used in CI.
+const FLAKY_TESTDATA_RUN_CONTRACTS: &str = "Issue4232Test|Issue4640Test";
 
 // Run `forge test` on `/testdata`.
 forgetest!(testdata, |_prj, cmd| {


### PR DESCRIPTION
The required test matrix currently includes two tests that depend on the public Moonbeam RPC. Provider-side failures can therefore fail both the Anvil fork test and Forge's broader testdata suite without indicating a Foundry regression.

This moves the live Moonbeam coverage to the existing nightly flaky profile and adds a deterministic unit test for Moonbeam prevrandao normalization. The behavior remains covered without making required CI depend on public RPC availability.

AI assistance was used to implement and validate this change.
