### PR TITLE
fix(symbolic): preserve reverted recordings

### DIFF
--- a/.changelog/preserve-symbolic-reverted-recordings.md
+++ b/.changelog/preserve-symbolic-reverted-recordings.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Preserved symbolic log and storage access recordings from reverted child frames.

--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -1069,6 +1069,7 @@ impl SymbolicExecutor {
             parent.storage_store_hooks = outcome.state.storage_store_hooks.clone();
             parent.mapping_storage_store_hooks = outcome.state.mapping_storage_store_hooks.clone();
             parent.inherit_mapping_hook_provenance(&outcome.state);
+            parent.inherit_inspector_recordings(&outcome.state);
 
             if let Some(assumption) = parent.assume_no_revert_next_call.take()
                 && matches!(outcome.status, TopLevelCallStatus::Revert)
@@ -1103,7 +1104,6 @@ impl SymbolicExecutor {
                         } else {
                             parent.expected_revert = Some(expected);
                         }
-                        parent.access_record = outcome.state.access_record.clone();
                         parent.expected_calls = outcome.state.expected_calls.clone();
                         parent.expected_creates = outcome.state.expected_creates.clone();
                         parent.call_mocks = outcome.state.call_mocks.clone();
@@ -1130,8 +1130,6 @@ impl SymbolicExecutor {
             match outcome.status {
                 TopLevelCallStatus::Success => {
                     parent.block = outcome.state.block.clone();
-                    parent.recorded_logs = outcome.state.recorded_logs.clone();
-                    parent.access_record = outcome.state.access_record.clone();
                     parent.expected_emit = outcome.state.expected_emit.clone();
                     parent.expected_calls = outcome.state.expected_calls.clone();
                     parent.expected_creates = outcome.state.expected_creates.clone();

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -202,6 +202,7 @@ impl SymbolicExecutor {
             parent.storage_store_hooks = outcome.state.storage_store_hooks.clone();
             parent.mapping_storage_store_hooks = outcome.state.mapping_storage_store_hooks.clone();
             parent.inherit_mapping_hook_provenance(&outcome.state);
+            parent.inherit_inspector_recordings(&outcome.state);
 
             if let Some(assumption) = parent.assume_no_revert_next_call.take()
                 && matches!(outcome.status, TopLevelCallStatus::Revert)
@@ -236,7 +237,6 @@ impl SymbolicExecutor {
                         } else {
                             parent.expected_revert = Some(expected);
                         }
-                        parent.access_record = outcome.state.access_record.clone();
                         parent.expected_calls = outcome.state.expected_calls.clone();
                         parent.expected_creates = pending_expected_creates.clone();
                         parent.call_mocks = outcome.state.call_mocks.clone();
@@ -261,8 +261,6 @@ impl SymbolicExecutor {
                 TopLevelCallStatus::Success => {
                     parent.world = outcome.state.world.clone();
                     parent.block = outcome.state.block.clone();
-                    parent.recorded_logs = outcome.state.recorded_logs.clone();
-                    parent.access_record = outcome.state.access_record.clone();
                     parent.expected_emit = outcome.state.expected_emit.clone();
                     parent.expected_calls = outcome.state.expected_calls.clone();
                     parent.expected_creates = pending_expected_creates.clone();

--- a/crates/evm/symbolic/src/executor/create.rs
+++ b/crates/evm/symbolic/src/executor/create.rs
@@ -128,6 +128,7 @@ impl SymbolicExecutor {
             parent.storage_store_hooks = outcome.state.storage_store_hooks.clone();
             parent.mapping_storage_store_hooks = outcome.state.mapping_storage_store_hooks.clone();
             parent.inherit_mapping_hook_provenance(&outcome.state);
+            parent.inherit_inspector_recordings(&outcome.state);
             parent.return_data = SymReturnData::empty(&mut self.cx);
 
             if let Some(assumption) = parent.assume_no_revert_next_call.take()
@@ -163,7 +164,6 @@ impl SymbolicExecutor {
                         } else {
                             parent.expected_revert = Some(expected);
                         }
-                        parent.access_record = outcome.state.access_record.clone();
                         parent.expected_calls = outcome.state.expected_calls.clone();
                         parent.expected_creates = pending_expected_creates.clone();
                         parent.call_mocks = outcome.state.call_mocks.clone();
@@ -180,8 +180,6 @@ impl SymbolicExecutor {
                 TopLevelCallStatus::Success => {
                     parent.world = outcome.state.world.clone();
                     parent.block = outcome.state.block.clone();
-                    parent.recorded_logs = outcome.state.recorded_logs.clone();
-                    parent.access_record = outcome.state.access_record.clone();
                     parent.expected_emit = outcome.state.expected_emit.clone();
                     parent.expected_calls = outcome.state.expected_calls.clone();
                     parent.expected_creates = pending_expected_creates.clone();

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -430,11 +430,15 @@ impl PathState {
         self.mapping_hook_keccak_preimages = child.mapping_hook_keccak_preimages.clone();
     }
 
+    pub(crate) fn inherit_inspector_recordings(&mut self, child: &Self) {
+        self.recorded_logs = child.recorded_logs.clone();
+        self.access_record = child.access_record.clone();
+    }
+
     pub(crate) fn merge_reverted_top_level_effects(&mut self, reverted: &Self) {
         self.merge_noncommitting_check_constraints(reverted);
         self.block = reverted.block.clone();
-        self.recorded_logs = reverted.recorded_logs.clone();
-        self.access_record = reverted.access_record.clone();
+        self.inherit_inspector_recordings(reverted);
         self.expected_revert = reverted.expected_revert.clone();
         self.assume_no_revert_next_call = reverted.assume_no_revert_next_call.clone();
         self.expected_emit = reverted.expected_emit.clone();
@@ -930,6 +934,7 @@ impl AccessRecord {
     }
 
     pub(crate) fn write(&mut self, address: Address, slot: SymExpr) {
+        self.read(address, slot.clone());
         Self::push_unique_slot(self.writes.entry(address).or_default(), slot);
     }
 

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -494,6 +494,15 @@ contract SymbolicLogEmitter {
     }
 }
 
+contract SymbolicRevertingLogConstructor {
+    event ConstructorLog();
+
+    constructor() {
+        emit ConstructorLog();
+        revert();
+    }
+}
+
 contract SymbolicRecordedLogs is Test {
     event Local(uint256 indexed topic, bytes data);
 
@@ -512,7 +521,7 @@ contract SymbolicRecordedLogs is Test {
         try emitter.fail(topic + 2, data) {} catch {}
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
-        assertEq(logs.length, 2);
+        assertEq(logs.length, 3);
 
         assertEq(logs[0].topics.length, 2);
         assertEq(logs[0].topics[0], keccak256("Local(uint256,bytes)"));
@@ -526,6 +535,11 @@ contract SymbolicRecordedLogs is Test {
         assertEq(logs[1].topics[0], keccak256("Helper(uint256,bytes)"));
         assertEq(logs[1].topics[1], bytes32(topic + 1));
         assertEq(logs[1].emitter, address(emitter));
+
+        assertEq(logs[2].topics.length, 2);
+        assertEq(logs[2].topics[0], keccak256("Helper(uint256,bytes)"));
+        assertEq(logs[2].topics[1], bytes32(topic + 2));
+        assertEq(logs[2].emitter, address(emitter));
 
         Vm.Log[] memory drained = vm.getRecordedLogs();
         assertEq(drained.length, 0);
@@ -541,6 +555,15 @@ contract SymbolicRecordedLogs is Test {
 
         Vm.Log[] memory drained = vm.getRecordedLogs();
         assertEq(drained.length, 0);
+    }
+
+    function checkRecordedRevertedCreate() public {
+        vm.recordLogs();
+        try new SymbolicRevertingLogConstructor() {} catch {}
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        assertEq(logs[0].topics[0], keccak256("ConstructorLog()"));
     }
 }
 "#,
@@ -562,6 +585,12 @@ contract SymbolicRecordedLogs is Test {
         &stdout,
         foundry_test_utils::str![[r#"
 [PASS] checkRecordedLogsJson(uint256,bytes)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRecordedRevertedCreate()
 "#]],
     );
     assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
@@ -3559,6 +3588,15 @@ forgetest_init!(symbolic_vm_record_accesses_tracks_symbolic_slots, |prj, cmd| {
         r#"
 import "forge-std/Test.sol";
 
+contract SymbolicRevertingStorageTarget {
+    function storeThenRevert(bytes32 slot, bytes32 stored) external {
+        assembly {
+            sstore(slot, stored)
+        }
+        revert();
+    }
+}
+
 contract SymbolicRecordAccesses is Test {
     function checkRecordAccesses(bytes32 slot, bytes32 stored) public {
         vm.record();
@@ -3624,9 +3662,37 @@ contract SymbolicRecordAccesses is Test {
 
         vm.stopRecord();
     }
+
+    function testRecordRevertedChildAccesses() public {
+        recordRevertedChildAccesses();
+    }
+
+    function checkRecordAccessesRevertedChild() public {
+        recordRevertedChildAccesses();
+    }
+
+    function recordRevertedChildAccesses() internal {
+        SymbolicRevertingStorageTarget target = new SymbolicRevertingStorageTarget();
+        bytes32 slot = bytes32(uint256(7));
+
+        vm.record();
+        (bool ok,) = address(target).call(
+            abi.encodeCall(target.storeThenRevert, (slot, bytes32(uint256(1))))
+        );
+        assertFalse(ok);
+
+        (bytes32[] memory reads, bytes32[] memory writes) = vm.accesses(address(target));
+        assertEq(reads.length, 1);
+        assertEq(writes.length, 1);
+        assertEq(reads[0], slot);
+        assertEq(writes[0], slot);
+    }
 }
 "#,
     );
+
+    cmd.args(["test", "--match-test", "testRecordRevertedChildAccesses"]).assert_success();
+    cmd.forge_fuse();
 
     let stdout = cmd
         .args(["test", "--symbolic", "--match-test", "checkRecordAccesses"])
@@ -3638,6 +3704,12 @@ contract SymbolicRecordAccesses is Test {
         &stdout,
         foundry_test_utils::str![[r#"
 [PASS] checkRecordAccesses(bytes32,bytes32)
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkRecordAccessesRevertedChild()
 "#]],
     );
     assert_relevant_lines(
@@ -4150,7 +4222,10 @@ contract OkDeployCodeCtor {
 }
 
 contract RevertingDeployCodeCtor {
+    event ConstructorLog();
+
     constructor() {
+        emit ConstructorLog();
         require(false, "ctor");
     }
 }
@@ -4176,8 +4251,13 @@ contract SymbolicDeployCodeCheatcode is Test {
     string constant TARGET = "test/SymbolicDeployCodeCheatcode.t.sol";
 
     function checkDeployCodeExpectedRevert() public {
+        vm.recordLogs();
         vm.expectRevert();
         vm.deployCode(string.concat(TARGET, ":RevertingDeployCodeCtor"));
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        assertEq(logs[0].topics[0], keccak256("ConstructorLog()"));
     }
 
     function checkDeployCodeBranchingConstructor() public {


### PR DESCRIPTION
Preserves log and storage-access recordings from reverted child calls, creates, and `deployCode` executions, matching concrete Forge inspector behavior while still rolling back transactional state.