### PR TITLE
perf(symbolic): reclaim dead hashcons entries

### DIFF
--- a/.changelog/symbolic-hashcons-gc.md
+++ b/.changelog/symbolic-hashcons-gc.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Bound symbolic expression hash-consing memory by periodically reclaiming dead entries.

--- a/crates/evm/symbolic/src/runtime/expr/hashcons.rs
+++ b/crates/evm/symbolic/src/runtime/expr/hashcons.rs
@@ -100,16 +100,18 @@ impl<T: fmt::Debug> fmt::Debug for HashConsed<T> {
 }
 
 type HashConsHasher = FixedState;
+const MIN_GC_THRESHOLD: usize = 1024;
 
 /// Hash-consing table for sharing structurally equal immutable values.
 ///
 /// The table stores weak references so interned values disappear when the rest of
 /// the symbolic state stops using them. `make` removes dead entries encountered
-/// while looking up the new value, keeping short-lived rewrites from growing the
-/// table for the lifetime of the context.
+/// during lookup and periodically sweeps distinct dead values before they can
+/// grow the table without bound.
 pub(in crate::runtime) struct HashCons<T> {
     table: HashTable<HashConsEntry<T>>,
     hash_builder: HashConsHasher,
+    gc_threshold: usize,
 }
 
 struct HashConsEntry<T> {
@@ -125,7 +127,11 @@ impl<T> HashConsEntry<T> {
 
 impl<T> HashCons<T> {
     pub(in crate::runtime) fn new() -> Self {
-        Self { table: HashTable::new(), hash_builder: HashConsHasher::default() }
+        Self {
+            table: HashTable::new(),
+            hash_builder: HashConsHasher::default(),
+            gc_threshold: MIN_GC_THRESHOLD,
+        }
     }
 
     fn hash<Q: Hash + ?Sized>(&self, value: &Q) -> u64 {
@@ -135,6 +141,11 @@ impl<T> HashCons<T> {
 
 impl<T: Eq + Hash> HashCons<T> {
     pub(in crate::runtime) fn make(&mut self, value: T) -> HashConsed<T> {
+        if self.table.len() >= self.gc_threshold {
+            self.table.retain(|entry| entry.value.strong_count() != 0);
+            self.gc_threshold = self.table.len().saturating_mul(2).max(MIN_GC_THRESHOLD);
+        }
+
         let hash = self.hash(&value);
         loop {
             let mut found = None;
@@ -225,6 +236,20 @@ mod tests {
         }
 
         assert_eq!(table.table.len(), 1);
+    }
+
+    #[test]
+    fn make_reclaims_distinct_dropped_values() {
+        let mut table = HashCons::<String>::new();
+        let retained = table.make("retained".to_string());
+
+        for value in 0..MIN_GC_THRESHOLD - 1 {
+            drop(table.make(value.to_string()));
+        }
+        let same = table.make("retained".to_string());
+
+        assert_eq!(table.table.len(), 1);
+        assert_eq!(retained, same);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- periodically sweep dead weak entries from the symbolic expression hash-consing table
- adapt the next sweep threshold to the surviving live set, keeping scans amortized
- preserve live interned identity and existing same-value reclamation

## Why

The table stores weak references, but distinct short-lived expressions were never removed unless a later expression happened to match the same hash-table entry. Long executor-heavy runs therefore accumulated one dead entry per expression for the lifetime of the symbolic context.

A macOS `sample` profile of a 10,000,000-iteration straight-line symbolic loop attributed 37.7% of active executor-thread samples to `HashCons::make`, with additional time in table growth and allocation.

## Benchmarks

Three runs per side using the same profiling build and `/usr/bin/time -lp`; values are medians:

| metric | master | candidate | delta |
| --- | ---: | ---: | ---: |
| wall | 20.02s | 8.53s | -57.4% |
| user CPU | 19.02s | 8.32s | -56.3% |
| peak RSS | 3,813,851,136 B | 52,248,576 B | -98.6% |

Both sides executed the same bounded symbolic loop and stopped at the same max-depth outcome. Retired instruction counts were effectively unchanged; the speedup comes from avoiding hash-table growth and its cache/allocator cost.

The pinned real-project symbolic suites remain behavior-identical:

| suite | result | deterministic symbolic metrics | wall |
| --- | --- | --- | ---: |
| Solady v0.1.26 | 11 pass, 2 incomplete | 35 paths, 168 solver queries, 56 SMT queries | 1.218s → 1.229s (+0.9%) |
| Angstrom | 1 incomplete | 9 paths, 12 solver queries, 1 SMT query | 287.3ms → 288.4ms (+0.4%) |
| Farcaster | 2 pass | 14 paths, 14 solver queries, 9 SMT queries | 106.8ms → 107.1ms (+0.3%) |

Solady used 20 timing runs; Angstrom and Farcaster used 30. These short suites are neutral within run-to-run noise.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo +1.96.0 nextest run -p foundry-evm-symbolic` (277 passed)
- `cargo +1.96.0 check -p foundry-evm-symbolic -p forge`
- `cargo +nightly clippy -p foundry-evm-symbolic -p forge --all-targets -- -D warnings`
- exact base/candidate symbolic JSON comparison on Solady, Angstrom, and Farcaster

## AI assistance

This PR was implemented with Codex assistance. I reviewed the profile, patch, benchmark design, and validation results. PR responses may also be AI-assisted.
