### PR TITLE
fix(anvil): recover malformed IPC framing

### DIFF
--- a/.changelog/recover-ipc-framing.md
+++ b/.changelog/recover-ipc-framing.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed malformed IPC delimiters corrupting subsequent requests on the same connection.

--- a/crates/anvil/server/src/ipc.rs
+++ b/crates/anvil/server/src/ipc.rs
@@ -138,6 +138,7 @@ impl tokio_util::codec::Decoder for JsonRpcCodec {
 
         for idx in 0..buf.as_ref().len() {
             let byte = buf.as_ref()[idx];
+            let mut malformed = false;
 
             if (byte == b'{' || byte == b'[') && !in_str {
                 if depth == 0 {
@@ -145,7 +146,11 @@ impl tokio_util::codec::Decoder for JsonRpcCodec {
                 }
                 depth += 1;
             } else if (byte == b'}' || byte == b']') && !in_str {
-                depth -= 1;
+                if depth == 0 {
+                    malformed = true;
+                } else {
+                    depth -= 1;
+                }
             } else if byte == b'"' && !is_escaped {
                 in_str = !in_str;
             } else if is_whitespace(byte) {
@@ -153,7 +158,7 @@ impl tokio_util::codec::Decoder for JsonRpcCodec {
             }
             is_escaped = byte == b'\\' && !is_escaped && in_str;
 
-            if depth == 0 && idx != start_idx && idx - start_idx + 1 > whitespaces {
+            if malformed || (depth == 0 && idx != start_idx && idx - start_idx + 1 > whitespaces) {
                 let bts = buf.split_to(idx + 1);
                 return match String::from_utf8(bts.as_ref().to_vec()) {
                     Ok(val) => Ok(Some(val)),

--- a/crates/anvil/tests/it/ipc.rs
+++ b/crates/anvil/tests/it/ipc.rs
@@ -7,6 +7,10 @@ use anvil::{NodeConfig, spawn};
 use futures::StreamExt;
 use std::time::Duration;
 use tempfile::TempDir;
+#[cfg(unix)]
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(unix)]
+use tokio::net::UnixStream;
 
 fn ipc_config() -> (Option<TempDir>, NodeConfig) {
     let path;
@@ -56,6 +60,31 @@ async fn dropping_handle_closes_ipc_connections() {
     })
     .await
     .expect("IPC connection continued serving requests after node shutdown");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn malformed_delimiter_does_not_corrupt_ipc_connection() {
+    let (_dir, config) = ipc_config();
+    let (_api, handle) = spawn(config).await;
+    let connection = UnixStream::connect(handle.ipc_path().unwrap()).await.unwrap();
+    let (reader, mut writer) = connection.into_split();
+    let mut reader = BufReader::new(reader);
+    let mut response = String::new();
+
+    writer.write_all(b"}").await.unwrap();
+    reader.read_line(&mut response).await.unwrap();
+    let malformed = serde_json::from_str::<serde_json::Value>(&response).unwrap();
+    assert_eq!(malformed["error"]["code"], -32600);
+
+    response.clear();
+    writer
+        .write_all(br#"{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}"#)
+        .await
+        .unwrap();
+    reader.read_line(&mut response).await.unwrap();
+    let valid = serde_json::from_str::<serde_json::Value>(&response).unwrap();
+    assert_eq!(valid["result"], "0x7a69");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Unmatched closing JSON delimiters currently drive Anvil’s IPC framing depth below zero, corrupting subsequent valid requests on the same connection.

This change consumes an unmatched `}` or `]` as a single malformed request without decrementing the framing depth. The connection can therefore return an invalid-request response and continue processing later requests normally.