### PR TITLE
fix(anvil): support block IDs in witnesses

### DIFF
--- a/.changelog/anvil-execution-witness-block-id.md
+++ b/.changelog/anvil-execution-witness-block-id.md
@@ -2,4 +2,4 @@
 anvil: patch
 ---
 
-Added block hash and EIP-1898 selectors and the optional legacy mode to `debug_executionWitness`.
+Added block hash and EIP-1898 selectors to `debug_executionWitness`, resolving hashes to the exact block they name.

--- a/.changelog/anvil-execution-witness-block-id.md
+++ b/.changelog/anvil-execution-witness-block-id.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Added block hash and EIP-1898 selectors and the optional legacy mode to `debug_executionWitness`.

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -39,6 +39,14 @@ pub struct Params<T> {
     pub params: T,
 }
 
+/// The witness generation mode supported by `debug_executionWitness`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExecutionWitnessMode {
+    /// Produces the legacy execution witness format.
+    Legacy,
+}
+
 /// Represents ethereum JSON-RPC API
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(tag = "method", content = "params")]
@@ -410,8 +418,8 @@ pub enum EthRequest {
     DebugAccountInfoAt(BlockId, Index, Address),
 
     /// reth's `debug_executionWitness` endpoint.
-    #[serde(rename = "debug_executionWitness", with = "sequence")]
-    DebugExecutionWitness(BlockNumber),
+    #[serde(rename = "debug_executionWitness")]
+    DebugExecutionWitness(BlockId, #[serde(default)] Option<ExecutionWitnessMode>),
 
     /// geth's `debug_traceBlock` endpoint.
     #[serde(rename = "debug_traceBlock")]
@@ -1897,9 +1905,25 @@ true}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
-        let s = r#"{"method": "debug_executionWitness", "params": ["latest"]}"#;
+        let s = r#"{"method": "debug_executionWitness", "params": ["latest", null]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "debug_executionWitness", "params": ["0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "legacy"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "debug_executionWitness", "params": [{"blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": true}, "legacy"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "debug_executionWitness", "params": [{"blockNumber": "0x1"}, null]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "debug_executionWitness", "params": ["latest", "canonical"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        assert!(serde_json::from_value::<EthRequest>(value).is_err());
     }
 
     #[test]

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -39,14 +39,6 @@ pub struct Params<T> {
     pub params: T,
 }
 
-/// The witness generation mode supported by `debug_executionWitness`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ExecutionWitnessMode {
-    /// Produces the legacy execution witness format.
-    Legacy,
-}
-
 /// Represents ethereum JSON-RPC API
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(tag = "method", content = "params")]
@@ -418,8 +410,8 @@ pub enum EthRequest {
     DebugAccountInfoAt(BlockId, Index, Address),
 
     /// reth's `debug_executionWitness` endpoint.
-    #[serde(rename = "debug_executionWitness")]
-    DebugExecutionWitness(BlockId, #[serde(default)] Option<ExecutionWitnessMode>),
+    #[serde(rename = "debug_executionWitness", with = "sequence")]
+    DebugExecutionWitness(BlockId),
 
     /// geth's `debug_traceBlock` endpoint.
     #[serde(rename = "debug_traceBlock")]
@@ -1905,25 +1897,21 @@ true}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
-        let s = r#"{"method": "debug_executionWitness", "params": ["latest", null]}"#;
+        let s = r#"{"method": "debug_executionWitness", "params": ["latest"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
-        let s = r#"{"method": "debug_executionWitness", "params": ["0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "legacy"]}"#;
+        let s = r#"{"method": "debug_executionWitness", "params": ["0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
-        let s = r#"{"method": "debug_executionWitness", "params": [{"blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": true}, "legacy"]}"#;
+        let s = r#"{"method": "debug_executionWitness", "params": [{"blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": true}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
-        let s = r#"{"method": "debug_executionWitness", "params": [{"blockNumber": "0x1"}, null]}"#;
+        let s = r#"{"method": "debug_executionWitness", "params": [{"blockNumber": "0x1"}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
-
-        let s = r#"{"method": "debug_executionWitness", "params": ["latest", "canonical"]}"#;
-        let value: serde_json::Value = serde_json::from_str(s).unwrap();
-        assert!(serde_json::from_value::<EthRequest>(value).is_err());
     }
 
     #[test]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -86,7 +86,7 @@ use alloy_serde::WithOtherFields;
 use alloy_sol_types::{SolCall, SolValue, sol};
 use anvil_core::{
     eth::{
-        EthRequest, ExecutionWitnessMode,
+        EthRequest,
         block::{BlockInfo, canonical_block},
         transaction::{MaybeImpersonatedTransaction, PendingTransaction},
     },
@@ -1628,11 +1628,7 @@ impl EthApi<FoundryNetwork> {
     /// contents and limitations.
     ///
     /// Handler for RPC call: `debug_executionWitness`.
-    pub async fn debug_execution_witness(
-        &self,
-        block: BlockId,
-        _mode: Option<ExecutionWitnessMode>,
-    ) -> Result<ExecutionWitness> {
+    pub async fn debug_execution_witness(&self, block: BlockId) -> Result<ExecutionWitness> {
         node_info!("debug_executionWitness");
         self.backend.debug_execution_witness(block).await
     }
@@ -2133,8 +2129,8 @@ impl EthApi<FoundryNetwork> {
             EthRequest::DebugAccountInfoAt(block_id, tx_index, address) => {
                 self.debug_account_info_at(block_id, tx_index, address).await.to_rpc_result()
             }
-            EthRequest::DebugExecutionWitness(block, mode) => {
-                self.debug_execution_witness(block, mode).await.to_rpc_result()
+            EthRequest::DebugExecutionWitness(block) => {
+                self.debug_execution_witness(block).await.to_rpc_result()
             }
             EthRequest::DebugTraceBlock(rlp_block, opts) => {
                 self.debug_trace_block(rlp_block, opts).await.to_rpc_result()

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -86,7 +86,7 @@ use alloy_serde::WithOtherFields;
 use alloy_sol_types::{SolCall, SolValue, sol};
 use anvil_core::{
     eth::{
-        EthRequest,
+        EthRequest, ExecutionWitnessMode,
         block::{BlockInfo, canonical_block},
         transaction::{MaybeImpersonatedTransaction, PendingTransaction},
     },
@@ -1628,7 +1628,11 @@ impl EthApi<FoundryNetwork> {
     /// contents and limitations.
     ///
     /// Handler for RPC call: `debug_executionWitness`.
-    pub async fn debug_execution_witness(&self, block: BlockNumber) -> Result<ExecutionWitness> {
+    pub async fn debug_execution_witness(
+        &self,
+        block: BlockId,
+        _mode: Option<ExecutionWitnessMode>,
+    ) -> Result<ExecutionWitness> {
         node_info!("debug_executionWitness");
         self.backend.debug_execution_witness(block).await
     }
@@ -2129,8 +2133,8 @@ impl EthApi<FoundryNetwork> {
             EthRequest::DebugAccountInfoAt(block_id, tx_index, address) => {
                 self.debug_account_info_at(block_id, tx_index, address).await.to_rpc_result()
             }
-            EthRequest::DebugExecutionWitness(block) => {
-                self.debug_execution_witness(block).await.to_rpc_result()
+            EthRequest::DebugExecutionWitness(block, mode) => {
+                self.debug_execution_witness(block, mode).await.to_rpc_result()
             }
             EthRequest::DebugTraceBlock(rlp_block, opts) => {
                 self.debug_trace_block(rlp_block, opts).await.to_rpc_result()

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -179,7 +179,7 @@ use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, POST_EXEC_TX_TYPE_ID};
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use revm::{
-    Database as RevmDatabase, DatabaseCommit, Inspector,
+    Database as RevmDatabase, DatabaseCommit, DatabaseRef as RevmDatabaseRef, Inspector,
     context::{Block as RevmBlock, BlockEnv, Cfg, CfgEnv, ContextSetters, ContextTr, TxEnv},
     context_interface::{
         JournalTr,
@@ -7064,20 +7064,45 @@ where
         &self,
         block: BlockId,
     ) -> Result<ExecutionWitness, BlockchainError> {
-        let number = self.ensure_block_number(Some(block)).await?;
-        let Some(parent) = number.checked_sub(1) else {
+        // Resolve hashes to the exact block they name instead of reducing them to a number: a
+        // hash can refer to a block that was since replaced at the same height (e.g. via
+        // `anvil_loadState`) and must not be conflated with the canonical block at that number.
+        let block = match block {
+            BlockId::Hash(id) => {
+                let block =
+                    self.get_block_by_hash(id.block_hash).ok_or(BlockchainError::BlockNotFound)?;
+                if id.require_canonical == Some(true)
+                    && self.block_hash_by_number(block.header.number()) != Some(id.block_hash)
+                {
+                    return Err(BlockchainError::Message(
+                        "hash is not currently canonical".to_string(),
+                    ));
+                }
+                block
+            }
+            BlockId::Number(number) => {
+                let number = self.ensure_block_number(Some(number)).await?;
+                self.get_block(number).ok_or(BlockchainError::BlockNotFound)?
+            }
+        };
+
+        if block.header.number() == self.genesis_number() {
             return Err(BlockchainError::Message(
                 "genesis block has no parent state to build a witness from".to_string(),
             ));
-        };
+        }
 
+        // Walk ancestors by parent hash so a non-canonical block collects its own chain of
+        // headers.
         let mut headers = Vec::new();
-        for ancestor in (number.saturating_sub(BLOCKHASH_HISTORY)..number).rev() {
-            let Some(block) = self.get_block(ancestor) else { break };
+        let mut ancestor = block.header.parent_hash;
+        while (headers.len() as u64) < BLOCKHASH_HISTORY {
+            let Some(block) = self.get_block_by_hash(ancestor) else { break };
+            ancestor = block.header.parent_hash;
             headers.push(alloy_rlp::encode(&block.header).into());
         }
 
-        self.with_database_at(Some(BlockRequest::Number(parent)), |state, _| {
+        let build = |state: &StateDb| -> Result<ExecutionWitness, BlockchainError> {
             let Some(accounts) = state.maybe_full_db() else {
                 return Err(BlockchainError::Message(
                     "debug_executionWitness is not supported while forking".to_string(),
@@ -7107,8 +7132,21 @@ where
             keys.dedup();
 
             Ok(ExecutionWitness { state: nodes, codes, keys, headers })
-        })
-        .await?
+        };
+
+        // The witness is built from the parent block's state, looked up by the parent hash so
+        // the state matches the requested block even off the canonical chain.
+        let parent_hash = block.header.parent_hash;
+        let read_guard = self.states.upgradable_read();
+        if let Some(state) = read_guard.get_state(&parent_hash) {
+            build(state)
+        } else {
+            let mut write_guard = RwLockUpgradableReadGuard::upgrade(read_guard);
+            let state = write_guard
+                .get_on_disk_state(&parent_hash)
+                .ok_or(BlockchainError::BlockNotFound)?;
+            build(state)
+        }
     }
 
     /// Returns account information after replaying a block through the transaction at `tx_index`.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -7062,13 +7062,9 @@ where
     ///   known locally, which may be fewer than 256.
     pub async fn debug_execution_witness(
         &self,
-        block: BlockNumber,
+        block: BlockId,
     ) -> Result<ExecutionWitness, BlockchainError> {
-        let number = self.convert_block_number(Some(block));
-        let best = self.best_number();
-        if number > best {
-            return Err(BlockchainError::BlockOutOfRange(best, number));
-        }
+        let number = self.ensure_block_number(Some(block)).await?;
         let Some(parent) = number.checked_sub(1) else {
             return Err(BlockchainError::Message(
                 "genesis block has no parent state to build a witness from".to_string(),

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -1200,7 +1200,7 @@ async fn can_get_execution_witness() {
     let number = receipt.block_number.unwrap();
 
     // No witness exists for the genesis block since it has no parent state.
-    api.debug_execution_witness(BlockId::number(0), None).await.unwrap_err();
+    api.debug_execution_witness(BlockId::number(0)).await.unwrap_err();
 
     let witness: ExecutionWitness = provider
         .client()
@@ -1211,17 +1211,14 @@ async fn can_get_execution_witness() {
     let block = provider.get_block(BlockId::number(number)).await.unwrap().unwrap();
     let by_hash: ExecutionWitness = provider
         .client()
-        .request("debug_executionWitness", (BlockId::hash(block.header.hash), Some("legacy")))
+        .request("debug_executionWitness", (BlockId::hash(block.header.hash),))
         .await
         .unwrap();
     assert_eq!(by_hash, witness);
 
     let by_eip1898: ExecutionWitness = provider
         .client()
-        .request(
-            "debug_executionWitness",
-            (BlockId::hash_canonical(block.header.hash), Option::<&str>::None),
-        )
+        .request("debug_executionWitness", (BlockId::hash_canonical(block.header.hash),))
         .await
         .unwrap();
     assert_eq!(by_eip1898, witness);
@@ -1251,4 +1248,70 @@ async fn can_get_execution_witness() {
         .await
         .unwrap();
     assert_eq!(historical, witness);
+}
+
+// After `anvil_loadState` replaces a block at the same height, the replaced block remains
+// addressable by hash and must resolve to its own witness instead of the canonical block's.
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_execution_witness_for_replaced_block() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    let accounts: Vec<_> = handle.dev_wallets().collect();
+    let signer: EthereumWallet = accounts[0].clone().into();
+    let from = accounts[0].address();
+    let to = accounts[1].address();
+    let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
+
+    let genesis_dump = api.anvil_dump_state(None).await.unwrap();
+
+    // A transfer in block 1 so the parent state of block 2 differs from the replacement chain.
+    let tx = TransactionRequest::default().with_from(from).with_to(to).with_value(U256::from(100));
+    provider.send_transaction(WithOtherFields::new(tx)).await.unwrap().get_receipt().await.unwrap();
+    api.mine_one().await.unwrap();
+
+    let stale = provider.get_block(BlockId::number(2)).await.unwrap().unwrap();
+    let stale_witness: ExecutionWitness = provider
+        .client()
+        .request("debug_executionWitness", (BlockId::hash(stale.header.hash),))
+        .await
+        .unwrap();
+
+    // Rewind to genesis and mine a different chain to the same height: block 2 is replaced, but
+    // the old block remains addressable by hash.
+    assert!(api.anvil_load_state(genesis_dump).await.unwrap());
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
+
+    let canonical = provider.get_block(BlockId::number(2)).await.unwrap().unwrap();
+    assert_ne!(canonical.header.hash, stale.header.hash);
+
+    // The stale hash still resolves to its own witness, not the canonical block's.
+    let by_stale_hash: ExecutionWitness = provider
+        .client()
+        .request("debug_executionWitness", (BlockId::hash(stale.header.hash),))
+        .await
+        .unwrap();
+    assert_eq!(by_stale_hash, stale_witness);
+
+    let canonical_witness: ExecutionWitness =
+        provider.client().request("debug_executionWitness", (BlockId::number(2),)).await.unwrap();
+    assert_ne!(canonical_witness, stale_witness);
+
+    // The replaced block is no longer canonical, so `requireCanonical` must reject it while
+    // still serving the canonical block at the same height.
+    provider
+        .client()
+        .request::<_, ExecutionWitness>(
+            "debug_executionWitness",
+            (BlockId::hash_canonical(stale.header.hash),),
+        )
+        .await
+        .unwrap_err();
+
+    let by_canonical_hash: ExecutionWitness = provider
+        .client()
+        .request("debug_executionWitness", (BlockId::hash_canonical(canonical.header.hash),))
+        .await
+        .unwrap();
+    assert_eq!(by_canonical_hash, canonical_witness);
 }

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -1200,13 +1200,31 @@ async fn can_get_execution_witness() {
     let number = receipt.block_number.unwrap();
 
     // No witness exists for the genesis block since it has no parent state.
-    api.debug_execution_witness(BlockNumberOrTag::Number(0)).await.unwrap_err();
+    api.debug_execution_witness(BlockId::number(0), None).await.unwrap_err();
 
     let witness: ExecutionWitness = provider
         .client()
         .request("debug_executionWitness", (BlockNumberOrTag::Number(number),))
         .await
         .unwrap();
+
+    let block = provider.get_block(BlockId::number(number)).await.unwrap().unwrap();
+    let by_hash: ExecutionWitness = provider
+        .client()
+        .request("debug_executionWitness", (BlockId::hash(block.header.hash), Some("legacy")))
+        .await
+        .unwrap();
+    assert_eq!(by_hash, witness);
+
+    let by_eip1898: ExecutionWitness = provider
+        .client()
+        .request(
+            "debug_executionWitness",
+            (BlockId::hash_canonical(block.header.hash), Option::<&str>::None),
+        )
+        .await
+        .unwrap();
+    assert_eq!(by_eip1898, witness);
 
     // The witness contains the full parent state trie, so the parent state root must be among the
     // collected nodes.


### PR DESCRIPTION
Follow-up to #16185. `debug_executionWitness` now accepts reth-compatible `BlockId` selectors, including block hashes and EIP-1898 objects. The original request type narrowed the selector to `BlockNumberOrTag`.

Hashes are resolved to the exact block they name instead of being reduced to a number: the witness is built from the parent state looked up by the parent hash and the ancestor headers are walked by parent hash. A block that was replaced at the same height (e.g. via `anvil_loadState`) therefore still resolves to its own witness rather than the canonical block's, and `requireCanonical: true` rejects hashes that are no longer canonical.

AI assisted with the implementation and tests.