### PR TITLE
fix(script): restrict sensitive cache files

### DIFF
--- a/.changelog/script-sensitive-cache-permissions.md
+++ b/.changelog/script-sensitive-cache-permissions.md
@@ -1,0 +1,7 @@
+---
+forge-script: patch
+forge-script-sequence: patch
+foundry-common: patch
+---
+
+Restricted sensitive script cache files containing RPC URLs to owner-only permissions on Unix.

--- a/crates/common/src/fs.rs
+++ b/crates/common/src/fs.rs
@@ -3,6 +3,8 @@
 use crate::errors::FsPathError;
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use serde::{Serialize, de::DeserializeOwned};
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::{
     fs::{self, File},
     io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write},
@@ -95,7 +97,25 @@ pub fn write_json_file<T: Serialize>(path: &Path, obj: &T) -> Result<()> {
 
 /// Writes the object as a pretty JSON object.
 pub fn write_pretty_json_file<T: Serialize>(path: &Path, obj: &T) -> Result<()> {
-    let file = create_file(path)?;
+    write_pretty_json(path, obj, create_file(path)?)
+}
+
+/// Writes an object as pretty JSON with owner-only permissions on Unix.
+pub fn write_sensitive_json_file<T: Serialize>(path: &Path, obj: &T) -> Result<()> {
+    let mut options = File::options();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let file = options.open(path).map_err(|err| FsPathError::create_file(err, path))?;
+    #[cfg(unix)]
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+        .map_err(|err| FsPathError::write(err, path))?;
+
+    write_pretty_json(path, obj, file)
+}
+
+fn write_pretty_json<T: Serialize>(path: &Path, obj: &T, file: File) -> Result<()> {
     let mut writer = BufWriter::new(file);
     serde_json::to_writer_pretty(&mut writer, obj)
         .map_err(|source| FsPathError::WriteJson { source, path: path.into() })?;
@@ -265,6 +285,22 @@ pub fn canonicalize_path(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_write_sensitive_json_file_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["new", "existing"] {
+            let path = dir.path().join(name);
+            if name == "existing" {
+                fs::write(&path, []).unwrap();
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+            }
+
+            write_sensitive_json_file(&path, &()).unwrap();
+            assert_eq!(fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+        }
+    }
 
     #[test]
     fn test_normalize_path() {

--- a/crates/script-sequence/src/sequence.rs
+++ b/crates/script-sequence/src/sequence.rs
@@ -141,7 +141,7 @@ impl<N: Network> ScriptSequence<N> {
 
         // cache folder writes
         //../run-latest.json
-        fs::write_pretty_json_file(sensitive_path, &sensitive_script_sequence)?;
+        fs::write_sensitive_json_file(sensitive_path, &sensitive_script_sequence)?;
         if save_ts {
             //../run-[timestamp].json
             fs::copy(sensitive_path, sensitive_path.with_file_name(&ts_name))?;

--- a/crates/script/src/multi_sequence.rs
+++ b/crates/script/src/multi_sequence.rs
@@ -139,7 +139,7 @@ impl<N: Network> MultiChainSequence<N> {
 
         // cache writes
         //../Contract-latest/run.json
-        fs::write_pretty_json_file(&self.sensitive_path, &sensitive_sequence)?;
+        fs::write_sensitive_json_file(&self.sensitive_path, &sensitive_sequence)?;
 
         if save_ts {
             //../Contract-[timestamp]/run.json


### PR DESCRIPTION
## Summary

- write sensitive script cache JSON with owner-only permissions on Unix
- correct permissions on both new and pre-existing cache files
- use the same writer for single-chain and multi-chain script sequences
- cover the filesystem behavior with a focused regression test

## Motivation

Script sequence caches intentionally store RPC URLs separately as sensitive values because URLs can contain provider credentials. They were written with ordinary `File::create`, so a normal `022` umask produced `0644` files and pre-existing broadly readable files retained their permissions.

The regression test covers both a new file and a pre-existing `0644` file. Both are now `0600` on Unix. Non-Unix behavior remains unchanged.

## Validation

- `cargo test -p foundry-common test_write_sensitive_json_file_permissions`
- `cargo test -p forge-script-sequence`
- `cargo clippy -p foundry-common -p forge-script-sequence -p forge-script --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
