### PR TITLE
fix(forge): report canonical fork blocks

### DIFF
--- a/.changelog/canonical-fork-block-reporting.md
+++ b/.changelog/canonical-fork-block-reporting.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed failed fork tests to report the backing fork block after `vm.roll` and fork snapshot changes.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1088,6 +1088,7 @@ impl Cheatcode for deleteSnapshotCall {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
         ccx.state.env_overrides_snapshots.remove(snapshotId);
+        ccx.state.fork_block_number_override_snapshots.remove(snapshotId);
         ccx.state.context_snapshots.remove(snapshotId);
         ccx.state.delete_created_accounts_snapshot(*snapshotId);
         Ok(result.abi_encode())
@@ -1099,6 +1100,7 @@ impl Cheatcode for deleteStateSnapshotCall {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
         ccx.state.env_overrides_snapshots.remove(snapshotId);
+        ccx.state.fork_block_number_override_snapshots.remove(snapshotId);
         ccx.state.context_snapshots.remove(snapshotId);
         ccx.state.delete_created_accounts_snapshot(*snapshotId);
         Ok(result.abi_encode())
@@ -1111,6 +1113,7 @@ impl Cheatcode for deleteSnapshotsCall {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
         ccx.state.env_overrides_snapshots.clear();
+        ccx.state.fork_block_number_override_snapshots.clear();
         ccx.state.context_snapshots.clear();
         ccx.state.clear_created_accounts_snapshots();
         Ok(Default::default())
@@ -1122,6 +1125,7 @@ impl Cheatcode for deleteStateSnapshotsCall {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
         ccx.state.env_overrides_snapshots.clear();
+        ccx.state.fork_block_number_override_snapshots.clear();
         ccx.state.context_snapshots.clear();
         ccx.state.clear_created_accounts_snapshots();
         Ok(Default::default())
@@ -1591,6 +1595,7 @@ fn inner_snapshot_state<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCtxt<'_, '_, FEN
     // snapshot so they can be rolled back in lockstep with `EvmEnv`. See
     // `Cheatcodes::env_overrides_snapshots`.
     ccx.state.env_overrides_snapshots.insert(id, all_env_overrides);
+    ccx.state.fork_block_number_override_snapshots.insert(id, ccx.state.fork_block_number_override);
     let factory = FEN::EvmFactory::default();
     ccx.state.context_snapshots.insert(
         id,
@@ -1667,6 +1672,11 @@ fn inner_revert_to_state<FEN: FoundryEvmNetwork>(
         if let Some(snap) = ccx.state.env_overrides_snapshots.get(&snapshot_id) {
             ccx.state.env_overrides = snap.clone();
         }
+        if let Some(&fork_block_number) =
+            ccx.state.fork_block_number_override_snapshots.get(&snapshot_id)
+        {
+            ccx.state.fork_block_number_override = fork_block_number;
+        }
         ccx.state.revert_created_accounts(snapshot_id, false);
         sync_tx_after_env_override_restore(ccx);
         Ok(true.abi_encode())
@@ -1699,6 +1709,11 @@ fn inner_revert_to_state_and_delete<FEN: FoundryEvmNetwork>(
         ccx.ecx.set_evm(evm_env);
         if let Some(snap) = ccx.state.env_overrides_snapshots.remove(&snapshot_id) {
             ccx.state.env_overrides = snap;
+        }
+        if let Some(fork_block_number) =
+            ccx.state.fork_block_number_override_snapshots.remove(&snapshot_id)
+        {
+            ccx.state.fork_block_number_override = fork_block_number;
         }
         ccx.state.revert_created_accounts(snapshot_id, true);
         sync_tx_after_env_override_restore(ccx);

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -472,6 +472,7 @@ fn record_fork_switch<FEN: FoundryEvmNetwork>(
     propagated: Vec<(Address, usize)>,
 ) {
     let target_fork_id = ccx.ecx.db().active_fork_id();
+    ccx.state.fork_block_number_override = ccx.ecx.db().active_fork_block_number();
     if source_fork_id != target_fork_id {
         ccx.state.commit_created_account_changes(source_fork_id);
     }
@@ -485,6 +486,7 @@ fn record_fork_roll<FEN: FoundryEvmNetwork>(
 ) {
     let active_fork_id = ccx.ecx.db().active_fork_id();
     if target_fork_id.is_none() || target_fork_id == active_fork_id {
+        ccx.state.fork_block_number_override = ccx.ecx.db().active_fork_block_number();
         ccx.state.commit_created_account_changes(active_fork_id);
     }
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -685,6 +685,11 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// execution block environment.
     pub block: Option<BlockEnvFor<FEN>>,
 
+    /// The active fork block override updated by a fork-switching cheatcode.
+    ///
+    /// This persists fork changes made through a copy-on-write backend between invariant calls.
+    pub fork_block_number_override: Option<u64>,
+
     /// Currently active EIP-7702 delegations that will be consumed when building the next
     /// transaction. Set by `vm.attachDelegation()` and consumed via `.take()` during
     /// transaction construction.
@@ -878,6 +883,9 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// the post-snapshot value even though `EvmEnv` was rolled back.
     pub env_overrides_snapshots: HashMap<U256, HashMap<Option<LocalForkId>, EnvOverrides>>,
 
+    /// Per-state-snapshot copies of [`Self::fork_block_number_override`].
+    pub fork_block_number_override_snapshots: HashMap<U256, Option<u64>>,
+
     /// Transaction-position context and family-owned execution state captured atomically alongside
     /// state snapshots.
     pub context_snapshots: HashMap<U256, (ChainContextFor<FEN>, TransactionStateFor<FEN>)>,
@@ -912,6 +920,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             labels: config.labels.clone(),
             config,
             block: Default::default(),
+            fork_block_number_override: Default::default(),
             active_delegations: Default::default(),
             active_blob_sidecar: Default::default(),
             gas_price: Default::default(),
@@ -968,6 +977,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             execution_evm_version: None,
             env_overrides: Default::default(),
             env_overrides_snapshots: Default::default(),
+            fork_block_number_override_snapshots: Default::default(),
             context_snapshots: Default::default(),
             in_isolation_context: false,
         }

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -42,7 +42,6 @@ use foundry_evm_core::{
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::ObservedCall;
-use foundry_evm_networks::arbitrum;
 use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     bytecode::Bytecode,
@@ -1551,17 +1550,6 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
     has_state_snapshot_failure: bool,
     fork_block_number: Option<u64>,
 ) -> eyre::Result<RawCallResult<FEN>> {
-    // The backend carries the canonical fork pin, but a call may advance the execution block
-    // without publishing its copy-on-write backend (notably invariant `rollFork` calls). Use the
-    // post-call EVM block on regular chains so a later failing invariant observes that advancement.
-    // Arbitrum is the exception: its EVM block can be the lower L1 block while the fork pin is L2.
-    let fork_block_number = fork_block_number.map(|block| {
-        if arbitrum::is_arbitrum_chain(evm_env.cfg_env.chain_id) {
-            block
-        } else {
-            evm_env.block_env.number().saturating_to::<u64>()
-        }
-    });
     let execution_cancelled = inspector.execution_cancelled();
     let (exit_reason, gas_refunded, gas_used, out, exec_logs) = match result {
         ExecutionResult::Success { reason, gas, output, logs } => {
@@ -1602,6 +1590,10 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
         chisel_state,
         reverter,
     } = inspector.collect();
+    let fork_block_number = cheatcodes
+        .as_ref()
+        .and_then(|cheats| cheats.fork_block_number_override)
+        .or(fork_block_number);
     let debug_bytecodes = collect_debug_bytecodes(traces.as_ref(), db);
 
     if logs.is_empty() {

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -1217,6 +1217,86 @@ Tip: Run `forge test --rerun` to retry only the 2 failed tests
 "#]]);
 });
 
+forgetest_init!(invariant_roll_inactive_fork_preserves_active_block, |prj, cmd| {
+    prj.add_rpc_endpoints();
+    prj.update_config(|config| {
+        config.fuzz.seed = Some(U256::from(119u32));
+        config.invariant.shrink_run_limit = 0;
+    });
+
+    prj.add_test(
+        "InvariantInactiveRollFork.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract InactiveRollForkHandler is Test {
+    uint256 immutable inactiveFork;
+    uint256 public calls;
+
+    constructor(uint256 inactiveFork_) {
+        inactiveFork = inactiveFork_;
+    }
+
+    function work() external {
+        calls++;
+        if (calls == 1) {
+            vm.rollFork(block.number + 1);
+        } else {
+            vm.rollFork(inactiveFork, block.number + 1);
+        }
+    }
+}
+
+contract InvariantInactiveRollForkTest is Test {
+    InactiveRollForkHandler forkHandler;
+
+    function setUp() public {
+        vm.createSelectFork("mainnet", 19812632);
+        uint256 inactiveFork = vm.createFork("mainnet", 19812632);
+        forkHandler = new InactiveRollForkHandler(inactiveFork);
+        targetContract(address(forkHandler));
+    }
+
+    /// forge-config: default.invariant.runs = 1
+    /// forge-config: default.invariant.depth = 2
+    function invariant_inactive_roll_preserves_active_block() public view {
+        require(forkHandler.calls() < 2, "inactive fork rolled");
+    }
+}
+"#,
+    );
+
+    assert_invariant(cmd.args(["test", "-j1"])).failure().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/InvariantInactiveRollFork.t.sol:InvariantInactiveRollForkTest
+[FAIL: inactive fork rolled]
+	[SEQUENCE]
+ invariant_inactive_roll_preserves_active_block() (block: 19812633) ([RUNS])
+
+[STATS]
+
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/InvariantInactiveRollFork.t.sol:InvariantInactiveRollForkTest
+[FAIL: inactive fork rolled]
+	[SEQUENCE]
+ invariant_inactive_roll_preserves_active_block() (block: 19812633) ([RUNS])
+
+Encountered a total of 1 failing tests, 0 tests succeeded
+
+Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+[SEED] (use `--fuzz-seed` to reproduce)
+
+"#]]);
+});
+
 forgetest_init!(invariant_scrape_values, |prj, cmd| {
     prj.update_config(|config| {
         config.invariant.depth = 10;

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -1280,6 +1280,10 @@ interface Vm {{
     function createSelectFork(string calldata url, uint256 blockNumber)
         external
         returns (uint256 forkId);
+    function roll(uint256 newHeight) external;
+    function rollFork(uint256 blockNumber) external;
+    function snapshotState() external returns (uint256 snapshotId);
+    function revertToState(uint256 snapshotId) external returns (bool success);
 }}
 
 contract ForkBlockTest {{
@@ -1288,6 +1292,20 @@ contract ForkBlockTest {{
     function testForkFailure() public {{
         vm.createSelectFork("{endpoint}", 7);
         require(false, "fork failure");
+    }}
+
+    function testForkFailureAfterRoll() public {{
+        vm.createSelectFork("{endpoint}", 7);
+        vm.roll(99);
+        require(false, "fork failure after roll");
+    }}
+
+    function testForkFailureAfterRevert() public {{
+        vm.createSelectFork("{endpoint}", 7);
+        uint256 snapshot = vm.snapshotState();
+        vm.rollFork(6);
+        vm.revertToState(snapshot);
+        require(false, "fork failure after revert");
     }}
 
     function testForkSuccess() public {{
@@ -1309,23 +1327,27 @@ contract ForkBlockTest {{
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
-Ran 4 tests for test/ForkBlock.t.sol:ForkBlockTest
+Ran 6 tests for test/ForkBlock.t.sol:ForkBlockTest
 [FAIL: fork failure] testForkFailure() (block: 7) ([GAS])
+[FAIL: fork failure after revert] testForkFailureAfterRevert() (block: 7) ([GAS])
+[FAIL: fork failure after roll] testForkFailureAfterRoll() (block: 7) ([GAS])
 [PASS] testForkSuccess() ([GAS])
 [FAIL: local failure] testLocalFailure() ([GAS])
 [PASS] testLocalSuccess() ([GAS])
-Suite result: FAILED. 2 passed; 2 failed; 0 skipped; [ELAPSED]
+Suite result: FAILED. 2 passed; 4 failed; 0 skipped; [ELAPSED]
 
-Ran 1 test suite [ELAPSED]: 2 tests passed, 2 failed, 0 skipped (4 total tests)
+Ran 1 test suite [ELAPSED]: 2 tests passed, 4 failed, 0 skipped (6 total tests)
 
 Failing tests:
-Encountered 2 failing tests in test/ForkBlock.t.sol:ForkBlockTest
+Encountered 4 failing tests in test/ForkBlock.t.sol:ForkBlockTest
 [FAIL: fork failure] testForkFailure() (block: 7) ([GAS])
+[FAIL: fork failure after revert] testForkFailureAfterRevert() (block: 7) ([GAS])
+[FAIL: fork failure after roll] testForkFailureAfterRoll() (block: 7) ([GAS])
 [FAIL: local failure] testLocalFailure() ([GAS])
 
-Encountered a total of 2 failing tests, 2 tests succeeded
+Encountered a total of 4 failing tests, 2 tests succeeded
 
-Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --rerun` to retry only the 4 failed tests
 Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);


### PR DESCRIPTION
Failed fork tests can report the execution block after `vm.roll` rather than the backing fork block, producing misleading reproduction information.

This preserves the canonical fork block while separately tracking real fork transitions such as `rollFork` and `selectFork`, including invariant campaigns using copy-on-write backends. Snapshot restoration and inactive fork rolls also preserve the correct active fork block.