### PR TITLE
perf(forge): borrow test summaries

### DIFF
--- a/.changelog/forge-borrow-test-summary.md
+++ b/.changelog/forge-borrow-test-summary.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Reduced peak memory usage when printing `forge test --summary` results.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -2131,7 +2131,7 @@ impl TestArgs {
                 sh_println!("{}", outcome.summary(multi_pass_timer.elapsed()))?;
             }
             if self.summary && !outcome.results.is_empty() {
-                let summary_report = TestSummaryReport::new(self.detailed, outcome.clone());
+                let summary_report = TestSummaryReport::new(self.detailed, &outcome);
                 sh_println!("{}", &summary_report)?;
             }
 
@@ -3331,7 +3331,7 @@ impl TestArgs {
         }
 
         if !is_multi_pass && self.summary && !outcome.results.is_empty() {
-            let summary_report = TestSummaryReport::new(self.detailed, outcome.clone());
+            let summary_report = TestSummaryReport::new(self.detailed, &outcome);
             sh_println!("{summary_report}")?;
         }
 

--- a/crates/forge/src/cmd/test/summary.rs
+++ b/crates/forge/src/cmd/test/summary.rs
@@ -9,31 +9,31 @@ use serde_json::json;
 use std::{collections::HashMap, fmt::Display};
 
 /// Represents a test summary report.
-pub struct TestSummaryReport {
+pub struct TestSummaryReport<'a> {
     /// Whether the report should be detailed.
     is_detailed: bool,
     /// The test outcome to report.
-    outcome: TestOutcome,
+    outcome: &'a TestOutcome,
 }
 
-impl TestSummaryReport {
-    pub const fn new(is_detailed: bool, outcome: TestOutcome) -> Self {
+impl<'a> TestSummaryReport<'a> {
+    pub const fn new(is_detailed: bool, outcome: &'a TestOutcome) -> Self {
         Self { is_detailed, outcome }
     }
 }
 
-impl Display for TestSummaryReport {
+impl Display for TestSummaryReport<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         if shell::is_json() {
-            writeln!(f, "{}", self.format_json_output(&self.is_detailed, &self.outcome))?;
+            writeln!(f, "{}", self.format_json_output(&self.is_detailed, self.outcome))?;
         } else {
-            writeln!(f, "\n{}", self.format_table_output(&self.is_detailed, &self.outcome))?;
+            writeln!(f, "\n{}", self.format_table_output(&self.is_detailed, self.outcome))?;
         }
         Ok(())
     }
 }
 
-impl TestSummaryReport {
+impl TestSummaryReport<'_> {
     // Helper function to format the JSON output.
     fn format_json_output(&self, is_detailed: &bool, outcome: &TestOutcome) -> String {
         let output = json!({


### PR DESCRIPTION
`forge test --summary` deep-clones the complete test outcome just to render aggregate counts, temporarily duplicating retained logs, traces, labels, bytecodes, coverage, and counterexamples. This borrows the outcome in both the standard and multi-network summary paths instead, without changing output. Amp was used for investigation, implementation, benchmarking, tests, and drafting this description; I reviewed the resulting code and evidence.

### Results

Profiling builds on a deterministic setup-heavy fixture with 1,000 tests; Hyperfine used five measured runs, and peak RSS is the mean of three `/usr/bin/time -lp` runs. The meaningful result is memory usage; wall time remains sub-second.

| Metric | `master` | This PR |
| --- | ---: | ---: |
| Peak RSS | 2.19 GB | 1.12 GB |
| Wall time | 784 ± 46 ms | 591 ± 15 ms |