### PR TITLE
test(anvil): expect IPC parse errors

### DIFF
--- a/crates/anvil/tests/it/ipc.rs
+++ b/crates/anvil/tests/it/ipc.rs
@@ -75,7 +75,7 @@ async fn malformed_delimiter_does_not_corrupt_ipc_connection() {
     writer.write_all(b"}").await.unwrap();
     reader.read_line(&mut response).await.unwrap();
     let malformed = serde_json::from_str::<serde_json::Value>(&response).unwrap();
-    assert_eq!(malformed["error"]["code"], -32600);
+    assert_eq!(malformed["error"]["code"], -32700);
 
     response.clear();
     writer


### PR DESCRIPTION
## Motivation

Follow-up to #16226 and #16227.

The IPC framing test added in #16226 expected -32600 for a lone }, but #16227 changed malformed JSON syntax to return the standard -32700 parse error. A merge conflict between those changes left the test with the stale expectation. This updates the assertion to match the normalized behavior without changing framing coverage