### PR TITLE
fix(cast): treat bare wallet new name as default keystore account

### DIFF
--- a/.changelog/cast-wallet-new-bare-account-name.md
+++ b/.changelog/cast-wallet-new-bare-account-name.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+`cast wallet new <name>` now saves a named keystore to the default directory, matching `cast wallet import <name>`. Arguments that resolve to an existing path, or that fail to resolve for any reason other than not existing, keep reporting an error.

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -47,10 +47,15 @@ pub enum WalletSubcommands {
     ///
     /// Examples:
     /// - cast wallet new (print a new private key and address)
+    /// - cast wallet new my-wallet (save to the default keystore directory)
     /// - cast wallet new ~/.foundry/keystores dev (save to an encrypted keystore)
     #[command(verbatim_doc_comment, visible_alias = "n")]
     New {
         /// If provided, then keypair will be written to an encrypted JSON keystore.
+        ///
+        /// A single bare argument that is not an existing directory is treated as ACCOUNT_NAME and
+        /// saved under the default keystore directory (`~/.foundry/keystores`), matching
+        /// `cast wallet import <name>`.
         path: Option<String>,
 
         /// Account name for the keystore file. If provided, the keystore file
@@ -381,7 +386,7 @@ impl WalletSubcommands {
         match self {
             Self::New {
                 path,
-                account_name,
+                mut account_name,
                 unsafe_password,
                 number,
                 password,
@@ -389,12 +394,9 @@ impl WalletSubcommands {
                 touch_id,
             } => {
                 ensure_touch_id_available(touch_id)?;
-                if let Some(name) = &account_name {
-                    ensure_account_name_available(name)?;
-                }
 
                 let path = match path {
-                    Some(path) => Some(existing_dir(&path)?),
+                    Some(path) => Some(resolve_new_dir(path, &mut account_name)?),
                     None if unsafe_password.is_some() || password || touch_id => {
                         let path = resolve_keystore_dir(None)?;
                         fs::create_dir_all(&path)?;
@@ -402,6 +404,10 @@ impl WalletSubcommands {
                     }
                     None => None,
                 };
+
+                if let Some(name) = &account_name {
+                    ensure_account_name_available(name)?;
+                }
 
                 let json = match path {
                     Some(path) => new_keystores(
@@ -1049,17 +1055,46 @@ fn password_or_prompt(password: Option<String>, prompt: &str) -> Result<String> 
     }
 }
 
-/// Canonicalizes `path`, which must be an existing directory.
-fn existing_dir(path: &str) -> Result<PathBuf> {
-    let dir = dunce::canonicalize(path).map_err(|e| {
-        eyre::eyre!(
+/// Resolves the directory for `cast wallet new`.
+///
+/// A missing bare name is rewritten into `account_name` and stored in the default keystore
+/// directory, matching `cast wallet import <name>`. Path-like values and resolution failures
+/// other than `NotFound` still error.
+fn resolve_new_dir(path: String, account_name: &mut Option<String>) -> Result<PathBuf> {
+    match dunce::canonicalize(&path) {
+        Ok(dir) if dir.is_dir() => Ok(dir),
+        Ok(dir) => eyre::bail!("`{}` is not a directory", dir.display()),
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound
+                && account_name.is_none()
+                && is_bare_account_name(&path) =>
+        {
+            *account_name = Some(path);
+            let dir = resolve_keystore_dir(None)?;
+            fs::create_dir_all(&dir)?;
+            Ok(dir)
+        }
+        Err(e) => eyre::bail!(
             "If you specified a directory, please make sure it exists, or create it before running `cast wallet new <DIR>`.\n{path} is not a directory.\nError: {e}"
-        )
-    })?;
-    if !dir.is_dir() {
-        eyre::bail!("`{}` is not a directory", dir.display());
+        ),
     }
-    Ok(dir)
+}
+
+/// Returns true when `value` is a bare keystore account name rather than a filesystem path.
+///
+/// Path-like values (`.`, `..`, anything containing a separator or `:`, including Windows
+/// prefixes such as `C:foo` and ADS names such as `foo:bar`) stay on the existing
+/// directory-resolution path for `cast wallet new`.
+fn is_bare_account_name(value: &str) -> bool {
+    !value.is_empty()
+        && value != "."
+        && value != ".."
+        && !value.contains('/')
+        && !value.contains('\\')
+        // `C:foo` is a drive-relative path; `foo:bar` is an alternate data stream on
+        // Windows. Joining either can write outside the default keystore directory
+        // or hide the keystore in a stream so listing/loading miss it.
+        && !value.contains(':')
 }
 
 /// Resolves the keystore directory, defaulting to `~/.foundry/keystores`.
@@ -1544,5 +1579,32 @@ mod tests {
         for invalid in ["../pwned", "nested/alias", "foo/../bar", "..", ".", "", "foo\\bar"] {
             assert!(ensure_account_name_available(invalid).is_err(), "{invalid:?}");
         }
+    }
+
+    #[test]
+    fn can_parse_wallet_new_bare_account_name() {
+        let args = WalletSubcommands::parse_from(["foundry-cli", "new", "my-wallet"]);
+        match args {
+            WalletSubcommands::New { path, account_name, .. } => {
+                assert_eq!(path.as_deref(), Some("my-wallet"));
+                assert_eq!(account_name, None);
+            }
+            _ => panic!("expected WalletSubcommands::New"),
+        }
+    }
+
+    #[test]
+    fn bare_account_name_heuristic() {
+        assert!(is_bare_account_name("my-wallet"));
+        assert!(is_bare_account_name("dev"));
+        assert!(!is_bare_account_name(""));
+        assert!(!is_bare_account_name("."));
+        assert!(!is_bare_account_name(".."));
+        assert!(!is_bare_account_name("./missing-dir"));
+        assert!(!is_bare_account_name("missing-dir/"));
+        assert!(!is_bare_account_name("/tmp/keystores"));
+        assert!(!is_bare_account_name(r"C:\keystores"));
+        assert!(!is_bare_account_name("C:foo"));
+        assert!(!is_bare_account_name("foo:bar"));
     }
 }

--- a/crates/cast/tests/cli/wallet_keystore.rs
+++ b/crates/cast/tests/cli/wallet_keystore.rs
@@ -1,6 +1,8 @@
 //! CLI tests for wallet keystore commands.
 
 use super::*;
+#[cfg(unix)]
+use std::os::unix::fs::{PermissionsExt, symlink};
 
 casttest!(browser_wallet_commands_expose_browser_option, |_prj, cmd| {
     for (name, args) in [
@@ -309,6 +311,87 @@ Created new encrypted keystore file: [..]
     let keystore_path = dirs::home_dir().unwrap().join(".foundry").join("keystores");
     assert!(keystore_path.exists());
     assert!(keystore_path.is_dir());
+});
+
+// tests that `cast wallet new <name>` treats a bare account name like `cast wallet import <name>`
+casttest!(new_wallet_bare_account_name_uses_default_keystore, |prj, cmd| {
+    let account = "issue-16209-account";
+    cmd.env("HOME", prj.root());
+    cmd.args(["wallet", "new", account, "--unsafe-password", "test"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+0x[..]
+
+"#]])
+        .stderr_eq(str![[r#"
+Created new encrypted keystore file: [..]
+[ADDRESS]
+
+"#]]);
+
+    let keystore_path = prj.root().join(".foundry").join("keystores").join(account);
+    assert!(keystore_path.is_file(), "expected keystore at {}", keystore_path.display());
+});
+
+// tests that a missing path-like argument is still treated as a directory, not an account name
+casttest!(new_wallet_missing_dir_still_errors, |_prj, cmd| {
+    cmd.args(["wallet", "new", "./missing-keystore-dir", "--unsafe-password", "test"])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: If you specified a directory, please make sure it exists, or create it before running `cast wallet new <DIR>`.
+./missing-keystore-dir is not a directory.
+Error: [..]
+
+"#]]);
+});
+
+// tests that a bare argument whose resolution fails for a reason other than the path being
+// missing is reported, rather than silently falling back to the default keystore directory
+#[cfg(unix)]
+casttest!(new_wallet_bare_name_unresolvable_symlink_errors, |prj, cmd| {
+    /// Restores search permission so the temporary project can be torn down, even on panic.
+    struct RestorePermissions<'a>(&'a Path);
+
+    impl Drop for RestorePermissions<'_> {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(self.0, fs::Permissions::from_mode(0o755));
+        }
+    }
+
+    let account = "inaccessible-wallet";
+    // Resolving a symlink through a directory without search permission fails with
+    // `PermissionDenied` instead of `NotFound`.
+    let locked = prj.root().join("locked");
+    fs::create_dir_all(locked.join("keystores")).unwrap();
+    symlink(locked.join("keystores"), prj.root().join(account)).unwrap();
+    fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+    let _restore = RestorePermissions(&locked);
+
+    cmd.env("HOME", prj.root());
+    cmd.args(["wallet", "new", account, "--unsafe-password", "test"])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: If you specified a directory, please make sure it exists, or create it before running `cast wallet new <DIR>`.
+inaccessible-wallet is not a directory.
+Error: [..]
+
+"#]]);
+
+    let keystore_path = prj.root().join(".foundry").join("keystores").join(account);
+    assert!(!keystore_path.exists(), "unexpected keystore at {}", keystore_path.display());
+});
+
+// tests that the two-positional `[PATH] [ACCOUNT_NAME]` form still errors for a missing
+// separator-free directory, rather than treating the first argument as an account name
+casttest!(new_wallet_missing_dir_with_account_name_still_errors, |_prj, cmd| {
+    cmd.args(["wallet", "new", "missing-dir", "account-name", "--unsafe-password", "test"])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: If you specified a directory, please make sure it exists, or create it before running `cast wallet new <DIR>`.
+missing-dir is not a directory.
+Error: [..]
+
+"#]]);
 });
 
 casttest!(new_wallet_multiple_keys, |_prj, cmd| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md
-->

## Motivation

`cast wallet import <name>` saves to `~/.foundry/keystores` from a single bare account name. `cast wallet new <name>` does not: the first positional is always bound to `PATH`, so a name like `my-wallet` fails with "is not a directory".

This is the remaining gap from #11147. #9201 only covered the flag-triggered anonymous-keystore path (`cast wallet new --unsafe-password …` with no positionals). Downstream docs reasonably copy the import pattern and tell users to run `cast wallet new my-wallet`.

Fixes #16209

## Solution

If `cast wallet new` is given a single positional that `canonicalize` reports as `NotFound` and that does not look like a path (`.`, `..`, a separator, or a Windows drive prefix), treat it as `ACCOUNT_NAME` and write the keystore to `Config::foundry_keystores_dir()`.

Resolvable paths that are not directories, and canonicalization errors other than `NotFound` (for example `PermissionDenied`), still error. Explicit `PATH ACCOUNT_NAME` and the no-positional `--unsafe-password` / `--password` / `--touch-id` default-directory fallbacks are unchanged.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes