### PR TITLE
fix(anvil): normalize JSON-RPC error codes

### DIFF
--- a/.changelog/normalize-anvil-rpc-errors.md
+++ b/.changelog/normalize-anvil-rpc-errors.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Return the correct JSON-RPC errors for malformed JSON and unknown methods across Anvil transports.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio-util",
+ "tower",
  "tower-http 0.7.0",
  "tracing",
 ]

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -913,11 +913,28 @@ pub enum EthPubSub {
 }
 
 /// Container type for either a request or a pub sub
-#[derive(Clone, Debug, serde::Deserialize)]
-#[serde(untagged)]
+#[derive(Clone, Debug)]
 pub enum EthRpcCall {
     Request(Box<EthRequest>),
     PubSub(EthPubSub),
+}
+
+impl<'de> serde::Deserialize<'de> for EthRpcCall {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match value.get("method").and_then(serde_json::Value::as_str) {
+            Some("eth_subscribe" | "eth_unsubscribe") => serde_json::from_value(value)
+                .map(Self::PubSub)
+                .map_err(<D::Error as serde::de::Error>::custom),
+            _ => serde_json::from_value(value)
+                .map(Box::new)
+                .map(Self::Request)
+                .map_err(<D::Error as serde::de::Error>::custom),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -936,6 +953,14 @@ mod tests {
         let s = r#"{"method": "web3_sha3", "params":["0x68656c6c6f20776f726c64"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn unknown_rpc_call_preserves_method_error() {
+        let err = serde_json::from_str::<EthRpcCall>(r#"{"method":"no_such_method","params":[]}"#)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("unknown variant"));
     }
 
     #[test]
@@ -1774,6 +1799,7 @@ mod tests {
         let s = r#"{"id": 1, "method": "eth_subscribe", "params": ["newHeads"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthPubSub>(value).unwrap();
+        assert!(matches!(serde_json::from_str(s).unwrap(), EthRpcCall::PubSub(_)));
 
         let s = r#"{"id": 1, "method": "eth_subscribe", "params": ["logs", {"address":
 "0x8320fe7702b96808f7bbc0d4a888ed1468216cfd", "topics":

--- a/crates/anvil/server/Cargo.toml
+++ b/crates/anvil/server/Cargo.toml
@@ -41,6 +41,9 @@ thiserror.workspace = true
 clap = { version = "4", features = ["derive", "env"], optional = true }
 pin-project = "1"
 
+[dev-dependencies]
+tower.workspace = true
+
 [features]
 default = ["ipc"]
 ipc = ["dep:interprocess", "dep:bytes", "dep:tokio-util"]

--- a/crates/anvil/server/src/handler.rs
+++ b/crates/anvil/server/src/handler.rs
@@ -24,6 +24,10 @@ pub async fn handle<Http: RpcHandler, Ws>(
             .map(Json)
             .map(IntoResponse::into_response)
             .unwrap_or_else(|| StatusCode::NO_CONTENT.into_response()),
+        Err(JsonRejection::JsonSyntaxError(err)) => {
+            warn!(target: "rpc", ?err, "invalid request");
+            Json(Response::error(RpcError::parse_error())).into_response()
+        }
         Err(err) => {
             warn!(target: "rpc", ?err, "invalid request");
             Json(Response::error(RpcError::invalid_request())).into_response()
@@ -86,11 +90,15 @@ async fn handle_call<Handler: RpcHandler>(call: RpcCall, handler: Handler) -> Op
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{ServerConfig, http_router};
     use anvil_rpc::{
         request::{RequestParams, RpcNotification},
         response::ResponseResult,
     };
-    use axum::body::to_bytes;
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request as HttpRequest, header},
+    };
     use std::{
         pin::pin,
         sync::{
@@ -99,11 +107,28 @@ mod tests {
         },
         task::{Context, Poll, Waker},
     };
+    use tower::ServiceExt;
 
     #[derive(Clone, Default)]
     struct TestHandler {
         requests: Arc<AtomicUsize>,
     }
+
+    #[derive(Clone, Debug, serde::Deserialize)]
+    #[serde(tag = "method", content = "params")]
+    enum TypedRequest {
+        #[serde(rename = "known")]
+        Known(Vec<TestParam>),
+    }
+
+    #[derive(Clone, Debug, serde::Deserialize)]
+    enum TestParam {
+        #[serde(rename = "allowed")]
+        Allowed,
+    }
+
+    #[derive(Clone)]
+    struct TypedHandler;
 
     #[async_trait::async_trait]
     impl RpcHandler for TestHandler {
@@ -111,6 +136,17 @@ mod tests {
 
         async fn on_request(&self, _request: Self::Request) -> ResponseResult {
             self.requests.fetch_add(1, Ordering::Relaxed);
+            ResponseResult::success(())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RpcHandler for TypedHandler {
+        type Request = TypedRequest;
+
+        async fn on_request(&self, request: Self::Request) -> ResponseResult {
+            let TypedRequest::Known(params) = request;
+            drop(params);
             ResponseResult::success(())
         }
     }
@@ -132,6 +168,15 @@ mod tests {
         })
     }
 
+    fn typed_call(method: &str) -> RpcMethodCall {
+        RpcMethodCall {
+            jsonrpc: Version::V2,
+            method: method.to_owned(),
+            params: RequestParams::Array(vec![serde_json::json!("bogus")]),
+            id: Id::Number(1),
+        }
+    }
+
     fn run_ready<F: Future>(future: F) -> F::Output {
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -147,6 +192,21 @@ mod tests {
         let response = run_ready(handle_request(Request::Batch(vec![]), TestHandler::default()));
 
         assert_eq!(response, Some(Response::error(RpcError::invalid_request())));
+    }
+
+    #[test]
+    fn distinguishes_unknown_methods_from_unknown_parameter_variants() {
+        let unknown_method = run_ready(TypedHandler.on_call(typed_call("unknown")));
+        let invalid_params = run_ready(TypedHandler.on_call(typed_call("known")));
+
+        assert_eq!(
+            serde_json::to_value(unknown_method).unwrap()["error"]["code"],
+            serde_json::json!(-32601)
+        );
+        assert_eq!(
+            serde_json::to_value(invalid_params).unwrap()["error"]["code"],
+            serde_json::json!(-32602)
+        );
     }
 
     #[test]
@@ -190,5 +250,23 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
         assert!(run_ready(to_bytes(response.into_body(), usize::MAX)).unwrap().is_empty());
         assert_eq!(handler.requests.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn malformed_json_returns_parse_error() {
+        let request = HttpRequest::post("/")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{"))
+            .unwrap();
+        let response = run_ready(
+            http_router(ServerConfig::default(), TestHandler::default()).oneshot(request),
+        )
+        .unwrap();
+        let body = run_ready(to_bytes(response.into_body(), usize::MAX)).unwrap();
+
+        assert_eq!(
+            serde_json::from_slice::<Response>(&body).unwrap(),
+            Response::error(RpcError::parse_error())
+        );
     }
 }

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -114,7 +114,11 @@ pub trait RpcHandler: Clone + Send + Sync + 'static {
             }
             Err(err) => {
                 let err = err.to_string();
-                if err.contains("unknown variant") {
+                let method_not_found = serde_json::from_value::<Self::Request>(
+                    serde_json::json!({ "method": &method }),
+                )
+                .is_err_and(|err| err.to_string().contains("unknown variant"));
+                if method_not_found {
                     error!(target: "rpc", ?method, "failed to deserialize method due to unknown variant");
                     RpcResponse::new(id, RpcError::method_not_found())
                 } else {

--- a/crates/anvil/server/src/pubsub.rs
+++ b/crates/anvil/server/src/pubsub.rs
@@ -141,7 +141,12 @@ impl<Handler: PubSubRpcHandler, Connection> PubSubConnection<Handler, Connection
                 Ok(req) => handle_request(req, handler).await,
                 Err(err) => {
                     error!(target: "rpc", ?err, "invalid request");
-                    Some(Response::error(RpcError::invalid_request()))
+                    let err = if err.is_syntax() || err.is_eof() {
+                        RpcError::parse_error()
+                    } else {
+                        RpcError::invalid_request()
+                    };
+                    Some(Response::error(err))
                 }
             }
         }));
@@ -320,6 +325,15 @@ mod tests {
             response,
             Some(Response::Single(RpcResponse::from(RpcError::invalid_request())))
         );
+    }
+
+    #[test]
+    fn process_request_returns_parse_error_for_malformed_json() {
+        let mut connection = PubSubConnection::new((), TestHandler::default());
+        connection.process_request(serde_json::from_str("{"));
+
+        let response = run_ready(connection.processing.pop().unwrap());
+        assert_eq!(response, Some(Response::error(RpcError::parse_error())));
     }
 
     #[test]


### PR DESCRIPTION
Anvil currently classifies malformed JSON as an invalid request and loses unknown-method errors during pubsub dispatch, producing inconsistent error codes across HTTP, WebSocket, and IPC.

This separates syntax errors from structurally invalid requests, preserves method resolution errors through pubsub dispatch, and distinguishes unknown methods from invalid nested parameter values. All transports now return `-32700` for malformed JSON, `-32601` for unknown methods, and `-32602` for invalid parameters.