### PR TITLE
fix(forge): disable synthetic Tempo fees

### DIFF
--- a/.changelog/disable-synthetic-tempo-fees.md
+++ b/.changelog/disable-synthetic-tempo-fees.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm: patch
+---
+
+Fixed Tempo script execution charging or refunding fee tokens for synthetic transactions when using a non-zero gas price.

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1114,6 +1114,9 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
     ) -> (EvmEnvFor<FEN>, TxEnvFor<FEN>) {
         let mut cfg_env = self.evm_env.cfg_env.clone();
         cfg_env.spec = self.spec_id();
+        // Test transactions are synthetic and must not transfer real network fees. This remains
+        // necessary when the cheatcode handler restores the actual gas price during execution.
+        cfg_env.disable_fee_charge = true;
 
         // We always set the gas price to 0 so we can execute the transaction regardless of
         // network conditions - the actual gas price is kept in `self.block` and is applied
@@ -1928,6 +1931,27 @@ mod tests {
             &revm::context_interface::cfg::GasParams::new_spec(SpecId::AMSTERDAM),
         );
         assert!(executor.evm_env().cfg_env.is_amsterdam_eip8037_enabled());
+    }
+
+    #[test]
+    fn test_env_disables_fee_charging() {
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut evm_env = EvmEnvFor::<EthEvmNetwork>::default();
+        evm_env.cfg_env.disable_fee_charge = false;
+        let executor = ExecutorBuilder::default().build(
+            evm_env,
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+        );
+
+        let (evm_env, _) = executor.build_test_env(
+            CALLER,
+            TxKind::Call(Address::repeat_byte(0x11)),
+            Bytes::new(),
+            U256::ZERO,
+        );
+
+        assert!(evm_env.cfg_env.disable_fee_charge);
     }
 
     #[test]

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -4805,6 +4805,45 @@ forgetest!(can_execute_script_command_with_tempo, |prj, cmd| {
         .assert_success();
 });
 
+forgetest_async!(tempo_fork_script_with_fee_token_and_nonzero_gas_price, |prj, cmd| {
+    let script = prj.add_script(
+        "TempoFee.s.sol",
+        r#"
+contract TempoFeeScript {
+    function run() external {}
+}
+"#,
+    );
+
+    let (api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let fee_token = address!("0x20c0000000000000000000000000000000000000");
+    // Anvil's Tempo genesis is deliberately overfunded. Remove the synthetic caller and fee
+    // manager liquidity so the test exercises the same invalid refund path as a real fork.
+    api.anvil_deal_tip20(foundry_evm::constants::CALLER, fee_token, U256::ZERO).await.unwrap();
+    api.anvil_deal_tip20(
+        address!("0xfeec000000000000000000000000000000000000"),
+        fee_token,
+        U256::ZERO,
+    )
+    .await
+    .unwrap();
+    let rpc = handle.http_endpoint();
+
+    cmd.arg("script").arg(script).args([
+        "--rpc-url",
+        &rpc,
+        "--network",
+        "tempo",
+        "--tempo.fee-token",
+        "0x20c0000000000000000000000000000000000000",
+        "--with-gas-price",
+        "600000000",
+        "--block-gas-limit",
+        "18446744073709551615",
+    ]);
+    cmd.assert_success();
+});
+
 forgetest_async!(tempo_aa_script_broadcast_deploys_with_fee_token, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
     let script = prj.add_script(


### PR DESCRIPTION
Forge validates synthetic script and test transactions with a zero gas price so network balances cannot block local execution, then the cheatcode inspector restores the configured gas price. Tempo observes that restored price during post-transaction fee handling and attempts to refund a fee that was never collected, causing a TIP20 insufficient-balance error during script setup.

This marks synthetic test environments with `disable_fee_charge` while preserving the restored `tx.gasprice` semantics visible to Solidity. It also adds an executor invariant and a forked Tempo script regression using a non-zero gas price and maximum block gas limit, with local fee liquidity cleared so the original failure is reproduced.

This PR was written with Codex, including investigation, implementation, regression tests, and PR text.
