### PR TITLE
feat(chisel): expose last result as $_

### DIFF
--- a/.changelog/chisel-last-result.md
+++ b/.changelog/chisel-last-result.md
@@ -1,0 +1,5 @@
+---
+chisel: minor
+---
+
+Added `$_` for reusing the last evaluated Chisel result.

--- a/.changelog/chisel-last-result.md
+++ b/.changelog/chisel-last-result.md
@@ -2,4 +2,5 @@
 chisel: minor
 ---
 
-Added `$_` for reusing the last evaluated Chisel result.
+Added `$_` for reusing the last evaluated Chisel result. `!source`, `!edit`, `!save`, and `!export`
+use its ABI-decoding expansion so replayed source remains executable.

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -4,6 +4,7 @@
 //! of both builtin commands and Solidity snippets.
 
 use crate::{
+    executor::InspectResult,
     prelude::{ChiselCommand, ChiselResult, ChiselSession, SessionSourceConfig, SolidityHelper},
     source::SessionSource,
 };
@@ -137,23 +138,21 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         // Create new source with exact input appended and parse
         let (new_source, do_execute) = source.clone_with_new_line(input.to_string())?;
 
-        let (cf, res, last_result) = source.inspect(input).await?;
-        if let Some(res) = &res {
+        let InspectResult { control_flow, formatted_output, last_result } =
+            source.inspect(input).await?;
+        if let Some(last_result) = last_result {
+            self.last_result = Some(last_result);
+        }
+        if let Some(res) = &formatted_output {
             let _ = sh_println!("{res}");
         }
-        if cf.is_break() {
-            if last_result.is_some() {
-                self.last_result = last_result;
-            }
-            debug!(%input, ?res, "inspect success");
+        if control_flow.is_break() {
+            debug!(%input, ?formatted_output, "inspect success");
             return Ok(ControlFlow::Continue(()));
         }
 
         if do_execute {
             self.execute_and_replace(new_source).await?;
-            if last_result.is_some() {
-                self.last_result = last_result;
-            }
         } else {
             let out = new_source.build()?;
             debug!(%input, ?out, "skipped execute and rebuild source");
@@ -297,6 +296,7 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
 
     pub(crate) fn clear_source(&mut self) -> Result<()> {
         self.source_mut().clear();
+        self.last_result = None;
         sh_println!("Cleared session!")
     }
 
@@ -353,6 +353,7 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         new_session.source.config.initialize_local_context();
         new_session.source.build()?;
         self.session = new_session;
+        self.last_result = None;
         sh_println!("Loaded Chisel session! (ID = {})", self.session.id.as_ref().unwrap())
     }
 
@@ -608,7 +609,8 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         let source = self.source_mut();
         let line = format!("bytes32 __raw__; assembly {{ __raw__ := {var} }}");
         if let Ok((new_source, _)) = source.clone_with_new_line(line)
-            && let (_, Some(res), _) = new_source.inspect("__raw__").await?
+            && let InspectResult { formatted_output: Some(res), .. } =
+                new_source.inspect("__raw__").await?
         {
             sh_println!("{res}")?;
             return Ok(());

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -53,6 +53,7 @@ pub const CHISEL_CHAR: &str = "⚒️";
 pub struct ChiselDispatcher<FEN: FoundryEvmNetwork> {
     pub session: ChiselSession<FEN>,
     pub helper: SolidityHelper,
+    last_result: Option<String>,
 }
 
 /// Helper function that formats solidity source with the given [FormatterConfig]
@@ -65,7 +66,7 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
     /// Associated public function to create a new Dispatcher instance
     pub fn new(config: SessionSourceConfig<FEN>) -> eyre::Result<Self> {
         let session = ChiselSession::new(config)?;
-        Ok(Self { session, helper: Default::default() })
+        Ok(Self { session, helper: Default::default(), last_result: None })
     }
 
     /// Returns the optional ID of the current session.
@@ -118,11 +119,11 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
             };
         }
 
-        let source = self.source_mut();
-
         input = input.trim();
-        let (only_trivia, new_input) = preprocess(input);
+        let (only_trivia, new_input) = preprocess(input, self.last_result.as_deref())?;
         input = &*new_input;
+
+        let source = self.source_mut();
 
         // If the input is a comment, add it to the run code so we avoid running with empty input
         if only_trivia {
@@ -136,23 +137,29 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         // Create new source with exact input appended and parse
         let (new_source, do_execute) = source.clone_with_new_line(input.to_string())?;
 
-        let (cf, res) = source.inspect(input).await?;
+        let (cf, res, last_result) = source.inspect(input).await?;
         if let Some(res) = &res {
             let _ = sh_println!("{res}");
         }
         if cf.is_break() {
+            if last_result.is_some() {
+                self.last_result = last_result;
+            }
             debug!(%input, ?res, "inspect success");
             return Ok(ControlFlow::Continue(()));
         }
 
         if do_execute {
-            self.execute_and_replace(new_source).await.map(ControlFlow::Continue)
+            self.execute_and_replace(new_source).await?;
+            if last_result.is_some() {
+                self.last_result = last_result;
+            }
         } else {
             let out = new_source.build()?;
             debug!(%input, ?out, "skipped execute and rebuild source");
             *self.source_mut() = new_source;
-            Ok(ControlFlow::Continue(()))
         }
+        Ok(ControlFlow::Continue(()))
     }
 
     /// Decodes traces in the given [`ChiselResult`].
@@ -601,7 +608,7 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         let source = self.source_mut();
         let line = format!("bytes32 __raw__; assembly {{ __raw__ := {var} }}");
         if let Ok((new_source, _)) = source.clone_with_new_line(line)
-            && let (_, Some(res)) = new_source.inspect("__raw__").await?
+            && let (_, Some(res), _) = new_source.inspect("__raw__").await?
         {
             sh_println!("{res}")?;
             return Ok(());
@@ -645,11 +652,11 @@ fn ensure_loaded_session_network_matches(
     Ok(())
 }
 
-/// Preprocesses addresses to ensure they are correctly checksummed and returns whether the input
-/// only contained trivia (comments, whitespace).
-fn preprocess(input: &str) -> (bool, Cow<'_, str>) {
+/// Expands the previous result, checksums addresses, and returns whether the input only contained
+/// trivia (comments, whitespace).
+fn preprocess<'a>(input: &'a str, last_result: Option<&str>) -> Result<(bool, Cow<'a, str>)> {
     let mut only_trivia = true;
-    let mut new_input = Cow::Borrowed(input);
+    let mut replacements = Vec::new();
     for (pos, token) in solar::parse::Cursor::new(input).with_position() {
         use RawTokenKind::{BlockComment, LineComment, Literal, Whitespace};
 
@@ -658,17 +665,31 @@ fn preprocess(input: &str) -> (bool, Cow<'_, str>) {
         }
         only_trivia = false;
 
+        let range = pos..pos + token.len as usize;
+        if &input[range.clone()] == "$_" {
+            let last_result = last_result.ok_or_else(|| eyre::eyre!("no previous result"))?;
+            replacements.push((range, format!("({last_result})")));
+            continue;
+        }
+
         // Ensure that addresses are correctly checksummed.
         if let Literal { kind: RawLiteralKind::Int { base: Base::Hexadecimal, .. } } = token.kind
             && token.len == 42
+            && let Ok(addr) = input[range.clone()].parse::<Address>()
         {
-            let range = pos..pos + 42;
-            if let Ok(addr) = input[range.clone()].parse::<Address>() {
-                new_input.to_mut().replace_range(range, addr.to_checksum_buffer(None).as_str());
-            }
+            replacements.push((range, addr.to_checksum_buffer(None).to_string()));
         }
     }
-    (only_trivia, new_input)
+
+    if replacements.is_empty() {
+        Ok((only_trivia, Cow::Borrowed(input)))
+    } else {
+        let mut new_input = input.to_string();
+        for (range, replacement) in replacements.into_iter().rev() {
+            new_input.replace_range(range, &replacement);
+        }
+        Ok((only_trivia, Cow::Owned(new_input)))
+    }
 }
 
 #[cfg(test)]
@@ -813,7 +834,7 @@ mod tests {
     #[test]
     fn test_trivia() {
         fn only_trivia(s: &str) -> bool {
-            let (only_trivia, _new_input) = preprocess(s);
+            let (only_trivia, _new_input) = preprocess(s, None).unwrap();
             only_trivia
         }
         assert!(only_trivia("// line comment"));
@@ -823,5 +844,18 @@ mod tests {
         assert!(only_trivia("/* block comment */"));
         assert!(only_trivia(" \t\n  /* block \n \t comment */\n"));
         assert!(!only_trivia("/* block \n \t comment */\nwith \tother"));
+    }
+
+    #[test]
+    fn test_last_result_preprocessing() {
+        let result = "abi.decode(hex\"2a\", (uint256))";
+        let (_, input) = preprocess("uint256 answer = $_;", Some(result)).unwrap();
+        assert_eq!(input, format!("uint256 answer = ({result});"));
+
+        let literal = r#"string memory value = "$_"; // $_"#;
+        let (_, input) = preprocess(literal, Some(result)).unwrap();
+        assert_eq!(input, literal);
+
+        assert_eq!(preprocess("$_", None).unwrap_err().to_string(), "no previous result");
     }
 }

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -27,6 +27,23 @@ use solar::{
 use std::ops::ControlFlow;
 use yansi::Paint;
 
+/// Result of inspecting a Solidity snippet.
+#[derive(Debug)]
+pub struct InspectResult {
+    /// Whether the input was fully handled by inspection.
+    pub control_flow: ControlFlow<()>,
+    /// The formatted value to display, if any.
+    pub formatted_output: Option<String>,
+    /// An expression that recreates the inspected value, if any.
+    pub last_result: Option<String>,
+}
+
+impl InspectResult {
+    const fn empty(control_flow: ControlFlow<()>) -> Self {
+        Self { control_flow, formatted_output: None, last_result: None }
+    }
+}
+
 /// Executor implementation for [SessionSource]
 impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
     /// Runs the source with the [ChiselRunner]
@@ -57,20 +74,14 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
     ///
     /// ### Returns
     ///
-    /// If the input is valid `Ok((continue, formatted_output, last_result))` where:
-    /// - `continue` is true if the input should be appended to the source
-    /// - `formatted_output` is the formatted value, if any
-    /// - `last_result` is an expression that recreates the inspected value, if any
-    pub async fn inspect(
-        &self,
-        input: &str,
-    ) -> Result<(ControlFlow<()>, Option<String>, Option<String>)> {
+    /// If the input is valid, returns its [`InspectResult`].
+    pub async fn inspect(&self, input: &str) -> Result<InspectResult> {
         let line = format!("bytes memory inspectoor = abi.encode({input});");
         let mut source = match self.clone_with_new_line(line) {
             Ok((source, _)) => source,
             Err(err) => {
                 debug!(%err, "failed to build new source for inspection");
-                return Ok((ControlFlow::Continue(()), None, None));
+                return Ok(InspectResult::empty(ControlFlow::Continue(())));
             }
         };
 
@@ -100,7 +111,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                     })
                     .unwrap_or(false);
                 if should_execute {
-                    return Ok((ControlFlow::Continue(()), None, None));
+                    return Ok(InspectResult::empty(ControlFlow::Continue(())));
                 }
                 match source_without_inspector.execute().await {
                     Ok(res) => (res, Some(err)),
@@ -108,7 +119,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                         if self.config.foundry_config.verbosity >= 3 {
                             sh_err!("Could not inspect: {err}")?;
                         }
-                        return Ok((ControlFlow::Continue(()), None, None));
+                        return Ok(InspectResult::empty(ControlFlow::Continue(())));
                     }
                 }
             }
@@ -123,7 +134,11 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                 output.get_event(input).map(|eid| format_event_definition(gcx, gcx.hir.event(eid)))
             });
             if let Some(formatted_event) = formatted_event {
-                return Ok((ControlFlow::Break(()), Some(formatted_event?), None));
+                return Ok(InspectResult {
+                    control_flow: ControlFlow::Break(()),
+                    formatted_output: Some(formatted_event?),
+                    last_result: None,
+                });
             }
 
             // we were unable to check the event
@@ -132,7 +147,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
             }
 
             debug!(%err, %input, "failed abi encode input");
-            return Ok((ControlFlow::Break(()), None, None));
+            return Ok(InspectResult::empty(ControlFlow::Break(())));
         }
         drop(source_without_inspector);
 
@@ -176,7 +191,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
         });
 
         let Some((cont, ty)) = res_ty else {
-            return Ok((ControlFlow::Continue(()), None, None));
+            return Ok(InspectResult::empty(ControlFlow::Continue(())));
         };
 
         // the file compiled correctly, thus the last stack item must be the memory offset of
@@ -195,7 +210,11 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
         let last_result = format!("abi.decode(hex\"{}\", ({ty}))", hex::encode(data));
         let token = ty.abi_decode(data).wrap_err("Could not decode inspected values")?;
         let c = if cont { ControlFlow::Continue(()) } else { ControlFlow::Break(()) };
-        Ok((c, Some(format_token(token)), Some(last_result)))
+        Ok(InspectResult {
+            control_flow: c,
+            formatted_output: Some(format_token(token)),
+            last_result: Some(last_result),
+        })
     }
 
     async fn build_runner(&mut self, final_pc: usize) -> Result<ChiselRunner<FEN>> {

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -57,16 +57,20 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
     ///
     /// ### Returns
     ///
-    /// If the input is valid `Ok((continue, formatted_output))` where:
+    /// If the input is valid `Ok((continue, formatted_output, last_result))` where:
     /// - `continue` is true if the input should be appended to the source
     /// - `formatted_output` is the formatted value, if any
-    pub async fn inspect(&self, input: &str) -> Result<(ControlFlow<()>, Option<String>)> {
+    /// - `last_result` is an expression that recreates the inspected value, if any
+    pub async fn inspect(
+        &self,
+        input: &str,
+    ) -> Result<(ControlFlow<()>, Option<String>, Option<String>)> {
         let line = format!("bytes memory inspectoor = abi.encode({input});");
         let mut source = match self.clone_with_new_line(line) {
             Ok((source, _)) => source,
             Err(err) => {
                 debug!(%err, "failed to build new source for inspection");
-                return Ok((ControlFlow::Continue(()), None));
+                return Ok((ControlFlow::Continue(()), None, None));
             }
         };
 
@@ -96,7 +100,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                     })
                     .unwrap_or(false);
                 if should_execute {
-                    return Ok((ControlFlow::Continue(()), None));
+                    return Ok((ControlFlow::Continue(()), None, None));
                 }
                 match source_without_inspector.execute().await {
                     Ok(res) => (res, Some(err)),
@@ -104,7 +108,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                         if self.config.foundry_config.verbosity >= 3 {
                             sh_err!("Could not inspect: {err}")?;
                         }
-                        return Ok((ControlFlow::Continue(()), None));
+                        return Ok((ControlFlow::Continue(()), None, None));
                     }
                 }
             }
@@ -119,7 +123,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                 output.get_event(input).map(|eid| format_event_definition(gcx, gcx.hir.event(eid)))
             });
             if let Some(formatted_event) = formatted_event {
-                return Ok((ControlFlow::Break(()), Some(formatted_event?)));
+                return Ok((ControlFlow::Break(()), Some(formatted_event?), None));
             }
 
             // we were unable to check the event
@@ -128,7 +132,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
             }
 
             debug!(%err, %input, "failed abi encode input");
-            return Ok((ControlFlow::Break(()), None));
+            return Ok((ControlFlow::Break(()), None, None));
         }
         drop(source_without_inspector);
 
@@ -172,7 +176,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
         });
 
         let Some((cont, ty)) = res_ty else {
-            return Ok((ControlFlow::Continue(()), None));
+            return Ok((ControlFlow::Continue(()), None, None));
         };
 
         // the file compiled correctly, thus the last stack item must be the memory offset of
@@ -188,9 +192,10 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
         let Some(data) = data else {
             eyre::bail!("Failed to inspect last expression: could not retrieve data from memory");
         };
+        let last_result = format!("abi.decode(hex\"{}\", ({ty}))", hex::encode(data));
         let token = ty.abi_decode(data).wrap_err("Could not decode inspected values")?;
         let c = if cont { ControlFlow::Continue(()) } else { ControlFlow::Break(()) };
-        Ok((c, Some(format_token(token))))
+        Ok((c, Some(format_token(token)), Some(last_result)))
     }
 
     async fn build_runner(&mut self, final_pc: usize) -> Result<ChiselRunner<FEN>> {

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -195,6 +195,27 @@ repl_test!(int_min_values, |repl| {
     repl.expect("-57896044618658097711785492504343953926634992332820282019728792003956564819968");
 });
 
+// Issue #5370: The last evaluated result can be reused in subsequent input.
+repl_test!(last_result, |repl| {
+    repl.sendln("type(uint256).max");
+    repl.sendln("uint256 MAX = $_");
+    repl.sendln("MAX");
+    repl.expect(
+        "Decimal: 115792089237316195423570985008687907853269984665640564039457584007913129639935",
+    );
+
+    repl.sendln("uint256 value = 1");
+    repl.sendln("value = 2");
+    repl.sendln("uint256 assigned = $_");
+    repl.sendln("assigned");
+    repl.expect("Decimal: 2");
+
+    repl.sendln(r#""hello""#);
+    repl.sendln("string memory greeting = $_");
+    repl.sendln("greeting");
+    repl.expect("UTF-8: hello");
+});
+
 // Issue #4393: Test edit command with traces.
 // TODO: test `!edit`
 // repl_test!(edit_with_traces, |repl| {

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -216,6 +216,30 @@ repl_test!(last_result, |repl| {
     repl.expect("UTF-8: hello");
 });
 
+repl_test!(last_result_resets_with_session, |repl| {
+    let saved_id = unique_cache_id("last-result-saved");
+    let loaded_id = unique_cache_id("last-result-loaded");
+    let _cleanup = CacheCleanup(vec![saved_id.clone(), loaded_id.clone()]);
+
+    repl.sendln("uint256 persisted = 7");
+    repl.sendln(&format!("!save {saved_id}"));
+    std::fs::copy(cache_file(&saved_id), cache_file(&loaded_id)).unwrap();
+
+    repl.sendln(r#""stale""#);
+    repl.sendln_raw(&format!("!load {loaded_id}"));
+    repl.expect(&format!("Loaded Chisel session! (ID = {saved_id})"));
+    repl.expect_prompt();
+    repl.sendln_raw("$_");
+    repl.expect("no previous result");
+    repl.expect_prompt();
+
+    repl.sendln("persisted");
+    repl.sendln("!clear");
+    repl.sendln_raw("$_");
+    repl.expect("no previous result");
+    repl.expect_prompt();
+});
+
 // Issue #4393: Test edit command with traces.
 // TODO: test `!edit`
 // repl_test!(edit_with_traces, |repl| {


### PR DESCRIPTION
Chisel prints evaluated values but does not expose them to subsequent input, so even a simple workflow such as assigning `type(uint256).max` requires copying the value manually. Closes #5370.

This preserves each successfully inspected value as its existing ABI encoding and expands a standalone `$_` identifier to a typed `abi.decode` expression. Using the captured encoding means the previous expression is not re-evaluated, works for dynamic values such as strings, and keeps `$_` inside strings or comments untouched. Assignment expressions also replace the previous result after they execute successfully.

This PR was written primarily by OpenAI Codex.
