### PR TITLE
fix(symbolic): track runtime memory extents

### DIFF
--- a/.changelog/symbolic-copy-memory-size.md
+++ b/.changelog/symbolic-copy-memory-size.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Fixed symbolic zero-length memory copies incorrectly expanding `MSIZE`.

--- a/crates/evm/symbolic/src/runtime/memory.rs
+++ b/crates/evm/symbolic/src/runtime/memory.rs
@@ -44,23 +44,35 @@ pub(crate) enum BoundedCopySize {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SymMemory {
     symbolic_writes: Vec<SymbolicMemoryWrite>,
-    size: usize,
+    concrete_size: usize,
+    materialized_size: usize,
 }
 
 #[derive(Clone, Debug)]
 struct SymbolicMemoryWrite {
     offset: SymExpr,
     bytes: SymBytes,
+    access_size: Option<SymExpr>,
 }
 
 impl SymbolicMemoryWrite {
     fn size_after_access(&self, cx: &mut SymCx) -> SymExpr {
-        let len = SymExpr::constant(cx, U256::from(self.bytes.len()));
+        let len = self
+            .access_size
+            .clone()
+            .unwrap_or_else(|| SymExpr::constant(cx, U256::from(self.bytes.len())));
         let end = SymExpr::binop(cx, SymBinOp::Add, self.offset.clone(), len);
         let round = SymExpr::constant(cx, U256::from(31));
         let rounded = SymExpr::binop(cx, SymBinOp::Add, end, round);
         let mask = SymExpr::constant(cx, !U256::from(31));
-        SymExpr::binop(cx, SymBinOp::And, rounded, mask)
+        let rounded = SymExpr::binop(cx, SymBinOp::And, rounded, mask);
+        if let Some(access_size) = &self.access_size {
+            let is_empty = SymBoolExpr::eq_word_const(cx, access_size, U256::ZERO);
+            let zero = SymExpr::zero(cx);
+            SymExpr::ite(cx, is_empty, zero, rounded)
+        } else {
+            rounded
+        }
     }
 
     fn concrete_offset(&self) -> Option<usize> {
@@ -135,7 +147,9 @@ impl SymMemory {
         if bytes.is_empty() {
             return;
         }
-        self.size = self.size.max(Self::size_after_access(offset, bytes.len()));
+        let size = Self::size_after_access(offset, bytes.len());
+        self.concrete_size = self.concrete_size.max(size);
+        self.materialized_size = self.materialized_size.max(size);
         let offset = SymExpr::constant(cx, U256::from(offset));
         self.store_symbolic_bytes(offset, bytes);
     }
@@ -144,7 +158,26 @@ impl SymMemory {
         if bytes.is_empty() {
             return;
         }
-        self.symbolic_writes.push(SymbolicMemoryWrite { offset, bytes });
+        self.symbolic_writes.push(SymbolicMemoryWrite { offset, bytes, access_size: None });
+    }
+
+    fn store_symbolic_sized_bytes(
+        &mut self,
+        offset: SymExpr,
+        bytes: SymBytes,
+        access_size: SymExpr,
+    ) {
+        if !bytes.is_empty()
+            && let Some(offset) = offset.eval().and_then(|offset| usize::try_from(offset).ok())
+        {
+            let size = Self::size_after_access(offset, bytes.len());
+            self.materialized_size = self.materialized_size.max(size);
+        }
+        self.symbolic_writes.push(SymbolicMemoryWrite {
+            offset,
+            bytes,
+            access_size: Some(access_size),
+        });
     }
 
     pub(crate) fn store_bytes_offset(&mut self, cx: &mut SymCx, offset: SymExpr, bytes: SymBytes) {
@@ -185,7 +218,7 @@ impl SymMemory {
         offset: &SymExpr,
     ) -> Result<SymExpr, SymbolicError> {
         let mut result = SymExpr::zero(cx);
-        for candidate in (0..self.size).rev() {
+        for candidate in (0..self.materialized_size).rev() {
             let candidate_expr = SymExpr::constant(cx, U256::from(candidate));
             let condition = SymBoolExpr::eq(cx, offset.clone(), candidate_expr);
             let word = self.load_word(cx, candidate)?;
@@ -388,7 +421,7 @@ impl SymMemory {
         delta: usize,
     ) -> SymExpr {
         let mut result = SymExpr::zero(cx);
-        for candidate in (delta..self.size).rev() {
+        for candidate in (delta..self.materialized_size).rev() {
             let candidate_expr = SymExpr::constant(cx, U256::from(candidate - delta));
             let condition = SymBoolExpr::eq(cx, offset.clone(), candidate_expr);
             let byte = self.byte(cx, candidate);
@@ -398,9 +431,9 @@ impl SymMemory {
     }
 
     pub(crate) fn size_word(&self, cx: &mut SymCx) -> SymExpr {
-        let mut size = SymExpr::constant(cx, U256::from(self.size));
+        let mut size = SymExpr::constant(cx, U256::from(self.concrete_size));
         for write in &self.symbolic_writes {
-            if write.concrete_offset().is_some() {
+            if write.concrete_offset().is_some() && write.access_size.is_none() {
                 continue;
             }
             let write_size = write.size_after_access(cx);
@@ -441,7 +474,8 @@ impl SymMemory {
                     })
                     .collect::<Vec<_>>();
                 let bytes = SymBytes::exprs(cx, bytes);
-                self.store_bytes(cx, dest, bytes);
+                let dest = SymExpr::constant(cx, U256::from(dest));
+                self.store_symbolic_sized_bytes(dest, bytes, size);
             }
         } else {
             let bytes = (0..src.len())
@@ -452,7 +486,7 @@ impl SymMemory {
                 })
                 .collect();
             let bytes = SymBytes::exprs(cx, bytes);
-            self.store_symbolic_bytes(dest, bytes);
+            self.store_symbolic_sized_bytes(dest, bytes, size);
         }
         Ok(())
     }
@@ -582,32 +616,32 @@ impl SymMemory {
     ) -> Result<(), SymbolicError> {
         match size {
             BoundedCopySize::Concrete(size) => {
-                let size = (*size).min(return_data.len());
-                if size != 0 {
-                    if return_data.has_symbolic_len() {
-                        let bytes = (0..size)
+                if *size != 0 {
+                    let copy_size = (*size).min(return_data.len());
+                    let bytes = if return_data.has_symbolic_len() {
+                        let bytes = (0..copy_size)
                             .map(|idx| self.call_output_byte(cx, &dest, idx, None, return_data))
                             .collect::<Vec<_>>();
-                        let bytes = SymBytes::exprs(cx, bytes);
-                        self.store_bytes_offset(cx, dest, bytes);
+                        SymBytes::exprs(cx, bytes)
                     } else {
                         let offset = SymExpr::zero(cx);
-                        let bytes = return_data.read_bytes_offset(cx, offset, size);
-                        self.store_bytes_offset(cx, dest, bytes);
-                    }
+                        return_data.read_bytes_offset(cx, offset, copy_size)
+                    };
+                    let size = SymExpr::constant(cx, U256::from(*size));
+                    self.store_symbolic_sized_bytes(dest, bytes, size);
                 }
             }
             BoundedCopySize::Symbolic { size, max_size } => {
                 let output_size = size.clone();
-                let max_size = (*max_size).min(return_data.len());
-                if max_size != 0 {
-                    let bytes = (0..max_size)
+                if *max_size != 0 {
+                    let copy_size = (*max_size).min(return_data.len());
+                    let bytes = (0..copy_size)
                         .map(|idx| {
                             self.call_output_byte(cx, &dest, idx, Some(&output_size), return_data)
                         })
                         .collect::<Vec<_>>();
                     let bytes = SymBytes::exprs(cx, bytes);
-                    self.store_bytes_offset(cx, dest, bytes);
+                    self.store_symbolic_sized_bytes(dest, bytes, output_size);
                 }
             }
         }

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -731,6 +731,26 @@ fn memory_copies_symbolic_bytecode_size_with_guarded_tail() {
 }
 
 #[test]
+fn memory_symbolic_copy_size_controls_extent() {
+    let mut cx = SymCx::new();
+    let mut memory = SymMemory::default();
+    let dest = SymExpr::constant(&mut cx, U256::from(0x100));
+    let size = SymExpr::var(&mut cx, "size");
+    let bytes = (0u8..4).map(|idx| SymExpr::constant(&mut cx, U256::from(idx + 1))).collect();
+    let bytes = SymBytes::exprs(&mut cx, bytes);
+    memory.copy_bytes_size_offset(&mut cx, dest, size, bytes).unwrap();
+    let memory_size = memory.size_word(&mut cx);
+
+    let size_zero = symbolic_model(&mut cx, [("size".to_string(), U256::ZERO)]);
+    assert_eq!(memory_size.eval_model(&size_zero).unwrap(), U256::ZERO);
+
+    for size in 1..=4 {
+        let model = symbolic_model(&mut cx, [("size".to_string(), U256::from(size))]);
+        assert_eq!(memory_size.eval_model(&model).unwrap(), U256::from(0x120));
+    }
+}
+
+#[test]
 fn memory_copies_folded_symbolic_size_prefix_only() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
@@ -1291,6 +1311,42 @@ fn memory_call_output_accepts_symbolic_size_with_guarded_tail() {
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_four).unwrap(),
         vec![1, 2, 3, 4]
     );
+}
+
+#[test]
+fn memory_call_output_size_controls_extent() {
+    let mut cx = SymCx::new();
+    let return_data = SymReturnData::empty(&mut cx);
+    let mut memory = SymMemory::default();
+    let dest = SymExpr::constant(&mut cx, U256::from(0x100));
+    let size = SymExpr::var(&mut cx, "size");
+    let copy_size = BoundedCopySize::Symbolic { size, max_size: 4 };
+
+    memory.copy_call_output_offset(&mut cx, dest, &copy_size, &return_data).unwrap();
+    let memory_size = memory.size_word(&mut cx);
+
+    let size_zero = symbolic_model(&mut cx, [("size".to_string(), U256::ZERO)]);
+    assert_eq!(memory_size.eval_model(&size_zero).unwrap(), U256::ZERO);
+
+    let size_one = symbolic_model(&mut cx, [("size".to_string(), U256::from(1))]);
+    assert_eq!(memory_size.eval_model(&size_one).unwrap(), U256::from(0x120));
+}
+
+#[test]
+fn memory_call_output_preserves_symbolic_read_bound() {
+    let mut cx = SymCx::new();
+    let return_data = SymReturnData::from_concrete_bytes(&mut cx, vec![1]);
+    let mut memory = SymMemory::default();
+    let dest = SymExpr::constant(&mut cx, U256::from(0x100));
+
+    memory
+        .copy_call_output_offset(&mut cx, dest, &BoundedCopySize::Concrete(1), &return_data)
+        .unwrap();
+
+    let offset = SymExpr::var(&mut cx, "offset");
+    let value = memory.load_word_offset(&mut cx, offset).unwrap();
+    let model = symbolic_model(&mut cx, [("offset".to_string(), U256::from(0x100))]);
+    assert_eq!(value.eval_model(&model).unwrap(), U256::from(1) << 248);
 }
 
 #[test]

--- a/crates/forge/tests/cli/test_cmd/symbolic_memory.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_memory.rs
@@ -214,6 +214,44 @@ contract SymbolicMsizeAfterWrite {
     assert!(!stdout.contains("symbolic MSIZE after symbolic memory write"), "{stdout}");
 });
 
+forgetest_init!(symbolic_msize_respects_zero_symbolic_copy_size, |prj, cmd| {
+    skip_unless_z3!("symbolic_msize_respects_zero_symbolic_copy_size");
+
+    prj.add_test(
+        "SymbolicMsizeAfterCopy.t.sol",
+        r#"
+contract SymbolicMsizeAfterCopy {
+    function checkZeroLengthCopy(uint8 n) public pure {
+        uint256 size = uint256(n & 3);
+        uint256 beforeSize;
+        uint256 afterSize;
+        assembly {
+            beforeSize := msize()
+            calldatacopy(0x100, 0, size)
+            afterSize := msize()
+        }
+
+        assert(size != 0 || afterSize != beforeSize);
+    }
+}
+"#,
+    );
+
+    let stdout =
+        assert_symbolic(cmd.args(["test", "--symbolic", "--match-test", "checkZeroLengthCopy"]))
+            .failure()
+            .get_output()
+            .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        str![[r#"
+[FAIL: panic: assertion failed
+"#]],
+    );
+    assert!(!stdout.contains("symbolic counterexample did not replay"), "{stdout}");
+});
+
 forgetest_init!(symbolic_sha3_accepts_symbolic_offset, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(


### PR DESCRIPTION
Bounded symbolic memory operations materialize their maximum possible byte count, but previously reused that analysis bound when computing `MSIZE`. This caused zero-length copies to expand memory and could produce false proofs.

Separate EVM-visible memory extent from the internal materialized-byte bound used by symbolic reads. This also corrects CALL output handling, where the requested output size controls memory expansion while returndata length controls how many bytes are overwritten.