### PR TITLE
feat(anvil): add getLastBlockWallTime RPC

### DIFF
--- a/.changelog/anvil-last-block-wall-time.md
+++ b/.changelog/anvil-last-block-wall-time.md
@@ -1,0 +1,5 @@
+---
+anvil: minor
+---
+
+Added the `anvil_getLastBlockWallTime` RPC method to return when the latest block was created as UNIX time in milliseconds.

--- a/.changelog/anvil-last-block-wall-time.md
+++ b/.changelog/anvil-last-block-wall-time.md
@@ -2,4 +2,4 @@
 anvil: minor
 ---
 
-Added the `anvil_getLastBlockWallTime` RPC method to return when the latest block was created as UNIX time in milliseconds.
+Added the `anvil_getLastBlockWallTime` RPC method to return when the current head was installed as UNIX time in milliseconds.

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -272,7 +272,7 @@ pub enum EthRequest {
     #[serde(rename = "anvil_getGenesisTime", with = "empty_params")]
     GetGenesisTime(()),
 
-    /// Returns the UNIX wall time in milliseconds when the latest block was created.
+    /// Returns the UNIX wall time in milliseconds when the current head was installed.
     #[serde(rename = "anvil_getLastBlockWallTime", with = "empty_params")]
     GetLastBlockWallTime(()),
 

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -272,6 +272,10 @@ pub enum EthRequest {
     #[serde(rename = "anvil_getGenesisTime", with = "empty_params")]
     GetGenesisTime(()),
 
+    /// Returns the UNIX wall time in milliseconds when the latest block was created.
+    #[serde(rename = "anvil_getLastBlockWallTime", with = "empty_params")]
+    GetLastBlockWallTime(()),
+
     #[serde(rename = "eth_getTransactionByBlockHashAndIndex")]
     EthGetTransactionByBlockHashAndIndex(B256, Index),
 
@@ -1107,6 +1111,16 @@ mod tests {
         let s = r#"{"method": "anvil_getAutomine", "params": []}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_custom_get_last_block_wall_time() {
+        let s = r#"{"method": "anvil_getLastBlockWallTime", "params": []}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        assert!(matches!(
+            serde_json::from_value::<EthRequest>(value).unwrap(),
+            EthRequest::GetLastBlockWallTime(())
+        ));
     }
 
     #[test]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -761,7 +761,7 @@ impl<N: Network> EthApi<N> {
         Ok(self.backend.genesis_time())
     }
 
-    /// Returns the UNIX wall time in milliseconds when the latest block was created.
+    /// Returns the UNIX wall time in milliseconds when the current head was installed.
     ///
     /// Handler for RPC call: `anvil_getLastBlockWallTime`
     pub fn anvil_get_last_block_wall_time(&self) -> Result<u64> {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -569,7 +569,7 @@ impl<N: Network> EthApi<N> {
     pub fn evm_set_time(&self, timestamp: u64) -> Result<u64> {
         node_info!("evm_setTime");
         let now = self.backend.time().current_call_timestamp();
-        self.backend.time().reset(timestamp);
+        self.backend.time().set_time(timestamp);
 
         // number of seconds between the given timestamp and the current time.
         let offset = timestamp.saturating_sub(now);
@@ -759,6 +759,14 @@ impl<N: Network> EthApi<N> {
     pub fn anvil_get_genesis_time(&self) -> Result<u64> {
         node_info!("anvil_getGenesisTime");
         Ok(self.backend.genesis_time())
+    }
+
+    /// Returns the UNIX wall time in milliseconds when the latest block was created.
+    ///
+    /// Handler for RPC call: `anvil_getLastBlockWallTime`
+    pub fn anvil_get_last_block_wall_time(&self) -> Result<u64> {
+        node_info!("anvil_getLastBlockWallTime");
+        Ok(self.backend.time().last_block_wall_time())
     }
 
     /// Reset the fork to a fresh forked state, and optionally update the fork config.
@@ -2059,6 +2067,9 @@ impl EthApi<FoundryNetwork> {
                 self.anvil_get_blob_by_tx_hash(hash).to_rpc_result()
             }
             EthRequest::GetGenesisTime(()) => self.anvil_get_genesis_time().to_rpc_result(),
+            EthRequest::GetLastBlockWallTime(()) => {
+                self.anvil_get_last_block_wall_time().to_rpc_result()
+            }
             EthRequest::EthGetRawTransactionByBlockHashAndIndex(hash, index) => {
                 self.raw_transaction_by_block_hash_and_index(hash, index).await.to_rpc_result()
             }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5087,7 +5087,9 @@ impl<N: Network> Backend<N> {
         let Some((num, hash)) = self.active_state_snapshots.lock().remove(&id) else {
             return Ok(false);
         };
-        let best_block_hash = {
+        let block = self.block_by_hash(hash).await?.ok_or(BlockchainError::BlockNotFound)?;
+
+        {
             // revert the storage that's newer than the snapshot
             let current_height = self.best_number();
             let mut storage = self.blockchain.storage.write();
@@ -5108,10 +5110,7 @@ impl<N: Network> Backend<N> {
 
             storage.best_number = num;
             storage.best_hash = hash;
-            hash
-        };
-        let block =
-            self.block_by_hash(best_block_hash).await?.ok_or(BlockchainError::BlockNotFound)?;
+        }
 
         let reset_time = block.header.timestamp();
         self.time.reset(reset_time);
@@ -9798,6 +9797,25 @@ mod tests {
             source_fork_block_number: None,
             source_fork_block_hash: None,
         }
+    }
+
+    #[tokio::test]
+    async fn missing_snapshot_block_does_not_change_head() {
+        let (api, _handle) = spawn(NodeConfig::test()).await;
+        let snapshot_hash = api.backend.best_hash();
+        let snapshot = api.backend.create_state_snapshot().await;
+        api.mine_one().await.unwrap();
+        let best_number = api.backend.best_number();
+        let best_hash = api.backend.best_hash();
+        let head_wall_time = api.backend.time().last_block_wall_time();
+
+        api.backend.blockchain.storage.write().blocks.remove(&snapshot_hash);
+        let err = api.backend.revert_state_snapshot(snapshot).await.unwrap_err();
+
+        assert!(matches!(err, super::BlockchainError::BlockNotFound));
+        assert_eq!(api.backend.best_number(), best_number);
+        assert_eq!(api.backend.best_hash(), best_hash);
+        assert_eq!(api.backend.time().last_block_wall_time(), head_wall_time);
     }
 
     struct CacheFlushingDb(BlockchainDb);

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5926,7 +5926,6 @@ where
 
             storage.blocks.insert(block_hash, block);
             storage.hashes.insert(block_number, block_hash);
-            self.time.mark_block_created();
             #[cfg(feature = "monad")]
             if let Some(participants) = monad_participants {
                 storage.monad_block_participants.insert(block_hash, participants);
@@ -5969,6 +5968,8 @@ where
                     .saturating_sub(transaction_block_keeper.try_into().unwrap_or(u64::MAX));
                 storage.remove_block_transactions_by_number(to_clear)
             }
+
+            self.time.mark_block_created();
 
             // we intentionally set the difficulty to `0` for newer blocks
             evm_env.block_env.difficulty = U256::from(0);

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5926,6 +5926,7 @@ where
 
             storage.blocks.insert(block_hash, block);
             storage.hashes.insert(block_number, block_hash);
+            self.time.mark_block_created();
             #[cfg(feature = "monad")]
             if let Some(participants) = monad_participants {
                 storage.monad_block_participants.insert(block_hash, participants);

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -64,7 +64,7 @@ impl TimeManager {
         self.reset_timestamp(start_timestamp, true);
     }
 
-    /// Sets the current timestamp without changing when the latest block was created.
+    /// Sets the current timestamp without changing when the current head was installed.
     pub fn set_time(&self, timestamp: u64) {
         self.reset_timestamp(timestamp, false);
     }
@@ -86,7 +86,7 @@ impl TimeManager {
         self.state.read().offset
     }
 
-    /// Returns the UNIX wall time in milliseconds when the latest block was created.
+    /// Returns the UNIX wall time in milliseconds when the current head was installed.
     pub fn last_block_wall_time(&self) -> u64 {
         self.state.read().last_block_wall_time
     }

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -22,6 +22,7 @@ struct TimeState {
     offset: i128,
     offset_reset_generation: u64,
     last_timestamp: u64,
+    last_block_wall_time: u64,
     next_exact_timestamp: Option<TimestampOverride>,
     interval: Option<u64>,
     next_override_generation: u64,
@@ -60,10 +61,22 @@ impl TimeManager {
     /// Resets the current time manager to the given timestamp, resetting the offsets and
     /// next block timestamp option
     pub fn reset(&self, start_timestamp: u64) {
-        let current = duration_since_unix_epoch().as_secs() as i128;
+        self.reset_timestamp(start_timestamp, true);
+    }
+
+    /// Sets the current timestamp without changing when the latest block was created.
+    pub fn set_time(&self, timestamp: u64) {
+        self.reset_timestamp(timestamp, false);
+    }
+
+    fn reset_timestamp(&self, start_timestamp: u64, mark_new_head: bool) {
+        let current = duration_since_unix_epoch();
         let mut state = self.state.write();
         state.last_timestamp = start_timestamp;
-        state.offset = (start_timestamp as i128) - current;
+        if mark_new_head {
+            state.last_block_wall_time = current.as_millis().try_into().unwrap_or(u64::MAX);
+        }
+        state.offset = (start_timestamp as i128) - current.as_secs() as i128;
         state.offset_reset_generation = state.offset_reset_generation.wrapping_add(1);
         state.next_exact_timestamp = None;
         state.next_override_generation = state.next_override_generation.wrapping_add(1);
@@ -71,6 +84,17 @@ impl TimeManager {
 
     pub fn offset(&self) -> i128 {
         self.state.read().offset
+    }
+
+    /// Returns the UNIX wall time in milliseconds when the latest block was created.
+    pub fn last_block_wall_time(&self) -> u64 {
+        self.state.read().last_block_wall_time
+    }
+
+    /// Records that a new latest block was created.
+    pub(crate) fn mark_block_created(&self) {
+        self.state.write().last_block_wall_time =
+            duration_since_unix_epoch().as_millis().try_into().unwrap_or(u64::MAX);
     }
 
     /// Adds the given `offset` to the already tracked offset and returns the result

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -391,6 +391,30 @@ async fn can_mine_manually() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn get_last_block_wall_time_updates_after_mining() {
+    let before_spawn =
+        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    let genesis_wall_time = api.anvil_get_last_block_wall_time().unwrap();
+    let after_spawn =
+        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
+    assert!((before_spawn..=after_spawn).contains(&genesis_wall_time));
+
+    api.evm_set_time(api.backend.time().current_call_timestamp() + 60).unwrap();
+    assert_eq!(api.anvil_get_last_block_wall_time().unwrap(), genesis_wall_time);
+
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    let before_mining =
+        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
+    api.mine_one().await.unwrap();
+
+    let block_wall_time = api.anvil_get_last_block_wall_time().unwrap();
+    let after_mining =
+        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
+    assert!((before_mining..=after_mining).contains(&block_wall_time));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_set_next_timestamp() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -394,21 +394,26 @@ async fn can_mine_manually() {
 async fn get_last_block_wall_time_updates_after_mining() {
     let before_spawn =
         SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
-    let (api, _handle) = spawn(NodeConfig::test()).await;
-    let genesis_wall_time = api.anvil_get_last_block_wall_time().unwrap();
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let genesis_wall_time: u64 =
+        provider.raw_request("anvil_getLastBlockWallTime".into(), ()).await.unwrap();
     let after_spawn =
         SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
     assert!((before_spawn..=after_spawn).contains(&genesis_wall_time));
 
     api.evm_set_time(api.backend.time().current_call_timestamp() + 60).unwrap();
-    assert_eq!(api.anvil_get_last_block_wall_time().unwrap(), genesis_wall_time);
+    let unchanged_wall_time: u64 =
+        provider.raw_request("anvil_getLastBlockWallTime".into(), ()).await.unwrap();
+    assert_eq!(unchanged_wall_time, genesis_wall_time);
 
     tokio::time::sleep(Duration::from_millis(2)).await;
     let before_mining =
         SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
     api.mine_one().await.unwrap();
 
-    let block_wall_time = api.anvil_get_last_block_wall_time().unwrap();
+    let block_wall_time: u64 =
+        provider.raw_request("anvil_getLastBlockWallTime".into(), ()).await.unwrap();
     let after_mining =
         SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
     assert!((before_mining..=after_mining).contains(&block_wall_time));


### PR DESCRIPTION
Adds `anvil_getLastBlockWallTime`, returning the UNIX wall time in milliseconds when the current head was published. The marker updates only after successful mining, remains unchanged by `evm_setTime`, and resets when another head is installed.

This enables precise clock synchronization for real-time clients where second-resolution block timestamps are insufficient.

Closes #8217.