### PR TITLE
fix(anvil): redact fork credentials

### DIFF
--- a/.changelog/redact-anvil-fork-credentials.md
+++ b/.changelog/redact-anvil-fork-credentials.md
@@ -1,0 +1,6 @@
+---
+anvil: patch
+foundry-common: patch
+---
+
+Redacted credentials and API keys from Anvil fork endpoint output, errors, and diagnostic logs.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -476,7 +476,7 @@ Genesis Number
             json!({
               "available_accounts": available_accounts,
               "private_keys": private_keys,
-              "endpoint": fork.eth_rpc_url().unwrap_or_default(),
+              "endpoint": fork.eth_rpc_url().as_deref().map(redact_url).unwrap_or_default(),
               "block_number": fork.block_number(),
               "block_hash": fork.block_hash(),
               "chain_id": fork.execution_chain_id(),
@@ -2433,6 +2433,11 @@ mod tests {
 
         let fork = api.backend.get_fork().unwrap();
         let output = config.as_string(Some(&fork));
+        let temp = tempfile::tempdir().unwrap();
+        let config_out = temp.path().join("config.json");
+        config.config_out = Some(config_out.clone());
+        config.print(Some(&fork)).unwrap();
+        let json = serde_json::from_slice::<Value>(&std::fs::read(config_out).unwrap()).unwrap();
 
         assert!(output.contains(&redact_url(&fork_url)));
         assert!(output.contains("https://mirror.example/"));
@@ -2440,6 +2445,9 @@ mod tests {
         assert!(!output.contains("password"));
         assert!(!output.contains("private-api-key"));
         assert!(!output.contains("secret"));
+        assert_eq!(json["endpoint"], redact_url(&fork_url));
+        assert!(!json.to_string().contains("password"));
+        assert!(!json.to_string().contains("secret"));
     }
 
     #[test]

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -39,7 +39,7 @@ use anvil_server::ServerConfig;
 use eyre::{Context, Result};
 use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING, REQUEST_TIMEOUT,
-    provider::{ProviderBuilder, RetryProvider, is_rpc_method_not_found},
+    provider::{ProviderBuilder, RetryProvider, is_rpc_method_not_found, redact_url},
 };
 use foundry_config::Config;
 #[cfg(feature = "monad")]
@@ -341,7 +341,7 @@ Block number:   {}
 Block hash:     {:?}
 Chain ID:       {}
 "#,
-                fork.eth_rpc_url().as_deref().unwrap_or("none"),
+                fork.eth_rpc_url().as_deref().map(redact_url).unwrap_or_else(|| "none".to_string()),
                 fork.block_number(),
                 fork.block_hash(),
                 fork.execution_chain_id()
@@ -353,7 +353,7 @@ Chain ID:       {}
             if self.fork_urls.len() > 1 {
                 let _ = writeln!(s, "Endpoints:      {}", self.fork_urls.len());
                 for (i, url) in self.fork_urls.iter().enumerate() {
-                    let _ = writeln!(s, "  ({i}) {url}");
+                    let _ = writeln!(s, "  ({i}) {}", redact_url(url));
                 }
             }
 
@@ -1728,7 +1728,7 @@ impl NodeConfig {
                     "fork endpoints must use the same chain ID: expected {}, got {} from {}",
                     expected.source_chain_id,
                     before.source_chain_id,
-                    eth_rpc_url
+                    redact_url(eth_rpc_url)
                 );
             }
             return Ok(
@@ -1798,7 +1798,7 @@ impl NodeConfig {
         evm_env: &mut EvmEnv,
         fees: &FeeManager,
     ) -> Result<(ForkedDatabase<AnyNetwork>, ClientForkConfig, Option<ForkTransactionReplay>)> {
-        debug!(target: "node", ?eth_rpc_url, "setting up fork db");
+        debug!(target: "node", eth_rpc_url=%redact_url(&eth_rpc_url), "setting up fork db");
         if self.fork_chain_id.is_some() {
             eyre::ensure!(
                 self.fork_urls.len() == 1,
@@ -2002,8 +2002,9 @@ latest block number: {latest_block}"
                 .await?
             {
                 eyre::bail!(
-                    "fork fallback endpoint `{mirror_url}` does not expose the primary endpoint's \
-                     execution and block context"
+                    "fork fallback endpoint `{}` does not expose the primary endpoint's execution \
+                     and block context",
+                    redact_url(mirror_url)
                 );
             }
         }
@@ -2028,7 +2029,8 @@ latest block number: {latest_block}"
         // configured. This ensures bootstrap used only the primary endpoint for consistency,
         // while ongoing requests are distributed across all endpoints.
         let provider = if self.fork_urls.len() > 1 {
-            debug!(target: "node", urls=?self.fork_urls, "using multi-endpoint round-robin provider");
+            let urls = self.fork_urls.iter().map(|url| redact_url(url)).collect::<Vec<_>>();
+            debug!(target: "node", ?urls, "using multi-endpoint round-robin provider");
             Arc::new(
                 ProviderBuilder::new(&eth_rpc_url)
                     .timeout(self.fork_request_timeout)
@@ -2419,6 +2421,26 @@ async fn find_latest_fork_block<P: Provider<AnyNetwork>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fork_output_redacts_endpoint_credentials() {
+        let (_api, source) = crate::spawn(NodeConfig::test()).await;
+        let fork_url = source.http_endpoint().replacen("http://", "http://user:password@", 1)
+            + "/?api_key=secret";
+        let mut config = NodeConfig::test().with_eth_rpc_url(Some(fork_url.clone()));
+        let (api, _handle) = crate::spawn(config.clone()).await;
+        config.fork_urls.push("https://mirror.example/private-api-key?token=secret".to_string());
+
+        let fork = api.backend.get_fork().unwrap();
+        let output = config.as_string(Some(&fork));
+
+        assert!(output.contains(&redact_url(&fork_url)));
+        assert!(output.contains("https://mirror.example/"));
+        assert!(!output.contains("user"));
+        assert!(!output.contains("password"));
+        assert!(!output.contains("private-api-key"));
+        assert!(!output.contains("secret"));
+    }
 
     #[test]
     fn test_prune_history() {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -97,6 +97,7 @@ use anvil_rpc::{
     response::ResponseResult,
 };
 use foundry_common::{
+    provider::redact_url,
     tempo::{PaymentLaneClassification, PaymentLaneReason, classify_payment_lane},
     version::{COMMIT_SHA, SEMVER_VERSION},
 };
@@ -636,7 +637,7 @@ impl<N: Network> EthApi<N> {
         let mut node_config = self.backend.node_config.write().await;
         if let Some((fork, provider, endpoint_identity)) = staged_fork {
             let mut config = fork.config.write();
-            trace!(target: "backend", "Updated fork rpc from \"{}\" to \"{}\"", config.eth_rpc_url().unwrap_or("none"), url);
+            trace!(target: "backend", "Updated fork rpc from \"{}\" to \"{}\"", config.eth_rpc_url().map(redact_url).unwrap_or_else(|| "none".to_string()), redact_url(&url));
             config.provider = provider;
             config.fork_urls = vec![url.clone()];
             config.fork_chain_id = None;

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -65,6 +65,19 @@ pub fn is_rpc_method_not_found(error: &TransportError) -> bool {
         .is_some_and(|code| code == -32601)
 }
 
+/// Returns an RPC URL safe for display by retaining only its scheme, host, and port.
+pub fn redact_url(raw: &str) -> String {
+    let Ok(mut redacted) = Url::parse(raw) else {
+        return "<redacted>".to_owned();
+    };
+    let _ = redacted.set_username("");
+    let _ = redacted.set_password(None);
+    redacted.set_path("");
+    redacted.set_query(None);
+    redacted.set_fragment(None);
+    redacted.to_string()
+}
+
 fn rpc_error_code(body: &str) -> Option<i64> {
     // HTTP transports may append human-readable diagnostics after the JSON-RPC body. Parse the
     // first complete JSON value instead of requiring the entire body to be JSON.
@@ -217,7 +230,7 @@ impl<N: Network> ProviderBuilder<N> {
                 }
                 _ => Err(err),
             })
-            .wrap_err_with(|| format!("invalid provider URL: {url_str:?}"));
+            .wrap_err_with(|| format!("invalid provider URL: {:?}", redact_url(url_str)));
 
         // Use the final URL string to guess if it's a local URL.
         let is_local = url.as_ref().is_ok_and(|url| guess_local_url(url.as_str()));
@@ -622,6 +635,26 @@ mod tests {
     use alloy_json_rpc::ErrorPayload;
 
     use super::*;
+
+    #[test]
+    fn redacts_url_credentials_and_resource() {
+        let url = "https://user:password@example.com:8545/private-key?token=secret#fragment";
+
+        assert_eq!(redact_url(url), "https://example.com:8545/");
+        assert_eq!(redact_url("not a URL with secret"), "<redacted>");
+    }
+
+    #[test]
+    fn invalid_provider_url_error_is_redacted() {
+        let builder = ProviderBuilder::<AnyNetwork>::new(
+            "https://example.com:bad/private-api-key?token=secret",
+        );
+
+        let error = builder.url.unwrap_err().to_string();
+        assert!(error.contains("<redacted>"));
+        assert!(!error.contains("private-api-key"));
+        assert!(!error.contains("secret"));
+    }
 
     #[test]
     fn method_not_found_classification_is_exact() {

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -18,8 +18,15 @@ use alloy_transport::{
 };
 use alloy_transport_ipc::IpcConnect;
 use alloy_transport_ws::WsConnect;
+use regex::{Captures, Regex};
 use reqwest::header::{HeaderName, HeaderValue};
-use std::{error::Error as StdError, fmt, path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    error::Error as StdError,
+    fmt,
+    path::PathBuf,
+    str::FromStr,
+    sync::{Arc, LazyLock},
+};
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tower::Service;
@@ -30,6 +37,9 @@ use url::Url;
 /// Endpoints matching these patterns always use the MPP WebSocket transport,
 /// regardless of whether local MPP keys have been discovered.
 const KNOWN_MPP_HOSTS: &[&str] = &[".mpp.tempo.xyz", ".mpp.moderato.tempo.xyz"];
+
+static HTTP_URL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)https?://[^\s<>"']+"#).expect("valid URL regex"));
 
 /// Returns `true` if `url` points to a known MPP-enabled RPC service.
 fn is_known_mpp_endpoint(url: &Url) -> bool {
@@ -367,11 +377,6 @@ fn redact_http_transport_error(error: TransportError, endpoint: &Url) -> Transpo
         return error;
     };
     let safe_endpoint = redact_url(endpoint.as_str());
-    let mut request_endpoint = endpoint.clone();
-    let _ = request_endpoint.set_username("");
-    let _ = request_endpoint.set_password(None);
-    request_endpoint.set_query(None);
-    request_endpoint.set_fragment(None);
 
     let mut message = String::new();
     let mut error: Option<&(dyn StdError + 'static)> = Some(source.as_ref());
@@ -382,9 +387,17 @@ fn redact_http_transport_error(error: TransportError, endpoint: &Url) -> Transpo
         message.push_str(&source.to_string());
         error = source.source();
     }
-    for sensitive in [endpoint.as_str(), request_endpoint.as_str()] {
-        message = message.replace(sensitive, &safe_endpoint);
-    }
+    let message = HTTP_URL_RE.replace_all(&message, |captures: &Captures<'_>| {
+        let candidate = &captures[0];
+        let Ok(url) = Url::parse(candidate) else { return candidate.to_owned() };
+        if url.host() == endpoint.host()
+            && url.port_or_known_default() == endpoint.port_or_known_default()
+        {
+            safe_endpoint.clone()
+        } else {
+            candidate.to_owned()
+        }
+    });
     TransportErrorKind::custom_str(&message)
 }
 
@@ -506,6 +519,22 @@ mod tests {
         assert!(!report.contains("secret"));
         assert!(report.to_lowercase().contains("connection refused"));
         assert!(report.contains("cast tempo login"));
+    }
+
+    #[test]
+    fn http_transport_errors_redact_normalized_endpoint_variants() {
+        let endpoint =
+            Url::parse("https://user:password@example.com/private-api-key?token=secret").unwrap();
+        let error = TransportErrorKind::custom_str(
+            "request to https://USER:normalized@example.com:443/different%2Fpath?key=other failed",
+        );
+
+        let report = redact_http_transport_error(error, &endpoint).to_string();
+
+        assert!(report.contains("https://example.com/"));
+        assert!(!report.contains("normalized"));
+        assert!(!report.contains("different"));
+        assert!(!report.contains("other"));
     }
 
     #[tokio::test]

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -4,7 +4,10 @@
 
 use crate::{
     DEFAULT_USER_AGENT, REQUEST_TIMEOUT,
-    provider::mpp::transport::{LazyMppHttpTransport, lazy_mpp_ws_connect},
+    provider::{
+        mpp::transport::{LazyMppHttpTransport, lazy_mpp_ws_connect},
+        redact_url,
+    },
 };
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use alloy_pubsub::{PubSubConnect, PubSubFrontend};
@@ -16,7 +19,7 @@ use alloy_transport::{
 use alloy_transport_ipc::IpcConnect;
 use alloy_transport_ws::WsConnect;
 use reqwest::header::{HeaderName, HeaderValue};
-use std::{fmt, path::PathBuf, str::FromStr, sync::Arc};
+use std::{error::Error as StdError, fmt, path::PathBuf, str::FromStr, sync::Arc};
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tower::Service;
@@ -176,7 +179,7 @@ impl RuntimeTransportBuilder {
 
 impl fmt::Display for RuntimeTransport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RuntimeTransport {}", self.url)
+        write!(f, "RuntimeTransport {}", redact_url(self.url.as_str()))
     }
 }
 
@@ -288,17 +291,17 @@ impl RuntimeTransport {
             if let Some(auth) = auth {
                 ws = ws.with_auth(auth);
             }
-            ws.into_service()
-                .await
-                .map_err(|e| RuntimeTransportError::TransportError(e, self.url.to_string()))?
+            ws.into_service().await.map_err(|e| {
+                RuntimeTransportError::TransportError(e, redact_url(self.url.as_str()))
+            })?
         } else {
             let mut ws = WsConnect::new(self.url.to_string());
             if let Some(auth) = auth {
                 ws = ws.with_auth(auth);
             }
-            ws.into_service()
-                .await
-                .map_err(|e| RuntimeTransportError::TransportError(e, self.url.to_string()))?
+            ws.into_service().await.map_err(|e| {
+                RuntimeTransportError::TransportError(e, redact_url(self.url.as_str()))
+            })?
         };
 
         Ok(InnerTransport::Ws(service))
@@ -340,11 +343,13 @@ impl RuntimeTransport {
 
             // SAFETY: We just checked that the inner transport exists.
             match inner.clone().expect("must've been initialized") {
-                InnerTransport::Http(mut http) => http.call(req),
-                InnerTransport::Ws(mut ws) => ws.call(req),
-                InnerTransport::Ipc(mut ipc) => ipc.call(req),
+                InnerTransport::Http(mut http) => http
+                    .call(req)
+                    .await
+                    .map_err(|error| redact_http_transport_error(error, &this.url)),
+                InnerTransport::Ws(mut ws) => ws.call(req).await,
+                InnerTransport::Ipc(mut ipc) => ipc.call(req).await,
             }
-            .await
         })
     }
 
@@ -355,6 +360,32 @@ impl RuntimeTransport {
     {
         BoxTransport::new(self)
     }
+}
+
+fn redact_http_transport_error(error: TransportError, endpoint: &Url) -> TransportError {
+    let alloy_json_rpc::RpcError::Transport(TransportErrorKind::Custom(source)) = &error else {
+        return error;
+    };
+    let safe_endpoint = redact_url(endpoint.as_str());
+    let mut request_endpoint = endpoint.clone();
+    let _ = request_endpoint.set_username("");
+    let _ = request_endpoint.set_password(None);
+    request_endpoint.set_query(None);
+    request_endpoint.set_fragment(None);
+
+    let mut message = String::new();
+    let mut error: Option<&(dyn StdError + 'static)> = Some(source.as_ref());
+    while let Some(source) = error {
+        if !message.is_empty() {
+            message.push_str(": ");
+        }
+        message.push_str(&source.to_string());
+        error = source.source();
+    }
+    for sensitive in [endpoint.as_str(), request_endpoint.as_str()] {
+        message = message.replace(sensitive, &safe_endpoint);
+    }
+    TransportErrorKind::custom_str(&message)
 }
 
 impl tower::Service<RequestPacket> for RuntimeTransport {
@@ -429,6 +460,73 @@ fn url_to_file_path(url: &Url) -> Result<PathBuf, ()> {
 mod tests {
     use super::*;
     use reqwest::header::HeaderMap;
+    use std::io;
+
+    #[derive(Debug, Error)]
+    #[error("request to https://example.com/private-api-key failed")]
+    struct ProviderError {
+        #[source]
+        source: io::Error,
+    }
+
+    #[test]
+    fn http_transport_errors_preserve_provider_guidance() {
+        let endpoint =
+            Url::parse("https://user:password@example.com/private-api-key?token=secret").unwrap();
+        let error = TransportErrorKind::custom(ProviderError {
+            source: io::Error::other(
+                "Authorize an access key with:\n  cast tempo login --no-browser",
+            ),
+        });
+
+        let report = redact_http_transport_error(error, &endpoint).to_string();
+
+        assert!(report.contains("https://example.com/"));
+        assert!(report.contains("cast tempo login --no-browser"));
+        assert!(!report.contains("password"));
+        assert!(!report.contains("private-api-key"));
+        assert!(!report.contains("secret"));
+    }
+
+    #[test]
+    fn http_transport_errors_redact_endpoint_paths() {
+        let endpoint =
+            Url::parse("https://user:password@example.com/private-api-key?token=secret").unwrap();
+        let error = TransportErrorKind::custom_str(concat!(
+            "request to https://example.com/private-api-key failed: connection refused\n\n",
+            "Authorize an access key with:\n  cast tempo login"
+        ));
+
+        let error = redact_http_transport_error(error, &endpoint);
+        let report = error.to_string();
+
+        assert!(report.contains("https://example.com/"));
+        assert!(!report.contains("password"));
+        assert!(!report.contains("private-api-key"));
+        assert!(!report.contains("secret"));
+        assert!(report.to_lowercase().contains("connection refused"));
+        assert!(report.contains("cast tempo login"));
+    }
+
+    #[tokio::test]
+    async fn websocket_error_redacts_url_credentials() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let url = Url::parse(&format!(
+            "ws://user:password@{address}/private-api-key?token=secret#fragment"
+        ))
+        .unwrap();
+        let transport = RuntimeTransportBuilder::new(url).build();
+
+        let error = transport.connect_ws().await.unwrap_err().to_string();
+
+        assert!(error.contains(&format!("ws://{address}/")));
+        assert!(!error.contains("user"));
+        assert!(!error.contains("password"));
+        assert!(!error.contains("private-api-key"));
+        assert!(!error.contains("secret"));
+    }
 
     #[tokio::test]
     async fn test_user_agent_header() {


### PR DESCRIPTION
Anvil renders fork RPC URLs in startup output and provider errors. Because these URLs commonly contain credentials in userinfo, paths, or query parameters, this can expose API keys through terminal and CI logs.

This change limits displayed endpoints to their scheme, host, and port across startup output and HTTP, WebSocket, parsing, and validation errors. Complete URLs remain available internally and through explicit configuration APIs, while connection diagnostics and MPP login guidance are preserved.