### PR TITLE
fix(anvil): restore fee state on revert

### DIFF
--- a/.changelog/anvil-revert-fee-state.md
+++ b/.changelog/anvil-revert-fee-state.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed `evm_revert` retaining fee state from reverted blocks.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -38,7 +38,7 @@ use crate::{
             validate::TransactionValidator,
         },
         error::{BlockchainError, ErrDetail, InvalidTransactionError},
-        fees::{FeeDetails, FeeManager, MIN_SUGGESTED_PRIORITY_FEE},
+        fees::{FeeDetails, FeeManager, FeeSnapshot, MIN_SUGGESTED_PRIORITY_FEE},
         macros::node_info,
         pool::transactions::PoolTransaction,
         preserve_simulation_request_fields,
@@ -979,6 +979,12 @@ impl<T> BlockRequest<T> {
     }
 }
 
+struct StateSnapshot {
+    block_number: u64,
+    block_hash: B256,
+    fees: FeeSnapshot,
+}
+
 /// Gives access to the [revm::Database]
 pub struct Backend<N: Network> {
     /// Access to [`revm::Database`] abstraction.
@@ -1027,7 +1033,7 @@ pub struct Backend<N: Network> {
     /// removed from the canonical chain due to a reorg.
     new_block_listeners: Arc<Mutex<Vec<UnboundedSender<ChainNotification>>>>,
     /// Keeps track of active state snapshots at a specific block.
-    active_state_snapshots: Arc<Mutex<HashMap<U256, (u64, B256)>>>,
+    active_state_snapshots: Arc<Mutex<HashMap<U256, StateSnapshot>>>,
     enable_steps_tracing: bool,
     print_logs: bool,
     print_traces: bool,
@@ -1923,12 +1929,19 @@ impl<N: Network> Backend<N> {
         let hash = self.best_hash();
         let id = self.db.write().await.snapshot_state();
         trace!(target: "backend", "creating snapshot {} at {}", id, num);
-        self.active_state_snapshots.lock().insert(id, (num, hash));
+        self.active_state_snapshots.lock().insert(
+            id,
+            StateSnapshot { block_number: num, block_hash: hash, fees: self.fees.snapshot() },
+        );
         id
     }
 
     pub fn list_state_snapshots(&self) -> BTreeMap<U256, (u64, B256)> {
-        self.active_state_snapshots.lock().clone().into_iter().collect()
+        self.active_state_snapshots
+            .lock()
+            .iter()
+            .map(|(&id, snapshot)| (id, (snapshot.block_number, snapshot.block_hash)))
+            .collect()
     }
 
     /// Returns the environment for the next block
@@ -5098,10 +5111,14 @@ impl<N: Network> Backend<N> {
 
     /// Reverts the state to the state snapshot identified by the given `id`.
     pub async fn revert_state_snapshot(&self, id: U256) -> Result<bool, BlockchainError> {
-        let Some((num, hash)) = self.active_state_snapshots.lock().remove(&id) else {
+        let Some(snapshot) = self.active_state_snapshots.lock().remove(&id) else {
             return Ok(false);
         };
+        let StateSnapshot { block_number: num, block_hash: hash, fees } = snapshot;
         let block = self.block_by_hash(hash).await?.ok_or(BlockchainError::BlockNotFound)?;
+        if !self.db.write().await.revert_state(id, RevertStateSnapshotAction::RevertRemove) {
+            return Ok(false);
+        }
 
         {
             // revert the storage that's newer than the snapshot
@@ -5146,7 +5163,8 @@ impl<N: Network> Backend<N> {
                 ..Default::default()
             };
         }
-        Ok(self.db.write().await.revert_state(id, RevertStateSnapshotAction::RevertRemove))
+        self.fees.restore(fees);
+        Ok(true)
     }
 
     /// executes the transactions without writing to the underlying database

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -64,6 +64,13 @@ struct FeeState {
     gas_price: u128,
 }
 
+/// Chain-derived fee state for the next block.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FeeSnapshot {
+    base_fee: u64,
+    blob_excess_gas_and_price: BlobExcessGasAndPrice,
+}
+
 impl FeeManager {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -106,6 +113,22 @@ impl FeeManager {
     /// Replaces all mutable fee state with a staged manager's values.
     pub(crate) fn replace_from(&self, other: &Self) {
         *self.state.write() = *other.state.read();
+    }
+
+    /// Captures the chain-derived fee state for the next block.
+    pub(crate) fn snapshot(&self) -> FeeSnapshot {
+        let state = self.state.read();
+        FeeSnapshot {
+            base_fee: state.base_fee,
+            blob_excess_gas_and_price: state.blob_excess_gas_and_price,
+        }
+    }
+
+    /// Restores the chain-derived fee state for the next block.
+    pub(crate) fn restore(&self, snapshot: FeeSnapshot) {
+        let mut state = self.state.write();
+        state.base_fee = snapshot.base_fee;
+        state.blob_excess_gas_and_price = snapshot.blob_excess_gas_and_price;
     }
 
     /// Returns the active Tempo hardfork, if running a Tempo chain.

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -750,6 +750,23 @@ async fn test_fork_revert_next_block_timestamp() {
     assert!(block.header.timestamp >= latest_block.header.timestamp);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_revert_restores_next_block_base_fee() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    let base_fee = api.base_fee().unwrap();
+    let state_snapshot = api.evm_snapshot().await.unwrap();
+
+    api.mine_one().await.unwrap();
+    let first_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_ne!(api.base_fee().unwrap(), base_fee);
+    api.evm_revert(state_snapshot).await.unwrap();
+    assert_eq!(api.base_fee().unwrap(), base_fee);
+
+    api.mine_one().await.unwrap();
+    let remined_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(remined_block.header.base_fee_per_gas, first_block.header.base_fee_per_gas);
+}
+
 // Tests that `anvil_setNextBlockPrevRandao` overrides the `prevrandao` (block header `mixHash`) of
 // the next mined block, and that the override is one-shot: subsequent blocks fall back to anvil's
 // default per-block `prevrandao` derivation.


### PR DESCRIPTION
Mining advances next-block base and blob fee state outside the database snapshot. As a result, `evm_revert` restored the chain head and database while retaining fee progression from reverted blocks, causing a replacement block to use a different base fee.

This stores the chain-derived next-block fee state with each snapshot and restores it only after the database revert succeeds. Persistent gas-price configuration and fee rules remain unchanged. Regression coverage verifies that mining, reverting, and remining produces the same base fee.