### PR TITLE
chore(deps): update `h2` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6675,9 +6675,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Update `h2` from `0.4.15` to `0.4.16` to address RustSec advisory RUSTSEC-2026-0258. This is a lockfile-only dependency update; no application code changes are required.