### PR TITLE
feat(forge): add forge dependencies command

### DIFF
--- a/.changelog/forge-dependencies-command.md
+++ b/.changelog/forge-dependencies-command.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added `forge dependencies` (alias `forge deps`), listing installed Git submodule and Soldeer dependencies in one table or as JSON.

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -797,9 +797,21 @@ ignore them in the `.gitignore` file."
         self.cmd().args(["submodule", "status"]).get_stdout_lossy().map(|stdout| stdout.parse())?
     }
 
-    /// Returns submodules at or below `path`, with paths relative to this Git root.
-    pub fn submodules_in(&self, path: &Path) -> Result<Vec<SubmoduleCheckout>> {
-        self.submodules_in_worktree(path, self.root, Path::new(""))
+    /// Parses one line of `git submodule status`'s output (a single leading status char,
+    /// optional, then the checkout's rev) into a status/rev pair.
+    fn parse_submodule_status_line(line: &str) -> Result<(SubmoduleCheckoutStatus, &str)> {
+        let (status, rev) = match line.as_bytes().first() {
+            Some(b'-') => (SubmoduleCheckoutStatus::Uninitialized, &line[1..]),
+            Some(b'+') => (SubmoduleCheckoutStatus::Modified, &line[1..]),
+            Some(b'U') => (SubmoduleCheckoutStatus::Conflicted, &line[1..]),
+            Some(_) => (SubmoduleCheckoutStatus::Current, line),
+            None => return Err(eyre::eyre!("missing submodule status")),
+        };
+        let rev = rev
+            .split_ascii_whitespace()
+            .next()
+            .ok_or_else(|| eyre::eyre!("invalid submodule status"))?;
+        Ok((status, rev))
     }
 
     /// Returns submodules at or below `path`, with paths relative to this Git root, using mappings
@@ -818,6 +830,14 @@ ignore them in the `.gitignore` file."
             .exec()?;
         let (_, mappings) = self.submodule_mappings_at(worktree_root)?;
         let mut gitlinks = BTreeMap::new();
+        // Paths whose status still needs a `git submodule status` lookup, collected in the same
+        // order `git ls-files` emits them - always sorted by path, since that's how the Git index
+        // itself is ordered. Deferred to a single batched call after this loop instead of one
+        // subprocess spawn per submodule: for a repo with 25 submodules, N individual `git
+        // submodule status` calls measured ~2.5s versus ~1s for one batched call covering all of
+        // them - O(N) subprocess spawns instead of O(1), which extrapolates to 10+ seconds on a
+        // 100+-submodule monorepo for what's meant to be a quick status lookup.
+        let mut pending = Vec::new();
         for entry in output.stdout.split(|byte| *byte == 0).filter(|entry| !entry.is_empty()) {
             let Some(separator) = entry.iter().position(|byte| *byte == b'\t') else {
                 return Err(eyre::eyre!("invalid index entry"));
@@ -865,27 +885,39 @@ ignore them in the `.gitignore` file."
                 continue;
             }
 
-            let status = self
+            pending.push(submodule_path);
+        }
+
+        if !pending.is_empty() {
+            // Verified empirically: `git submodule status -- <p1> <p2> ...` always emits output
+            // sorted by path, regardless of the order the pathspecs are given as arguments -
+            // matching `pending`'s own order (ls-files's index-sorted iteration above), so a
+            // positional zip is safe without re-parsing each line's path back out (which would
+            // reopen exactly the whitespace/space-in-path ambiguity a NUL-delimited `ls-files`
+            // parse exists to avoid in the first place). The explicit length check below still
+            // guards against that assumption ever proving wrong for some pathological input.
+            let output = self
                 .cmd()
                 .args(["--literal-pathspecs", "submodule", "status", "--"])
-                .arg(&submodule_path)
+                .args(&pending)
                 .get_stdout_lossy()?;
-            let (status, rev) = match status.as_bytes().first() {
-                Some(b'-') => (SubmoduleCheckoutStatus::Uninitialized, &status[1..]),
-                Some(b'+') => (SubmoduleCheckoutStatus::Modified, &status[1..]),
-                Some(b'U') => (SubmoduleCheckoutStatus::Conflicted, &status[1..]),
-                Some(_) => (SubmoduleCheckoutStatus::Current, status.as_str()),
-                None => return Err(eyre::eyre!("missing submodule status")),
-            };
-            let rev = rev
-                .split_ascii_whitespace()
-                .next()
-                .ok_or_else(|| eyre::eyre!("invalid submodule status"))?;
-            gitlinks.insert(
-                submodule_path.clone(),
-                SubmoduleCheckout { status, rev: rev.to_string(), path: submodule_path },
-            );
+            let lines: Vec<&str> = output.lines().collect();
+            if lines.len() != pending.len() {
+                return Err(eyre::eyre!(
+                    "expected {} submodule status lines, got {}",
+                    pending.len(),
+                    lines.len()
+                ));
+            }
+            for (submodule_path, line) in pending.into_iter().zip(lines) {
+                let (status, rev) = Self::parse_submodule_status_line(line)?;
+                gitlinks.insert(
+                    submodule_path.clone(),
+                    SubmoduleCheckout { status, rev: rev.to_string(), path: submodule_path },
+                );
+            }
         }
+
         Ok(gitlinks.into_values().collect())
     }
 

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -901,6 +901,48 @@ ignore them in the `.gitignore` file."
             .map(|url| Some(url.trim().to_string()))
     }
 
+    /// Resolves a submodule's URL by its recorded `path` rather than assuming the `.gitmodules`
+    /// section name equals the path - they aren't required to match (e.g. `git submodule add
+    /// --name openzeppelin <url> lib/openzeppelin` records `path = lib/openzeppelin` under
+    /// section `openzeppelin`, so `git config submodule.<path>.url` finds nothing). `git_root`
+    /// is the directory containing `.gitmodules`.
+    pub fn submodule_url_for_path(self, git_root: &Path, path: &Path) -> Result<Option<String>> {
+        let gitmodules = git_root.join(".gitmodules");
+        if !gitmodules.exists() {
+            return Ok(None);
+        }
+
+        let output = self
+            .cmd()
+            .args(["config", "--null", "--file"])
+            .arg(&gitmodules)
+            .args(["--get-regexp", r"^submodule\..*\.path$"])
+            .output()?;
+        if output.status.code() != Some(0) {
+            return Ok(None);
+        }
+
+        let mut name = None;
+        for entry in output.stdout.split(|byte| *byte == 0).filter(|entry| !entry.is_empty()) {
+            let Some(separator) = entry.iter().position(|byte| *byte == b'\n') else { continue };
+            let key = std::str::from_utf8(&entry[..separator])?;
+            let value = std::str::from_utf8(&entry[separator + 1..])?;
+            if Path::new(value) == path {
+                name = key
+                    .strip_prefix("submodule.")
+                    .and_then(|k| k.strip_suffix(".path"))
+                    .map(String::from);
+                break;
+            }
+        }
+        let Some(name) = name else { return Ok(None) };
+
+        self.cmd()
+            .args(["config", "--get", &format!("submodule.{name}.url")])
+            .get_stdout_lossy()
+            .map(|url| Some(url.trim().to_string()))
+    }
+
     /// Returns whether `.gitmodules` contains the default section name or an exact path mapping.
     pub fn has_submodule_mapping(self, path: &Path) -> Result<bool> {
         let (names, paths) = self.submodule_mappings()?;

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -814,8 +814,12 @@ ignore them in the `.gitignore` file."
         Ok((status, rev))
     }
 
-    /// Returns submodules at or below `path`, with paths relative to this Git root, using mappings
-    /// from the enclosing worktree.
+    /// Returns submodules at or below `path`, with each `SubmoduleCheckout::path` relative to
+    /// `self.root` (this `Git` instance's own working directory - see [`Git::cmd`]), not
+    /// `worktree_root`. `worktree_root`/`worktree_prefix` are used only to resolve `.gitmodules`
+    /// mappings (via [`Git::submodule_mappings_at`]) against the enclosing worktree - which can
+    /// differ from `self.root` in a nested-monorepo layout, where a project subdirectory is its
+    /// own logical root but `.gitmodules` still lives at the actual Git repository root.
     pub fn submodules_in_worktree(
         &self,
         path: &Path,

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -916,27 +916,45 @@ ignore them in the `.gitignore` file."
             .cmd()
             .args(["config", "--null", "--file"])
             .arg(&gitmodules)
-            .args(["--get-regexp", r"^submodule\..*\.path$"])
+            .args(["--get-regexp", r"^submodule\..*\.(path|url)$"])
             .output()?;
         if output.status.code() != Some(0) {
             return Ok(None);
         }
 
-        let mut name = None;
+        // Collect both fields per section - `--get-regexp`'s output order isn't guaranteed to
+        // put `path` before `url` for the same section, so a single-pass match-then-break (as a
+        // prior version of this function did) can miss the url.
+        let mut sections: BTreeMap<String, (Option<PathBuf>, Option<String>)> = BTreeMap::new();
         for entry in output.stdout.split(|byte| *byte == 0).filter(|entry| !entry.is_empty()) {
             let Some(separator) = entry.iter().position(|byte| *byte == b'\n') else { continue };
             let key = std::str::from_utf8(&entry[..separator])?;
             let value = std::str::from_utf8(&entry[separator + 1..])?;
-            if Path::new(value) == path {
-                name = key
-                    .strip_prefix("submodule.")
-                    .and_then(|k| k.strip_suffix(".path"))
-                    .map(String::from);
-                break;
+            let Some(rest) = key.strip_prefix("submodule.") else { continue };
+            let Some((name, field)) = rest.rsplit_once('.') else { continue };
+            let slot = sections.entry(name.to_string()).or_default();
+            match field {
+                "path" => slot.0 = Some(PathBuf::from(value)),
+                "url" => slot.1 = Some(value.to_string()),
+                _ => {}
             }
         }
-        let Some(name) = name else { return Ok(None) };
 
+        let Some((name, (_, gitmodules_url))) =
+            sections.into_iter().find(|(_, (p, _))| p.as_deref() == Some(path))
+        else {
+            return Ok(None);
+        };
+
+        // `.gitmodules` doesn't always carry the URL itself - some setups rely on a local-only
+        // override (e.g. a `git config` `insteadOf` rewrite, or an entry from `git submodule
+        // sync` that was never re-exported to `.gitmodules`). Prefer `.gitmodules`'s copy when
+        // present; otherwise fall back to the local config entry keyed by the resolved section
+        // name, which is still correct even when `.gitmodules` has it and local config doesn't
+        // (the case a previous version of this function got backwards).
+        if let Some(url) = gitmodules_url {
+            return Ok(Some(url));
+        }
         self.cmd()
             .args(["config", "--get", &format!("submodule.{name}.url")])
             .get_stdout_lossy()

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -815,15 +815,23 @@ ignore them in the `.gitignore` file."
     }
 
     /// Returns submodules at or below `path`, with each `SubmoduleCheckout::path` relative to
-    /// `self.root` (this `Git` instance's own working directory - see [`Git::cmd`]), not
-    /// `worktree_root`. `worktree_root`/`worktree_prefix` are used only to resolve `.gitmodules`
-    /// mappings (via [`Git::submodule_mappings_at`]) against the enclosing worktree - which can
-    /// differ from `self.root` in a nested-monorepo layout, where a project subdirectory is its
-    /// own logical root but `.gitmodules` still lives at the actual Git repository root.
+    /// `self.root` (this `Git` instance's own working directory - see [`Git::cmd`]), not the
+    /// worktree `mappings` were resolved against. `mappings` is the set of paths `.gitmodules`
+    /// records (see [`Git::submodule_gitmodules_entries`]'s keys) - callers looping this over
+    /// multiple `path`s against the same worktree should compute it once and reuse it, rather
+    /// than letting each call re-parse `.gitmodules` via a fresh subprocess: verified empirically
+    /// with a `libs = ["libA", "libB", "libC"]` repro (a subprocess spy logging every `git`
+    /// invocation) that re-deriving `mappings` internally here, once per caller-side loop
+    /// iteration with byte-identical arguments every time, was exactly this redundant pattern.
+    /// `worktree_prefix` is still needed separately - it's used to convert each submodule's
+    /// `self.root`-relative path into the worktree-relative form `mappings`' paths are keyed by
+    /// (this can differ from `self.root` in a nested-monorepo layout, where a project
+    /// subdirectory is its own logical root but `.gitmodules` still lives at the actual Git
+    /// repository root).
     pub fn submodules_in_worktree(
         &self,
         path: &Path,
-        worktree_root: &Path,
+        mappings: &BTreeSet<PathBuf>,
         worktree_prefix: &Path,
     ) -> Result<Vec<SubmoduleCheckout>> {
         let pathspec = if path.as_os_str().is_empty() { Path::new(".") } else { path };
@@ -832,7 +840,6 @@ ignore them in the `.gitignore` file."
             .args(["--literal-pathspecs", "ls-files", "--stage", "-z", "--"])
             .arg(pathspec)
             .exec()?;
-        let (_, mappings) = self.submodule_mappings_at(worktree_root)?;
         let mut gitlinks = BTreeMap::new();
         // Paths whose status still needs a `git submodule status` lookup, collected in the same
         // order `git ls-files` emits them - always sorted by path, since that's how the Git index

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -971,6 +971,13 @@ ignore them in the `.gitignore` file."
         // clones from the local config's URL, not `.gitmodules`'s - so local config wins when
         // both are present. Fall back to `.gitmodules`'s copy only when local config has no entry
         // for this submodule at all (never had `git submodule init` run).
+        //
+        // An explicitly-empty local override (`git config submodule.<name>.url ""`) is treated
+        // the same as no entry, falling back to `.gitmodules` - this is a display choice, not a
+        // claim about what git would actually do: an empty local URL is itself a broken config
+        // state (`update --init` would try to clone from "" and fail), so there's no truthful
+        // single answer here either way. Showing `.gitmodules`'s value is simply the least
+        // misleading of two inaccurate options.
         if let Ok(url) = self
             .cmd()
             .args(["config", "--get", &format!("submodule.{name}.url")])

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -968,8 +968,27 @@ ignore them in the `.gitignore` file."
             .arg(&gitmodules)
             .args(["--get-regexp", r"^submodule\..*\.(path|url)$"])
             .output()?;
-        if output.status.code() != Some(0) {
-            return Ok(BTreeMap::new());
+        // `git config --get-regexp` exits 1 when nothing matches the pattern - a genuinely empty
+        // `.gitmodules` (or one with no `path`/`url` keys), which is not an error. Any OTHER
+        // non-zero exit (128 for a syntactically malformed `.gitmodules`, for one) is a real
+        // parse failure and must not be collapsed into the same "empty" result - this function's
+        // return value now also drives `MissingMapping` classification for every submodule in a
+        // project (see callers), not just the cosmetic URL lookup it originally served. Verified
+        // empirically: with `.gitmodules` hand-corrupted (unterminated `[submodule "..."` header,
+        // `git config` exits 128), treating that the same as "no entries" silently flipped a
+        // fully healthy, checked-out submodule to "orphaned" with no url and no indication
+        // `.gitmodules` itself was broken - actively misleading rather than merely incomplete.
+        // Matches `submodule_mappings_at`'s existing `Some(0)`/`Some(1)`/`_` handling.
+        match output.status.code() {
+            Some(0) => {}
+            Some(1) => return Ok(BTreeMap::new()),
+            _ => {
+                return Err(eyre::eyre!(
+                    "failed to parse {}: {}",
+                    gitmodules.display(),
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
         }
 
         // Collect both fields per section - `--get-regexp`'s output order isn't guaranteed to

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -901,15 +901,22 @@ ignore them in the `.gitignore` file."
             .map(|url| Some(url.trim().to_string()))
     }
 
-    /// Resolves a submodule's URL by its recorded `path` rather than assuming the `.gitmodules`
-    /// section name equals the path - they aren't required to match (e.g. `git submodule add
-    /// --name openzeppelin <url> lib/openzeppelin` records `path = lib/openzeppelin` under
-    /// section `openzeppelin`, so `git config submodule.<path>.url` finds nothing). `git_root`
-    /// is the directory containing `.gitmodules`.
-    pub fn submodule_url_for_path(self, git_root: &Path, path: &Path) -> Result<Option<String>> {
+    /// Parses `.gitmodules` once into a map of submodule path -> (section name, url if
+    /// `.gitmodules` itself carries one). `git_root` is the directory containing `.gitmodules`.
+    ///
+    /// A submodule's `.gitmodules` section name isn't required to match its `path` field (e.g.
+    /// `git submodule add --name openzeppelin <url> lib/openzeppelin` records `path =
+    /// lib/openzeppelin` under section `openzeppelin`), so the section name is kept alongside
+    /// the path for callers that need to resolve a URL by section name as a fallback - see
+    /// [`Git::submodule_url_for_path`]. Call this once per invocation and reuse the result across
+    /// every submodule, rather than re-parsing `.gitmodules` per submodule.
+    pub fn submodule_gitmodules_entries(
+        self,
+        git_root: &Path,
+    ) -> Result<BTreeMap<PathBuf, (String, Option<String>)>> {
         let gitmodules = git_root.join(".gitmodules");
         if !gitmodules.exists() {
-            return Ok(None);
+            return Ok(BTreeMap::new());
         }
 
         let output = self
@@ -919,12 +926,12 @@ ignore them in the `.gitignore` file."
             .args(["--get-regexp", r"^submodule\..*\.(path|url)$"])
             .output()?;
         if output.status.code() != Some(0) {
-            return Ok(None);
+            return Ok(BTreeMap::new());
         }
 
         // Collect both fields per section - `--get-regexp`'s output order isn't guaranteed to
-        // put `path` before `url` for the same section, so a single-pass match-then-break (as a
-        // prior version of this function did) can miss the url.
+        // put `path` before `url` for the same section, so a single-pass match-then-break can
+        // miss the url.
         let mut sections: BTreeMap<String, (Option<PathBuf>, Option<String>)> = BTreeMap::new();
         for entry in output.stdout.split(|byte| *byte == 0).filter(|entry| !entry.is_empty()) {
             let Some(separator) = entry.iter().position(|byte| *byte == b'\n') else { continue };
@@ -940,20 +947,29 @@ ignore them in the `.gitignore` file."
             }
         }
 
-        let Some((name, (_, gitmodules_url))) =
-            sections.into_iter().find(|(_, (p, _))| p.as_deref() == Some(path))
-        else {
-            return Ok(None);
-        };
+        Ok(sections
+            .into_iter()
+            .filter_map(|(name, (path, url))| path.map(|path| (path, (name, url))))
+            .collect())
+    }
+
+    /// Resolves a submodule's URL by its recorded `path`, given the `.gitmodules` entries
+    /// already parsed via a single [`Git::submodule_gitmodules_entries`] call.
+    pub fn submodule_url_for_path(
+        self,
+        entries: &BTreeMap<PathBuf, (String, Option<String>)>,
+        path: &Path,
+    ) -> Result<Option<String>> {
+        let Some((name, gitmodules_url)) = entries.get(path) else { return Ok(None) };
 
         // `.gitmodules` doesn't always carry the URL itself - some setups rely on a local-only
         // override (e.g. a `git config` `insteadOf` rewrite, or an entry from `git submodule
         // sync` that was never re-exported to `.gitmodules`). Prefer `.gitmodules`'s copy when
         // present; otherwise fall back to the local config entry keyed by the resolved section
-        // name, which is still correct even when `.gitmodules` has it and local config doesn't
-        // (the case a previous version of this function got backwards).
+        // name - this is still correct even when `.gitmodules` has the url and local config
+        // doesn't (a submodule that's never had `git submodule init` run).
         if let Some(url) = gitmodules_url {
-            return Ok(Some(url));
+            return Ok(Some(url.clone()));
         }
         self.cmd()
             .args(["config", "--get", &format!("submodule.{name}.url")])

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -962,19 +962,26 @@ ignore them in the `.gitignore` file."
     ) -> Result<Option<String>> {
         let Some((name, gitmodules_url)) = entries.get(path) else { return Ok(None) };
 
-        // `.gitmodules` doesn't always carry the URL itself - some setups rely on a local-only
-        // override (e.g. a `git config` `insteadOf` rewrite, or an entry from `git submodule
-        // sync` that was never re-exported to `.gitmodules`). Prefer `.gitmodules`'s copy when
-        // present; otherwise fall back to the local config entry keyed by the resolved section
-        // name - this is still correct even when `.gitmodules` has the url and local config
-        // doesn't (a submodule that's never had `git submodule init` run).
-        if let Some(url) = gitmodules_url {
-            return Ok(Some(url.clone()));
-        }
-        self.cmd()
+        // The repository-local `submodule.<name>.url` is the URL git itself actually fetches
+        // from once a submodule is initialized - it can intentionally diverge from `.gitmodules`
+        // (a manually pinned internal mirror, an `insteadOf` rewrite recorded via `git config`,
+        // anything not re-exported with `git submodule sync`), and *that* divergence is exactly
+        // what `.gitmodules`-first used to hide. Verified empirically: with local config and
+        // `.gitmodules` pointing at different remotes, a fresh `git submodule update --init`
+        // clones from the local config's URL, not `.gitmodules`'s - so local config wins when
+        // both are present. Fall back to `.gitmodules`'s copy only when local config has no entry
+        // for this submodule at all (never had `git submodule init` run).
+        if let Ok(url) = self
+            .cmd()
             .args(["config", "--get", &format!("submodule.{name}.url")])
             .get_stdout_lossy()
-            .map(|url| Some(url.trim().to_string()))
+        {
+            let url = url.trim();
+            if !url.is_empty() {
+                return Ok(Some(url.to_string()));
+            }
+        }
+        Ok(gitmodules_url.clone())
     }
 
     /// Returns whether `.gitmodules` contains the default section name or an exact path mapping.

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -99,6 +99,7 @@ pub fn run_command(args: Forge) -> Result<()> {
         ForgeSubcommand::Install(cmd) => global.block_on(cmd.run()),
         ForgeSubcommand::Reinit(cmd) => cmd.run(),
         ForgeSubcommand::Remove(cmd) => cmd.run(),
+        ForgeSubcommand::Dependencies(cmd) => cmd.run(),
         ForgeSubcommand::Remappings(cmd) => cmd.run(),
         ForgeSubcommand::Init(cmd) => global.block_on(cmd.run()),
         ForgeSubcommand::Completions { shell } => {

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -172,25 +172,34 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         // A registered but never-checked-out submodule - e.g. after a `git clone` without
         // `--recursive`, or a manual `rm -rf lib/foo` without `git submodule deinit` - isn't
         // actually installed.
-        //
-        // A `MissingMapping` gitlink (present in the index, but with no corresponding
-        // `.gitmodules` entry - e.g. `.gitmodules` was hand-edited or deleted without also
-        // running `git submodule deinit`) can never be initialized: `git submodule update --init`
-        // has nothing to clone from without a mapping. `submodules_in_worktree` reports it
-        // *without* consulting the real on-disk checkout at all - its "rev" is always the index's
-        // recorded sha, never the actual checkout - so on a fresh clone (where the directory is
-        // genuinely empty) this used to list a phantom "installed" dependency with a fabricated
-        // rev. Verified empirically: a fresh clone of a repo with a mappingless gitlink shows an
-        // empty `lib/<name>` directory, yet without this check `forge dependencies` still listed
-        // it as installed.
-        if matches!(
-            submodule.status(),
-            SubmoduleCheckoutStatus::Uninitialized | SubmoduleCheckoutStatus::MissingMapping
-        ) {
+        if submodule.status() == SubmoduleCheckoutStatus::Uninitialized {
             continue;
         }
 
         let path = submodule.path();
+
+        // A `MissingMapping` gitlink (present in the index, but with no corresponding
+        // `.gitmodules` entry - e.g. `.gitmodules` was hand-edited or deleted without also
+        // running `git submodule deinit`) can never be (re)initialized: `git submodule update
+        // --init` has nothing to clone from without a mapping. When the directory is genuinely
+        // empty (a fresh clone, where nothing was ever checked out), it isn't installed and
+        // shouldn't be listed - `submodules_in_worktree` reports this status without consulting
+        // the real checkout at all, so its "rev" is always a fabricated index-recorded sha in
+        // that case. But an empty directory is NOT the same as "every `MissingMapping` entry" -
+        // skipping unconditionally, this function's own first pass at this fix, also hid a real,
+        // populated, still-checked-out dependency whenever `.gitmodules` was edited away WITHOUT
+        // running `deinit` (the exact scenario named above: deinit is what clears the working
+        // tree, so skipping it leaves real content in place). Verified empirically both ways: a
+        // fresh clone leaves the directory genuinely empty, while a hand-edited-without-deinit
+        // `.gitmodules` leaves it fully populated - unconditionally skipping made a real, orphaned
+        // dependency vanish with zero indication anything was there, a worse failure mode (total
+        // invisibility) than the phantom-entry bug this exclusion was meant to fix.
+        let is_missing_mapping = submodule.status() == SubmoduleCheckoutStatus::MissingMapping;
+        let is_populated =
+            std::fs::read_dir(project_root.join(path)).is_ok_and(|mut e| e.next().is_some());
+        if is_missing_mapping && !is_populated {
+            continue;
+        }
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else { continue };
 
         // A `.gitmodules` section name isn't required to match its `path` field (e.g. `git
@@ -205,9 +214,15 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
 
         // A merge-conflicted submodule has no meaningful single revision to report (`git
         // submodule status` prints an all-zero placeholder SHA for it) - say so plainly rather
-        // than showing that placeholder or a stale lockfile pin.
+        // than showing that placeholder or a stale lockfile pin. A populated `MissingMapping`
+        // entry (reached this far, so the emptiness check above already passed) has no
+        // `.gitmodules` mapping to trust either - its `rev()` is the index's recorded sha, never
+        // verified against what's actually checked out on disk - so it gets the same "flag it
+        // plainly, don't dress it up as a normal healthy dependency" treatment.
         let version = if submodule.status() == SubmoduleCheckoutStatus::Conflicted {
             "conflicted".to_string()
+        } else if is_missing_mapping {
+            "orphaned".to_string()
         } else {
             // Prefer `foundry.lock`'s pinned tag/branch, but only when it still matches what's
             // actually checked out - if the submodule was manually moved to a different commit,

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -99,6 +99,13 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         lockfile.read()?;
     }
 
+    // `config.root` isn't guaranteed to be the canonical spelling of the project root - on
+    // macOS, `/tmp/project` (what a user or test harness typically passes) and
+    // `/private/tmp/project` (what `Config::canonic_at` resolves `install_lib_dir` and friends
+    // to) name the same directory but compare unequal as strings. Canonicalize before any
+    // `strip_prefix`/path-arithmetic, matching `Lockfile::check`'s own handling of this.
+    let project_root = dunce::canonicalize(&config.root).unwrap_or_else(|_| config.root.clone());
+
     // `Git`'s commands all run with `config.root` as their working directory (see
     // `Git::from_config`), and `git submodule status` prints paths relative to cwd - so
     // `submodule.path()` below is already relative to the project root, nested-monorepo layout
@@ -106,13 +113,11 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     // the same way, by a `Git` instance rooted the same way - see `install.rs`/`update.rs`), or
     // the displayed path.
     let install_lib_dir = config.install_lib_dir();
-    let lib = install_lib_dir.strip_prefix(&config.root).unwrap_or(install_lib_dir);
+    let lib = install_lib_dir.strip_prefix(&project_root).unwrap_or(install_lib_dir);
 
-    // `.gitmodules` (and therefore `git config submodule.<path>.url`) always keys on the path
-    // relative to the Git repository root, regardless of invocation cwd - so this is the one
-    // place that still needs a Git-root-relative path.
-    let git_root = Git::root_of(&config.root).unwrap_or_else(|_| config.root.clone());
-    let project_root = dunce::canonicalize(&config.root).unwrap_or_else(|_| config.root.clone());
+    // `.gitmodules` always keys its `path` field relative to the Git repository root, regardless
+    // of invocation cwd - so this is the one place that still needs a Git-root-relative path.
+    let git_root = Git::root_of(&config.root).unwrap_or_else(|_| project_root.clone());
     let project_prefix = project_root.strip_prefix(&git_root).unwrap_or(Path::new(""));
 
     let mut out = Vec::new();
@@ -128,14 +133,24 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         // last-known rev. Match git's own "is this submodule populated" check
         // (`<path>/.git` existing) rather than a bare directory-existence check, since a
         // never-initialized gitlink still leaves behind an empty directory.
-        if !config.root.join(path).join(".git").exists() {
+        if !project_root.join(path).join(".git").exists() {
             continue;
         }
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else { continue };
 
-        let url = git.submodule_url(&project_prefix.join(path)).ok().flatten();
+        // A `.gitmodules` section name isn't required to match its `path` field (e.g. `git
+        // submodule add --name openzeppelin <url> lib/openzeppelin`), and `git config
+        // submodule.<key>.url` is keyed by the section name - resolve it by path instead of
+        // assuming the two are the same string.
+        let url = git.submodule_url_for_path(&git_root, &project_prefix.join(path)).ok().flatten();
+
+        // Prefer `foundry.lock`'s pinned tag/branch, but only when it still matches what's
+        // actually checked out - if the submodule was manually moved to a different commit
+        // (`git submodule status`'s `+` marker), showing the stale locked version would
+        // misrepresent what's really on disk.
         let version = lockfile
             .get(path)
+            .filter(|dep| dep.rev() == submodule.rev())
             .map(ToString::to_string)
             .unwrap_or_else(|| format!("rev={}", submodule.rev()));
 

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -138,7 +138,21 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         // A registered but never-checked-out submodule - e.g. after a `git clone` without
         // `--recursive`, or a manual `rm -rf lib/foo` without `git submodule deinit` - isn't
         // actually installed.
-        if submodule.status() == SubmoduleCheckoutStatus::Uninitialized {
+        //
+        // A `MissingMapping` gitlink (present in the index, but with no corresponding
+        // `.gitmodules` entry - e.g. `.gitmodules` was hand-edited or deleted without also
+        // running `git submodule deinit`) can never be initialized: `git submodule update --init`
+        // has nothing to clone from without a mapping. `submodules_in_worktree` reports it
+        // *without* consulting the real on-disk checkout at all - its "rev" is always the index's
+        // recorded sha, never the actual checkout - so on a fresh clone (where the directory is
+        // genuinely empty) this used to list a phantom "installed" dependency with a fabricated
+        // rev. Verified empirically: a fresh clone of a repo with a mappingless gitlink shows an
+        // empty `lib/<name>` directory, yet without this check `forge dependencies` still listed
+        // it as installed.
+        if matches!(
+            submodule.status(),
+            SubmoduleCheckoutStatus::Uninitialized | SubmoduleCheckoutStatus::MissingMapping
+        ) {
             continue;
         }
 

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -8,7 +8,10 @@ use foundry_cli::utils::{Git, LoadConfig, SubmoduleCheckoutStatus};
 use foundry_common::shell;
 use foundry_config::{Config, impl_figment_convert_basic};
 use serde::Serialize;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
 /// CLI arguments for `forge dependencies`.
 #[derive(Clone, Debug, Parser)]
@@ -131,61 +134,88 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     let project_root = dunce::canonicalize(&config.root).unwrap_or_else(|_| config.root.clone());
 
     // `Git`'s commands all run with `config.root` as their working directory (see
-    // `Git::from_config`), so `lib`, scoped as a pathspec below, is relative to the project root,
-    // nested-monorepo layout or not.
-    let install_lib_dir = config.install_lib_dir();
-    let lib = install_lib_dir.strip_prefix(&project_root).unwrap_or(install_lib_dir);
-
-    // `libs` explicitly supports absolute paths, and a configured lib dir can be (or contain) a
-    // symlink resolving outside the Git repository entirely. `git ls-files` then exits 128 ("is
-    // outside repository") - not a per-line parse failure like the other cases in this function,
-    // but a structural one, and letting it propagate would fail the *whole* command, including
-    // the unrelated Soldeer half. Verified empirically: `libs = ["lib"]` with `lib` symlinked to
-    // a directory outside the repo reproduces exactly this exit-128 failure. Treat it the same as
-    // "not a Git repository" - there simply are no Git submodules to report from here.
-    let git_root_canonical = dunce::canonicalize(&git_root).unwrap_or_else(|_| git_root.clone());
-    let lib_target = project_root.join(lib);
-    // `dunce::canonicalize` requires the path to actually exist, so it can't tell an out-of-repo
-    // lib dir from an in-repo one that just hasn't been created yet (the common case, before the
-    // first `forge install`) - both fail identically, and the check above only fired on success,
-    // silently skipping the guard whenever the target didn't exist. Verified empirically: an
-    // absolute `libs` entry pointing outside the repo that doesn't exist yet reproduces the exact
-    // same exit-128 crash the guard above was written to prevent. When canonicalize can't resolve
-    // it, fall back to a purely lexical (`.`/`..`-collapsing, filesystem-free) normalization of
-    // both sides - it can't detect a not-yet-existing symlink that would resolve outside the repo
-    // once created, but that's a strictly narrower gap than treating every non-existent path as
-    // "assume it's fine."
-    let is_outside_repo = match dunce::canonicalize(&lib_target) {
-        Ok(lib_absolute) => !lib_absolute.starts_with(&git_root_canonical),
-        Err(_) => {
-            let lib_normalized = foundry_common::fs::normalize_path(&lib_target);
-            let git_root_normalized = foundry_common::fs::normalize_path(&git_root_canonical);
-            !lib_normalized.starts_with(&git_root_normalized)
-        }
-    };
-    if is_outside_repo {
-        return Ok(Vec::new());
+    // `Git::from_config`), so each `lib`, scoped as a pathspec below, is relative to the project
+    // root, nested-monorepo layout or not.
+    //
+    // `libs` legitimately supports MULTIPLE search directories (used for solc import
+    // resolution), and while `forge install` only ever installs new dependencies into the first
+    // entry (`Config::install_lib_dir`), existing submodules can perfectly well live under any
+    // configured entry - an older project, a manually added submodule, a `libs` array extended
+    // after some submodules were already added under a later entry. Scanning only
+    // `install_lib_dir()` silently dropped every submodule under any OTHER entry with zero
+    // indication anything was skipped - verified empirically with `libs = ["lib", "lib2"]` and a
+    // real, installed submodule under each: only the `lib/` one showed up. The same failure class
+    // rounds 1-2 of this fix already treated as unacceptable for a different mechanism (a real,
+    // installed dependency going invisible), just via single-directory scoping instead of an
+    // over-broad status check. `node_modules`-named entries are skipped, matching
+    // `install_lib_dir()`'s own filter (a Hardhat-style `libs` default) - falling back to `lib`
+    // when that filter leaves nothing, matching `install_lib_dir()`'s own fallback exactly, so a
+    // project with no explicit `libs` config behaves identically to before.
+    let mut lib_dirs: Vec<&Path> =
+        config.libs.iter().map(PathBuf::as_path).filter(|p| !p.ends_with("node_modules")).collect();
+    if lib_dirs.is_empty() {
+        lib_dirs.push(Path::new("lib"));
     }
 
+    let git_root_canonical = dunce::canonicalize(&git_root).unwrap_or_else(|_| git_root.clone());
     // `.gitmodules` always keys its `path` field relative to the Git repository root, regardless
     // of invocation cwd - so this is the one place that still needs a Git-root-relative path.
     let project_prefix = project_root.strip_prefix(&git_root).unwrap_or(Path::new(""));
-
     // Parsed once and reused for every submodule below, instead of re-parsing `.gitmodules` (and
     // spawning a fresh `git config` subprocess) per submodule.
     let gitmodules_entries = git.submodule_gitmodules_entries(&git_root).unwrap_or_default();
 
-    // NUL-delimited (`git ls-files --stage -z` under the hood) and status-tolerant per entry -
-    // unlike `Git::submodules()`'s whitespace-split `git submodule status` parser, this handles a
-    // submodule path containing a space correctly (that parser's path capture group is `[^\s]+`
-    // and rejects the whole line), and classifies each submodule's checkout status individually
-    // instead of failing the *entire* listing the moment one line looks unusual - a
-    // merge-conflicted submodule used to take down the whole command this way; scoping directly
-    // to `lib` here also replaces the old post-hoc `path.starts_with(lib)` filter.
-    let submodules = git.submodules_in_worktree(lib, &git_root, project_prefix)?;
+    let mut submodules = BTreeMap::new();
+    for install_lib_dir in lib_dirs {
+        let lib = install_lib_dir.strip_prefix(&project_root).unwrap_or(install_lib_dir);
+
+        // `libs` explicitly supports absolute paths, and a configured lib dir can be (or
+        // contain) a symlink resolving outside the Git repository entirely. `git ls-files` then
+        // exits 128 ("is outside repository") - not a per-line parse failure like the other
+        // cases in this function, but a structural one, and letting it propagate would fail the
+        // *whole* command, including every other `libs` entry and the unrelated Soldeer half.
+        // Verified empirically: `libs = ["lib"]` with `lib` symlinked to a directory outside the
+        // repo reproduces exactly this exit-128 failure. Skip just this entry, the same as if it
+        // simply weren't a Git repository - there are no Git submodules to report from here.
+        let lib_target = project_root.join(lib);
+        // `dunce::canonicalize` requires the path to actually exist, so it can't tell an
+        // out-of-repo lib dir from an in-repo one that just hasn't been created yet (the common
+        // case, before the first `forge install`) - both fail identically, and a success-only
+        // check silently skips the guard whenever the target doesn't exist. Verified
+        // empirically: an absolute `libs` entry pointing outside the repo that doesn't exist yet
+        // reproduces the exact same exit-128 crash. When canonicalize can't resolve it, fall
+        // back to a purely lexical (`.`/`..`-collapsing, filesystem-free) normalization of both
+        // sides - it can't detect a not-yet-existing symlink that would resolve outside the repo
+        // once created, but that's a strictly narrower gap than treating every non-existent path
+        // as "assume it's fine."
+        let is_outside_repo = match dunce::canonicalize(&lib_target) {
+            Ok(lib_absolute) => !lib_absolute.starts_with(&git_root_canonical),
+            Err(_) => {
+                let lib_normalized = foundry_common::fs::normalize_path(&lib_target);
+                let git_root_normalized = foundry_common::fs::normalize_path(&git_root_canonical);
+                !lib_normalized.starts_with(&git_root_normalized)
+            }
+        };
+        if is_outside_repo {
+            continue;
+        }
+
+        // NUL-delimited (`git ls-files --stage -z` under the hood) and status-tolerant per entry
+        // - unlike `Git::submodules()`'s whitespace-split `git submodule status` parser, this
+        // handles a submodule path containing a space correctly (that parser's path capture
+        // group is `[^\s]+` and rejects the whole line), and classifies each submodule's
+        // checkout status individually instead of failing the *entire* listing the moment one
+        // line looks unusual - a merge-conflicted submodule used to take down the whole command
+        // this way; scoping directly to `lib` here also replaces the old post-hoc
+        // `path.starts_with(lib)` filter. Merged by path across every `libs` entry - two entries
+        // that happen to overlap or nest would otherwise report the same submodule twice.
+        for submodule in git.submodules_in_worktree(lib, &git_root, project_prefix)? {
+            submodules.insert(submodule.path().clone(), submodule);
+        }
+    }
 
     let mut out = Vec::new();
-    for submodule in &submodules {
+    for submodule in submodules.values() {
         // A registered but never-checked-out submodule - e.g. after a `git clone` without
         // `--recursive`, or a manual `rm -rf lib/foo` without `git submodule deinit` - isn't
         // actually installed.

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -144,9 +144,26 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     // a directory outside the repo reproduces exactly this exit-128 failure. Treat it the same as
     // "not a Git repository" - there simply are no Git submodules to report from here.
     let git_root_canonical = dunce::canonicalize(&git_root).unwrap_or_else(|_| git_root.clone());
-    if let Ok(lib_absolute) = dunce::canonicalize(project_root.join(lib))
-        && !lib_absolute.starts_with(&git_root_canonical)
-    {
+    let lib_target = project_root.join(lib);
+    // `dunce::canonicalize` requires the path to actually exist, so it can't tell an out-of-repo
+    // lib dir from an in-repo one that just hasn't been created yet (the common case, before the
+    // first `forge install`) - both fail identically, and the check above only fired on success,
+    // silently skipping the guard whenever the target didn't exist. Verified empirically: an
+    // absolute `libs` entry pointing outside the repo that doesn't exist yet reproduces the exact
+    // same exit-128 crash the guard above was written to prevent. When canonicalize can't resolve
+    // it, fall back to a purely lexical (`.`/`..`-collapsing, filesystem-free) normalization of
+    // both sides - it can't detect a not-yet-existing symlink that would resolve outside the repo
+    // once created, but that's a strictly narrower gap than treating every non-existent path as
+    // "assume it's fine."
+    let is_outside_repo = match dunce::canonicalize(&lib_target) {
+        Ok(lib_absolute) => !lib_absolute.starts_with(&git_root_canonical),
+        Err(_) => {
+            let lib_normalized = foundry_common::fs::normalize_path(&lib_target);
+            let git_root_normalized = foundry_common::fs::normalize_path(&git_root_canonical);
+            !lib_normalized.starts_with(&git_root_normalized)
+        }
+    };
+    if is_outside_repo {
         return Ok(Vec::new());
     }
 

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -3,7 +3,7 @@ use clap::{Parser, ValueHint};
 use comfy_table::{
     Cell, Color, Row, Table, modifiers::UTF8_ROUND_CORNERS, presets::ASCII_MARKDOWN,
 };
-use eyre::Result;
+use eyre::{Context, Result};
 use foundry_cli::utils::{Git, LoadConfig};
 use foundry_common::shell;
 use foundry_config::{Config, impl_figment_convert_basic};
@@ -103,7 +103,9 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     // blocks `forge dependencies` entirely, even for an unrelated project subdirectory - fixing
     // that needs `Submodule`'s status parsing to tolerate individual bad lines, which is shared
     // by every other caller of `Git::submodules()` and out of scope here.
-    let submodules = git.submodules()?;
+    let submodules = git.submodules().wrap_err(
+        "failed to parse `git submodule status` - a merge-conflicted submodule can cause this",
+    )?;
 
     let mut lockfile = Lockfile::new(&config.root);
     if lockfile.exists() {

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -9,7 +9,7 @@ use foundry_common::shell;
 use foundry_config::{Config, impl_figment_convert_basic};
 use serde::Serialize;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
 };
 
@@ -164,6 +164,15 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     // Parsed once and reused for every submodule below, instead of re-parsing `.gitmodules` (and
     // spawning a fresh `git config` subprocess) per submodule.
     let gitmodules_entries = git.submodule_gitmodules_entries(&git_root).unwrap_or_default();
+    // `submodules_in_worktree` needs to know which paths `.gitmodules` actually maps, to
+    // classify `MissingMapping` - `gitmodules_entries`'s keys already are exactly that set (same
+    // `.gitmodules` parse, same "has a `path` field" criterion), so this reuses it rather than
+    // letting `submodules_in_worktree` re-derive the same set via its own separate subprocess.
+    // Verified empirically (a `git`-invocation spy) that without this, looping over multiple
+    // `libs` entries spawned that second `.gitmodules` parse once per entry with byte-identical
+    // arguments every time - the same "N subprocess spawns for one invariant answer" pattern the
+    // batched-status-call fix above already treats as worth avoiding.
+    let gitmodules_paths: BTreeSet<PathBuf> = gitmodules_entries.keys().cloned().collect();
 
     let mut submodules = BTreeMap::new();
     for install_lib_dir in lib_dirs {
@@ -209,7 +218,7 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         // this way; scoping directly to `lib` here also replaces the old post-hoc
         // `path.starts_with(lib)` filter. Merged by path across every `libs` entry - two entries
         // that happen to overlap or nest would otherwise report the same submodule twice.
-        for submodule in git.submodules_in_worktree(lib, &git_root, project_prefix)? {
+        for submodule in git.submodules_in_worktree(lib, &gitmodules_paths, project_prefix)? {
             submodules.insert(submodule.path().clone(), submodule);
         }
     }

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -162,8 +162,13 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     // of invocation cwd - so this is the one place that still needs a Git-root-relative path.
     let project_prefix = project_root.strip_prefix(&git_root).unwrap_or(Path::new(""));
     // Parsed once and reused for every submodule below, instead of re-parsing `.gitmodules` (and
-    // spawning a fresh `git config` subprocess) per submodule.
-    let gitmodules_entries = git.submodule_gitmodules_entries(&git_root).unwrap_or_default();
+    // spawning a fresh `git config` subprocess) per submodule. A genuine parse failure (a
+    // syntactically malformed `.gitmodules`, as opposed to a missing or genuinely empty one)
+    // propagates as a real error rather than being swallowed - this feeds `MissingMapping`
+    // classification below, so silently treating "can't parse" the same as "nothing mapped"
+    // would misreport every healthy submodule as orphaned instead of surfacing the real,
+    // easily-fixable `.gitmodules` syntax error.
+    let gitmodules_entries = git.submodule_gitmodules_entries(&git_root)?;
     // `submodules_in_worktree` needs to know which paths `.gitmodules` actually maps, to
     // classify `MissingMapping` - `gitmodules_entries`'s keys already are exactly that set (same
     // `.gitmodules` parse, same "has a `path` field" criterion), so this reuses it rather than

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -3,8 +3,8 @@ use clap::{Parser, ValueHint};
 use comfy_table::{
     Cell, Color, Row, Table, modifiers::UTF8_ROUND_CORNERS, presets::ASCII_MARKDOWN,
 };
-use eyre::{Context, Result};
-use foundry_cli::utils::{Git, LoadConfig};
+use eyre::Result;
+use foundry_cli::utils::{Git, LoadConfig, SubmoduleCheckoutStatus};
 use foundry_common::shell;
 use foundry_config::{Config, impl_figment_convert_basic};
 use serde::Serialize;
@@ -97,19 +97,6 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         // Not a Git repository - no submodules possible.
         return Ok(Vec::new());
     };
-    // Unlike the not-a-repo case above, a failure here is a real problem worth surfacing loudly:
-    // `git submodule status` fails its *entire* output (not just the offending line) if any
-    // submodule anywhere in the repo is merge-conflicted (`U<all-zeros> path`) - `Submodule`'s
-    // status-line regex only recognizes ` `/`+`/`-` prefixes, not `U`. Silently falling back to
-    // an empty list here would print "No dependencies found" while the repo is mid-conflict,
-    // which is exactly the kind of "looks empty but isn't" result this command exists to avoid.
-    // Trade-off worth knowing: this means one conflicted submodule anywhere in a large repo
-    // blocks `forge dependencies` entirely, even for an unrelated project subdirectory - fixing
-    // that needs `Submodule`'s status parsing to tolerate individual bad lines, which is shared
-    // by every other caller of `Git::submodules()` and out of scope here.
-    let submodules = git.submodules().wrap_err(
-        "failed to parse `git submodule status` - a merge-conflicted submodule can cause this",
-    )?;
 
     let mut lockfile = Lockfile::new(&config.root);
     if lockfile.exists() {
@@ -124,11 +111,8 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     let project_root = dunce::canonicalize(&config.root).unwrap_or_else(|_| config.root.clone());
 
     // `Git`'s commands all run with `config.root` as their working directory (see
-    // `Git::from_config`), and `git submodule status` prints paths relative to cwd - so
-    // `submodule.path()` below is already relative to the project root, nested-monorepo layout
-    // or not. No rebasing needed for the filter, the `foundry.lock` lookup (its keys are written
-    // the same way, by a `Git` instance rooted the same way - see `install.rs`/`update.rs`), or
-    // the displayed path.
+    // `Git::from_config`), so `lib`, scoped as a pathspec below, is relative to the project root,
+    // nested-monorepo layout or not.
     let install_lib_dir = config.install_lib_dir();
     let lib = install_lib_dir.strip_prefix(&project_root).unwrap_or(install_lib_dir);
 
@@ -140,22 +124,25 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     // spawning a fresh `git config` subprocess) per submodule.
     let gitmodules_entries = git.submodule_gitmodules_entries(&git_root).unwrap_or_default();
 
+    // NUL-delimited (`git ls-files --stage -z` under the hood) and status-tolerant per entry -
+    // unlike `Git::submodules()`'s whitespace-split `git submodule status` parser, this handles a
+    // submodule path containing a space correctly (that parser's path capture group is `[^\s]+`
+    // and rejects the whole line), and classifies each submodule's checkout status individually
+    // instead of failing the *entire* listing the moment one line looks unusual - a
+    // merge-conflicted submodule used to take down the whole command this way; scoping directly
+    // to `lib` here also replaces the old post-hoc `path.starts_with(lib)` filter.
+    let submodules = git.submodules_in_worktree(lib, &git_root, project_prefix)?;
+
     let mut out = Vec::new();
     for submodule in &submodules {
+        // A registered but never-checked-out submodule - e.g. after a `git clone` without
+        // `--recursive`, or a manual `rm -rf lib/foo` without `git submodule deinit` - isn't
+        // actually installed.
+        if submodule.status() == SubmoduleCheckoutStatus::Uninitialized {
+            continue;
+        }
+
         let path = submodule.path();
-        if !path.starts_with(lib) {
-            continue;
-        }
-        // `git submodule status`'s leading `-`/`+` status marker (which would say "not
-        // initialized") is stripped away by `Submodule::from_str`'s parsing, so a registered but
-        // never-checked-out submodule - e.g. after a `git clone` without `--recursive`, or a
-        // manual `rm -rf lib/foo` without `git submodule deinit` - still shows up here with its
-        // last-known rev. Match git's own "is this submodule populated" check
-        // (`<path>/.git` existing) rather than a bare directory-existence check, since a
-        // never-initialized gitlink still leaves behind an empty directory.
-        if !project_root.join(path).join(".git").exists() {
-            continue;
-        }
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else { continue };
 
         // A `.gitmodules` section name isn't required to match its `path` field (e.g. `git
@@ -167,22 +154,28 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
             .ok()
             .flatten();
 
-        // Prefer `foundry.lock`'s pinned tag/branch, but only when it still matches what's
-        // actually checked out - if the submodule was manually moved to a different commit
-        // (`git submodule status`'s `+` marker), showing the stale locked version would
-        // misrepresent what's really on disk.
-        let version = lockfile
-            .get(path)
-            // `git submodule status` always reports the full 40-char SHA, but a `DepIdentifier::Rev`
-            // entry (from `forge install dep@<rev>`) stores whatever string the user typed
-            // verbatim, abbreviated or not - `Tag`/`Branch` entries are already normalized to a
-            // full SHA via `git.get_rev()`, so a bare `==` silently rejects an accurate,
-            // still-matching abbreviated `Rev` pin. A short hash is only ever the checkout's own
-            // SHA prefixed with itself, never another commit's, so `starts_with` is exact for
-            // full-length revs and correct for abbreviated ones.
-            .filter(|dep| !dep.rev().is_empty() && submodule.rev().starts_with(dep.rev()))
-            .map(ToString::to_string)
-            .unwrap_or_else(|| format!("rev={}", submodule.rev()));
+        // A merge-conflicted submodule has no meaningful single revision to report (`git
+        // submodule status` prints an all-zero placeholder SHA for it) - say so plainly rather
+        // than showing that placeholder or a stale lockfile pin.
+        let version = if submodule.status() == SubmoduleCheckoutStatus::Conflicted {
+            "conflicted".to_string()
+        } else {
+            // Prefer `foundry.lock`'s pinned tag/branch, but only when it still matches what's
+            // actually checked out - if the submodule was manually moved to a different commit,
+            // showing the stale locked version would misrepresent what's really on disk.
+            lockfile
+                .get(path)
+                // `git submodule status` always reports the full 40-char SHA, but a
+                // `DepIdentifier::Rev` entry (from `forge install dep@<rev>`) stores whatever
+                // string the user typed verbatim, abbreviated or not - `Tag`/`Branch` entries are
+                // already normalized to a full SHA via `git.get_rev()`, so a bare `==` silently
+                // rejects an accurate, still-matching abbreviated `Rev` pin. A short hash is only
+                // ever the checkout's own SHA prefixed with itself, never another commit's, so
+                // `starts_with` is exact for full-length revs and correct for abbreviated ones.
+                .filter(|dep| !dep.rev().is_empty() && submodule.rev().starts_with(dep.rev()))
+                .map(ToString::to_string)
+                .unwrap_or_else(|| format!("rev={}", submodule.rev()))
+        };
 
         out.push(DependencyInfo {
             name: name.to_string(),
@@ -195,7 +188,6 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
 
     Ok(out)
 }
-
 /// Lists Soldeer-managed dependencies recorded in `soldeer.lock`.
 fn soldeer_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     let soldeer_lock_path = config.root.join(soldeer_core::lock::SOLDEER_LOCK);

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -62,11 +62,14 @@ impl DependenciesArgs {
         } else {
             table.apply_modifier(UTF8_ROUND_CORNERS);
         }
+        // Long URLs would otherwise stretch every row to the widest one.
+        table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
         table.set_header(vec![
             Cell::new("Name").fg(Color::Cyan),
             Cell::new("Source").fg(Color::Cyan),
             Cell::new("Version").fg(Color::Cyan),
             Cell::new("Path").fg(Color::Cyan),
+            Cell::new("URL").fg(Color::Cyan),
         ]);
         for dep in &dependencies {
             let mut row = Row::new();
@@ -74,6 +77,7 @@ impl DependenciesArgs {
             row.add_cell(Cell::new(dep.source));
             row.add_cell(Cell::new(&dep.version));
             row.add_cell(Cell::new(&dep.path));
+            row.add_cell(Cell::new(dep.url.as_deref().unwrap_or("-")));
             table.add_row(row);
         }
         sh_println!("{table}")?;
@@ -132,6 +136,10 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     // of invocation cwd - so this is the one place that still needs a Git-root-relative path.
     let project_prefix = project_root.strip_prefix(&git_root).unwrap_or(Path::new(""));
 
+    // Parsed once and reused for every submodule below, instead of re-parsing `.gitmodules` (and
+    // spawning a fresh `git config` subprocess) per submodule.
+    let gitmodules_entries = git.submodule_gitmodules_entries(&git_root).unwrap_or_default();
+
     let mut out = Vec::new();
     for submodule in &submodules {
         let path = submodule.path();
@@ -154,7 +162,10 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         // submodule add --name openzeppelin <url> lib/openzeppelin`), and `git config
         // submodule.<key>.url` is keyed by the section name - resolve it by path instead of
         // assuming the two are the same string.
-        let url = git.submodule_url_for_path(&git_root, &project_prefix.join(path)).ok().flatten();
+        let url = git
+            .submodule_url_for_path(&gitmodules_entries, &project_prefix.join(path))
+            .ok()
+            .flatten();
 
         // Prefer `foundry.lock`'s pinned tag/branch, but only when it still matches what's
         // actually checked out - if the submodule was manually moved to a different commit

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -8,7 +8,7 @@ use foundry_cli::utils::{Git, LoadConfig};
 use foundry_common::shell;
 use foundry_config::{Config, impl_figment_convert_basic};
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// CLI arguments for `forge dependencies`.
 #[derive(Clone, Debug, Parser)]
@@ -100,13 +100,17 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     }
 
     // `install_lib_dir` is absolute, but `git submodule status` reports paths relative to the
-    // Git root, so bring both onto the same (relative) footing before comparing. Assumes the
-    // project root is the Git root - a nested-monorepo project (root below the repo's top level)
-    // will report zero submodules here rather than misreporting a wrong one, since a mismatched
-    // prefix simply never matches `starts_with(lib)`.
+    // Git root, so bring both onto the same (relative) footing before comparing.
     let git_root = Git::root_of(&config.root).unwrap_or_else(|_| config.root.clone());
     let lib = config.install_lib_dir();
     let lib = lib.strip_prefix(&git_root).unwrap_or(lib);
+
+    // When the project root sits below the Git root (a nested monorepo layout), submodule paths
+    // from `git submodule status` are still Git-root-relative - rebase onto the project root so
+    // the displayed path matches what the user configured (e.g. `lib/forge-std`, not
+    // `apps/contracts/lib/forge-std`) rather than leaking the enclosing repo's layout.
+    let project_root = dunce::canonicalize(&config.root).unwrap_or_else(|_| config.root.clone());
+    let project_prefix = project_root.strip_prefix(&git_root).unwrap_or(Path::new(""));
 
     let mut out = Vec::new();
     for submodule in &submodules {
@@ -131,12 +135,13 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
             .get(path)
             .map(ToString::to_string)
             .unwrap_or_else(|| format!("rev={}", submodule.rev()));
+        let display_path = path.strip_prefix(project_prefix).unwrap_or(path);
 
         out.push(DependencyInfo {
             name: name.to_string(),
             source: "submodule",
             version,
-            path: path.display().to_string(),
+            path: display_path.display().to_string(),
             url,
         });
     }
@@ -161,8 +166,13 @@ fn soldeer_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
 
     let mut out = Vec::new();
     for entry in &lockfile.entries {
-        let path = entry.install_path(&deps_dir);
-        let path = path.strip_prefix(&config.root).unwrap_or(&path);
+        let install_path = entry.install_path(&deps_dir);
+        // A fresh clone (before `forge soldeer install`) or a manually deleted package still has
+        // a `soldeer.lock` entry - only report what's actually present on disk.
+        if !install_path.exists() {
+            continue;
+        }
+        let path = install_path.strip_prefix(&config.root).unwrap_or(&install_path);
 
         let url = match entry {
             soldeer_core::lock::LockEntry::Git(dep) => Some(dep.git.clone()),

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -3,7 +3,7 @@ use clap::{Parser, ValueHint};
 use comfy_table::{
     Cell, Color, Row, Table, modifiers::UTF8_ROUND_CORNERS, presets::ASCII_MARKDOWN,
 };
-use eyre::Result;
+use eyre::{Context, Result};
 use foundry_cli::utils::{Git, LoadConfig, SubmoduleCheckoutStatus};
 use foundry_common::shell;
 use foundry_config::{Config, impl_figment_convert_basic};
@@ -86,6 +86,26 @@ impl DependenciesArgs {
     }
 }
 
+/// Strips HTTP(S) userinfo (`user:pass@` / `token@`) from a dependency URL before it's ever
+/// displayed or serialized.
+///
+/// `forge install`/`git config submodule.<name>.url` both accept credentials embedded directly in
+/// the URL (`https://ghp_xxx@github.com/org/private-repo.git`, common for a private-repo token or
+/// CI credential), and Soldeer Git/HTTP URLs can carry the same. Verified empirically: a submodule
+/// whose effective local-config URL embeds a token was printed verbatim by `forge dependencies
+/// --json` before this redaction. Leaves the URL untouched if it doesn't parse as an absolute URL
+/// (e.g. SSH's `git@host:path` shorthand, which never round-trips through [`url::Url`] and has no
+/// parseable userinfo component to strip) or if it has no credentials to begin with.
+fn redact_url_credentials(url: String) -> String {
+    let Ok(mut parsed) = url::Url::parse(&url) else { return url };
+    if parsed.username().is_empty() && parsed.password().is_none() {
+        return url;
+    }
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    parsed.to_string()
+}
+
 /// Lists Git submodule dependencies under the project's install lib dir.
 ///
 /// `foundry.lock` (see [`Lockfile`]) is consulted, when present, to report the pinned tag/branch
@@ -115,6 +135,20 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     // nested-monorepo layout or not.
     let install_lib_dir = config.install_lib_dir();
     let lib = install_lib_dir.strip_prefix(&project_root).unwrap_or(install_lib_dir);
+
+    // `libs` explicitly supports absolute paths, and a configured lib dir can be (or contain) a
+    // symlink resolving outside the Git repository entirely. `git ls-files` then exits 128 ("is
+    // outside repository") - not a per-line parse failure like the other cases in this function,
+    // but a structural one, and letting it propagate would fail the *whole* command, including
+    // the unrelated Soldeer half. Verified empirically: `libs = ["lib"]` with `lib` symlinked to
+    // a directory outside the repo reproduces exactly this exit-128 failure. Treat it the same as
+    // "not a Git repository" - there simply are no Git submodules to report from here.
+    let git_root_canonical = dunce::canonicalize(&git_root).unwrap_or_else(|_| git_root.clone());
+    if let Ok(lib_absolute) = dunce::canonicalize(project_root.join(lib))
+        && !lib_absolute.starts_with(&git_root_canonical)
+    {
+        return Ok(Vec::new());
+    }
 
     // `.gitmodules` always keys its `path` field relative to the Git repository root, regardless
     // of invocation cwd - so this is the one place that still needs a Git-root-relative path.
@@ -166,7 +200,8 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         let url = git
             .submodule_url_for_path(&gitmodules_entries, &project_prefix.join(path))
             .ok()
-            .flatten();
+            .flatten()
+            .map(redact_url_credentials);
 
         // A merge-conflicted submodule has no meaningful single revision to report (`git
         // submodule status` prints an all-zero placeholder SHA for it) - say so plainly rather
@@ -209,11 +244,14 @@ fn soldeer_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         return Ok(Vec::new());
     }
 
-    // `read_lockfile` returns `Ok` with empty entries for malformed files, consistent with how
-    // `forge build`'s Soldeer integrity check already treats it.
-    let Ok(lockfile) = soldeer_core::lock::read_lockfile(&soldeer_lock_path) else {
-        return Ok(Vec::new());
-    };
+    // `read_lockfile` already converts malformed TOML to `Ok` with empty entries internally
+    // (`toml_edit::de::from_str(..).unwrap_or_default()`, logging a warning) - the only way it
+    // returns `Err` is a genuine I/O failure reading the path (`fs::read_to_string`), e.g.
+    // `soldeer.lock` being unreadable or, notably, being a *directory* rather than a file.
+    // Swallowing that here made an unreadable lockfile silently look identical to "zero Soldeer
+    // dependencies" instead of surfacing a real problem - propagate it with path context instead.
+    let lockfile = soldeer_core::lock::read_lockfile(&soldeer_lock_path)
+        .wrap_err_with(|| format!("failed to read {}", soldeer_lock_path.display()))?;
 
     let deps_dir = config.root.join("dependencies");
 
@@ -221,24 +259,45 @@ fn soldeer_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     for entry in &lockfile.entries {
         let install_path = entry.install_path(&deps_dir);
         // A fresh clone (before `forge soldeer install`) or a manually deleted package still has
-        // a `soldeer.lock` entry - only report what's actually present on disk.
-        if !install_path.exists() {
+        // a `soldeer.lock` entry - only report what's actually present on disk. For a Git-backed
+        // entry specifically, mere existence isn't enough: Soldeer's own integrity check
+        // (`check_git_dependency`) classifies an empty or non-Git directory at the install path
+        // as `Missing`, not installed - verified empirically that a bare empty directory at a
+        // Git entry's install path was otherwise listed here as if it were a real checkout.
+        // Requiring `.git` metadata is a lighter approximation of that same check (it doesn't
+        // also verify the checked-out commit matches the locked `rev`, which needs Soldeer's own
+        // async git plumbing), but it closes the reported false-positive.
+        let looks_installed = match entry {
+            soldeer_core::lock::LockEntry::Git(_) => install_path.join(".git").exists(),
+            _ => install_path.exists(),
+        };
+        if !looks_installed {
             continue;
         }
         let path = install_path.strip_prefix(&config.root).unwrap_or(&install_path);
 
-        let url = match entry {
-            soldeer_core::lock::LockEntry::Git(dep) => Some(dep.git.clone()),
-            soldeer_core::lock::LockEntry::Http(dep) => Some(dep.url.clone()),
-            _ => None,
+        // For a Git-backed entry, `version()` is only the *requirement* the dependency was
+        // installed against (e.g. a tag/branch spec) - the actually resolved, checked-out commit
+        // is `rev`, a separate field. A later `forge soldeer update` can move `rev` to a new
+        // commit while leaving the requirement string unchanged, so `version` alone doesn't
+        // identify what's actually on disk; append the locked rev, matching the `<label>=<value>@
+        // <rev>` convention `DepIdentifier`'s `Display` impl already uses for submodule pins.
+        let (url, version) = match entry {
+            soldeer_core::lock::LockEntry::Git(dep) => {
+                (Some(dep.git.clone()), format!("{}@{}", entry.version(), dep.rev))
+            }
+            soldeer_core::lock::LockEntry::Http(dep) => {
+                (Some(dep.url.clone()), entry.version().to_string())
+            }
+            _ => (None, entry.version().to_string()),
         };
 
         out.push(DependencyInfo {
             name: entry.name().to_string(),
             source: "soldeer",
-            version: entry.version().to_string(),
+            version,
             path: path.display().to_string(),
-            url,
+            url: url.map(redact_url_credentials),
         });
     }
 

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -1,7 +1,8 @@
 use crate::Lockfile;
 use clap::{Parser, ValueHint};
 use comfy_table::{
-    Cell, Color, Row, Table, modifiers::UTF8_ROUND_CORNERS, presets::ASCII_MARKDOWN,
+    Cell, Color, Row, Table,
+    presets::{ASCII_FULL, ASCII_MARKDOWN},
 };
 use eyre::{Context, Result};
 use foundry_cli::utils::{Git, LoadConfig, SubmoduleCheckoutStatus};
@@ -61,9 +62,9 @@ impl DependenciesArgs {
 
         let mut table = Table::new();
         if shell::is_markdown() {
-            table.load_preset(ASCII_MARKDOWN);
+            table.load_style(ASCII_MARKDOWN);
         } else {
-            table.apply_modifier(UTF8_ROUND_CORNERS);
+            table.load_style(ASCII_FULL.with_rounded_corners());
         }
         // Long URLs would otherwise stretch every row to the widest one.
         table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -99,16 +99,19 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         lockfile.read()?;
     }
 
-    // `install_lib_dir` is absolute, but `git submodule status` reports paths relative to the
-    // Git root, so bring both onto the same (relative) footing before comparing.
-    let git_root = Git::root_of(&config.root).unwrap_or_else(|_| config.root.clone());
-    let lib = config.install_lib_dir();
-    let lib = lib.strip_prefix(&git_root).unwrap_or(lib);
+    // `Git`'s commands all run with `config.root` as their working directory (see
+    // `Git::from_config`), and `git submodule status` prints paths relative to cwd - so
+    // `submodule.path()` below is already relative to the project root, nested-monorepo layout
+    // or not. No rebasing needed for the filter, the `foundry.lock` lookup (its keys are written
+    // the same way, by a `Git` instance rooted the same way - see `install.rs`/`update.rs`), or
+    // the displayed path.
+    let install_lib_dir = config.install_lib_dir();
+    let lib = install_lib_dir.strip_prefix(&config.root).unwrap_or(install_lib_dir);
 
-    // When the project root sits below the Git root (a nested monorepo layout), submodule paths
-    // from `git submodule status` are still Git-root-relative - rebase onto the project root so
-    // the displayed path matches what the user configured (e.g. `lib/forge-std`, not
-    // `apps/contracts/lib/forge-std`) rather than leaking the enclosing repo's layout.
+    // `.gitmodules` (and therefore `git config submodule.<path>.url`) always keys on the path
+    // relative to the Git repository root, regardless of invocation cwd - so this is the one
+    // place that still needs a Git-root-relative path.
+    let git_root = Git::root_of(&config.root).unwrap_or_else(|_| config.root.clone());
     let project_root = dunce::canonicalize(&config.root).unwrap_or_else(|_| config.root.clone());
     let project_prefix = project_root.strip_prefix(&git_root).unwrap_or(Path::new(""));
 
@@ -125,23 +128,22 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         // last-known rev. Match git's own "is this submodule populated" check
         // (`<path>/.git` existing) rather than a bare directory-existence check, since a
         // never-initialized gitlink still leaves behind an empty directory.
-        if !git_root.join(path).join(".git").exists() {
+        if !config.root.join(path).join(".git").exists() {
             continue;
         }
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else { continue };
 
-        let url = git.submodule_url(path).ok().flatten();
+        let url = git.submodule_url(&project_prefix.join(path)).ok().flatten();
         let version = lockfile
             .get(path)
             .map(ToString::to_string)
             .unwrap_or_else(|| format!("rev={}", submodule.rev()));
-        let display_path = path.strip_prefix(project_prefix).unwrap_or(path);
 
         out.push(DependencyInfo {
             name: name.to_string(),
             source: "submodule",
             version,
-            path: display_path.display().to_string(),
+            path: path.display().to_string(),
             url,
         });
     }

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -89,10 +89,21 @@ impl DependenciesArgs {
 /// to `foundry.lock` - listing is read-only.
 fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
     let git = Git::from_config(config);
-    let Ok(submodules) = git.submodules() else {
-        // Not a Git repository, or no submodules registered.
+    let Ok(git_root) = Git::root_of(&config.root) else {
+        // Not a Git repository - no submodules possible.
         return Ok(Vec::new());
     };
+    // Unlike the not-a-repo case above, a failure here is a real problem worth surfacing loudly:
+    // `git submodule status` fails its *entire* output (not just the offending line) if any
+    // submodule anywhere in the repo is merge-conflicted (`U<all-zeros> path`) - `Submodule`'s
+    // status-line regex only recognizes ` `/`+`/`-` prefixes, not `U`. Silently falling back to
+    // an empty list here would print "No dependencies found" while the repo is mid-conflict,
+    // which is exactly the kind of "looks empty but isn't" result this command exists to avoid.
+    // Trade-off worth knowing: this means one conflicted submodule anywhere in a large repo
+    // blocks `forge dependencies` entirely, even for an unrelated project subdirectory - fixing
+    // that needs `Submodule`'s status parsing to tolerate individual bad lines, which is shared
+    // by every other caller of `Git::submodules()` and out of scope here.
+    let submodules = git.submodules()?;
 
     let mut lockfile = Lockfile::new(&config.root);
     if lockfile.exists() {
@@ -117,7 +128,6 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
 
     // `.gitmodules` always keys its `path` field relative to the Git repository root, regardless
     // of invocation cwd - so this is the one place that still needs a Git-root-relative path.
-    let git_root = Git::root_of(&config.root).unwrap_or_else(|_| project_root.clone());
     let project_prefix = project_root.strip_prefix(&git_root).unwrap_or(Path::new(""));
 
     let mut out = Vec::new();
@@ -150,7 +160,14 @@ fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
         // misrepresent what's really on disk.
         let version = lockfile
             .get(path)
-            .filter(|dep| dep.rev() == submodule.rev())
+            // `git submodule status` always reports the full 40-char SHA, but a `DepIdentifier::Rev`
+            // entry (from `forge install dep@<rev>`) stores whatever string the user typed
+            // verbatim, abbreviated or not - `Tag`/`Branch` entries are already normalized to a
+            // full SHA via `git.get_rev()`, so a bare `==` silently rejects an accurate,
+            // still-matching abbreviated `Rev` pin. A short hash is only ever the checkout's own
+            // SHA prefixed with itself, never another commit's, so `starts_with` is exact for
+            // full-length revs and correct for abbreviated ones.
+            .filter(|dep| !dep.rev().is_empty() && submodule.rev().starts_with(dep.rev()))
             .map(ToString::to_string)
             .unwrap_or_else(|| format!("rev={}", submodule.rev()));
 

--- a/crates/forge/src/cmd/dependencies.rs
+++ b/crates/forge/src/cmd/dependencies.rs
@@ -1,0 +1,183 @@
+use crate::Lockfile;
+use clap::{Parser, ValueHint};
+use comfy_table::{
+    Cell, Color, Row, Table, modifiers::UTF8_ROUND_CORNERS, presets::ASCII_MARKDOWN,
+};
+use eyre::Result;
+use foundry_cli::utils::{Git, LoadConfig};
+use foundry_common::shell;
+use foundry_config::{Config, impl_figment_convert_basic};
+use serde::Serialize;
+use std::path::PathBuf;
+
+/// CLI arguments for `forge dependencies`.
+#[derive(Clone, Debug, Parser)]
+pub struct DependenciesArgs {
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    root: Option<PathBuf>,
+}
+
+impl_figment_convert_basic!(DependenciesArgs);
+
+/// A single installed dependency, either a Git submodule or a Soldeer package.
+#[derive(Debug, Clone, Serialize)]
+pub struct DependencyInfo {
+    /// The dependency name (submodule directory name, or Soldeer package name).
+    pub name: String,
+    /// The dependency manager that installed it.
+    pub source: &'static str,
+    /// A human readable version/revision identifier.
+    pub version: String,
+    /// Path to the dependency, relative to the project root.
+    pub path: String,
+    /// The upstream URL, if known.
+    pub url: Option<String>,
+}
+
+impl DependenciesArgs {
+    pub fn run(self) -> Result<()> {
+        let config = self.load_config()?;
+
+        let mut dependencies = submodule_dependencies(&config)?;
+        dependencies.extend(soldeer_dependencies(&config)?);
+        dependencies.sort_by(|a, b| a.name.cmp(&b.name));
+
+        if shell::is_json() {
+            sh_println!("{}", serde_json::to_string_pretty(&dependencies)?)?;
+            return Ok(());
+        }
+
+        if dependencies.is_empty() {
+            sh_println!("No dependencies found")?;
+            return Ok(());
+        }
+
+        let mut table = Table::new();
+        if shell::is_markdown() {
+            table.load_preset(ASCII_MARKDOWN);
+        } else {
+            table.apply_modifier(UTF8_ROUND_CORNERS);
+        }
+        table.set_header(vec![
+            Cell::new("Name").fg(Color::Cyan),
+            Cell::new("Source").fg(Color::Cyan),
+            Cell::new("Version").fg(Color::Cyan),
+            Cell::new("Path").fg(Color::Cyan),
+        ]);
+        for dep in &dependencies {
+            let mut row = Row::new();
+            row.add_cell(Cell::new(&dep.name));
+            row.add_cell(Cell::new(dep.source));
+            row.add_cell(Cell::new(&dep.version));
+            row.add_cell(Cell::new(&dep.path));
+            table.add_row(row);
+        }
+        sh_println!("{table}")?;
+
+        Ok(())
+    }
+}
+
+/// Lists Git submodule dependencies under the project's install lib dir.
+///
+/// `foundry.lock` (see [`Lockfile`]) is consulted, when present, to report the pinned tag/branch
+/// instead of just the raw revision the submodule is currently checked out at. This never writes
+/// to `foundry.lock` - listing is read-only.
+fn submodule_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
+    let git = Git::from_config(config);
+    let Ok(submodules) = git.submodules() else {
+        // Not a Git repository, or no submodules registered.
+        return Ok(Vec::new());
+    };
+
+    let mut lockfile = Lockfile::new(&config.root);
+    if lockfile.exists() {
+        lockfile.read()?;
+    }
+
+    // `install_lib_dir` is absolute, but `git submodule status` reports paths relative to the
+    // Git root, so bring both onto the same (relative) footing before comparing. Assumes the
+    // project root is the Git root - a nested-monorepo project (root below the repo's top level)
+    // will report zero submodules here rather than misreporting a wrong one, since a mismatched
+    // prefix simply never matches `starts_with(lib)`.
+    let git_root = Git::root_of(&config.root).unwrap_or_else(|_| config.root.clone());
+    let lib = config.install_lib_dir();
+    let lib = lib.strip_prefix(&git_root).unwrap_or(lib);
+
+    let mut out = Vec::new();
+    for submodule in &submodules {
+        let path = submodule.path();
+        if !path.starts_with(lib) {
+            continue;
+        }
+        // `git submodule status`'s leading `-`/`+` status marker (which would say "not
+        // initialized") is stripped away by `Submodule::from_str`'s parsing, so a registered but
+        // never-checked-out submodule - e.g. after a `git clone` without `--recursive`, or a
+        // manual `rm -rf lib/foo` without `git submodule deinit` - still shows up here with its
+        // last-known rev. Match git's own "is this submodule populated" check
+        // (`<path>/.git` existing) rather than a bare directory-existence check, since a
+        // never-initialized gitlink still leaves behind an empty directory.
+        if !git_root.join(path).join(".git").exists() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else { continue };
+
+        let url = git.submodule_url(path).ok().flatten();
+        let version = lockfile
+            .get(path)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("rev={}", submodule.rev()));
+
+        out.push(DependencyInfo {
+            name: name.to_string(),
+            source: "submodule",
+            version,
+            path: path.display().to_string(),
+            url,
+        });
+    }
+
+    Ok(out)
+}
+
+/// Lists Soldeer-managed dependencies recorded in `soldeer.lock`.
+fn soldeer_dependencies(config: &Config) -> Result<Vec<DependencyInfo>> {
+    let soldeer_lock_path = config.root.join(soldeer_core::lock::SOLDEER_LOCK);
+    if !soldeer_lock_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    // `read_lockfile` returns `Ok` with empty entries for malformed files, consistent with how
+    // `forge build`'s Soldeer integrity check already treats it.
+    let Ok(lockfile) = soldeer_core::lock::read_lockfile(&soldeer_lock_path) else {
+        return Ok(Vec::new());
+    };
+
+    let deps_dir = config.root.join("dependencies");
+
+    let mut out = Vec::new();
+    for entry in &lockfile.entries {
+        let path = entry.install_path(&deps_dir);
+        let path = path.strip_prefix(&config.root).unwrap_or(&path);
+
+        let url = match entry {
+            soldeer_core::lock::LockEntry::Git(dep) => Some(dep.git.clone()),
+            soldeer_core::lock::LockEntry::Http(dep) => Some(dep.url.clone()),
+            _ => None,
+        };
+
+        out.push(DependencyInfo {
+            name: entry.name().to_string(),
+            source: "soldeer",
+            version: entry.version().to_string(),
+            path: path.display().to_string(),
+            url,
+        });
+    }
+
+    Ok(out)
+}

--- a/crates/forge/src/cmd/mod.rs
+++ b/crates/forge/src/cmd/mod.rs
@@ -14,6 +14,7 @@ pub mod compiler;
 pub mod config;
 pub mod coverage;
 pub mod create;
+pub mod dependencies;
 pub mod doc;
 pub mod eip712;
 pub mod flatten;

--- a/crates/forge/src/lockfile.rs
+++ b/crates/forge/src/lockfile.rs
@@ -5,7 +5,7 @@ use eyre::{Context, OptionExt, Result};
 use foundry_cli::utils::{Git, SubmoduleCheckoutStatus};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, hash_map::Entry},
+    collections::{BTreeMap, BTreeSet, hash_map::Entry},
     path::{Path, PathBuf},
 };
 
@@ -208,8 +208,14 @@ impl<'a> Lockfile<'a> {
         })?;
 
         let repository_path = relative_path(&git_root, &project_root);
+        // The set of paths `.gitmodules` actually maps - `submodules_in_worktree` needs this to
+        // classify `MissingMapping`, and takes it as a parameter (rather than deriving it
+        // internally) so a caller looping over multiple paths against the same worktree can
+        // compute it once. This call site only calls it once, so behavior here is unchanged.
+        let gitmodules_paths: BTreeSet<PathBuf> =
+            git.submodule_gitmodules_entries(&git_root).unwrap_or_default().into_keys().collect();
         let git_submodules =
-            git.submodules_in_worktree(&repository_path, &git_root, project_prefix)?;
+            git.submodules_in_worktree(&repository_path, &gitmodules_paths, project_prefix)?;
         let mut submodules = BTreeMap::new();
         for submodule in &git_submodules {
             submodules.insert(submodule.path().clone(), submodule);

--- a/crates/forge/src/lockfile.rs
+++ b/crates/forge/src/lockfile.rs
@@ -211,9 +211,13 @@ impl<'a> Lockfile<'a> {
         // The set of paths `.gitmodules` actually maps - `submodules_in_worktree` needs this to
         // classify `MissingMapping`, and takes it as a parameter (rather than deriving it
         // internally) so a caller looping over multiple paths against the same worktree can
-        // compute it once. This call site only calls it once, so behavior here is unchanged.
+        // compute it once. This call site only calls it once, so behavior here is unchanged. A
+        // genuine `.gitmodules` parse failure propagates as a real error rather than being
+        // swallowed as "no mappings" - under `--locked` that would otherwise report a false
+        // `MissingSubmoduleMapping` mismatch for every submodule instead of the actual,
+        // easily-fixable `.gitmodules` syntax error.
         let gitmodules_paths: BTreeSet<PathBuf> =
-            git.submodule_gitmodules_entries(&git_root).unwrap_or_default().into_keys().collect();
+            git.submodule_gitmodules_entries(&git_root)?.into_keys().collect();
         let git_submodules =
             git.submodules_in_worktree(&repository_path, &gitmodules_paths, project_prefix)?;
         let mut submodules = BTreeMap::new();

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -1,9 +1,10 @@
 use crate::cmd::{
     bind::BindArgs, bind_json, build::BuildArgs, cache::CacheArgs, clone::CloneArgs,
-    compiler::CompilerArgs, config, coverage, create::CreateArgs, doc::DocArgs, eip712, flatten,
-    fmt::FmtArgs, fuzz::FuzzArgs, geiger, init::InitArgs, inspect, install::InstallArgs,
-    lint::LintArgs, lsp::LspArgs, reinit::ReinitArgs, remappings::RemappingArgs,
-    remove::RemoveArgs, selectors::SelectorsSubcommands, snapshot, soldeer, test, tree, update,
+    compiler::CompilerArgs, config, coverage, create::CreateArgs, dependencies::DependenciesArgs,
+    doc::DocArgs, eip712, flatten, fmt::FmtArgs, fuzz::FuzzArgs, geiger, init::InitArgs, inspect,
+    install::InstallArgs, lint::LintArgs, lsp::LspArgs, reinit::ReinitArgs,
+    remappings::RemappingArgs, remove::RemoveArgs, selectors::SelectorsSubcommands, snapshot,
+    soldeer, test, tree, update,
 };
 use clap::{Parser, Subcommand, ValueHint};
 use forge_script::ScriptArgs;
@@ -112,6 +113,14 @@ pub enum ForgeSubcommand {
     /// Remove one or multiple dependencies.
     #[command(visible_alias = "rm")]
     Remove(RemoveArgs),
+
+    /// List installed dependencies, both Git submodules and Soldeer packages.
+    ///
+    /// Examples:
+    /// - forge dependencies
+    /// - forge dependencies --json
+    #[command(verbatim_doc_comment, visible_alias = "deps")]
+    Dependencies(DependenciesArgs),
 
     /// Get the automatically inferred remappings for the project.
     #[command(visible_alias = "re")]

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -1,0 +1,159 @@
+//! Contains tests for `forge dependencies`.
+
+use foundry_test_utils::{forgetest_init, util::OutputExt};
+use soldeer_core::lock::{GitLockEntry, HttpLockEntry, LockEntry};
+use std::fs;
+
+/// Writes a synthetic `soldeer.lock` with an HTTP-sourced and a Git-sourced dependency, using
+/// Soldeer's own lockfile serializer so the fixture always matches the real on-disk schema.
+fn write_soldeer_lock(root: &std::path::Path) {
+    let entries = vec![
+        LockEntry::from(
+            HttpLockEntry::builder()
+                .name("test-dep")
+                .version("1.0.0")
+                .url("https://example.com/test-dep-1.0.0.zip")
+                .checksum("deadbeef")
+                .integrity("beef")
+                .build(),
+        ),
+        LockEntry::from(
+            GitLockEntry::builder()
+                .name("git-dep")
+                .version("2.0.0")
+                .git("https://github.com/example/git-dep.git")
+                .rev("abc123def456")
+                .build(),
+        ),
+    ];
+    let contents = soldeer_core::lock::generate_lockfile_contents(entries);
+    fs::write(root.join("soldeer.lock"), contents).unwrap();
+}
+
+// `forge dependencies` lists both the Git submodule dependencies (forge-std, installed by
+// `forgetest_init!`) and Soldeer dependencies (recorded in `soldeer.lock`) in one table.
+forgetest_init!(dependencies_lists_submodules_and_soldeer, |prj, cmd| {
+    write_soldeer_lock(prj.root());
+
+    let output = cmd.arg("dependencies").assert_success().get_output().stdout_lossy();
+
+    // Git submodule dependency, pinned via `forgetest_init!`'s own `foundry.lock`. Checking for
+    // "tag=" (rather than a hardcoded tag name/rev) keeps this from breaking every time
+    // forge-std cuts a new release, while still proving the lockfile pin was actually consulted
+    // instead of silently falling back to a bare `rev=<hash>` - see
+    // `dependencies_reports_lockfile_pinned_version` for a fixture-pinned, non-flaky version of
+    // this same assertion.
+    assert!(output.contains("forge-std"), "missing forge-std submodule entry:\n{output}");
+    assert!(output.contains("submodule"), "missing submodule source label:\n{output}");
+    assert!(output.contains("lib/forge-std"), "missing forge-std path:\n{output}");
+    assert!(
+        output.contains("tag=") || output.contains("branch="),
+        "expected forge-std to report its foundry.lock pin, not a bare rev:\n{output}"
+    );
+
+    // Soldeer dependencies, read from `soldeer.lock`.
+    assert!(output.contains("test-dep"), "missing test-dep entry:\n{output}");
+    assert!(output.contains("git-dep"), "missing git-dep entry:\n{output}");
+    assert!(output.contains("soldeer"), "missing soldeer source label:\n{output}");
+    assert!(output.contains("1.0.0"), "missing test-dep version:\n{output}");
+    assert!(output.contains("2.0.0"), "missing git-dep version:\n{output}");
+});
+
+// `--json` (the global flag shared by every `forge` subcommand) emits a machine-readable array
+// with the same dependencies, source-tagged.
+forgetest_init!(dependencies_json_output, |prj, cmd| {
+    write_soldeer_lock(prj.root());
+
+    let output = cmd.arg("dependencies").arg("--json").assert_success().get_output().stdout_lossy();
+
+    let parsed: serde_json::Value = serde_json::from_str(&output)
+        .unwrap_or_else(|err| panic!("expected valid JSON, got error {err}:\n{output}"));
+    let entries = parsed.as_array().expect("expected a JSON array");
+    assert_eq!(entries.len(), 3, "expected forge-std + 2 soldeer deps:\n{output}");
+
+    let names: Vec<&str> = entries.iter().map(|e| e["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"forge-std"));
+    assert!(names.contains(&"test-dep"));
+    assert!(names.contains(&"git-dep"));
+
+    let forge_std = entries.iter().find(|e| e["name"] == "forge-std").unwrap();
+    assert_eq!(forge_std["source"], "submodule");
+    assert_eq!(forge_std["path"], "lib/forge-std");
+
+    let test_dep = entries.iter().find(|e| e["name"] == "test-dep").unwrap();
+    assert_eq!(test_dep["source"], "soldeer");
+    assert_eq!(test_dep["version"], "1.0.0");
+    assert_eq!(test_dep["url"], "https://example.com/test-dep-1.0.0.zip");
+
+    let git_dep = entries.iter().find(|e| e["name"] == "git-dep").unwrap();
+    assert_eq!(git_dep["source"], "soldeer");
+    assert_eq!(git_dep["version"], "2.0.0");
+    assert_eq!(git_dep["url"], "https://github.com/example/git-dep.git");
+});
+
+// With no submodules and no `soldeer.lock`, the command reports an empty list rather than
+// erroring.
+forgetest_init!(dependencies_reports_none_when_absent, |prj, cmd| {
+    fs::remove_dir_all(prj.root().join("lib")).unwrap();
+    fs::remove_file(prj.root().join("foundry.lock")).ok();
+
+    cmd.arg("dependencies").assert_success().stdout_eq(str![[r#"
+No dependencies found
+
+"#]]);
+
+    cmd.forge_fuse().args(["dependencies", "--json"]).assert_success().stdout_eq(str![[r#"
+[]
+
+"#]]);
+});
+
+// A registered-but-never-checked-out submodule (e.g. after `git clone` without `--recursive`,
+// or a manual `rm -rf lib/forge-std` without `git submodule deinit`) still leaves a gitlink in
+// the index - `git submodule status` reports its last-known rev regardless. `forge dependencies`
+// must not report it as installed just because the directory happens to exist (it's left behind
+// empty in this scenario).
+forgetest_init!(dependencies_excludes_uninitialized_submodule, |prj, cmd| {
+    let forge_std = prj.root().join("lib/forge-std");
+    fs::remove_dir_all(&forge_std).unwrap();
+    fs::create_dir(&forge_std).unwrap();
+
+    let output = cmd.arg("dependencies").assert_success().get_output().stdout_lossy();
+    assert!(
+        !output.contains("forge-std"),
+        "uninitialized forge-std submodule should not be listed:\n{output}"
+    );
+
+    let json = cmd
+        .forge_fuse()
+        .args(["dependencies", "--json"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.as_array().unwrap().len(), 0, "expected no dependencies:\n{json}");
+});
+
+// A submodule pinned in `foundry.lock` (via a prior `forge install <dep>@<tag>`) reports the
+// pinned tag/rev pair instead of the bare checked-out rev.
+forgetest_init!(dependencies_reports_lockfile_pinned_version, |prj, cmd| {
+    fs::write(
+        prj.root().join("foundry.lock"),
+        r#"{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.9.4",
+      "rev": "680ee6692649dcc7c617e05b2144932618264a83"
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = cmd.arg("dependencies").assert_success().get_output().stdout_lossy();
+    assert!(
+        output.contains("tag=v1.9.4@680ee6692649dcc7c617e05b2144932618264a83"),
+        "expected forge-std to report its foundry.lock pin, not a bare rev:\n{output}"
+    );
+});

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -749,7 +749,11 @@ forgetest_init!(dependencies_excludes_submodule_missing_gitmodules_mapping, |prj
         "test setup should leave lib/ghost genuinely empty in the fresh clone"
     );
 
-    cmd.set_current_dir(clone_dir.path());
+    // `TestCommand::set_current_dir` only changes the *test binary's own* CWD - the underlying
+    // `Command` already has an explicit `.current_dir(prj.root())` baked in from construction
+    // (see `TestProject::forge_bin`), which always wins over an inherited CWD regardless. This
+    // command's `current_dir` method is the one that actually retargets the subprocess.
+    cmd.current_dir(clone_dir.path());
     let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
     assert!(
@@ -882,5 +886,64 @@ forgetest_init!(dependencies_excludes_soldeer_entry_without_git_metadata, |prj, 
     assert!(
         parsed.as_array().unwrap().iter().all(|d| d["name"] != "git-dep"),
         "an empty, non-Git directory at a Git entry's install path must not be listed as installed: {json}"
+    );
+});
+
+// The `MissingMapping` exclusion above only targets a genuinely empty checkout (a fresh clone,
+// where nothing was ever populated). Its own motivating scenario - `.gitmodules` hand-edited away
+// WITHOUT running `git submodule deinit` - is exactly the case where the real checkout is left
+// untouched: `deinit` is what clears the working tree, so skipping it leaves real content in
+// place. An earlier version of the fix skipped every `MissingMapping` entry unconditionally,
+// which silently hid a real, populated, orphaned dependency with zero indication anything was
+// there - arguably a worse failure mode (total invisibility) than the phantom-entry bug the fix
+// was meant to address. A populated orphan should still be listed, just flagged plainly.
+forgetest_init!(dependencies_shows_orphaned_populated_submodule_missing_mapping, |prj, cmd| {
+    let remote = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    run_git(&["init", "-q", "-b", "main"], remote.path());
+    fs::write(remote.path().join("contract.sol"), "real content").unwrap();
+    run_git(&["add", "-A"], remote.path());
+    run_git(&["commit", "-q", "-m", "dep init"], remote.path());
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote.path().to_str().unwrap(),
+            "lib/realdep",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add submodule"], prj.root());
+
+    // Orphan the mapping WITHOUT deinit - the real checkout stays fully populated, unlike the
+    // fresh-clone scenario the exclusion above targets. Same working copy throughout, no clone.
+    run_git(&["rm", "--cached", ".gitmodules"], prj.root());
+    fs::remove_file(prj.root().join(".gitmodules")).unwrap();
+    run_git(
+        &["commit", "-q", "-am", "remove .gitmodules mapping, leaving realdep still populated"],
+        prj.root(),
+    );
+    assert!(
+        prj.root().join("lib/realdep/contract.sol").exists(),
+        "test setup should leave lib/realdep's real content untouched"
+    );
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let dep =
+        parsed.as_array().unwrap().iter().find(|e| e["name"] == "realdep").unwrap_or_else(|| {
+            panic!("a populated, orphaned submodule must still be listed, not hidden: {json}")
+        });
+    assert_eq!(
+        dep["version"], "orphaned",
+        "a MissingMapping entry has no trustworthy rev - flag it plainly instead of fabricating one"
     );
 });

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -31,7 +31,14 @@ fn write_soldeer_lock(root: &std::path::Path) {
     ];
     let deps_dir = root.join("dependencies");
     for entry in &entries {
-        fs::create_dir_all(entry.install_path(&deps_dir)).unwrap();
+        let install_path = entry.install_path(&deps_dir);
+        fs::create_dir_all(&install_path).unwrap();
+        // A Git-backed entry additionally needs `.git` metadata to look installed - mere
+        // directory existence isn't enough, matching Soldeer's own integrity classification (see
+        // `dependencies_excludes_soldeer_entry_without_git_metadata`).
+        if matches!(entry, LockEntry::Git(_)) {
+            fs::create_dir_all(install_path.join(".git")).unwrap();
+        }
     }
     let contents = soldeer_core::lock::generate_lockfile_contents(entries);
     fs::write(root.join("soldeer.lock"), contents).unwrap();
@@ -67,7 +74,10 @@ forgetest_init!(dependencies_lists_submodules_and_soldeer, |prj, cmd| {
     assert!(output.contains("git-dep"), "missing git-dep entry:\n{output}");
     assert!(output.contains("soldeer"), "missing soldeer source label:\n{output}");
     assert!(output.contains("1.0.0"), "missing test-dep version:\n{output}");
-    assert!(output.contains("2.0.0"), "missing git-dep version:\n{output}");
+    assert!(
+        output.contains("2.0.0@abc123def456"),
+        "missing git-dep version+resolved-rev:\n{output}"
+    );
     assert!(
         output.contains("https://example.com/test-dep-1.0.0.zip"),
         "missing test-dep URL in table output:\n{output}"
@@ -102,7 +112,10 @@ forgetest_init!(dependencies_json_output, |prj, cmd| {
 
     let git_dep = entries.iter().find(|e| e["name"] == "git-dep").unwrap();
     assert_eq!(git_dep["source"], "soldeer");
-    assert_eq!(git_dep["version"], "2.0.0");
+    assert_eq!(
+        git_dep["version"], "2.0.0@abc123def456",
+        "must show the resolved rev alongside the version requirement, not just the requirement"
+    );
     assert_eq!(git_dep["url"], "https://github.com/example/git-dep.git");
 });
 
@@ -742,5 +755,132 @@ forgetest_init!(dependencies_excludes_submodule_missing_gitmodules_mapping, |prj
     assert!(
         parsed.as_array().unwrap().iter().all(|d| d["name"] != "ghost"),
         "an orphaned, mapping-less gitlink with an empty checkout must not be listed as installed: {json}"
+    );
+});
+
+// A submodule URL can carry embedded credentials (`https://<token>@host/...`) - `forge install`
+// and manual `git config submodule.<name>.url` overrides both accept this syntax, e.g. to pin a
+// private-repo token or CI credential. `forge dependencies --json` must not print it verbatim.
+forgetest_init!(dependencies_redacts_url_credentials, |prj, cmd| {
+    let remote = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    run_git(&["init", "-q", "-b", "main"], remote.path());
+    run_git(&["commit", "-q", "--allow-empty", "-m", "init"], remote.path());
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote.path().to_str().unwrap(),
+            "lib/dep",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add submodule"], prj.root());
+
+    // Simulate a token-embedded private-repo URL, as `forge install` itself would accept.
+    run_git(
+        &[
+            "config",
+            "submodule.lib/dep.url",
+            "https://ghp_supersecrettoken123@github.com/private-org/private-repo.git",
+        ],
+        prj.root(),
+    );
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    assert!(
+        !json.contains("ghp_supersecrettoken123"),
+        "credential leaked into --json output: {json}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let dep = parsed.as_array().unwrap().iter().find(|e| e["name"] == "dep").unwrap_or_else(|| {
+        panic!("expected a 'dep' submodule in {json}");
+    });
+    assert_eq!(
+        dep["url"].as_str().unwrap(),
+        "https://github.com/private-org/private-repo.git",
+        "url should be shown with credentials stripped, not omitted entirely"
+    );
+});
+
+// `libs` explicitly supports absolute paths and symlinked directories - a configured lib dir can
+// resolve entirely outside the Git repository. `git ls-files` then exits 128 ("outside
+// repository"), a structural failure distinct from every other per-entry-tolerant case this
+// command handles - letting it propagate previously failed the *whole* command, hiding even the
+// unrelated Soldeer half.
+forgetest_init!(dependencies_excludes_submodule_lib_dir_outside_git_root, |prj, cmd| {
+    let external = tempfile::tempdir().unwrap();
+    fs::remove_dir_all(prj.root().join("lib")).unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(external.path(), prj.root().join("lib")).unwrap();
+    fs::write(
+        prj.root().join("foundry.toml"),
+        r#"[profile.default]
+libs = ["lib"]
+"#,
+    )
+    .unwrap();
+    fs::remove_file(prj.root().join("foundry.lock")).ok();
+
+    write_soldeer_lock(prj.root());
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let names: Vec<&str> =
+        parsed.as_array().unwrap().iter().map(|e| e["name"].as_str().unwrap()).collect();
+    assert!(
+        names.contains(&"test-dep") && names.contains(&"git-dep"),
+        "an out-of-repo lib dir must not crash the whole command - Soldeer deps should still list: {json}"
+    );
+});
+
+// `read_lockfile` already converts malformed TOML to `Ok` with empty entries internally - the
+// only way it returns `Err` is a genuine I/O failure (e.g. `soldeer.lock` being unreadable, or a
+// directory rather than a file). That must be surfaced, not silently treated as "zero Soldeer
+// dependencies".
+forgetest_init!(dependencies_propagates_soldeer_lock_read_error, |prj, cmd| {
+    fs::create_dir(prj.root().join("soldeer.lock")).unwrap();
+
+    cmd.args(["dependencies", "--json"]).assert_failure().stderr_eq(str![[r#"
+Error: failed to read [..]soldeer.lock
+
+Context:
+- IO error for soldeer.lock: Is a directory (os error 21)
+
+"#]]);
+});
+
+// Mere directory existence isn't enough for a Git-backed Soldeer entry to count as installed -
+// Soldeer's own integrity check (`check_git_dependency`) classifies an empty or non-Git directory
+// at the install path as `Missing`. Requiring `.git` metadata closes that gap.
+forgetest_init!(dependencies_excludes_soldeer_entry_without_git_metadata, |prj, cmd| {
+    let entries = vec![LockEntry::from(
+        GitLockEntry::builder()
+            .name("git-dep")
+            .version("2.0.0")
+            .git("https://github.com/example/git-dep.git")
+            .rev("abc123def456")
+            .build(),
+    )];
+    let deps_dir = prj.root().join("dependencies");
+    // Directory exists (as if `forge soldeer install` started but never finished, or was manually
+    // emptied), but has no `.git` - not a real checkout.
+    fs::create_dir_all(entries[0].install_path(&deps_dir)).unwrap();
+    let contents = soldeer_core::lock::generate_lockfile_contents(entries);
+    fs::write(prj.root().join("soldeer.lock"), contents).unwrap();
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(
+        parsed.as_array().unwrap().iter().all(|d| d["name"] != "git-dep"),
+        "an empty, non-Git directory at a Git entry's install path must not be listed as installed: {json}"
     );
 });

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -1047,3 +1047,56 @@ libs = ["lib", "lib2"]
         "a real submodule under a non-first `libs` entry must not be silently dropped: {json}"
     );
 });
+
+// A malformed `.gitmodules` (a real Git parse failure, distinct from a missing or genuinely
+// empty file) must not be silently treated as "no submodules are mapped" - that would flip every
+// healthy, checked-out submodule to `MissingMapping` and misreport it as orphaned with no url,
+// hiding the real (easily-fixable) `.gitmodules` syntax error entirely. `git config` exits 1 for
+// "no matches" (legitimately empty) and something else non-zero (128 here) for a genuine parse
+// failure - the two must not be collapsed into the same result.
+forgetest_init!(dependencies_errors_loudly_on_malformed_gitmodules, |prj, cmd| {
+    let remote = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    run_git(&["init", "-q", "-b", "main"], remote.path());
+    run_git(&["commit", "-q", "--allow-empty", "-m", "init"], remote.path());
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote.path().to_str().unwrap(),
+            "lib/gooddep",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add healthy submodule"], prj.root());
+
+    // Corrupt `.gitmodules` with an unterminated section header - `git config` exits 128 on this,
+    // not 1 - while leaving the submodule's real, checked-out content on disk untouched.
+    let mut gitmodules = fs::read_to_string(prj.root().join(".gitmodules")).unwrap();
+    gitmodules.push_str("[submodule \"unterminated\n");
+    fs::write(prj.root().join(".gitmodules"), &gitmodules).unwrap();
+    assert_eq!(
+        Command::new("git")
+            .args(["config", "--null", "--file", ".gitmodules", "--get-regexp", "^submodule\\..*"])
+            .current_dir(prj.root())
+            .output()
+            .unwrap()
+            .status
+            .code(),
+        Some(128),
+        "test setup should reproduce a real git-config parse failure, not just an empty match"
+    );
+
+    cmd.arg("dependencies").assert_failure().stderr_eq(str![[r#"
+Error: failed to parse [..].gitmodules: fatal: bad config line [..] in file [..].gitmodules
+
+"#]]);
+});

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -982,3 +982,68 @@ libs = ["{}"]
         "a non-existent, out-of-repo lib dir must not crash the whole command - Soldeer deps should still list: {json}"
     );
 });
+
+// `libs` supports multiple search directories (used for solc import resolution), but `forge
+// install` only ever installs new dependencies into the first entry (`Config::install_lib_dir`).
+// Existing submodules can perfectly well live under any configured entry - an older project, a
+// manually added submodule, or a `libs` array extended after some submodules were already added
+// under a later entry. Scanning only the first entry silently dropped every submodule under any
+// other one, the same failure class (a real, installed dependency going invisible) rounds 1-2
+// already treated as unacceptable via a different mechanism.
+forgetest_init!(dependencies_scans_every_configured_libs_entry, |prj, cmd| {
+    let remote1 = tempfile::tempdir().unwrap();
+    let remote2 = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    for remote in [&remote1, &remote2] {
+        run_git(&["init", "-q", "-b", "main"], remote.path());
+        run_git(&["commit", "-q", "--allow-empty", "-m", "init"], remote.path());
+    }
+
+    fs::write(
+        prj.root().join("foundry.toml"),
+        r#"[profile.default]
+libs = ["lib", "lib2"]
+"#,
+    )
+    .unwrap();
+    fs::remove_file(prj.root().join("foundry.lock")).ok();
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote1.path().to_str().unwrap(),
+            "lib/dep-in-lib1",
+        ],
+        prj.root(),
+    );
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote2.path().to_str().unwrap(),
+            "lib2/dep-in-lib2",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add submodules under both libs entries"], prj.root());
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let names: Vec<&str> =
+        parsed.as_array().unwrap().iter().map(|e| e["name"].as_str().unwrap()).collect();
+    assert!(
+        names.contains(&"dep-in-lib1") && names.contains(&"dep-in-lib2"),
+        "a real submodule under a non-first `libs` entry must not be silently dropped: {json}"
+    );
+});

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -947,3 +947,38 @@ forgetest_init!(dependencies_shows_orphaned_populated_submodule_missing_mapping,
         "a MissingMapping entry has no trustworthy rev - flag it plainly instead of fabricating one"
     );
 });
+
+// The external-lib-dir guard above only fires when `dunce::canonicalize` succeeds, but
+// canonicalize requires the path to actually exist - so an out-of-repo `libs` entry that hasn't
+// been created yet (a CI checkout before an external mount is populated, or simply a typo) fails
+// canonicalize identically to the common, harmless case of an in-repo `libs` entry that just
+// hasn't been installed yet. The guard silently skipped itself in exactly the scenario it exists
+// to catch. This doesn't go through a symlink - the path is a plain absolute string that never
+// existed - so it exercises the canonicalize-failure fallback specifically.
+forgetest_init!(dependencies_excludes_nonexistent_external_lib_dir, |prj, cmd| {
+    fs::remove_dir_all(prj.root().join("lib")).unwrap();
+    fs::remove_file(prj.root().join("foundry.lock")).ok();
+    let outside = tempfile::tempdir().unwrap();
+    let never_created = outside.path().join("does-not-exist/lib");
+    fs::write(
+        prj.root().join("foundry.toml"),
+        format!(
+            r#"[profile.default]
+libs = ["{}"]
+"#,
+            never_created.display()
+        ),
+    )
+    .unwrap();
+
+    write_soldeer_lock(prj.root());
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let names: Vec<&str> =
+        parsed.as_array().unwrap().iter().map(|e| e["name"].as_str().unwrap()).collect();
+    assert!(
+        names.contains(&"test-dep") && names.contains(&"git-dep"),
+        "a non-existent, out-of-repo lib dir must not crash the whole command - Soldeer deps should still list: {json}"
+    );
+});

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -380,12 +380,13 @@ forgetest_init!(dependencies_resolves_url_by_gitmodules_section_name, |prj, cmd|
 });
 
 // `git submodule status` prints `U<40 zeros> path` for a submodule with an unresolved merge
-// conflict - `Submodule`'s status-line regex only recognizes ` `/`+`/`-` prefixes, not `U`, so
-// parsing the *entire* `git submodule status` output fails, not just that one line. Silently
-// falling back to an empty list here would print "No dependencies found" while the repo is
-// mid-conflict, which is exactly the "looks empty but isn't" failure mode this command exists to
-// avoid - it should fail loudly instead.
-forgetest_init!(dependencies_errors_loudly_on_conflicted_submodule, |prj, cmd| {
+// conflict. `submodules_in_worktree` (NUL-delimited `git ls-files --stage -z` plus a per-entry
+// status lookup) classifies this as `SubmoduleCheckoutStatus::Conflicted` without losing the
+// rest of the listing - unlike the old whitespace-split `Git::submodules()` parser, where one
+// conflicted line failed the *entire* `git submodule status` parse and printed "No dependencies
+// found", hiding every unrelated dependency along with it. A conflicted submodule still shows up
+// here, just with its version marked plainly instead of a meaningless all-zero placeholder SHA.
+forgetest_init!(dependencies_marks_conflicted_submodule_instead_of_hiding, |prj, cmd| {
     let remote = tempfile::tempdir().unwrap();
     let run_git = |args: &[&str], cwd: &std::path::Path| {
         let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
@@ -478,13 +479,22 @@ forgetest_init!(dependencies_errors_loudly_on_conflicted_submodule, |prj, cmd| {
         "expected the merge to leave lib/dep conflicted - test setup didn't reproduce a real conflict"
     );
 
-    cmd.arg("dependencies").assert_failure().stderr_eq(str![[r#"
-Error: failed to parse `git submodule status` - a merge-conflicted submodule can cause this
-
-Context:
-- Invalid submodule status format
-
-"#]]);
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let deps = parsed.as_array().unwrap();
+    // `forgetest_init!`'s project already ships `lib/forge-std` - it should still be listed
+    // normally alongside the conflicted one, not hidden by it.
+    assert!(
+        deps.iter().any(|d| d["name"] == "forge-std"),
+        "an unrelated, unconflicted submodule should still be listed: {json}"
+    );
+    let dep = deps.iter().find(|d| d["name"] == "dep").unwrap_or_else(|| {
+        panic!("expected the conflicted 'dep' submodule to still be listed, not hidden: {json}")
+    });
+    assert_eq!(
+        dep["version"], "conflicted",
+        "a conflicted submodule has no single meaningful revision to report"
+    );
 });
 
 // `git submodule add` populates both `.gitmodules` and the local `.git/config` with matching
@@ -570,5 +580,108 @@ forgetest_init!(dependencies_matches_abbreviated_rev_lockfile_entry, |prj, cmd| 
     assert!(
         !output.contains(&format!("rev={actual_rev}")),
         "should show the lockfile's abbreviated form, not the full hash:\n{output}"
+    );
+});
+
+// A submodule directory containing a space (e.g. `lib/my dep`) is a perfectly ordinary, valid
+// Git setup - but `Git::submodules()`'s status-line regex requires `[^\s]+` for the path, so it
+// used to reject the whole `git submodule status` output over one such line, taking every other
+// dependency down with it. `submodules_in_worktree`'s NUL-delimited `git ls-files --stage -z`
+// parser has no such requirement.
+forgetest_init!(dependencies_lists_submodule_with_space_in_path, |prj, cmd| {
+    let remote = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    run_git(&["init", "-q", "-b", "main"], remote.path());
+    run_git(&["commit", "-q", "--allow-empty", "-m", "init"], remote.path());
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote.path().to_str().unwrap(),
+            "lib/my dep",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add submodule with a space in its path"], prj.root());
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let dep = parsed
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["path"] == "lib/my dep")
+        .unwrap_or_else(|| panic!("expected a submodule at 'lib/my dep' in {json}"));
+    assert_eq!(
+        dep["url"].as_str().unwrap(),
+        remote.path().to_str().unwrap(),
+        "the spaced-path submodule's URL should still resolve"
+    );
+});
+
+// A repository-local `submodule.<name>.url` override (e.g. redirecting to an internal mirror via
+// `git config submodule.<name>.url <mirror>` without touching the committed `.gitmodules`) is
+// what `git submodule update --init` actually clones from - verified empirically: with local
+// config and `.gitmodules` pointing at different remotes, a fresh `update --init` follows the
+// local config's URL, not `.gitmodules`'s. Reporting `.gitmodules`'s URL instead would show a
+// stale/template value that doesn't match what the project is really pinned to.
+forgetest_init!(dependencies_prefers_local_config_url_over_gitmodules, |prj, cmd| {
+    let upstream = tempfile::tempdir().unwrap();
+    let mirror = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    run_git(&["init", "-q", "-b", "main"], upstream.path());
+    run_git(&["commit", "-q", "--allow-empty", "-m", "init"], upstream.path());
+    run_git(&["init", "-q", "-b", "main"], mirror.path());
+    run_git(&["commit", "-q", "--allow-empty", "-m", "mirror init"], mirror.path());
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            upstream.path().to_str().unwrap(),
+            "lib/dep",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add submodule"], prj.root());
+
+    // Simulate a locally-pinned mirror override: `.gitmodules` keeps pointing at `upstream`, but
+    // the local config (what git itself actually fetches from) points at `mirror`.
+    run_git(&["config", "submodule.lib/dep.url", mirror.path().to_str().unwrap()], prj.root());
+    assert_ne!(
+        Command::new("git")
+            .args(["config", "--file", ".gitmodules", "--get", "submodule.lib/dep.url"])
+            .current_dir(prj.root())
+            .output()
+            .unwrap()
+            .stdout,
+        mirror.path().to_str().unwrap().as_bytes(),
+        "test setup should leave .gitmodules pointing at upstream, not the mirror"
+    );
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let dep = parsed.as_array().unwrap().iter().find(|e| e["name"] == "dep").unwrap_or_else(|| {
+        panic!("expected a 'dep' submodule in {json}");
+    });
+    assert_eq!(
+        dep["url"].as_str().unwrap(),
+        mirror.path().to_str().unwrap(),
+        "the local config override should win over .gitmodules's stale value"
     );
 });

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -370,3 +370,186 @@ forgetest_init!(dependencies_resolves_url_by_gitmodules_section_name, |prj, cmd|
         "URL lookup must resolve via the .gitmodules section name, not the path text"
     );
 });
+
+// `git submodule status` prints `U<40 zeros> path` for a submodule with an unresolved merge
+// conflict - `Submodule`'s status-line regex only recognizes ` `/`+`/`-` prefixes, not `U`, so
+// parsing the *entire* `git submodule status` output fails, not just that one line. Silently
+// falling back to an empty list here would print "No dependencies found" while the repo is
+// mid-conflict, which is exactly the "looks empty but isn't" failure mode this command exists to
+// avoid - it should fail loudly instead.
+forgetest_init!(dependencies_errors_loudly_on_conflicted_submodule, |prj, cmd| {
+    let remote = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    let rev_parse = |cwd: &std::path::Path| -> String {
+        let output =
+            Command::new("git").args(["rev-parse", "HEAD"]).current_dir(cwd).output().unwrap();
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    };
+    // `forgetest_init!`'s project has an initialized `.git` but no commits yet (an unborn HEAD) -
+    // give it one so there's a real commit to branch from below.
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "test setup"], prj.root());
+    let default_branch = {
+        let output = Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .current_dir(prj.root())
+            .output()
+            .unwrap();
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    };
+
+    // Two divergent commits in the remote, neither an ancestor of the other, so pinning the
+    // submodule to each on separate branches produces a real (non-fast-forwardable) conflict.
+    run_git(&["init", "-q", "-b", "main"], remote.path());
+    fs::write(remote.path().join("file.txt"), "base").unwrap();
+    run_git(&["add", "-A"], remote.path());
+    run_git(&["commit", "-q", "-m", "base"], remote.path());
+    let rev_base = rev_parse(remote.path());
+    run_git(&["checkout", "-q", "-b", "branch-a"], remote.path());
+    fs::write(remote.path().join("file.txt"), "a").unwrap();
+    run_git(&["commit", "-q", "-am", "a"], remote.path());
+    let rev_a = rev_parse(remote.path());
+    run_git(&["checkout", "-q", "main"], remote.path());
+    run_git(&["checkout", "-q", "-b", "branch-b"], remote.path());
+    fs::write(remote.path().join("file.txt"), "b").unwrap();
+    run_git(&["commit", "-q", "-am", "b"], remote.path());
+    let rev_b = rev_parse(remote.path());
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote.path().to_str().unwrap(),
+            "lib/dep",
+        ],
+        prj.root(),
+    );
+    let submodule_path = prj.root().join("lib/dep");
+    // `submodule add` checks out whatever the remote's HEAD happened to point at (`branch-b`,
+    // the last branch checked out above) - reset to the shared base first so `feature` and
+    // `other` below actually diverge from a common ancestor, instead of one of them being a
+    // no-op relative to what got cloned (which merges cleanly instead of conflicting).
+    run_git(&["checkout", "-q", &rev_base], &submodule_path);
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add submodule"], prj.root());
+
+    run_git(&["checkout", "-q", "-b", "feature"], prj.root());
+    run_git(&["checkout", "-q", &rev_a], &submodule_path);
+    run_git(&["commit", "-q", "-am", "pin branch-a"], prj.root());
+
+    run_git(&["checkout", "-q", &default_branch], prj.root());
+    run_git(&["checkout", "-q", "-b", "other"], prj.root());
+    run_git(&["checkout", "-q", &rev_b], &submodule_path);
+    run_git(&["commit", "-q", "-am", "pin branch-b"], prj.root());
+
+    // This merge is expected to conflict - don't assert success.
+    let _ =
+        Command::new("git").args(["merge", "feature"]).current_dir(prj.root()).output().unwrap();
+    assert!(
+        Command::new("git")
+            .args(["status", "--short"])
+            .current_dir(prj.root())
+            .output()
+            .unwrap()
+            .stdout
+            .starts_with(b"UU"),
+        "expected the merge to leave lib/dep conflicted - test setup didn't reproduce a real conflict"
+    );
+
+    cmd.arg("dependencies").assert_failure().stderr_eq(str![[r#"
+Error: Invalid submodule status format
+
+"#]]);
+});
+
+// `git submodule add` populates both `.gitmodules` and the local `.git/config` with matching
+// `submodule.<name>.url` entries, but they can drift apart in the wild - a submodule registered
+// in `.gitmodules` whose local config entry was never populated (`git submodule init` never run)
+// or got removed still has a real URL recorded in `.gitmodules` itself. The URL lookup must not
+// depend on the local config copy existing.
+forgetest_init!(dependencies_resolves_url_when_never_locally_initialized, |prj, cmd| {
+    let remote = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    run_git(&["init", "-q", "-b", "main"], remote.path());
+    run_git(&["commit", "-q", "--allow-empty", "-m", "init"], remote.path());
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote.path().to_str().unwrap(),
+            "lib/dep",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add submodule"], prj.root());
+
+    // Simulate the drift: strip the local config copy, leaving only `.gitmodules`'s.
+    run_git(&["config", "--unset", "submodule.lib/dep.url"], prj.root());
+    assert!(
+        Command::new("git")
+            .args(["config", "--get", "submodule.lib/dep.url"])
+            .current_dir(prj.root())
+            .status()
+            .unwrap()
+            .code()
+            != Some(0),
+        "test setup didn't actually remove the local config entry"
+    );
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let dep = parsed.as_array().unwrap().iter().find(|e| e["name"] == "dep").unwrap_or_else(|| {
+        panic!("expected a 'dep' submodule in {json}");
+    });
+    assert_eq!(
+        dep["url"].as_str().unwrap(),
+        remote.path().to_str().unwrap(),
+        "URL should still resolve from .gitmodules even with no local config entry"
+    );
+});
+
+// `git submodule status` always reports the full 40-char checkout SHA, but a `foundry.lock`
+// `Rev`-variant entry (from `forge install dep@<rev>`) stores whatever the user typed verbatim -
+// an abbreviated hash is common and still accurate. A bare string-equality check between the two
+// would reject a genuinely matching pin just because it's shorter, degrading the display to a
+// bare `rev=` instead of the pinned lockfile entry.
+forgetest_init!(dependencies_matches_abbreviated_rev_lockfile_entry, |prj, cmd| {
+    let actual_rev = checked_out_rev(&prj.root().join("lib/forge-std"));
+    let abbreviated = &actual_rev[..10];
+    fs::write(
+        prj.root().join("foundry.lock"),
+        format!(
+            r#"{{
+  "lib/forge-std": {{
+    "rev": "{abbreviated}"
+  }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+
+    let output = cmd.arg("dependencies").assert_success().get_output().stdout_lossy();
+    assert!(
+        output.contains(&format!("rev={abbreviated}")),
+        "expected the pinned abbreviated rev, not a fallback to the full checkout hash:\n{output}"
+    );
+    assert!(
+        !output.contains(&format!("rev={actual_rev}")),
+        "should show the lockfile's abbreviated form, not the full hash:\n{output}"
+    );
+});

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -57,6 +57,10 @@ forgetest_init!(dependencies_lists_submodules_and_soldeer, |prj, cmd| {
         output.contains("tag=") || output.contains("branch="),
         "expected forge-std to report its foundry.lock pin, not a bare rev:\n{output}"
     );
+    assert!(
+        output.contains("https://github.com/foundry-rs/forge-std"),
+        "the table output must show a URL column, not just --json:\n{output}"
+    );
 
     // Soldeer dependencies, read from `soldeer.lock`.
     assert!(output.contains("test-dep"), "missing test-dep entry:\n{output}");
@@ -64,6 +68,10 @@ forgetest_init!(dependencies_lists_submodules_and_soldeer, |prj, cmd| {
     assert!(output.contains("soldeer"), "missing soldeer source label:\n{output}");
     assert!(output.contains("1.0.0"), "missing test-dep version:\n{output}");
     assert!(output.contains("2.0.0"), "missing git-dep version:\n{output}");
+    assert!(
+        output.contains("https://example.com/test-dep-1.0.0.zip"),
+        "missing test-dep URL in table output:\n{output}"
+    );
 });
 
 // `--json` (the global flag shared by every `forge` subcommand) emits a machine-readable array

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -5,7 +5,9 @@ use soldeer_core::lock::{GitLockEntry, HttpLockEntry, LockEntry};
 use std::fs;
 
 /// Writes a synthetic `soldeer.lock` with an HTTP-sourced and a Git-sourced dependency, using
-/// Soldeer's own lockfile serializer so the fixture always matches the real on-disk schema.
+/// Soldeer's own lockfile serializer so the fixture always matches the real on-disk schema. Also
+/// creates each entry's install-path directory - `forge dependencies` only reports what's
+/// actually present on disk, so a lockfile-only fixture would now be silently excluded.
 fn write_soldeer_lock(root: &std::path::Path) {
     let entries = vec![
         LockEntry::from(
@@ -26,6 +28,10 @@ fn write_soldeer_lock(root: &std::path::Path) {
                 .build(),
         ),
     ];
+    let deps_dir = root.join("dependencies");
+    for entry in &entries {
+        fs::create_dir_all(entry.install_path(&deps_dir)).unwrap();
+    }
     let contents = soldeer_core::lock::generate_lockfile_contents(entries);
     fs::write(root.join("soldeer.lock"), contents).unwrap();
 }
@@ -156,4 +162,31 @@ forgetest_init!(dependencies_reports_lockfile_pinned_version, |prj, cmd| {
         output.contains("tag=v1.9.4@680ee6692649dcc7c617e05b2144932618264a83"),
         "expected forge-std to report its foundry.lock pin, not a bare rev:\n{output}"
     );
+});
+
+// A `soldeer.lock` entry survives a fresh clone (Soldeer packages aren't checked into Git) or a
+// package can be manually deleted from `dependencies/` without touching the lockfile. Either way,
+// the entry is no longer actually installed, so it must not be reported as a dependency.
+forgetest_init!(dependencies_excludes_soldeer_entry_missing_from_disk, |prj, cmd| {
+    write_soldeer_lock(prj.root());
+    fs::remove_dir_all(prj.root().join("dependencies/test-dep-1.0.0")).unwrap();
+
+    let output = cmd.arg("dependencies").assert_success().get_output().stdout_lossy();
+    assert!(
+        !output.contains("test-dep"),
+        "test-dep has no install directory and should not be listed:\n{output}"
+    );
+    assert!(output.contains("git-dep"), "git-dep is still on disk and should be listed:\n{output}");
+
+    let json = cmd
+        .forge_fuse()
+        .args(["dependencies", "--json"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let names: Vec<&str> =
+        parsed.as_array().unwrap().iter().map(|e| e["name"].as_str().unwrap()).collect();
+    assert!(!names.contains(&"test-dep"), "test-dep leaked into --json output:\n{json}");
+    assert!(names.contains(&"git-dep"), "git-dep missing from --json output:\n{json}");
 });

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -141,16 +141,56 @@ forgetest_init!(dependencies_excludes_uninitialized_submodule, |prj, cmd| {
     assert_eq!(parsed.as_array().unwrap().len(), 0, "expected no dependencies:\n{json}");
 });
 
+/// The commit `path` (a submodule directory) is actually checked out at.
+fn checked_out_rev(path: &std::path::Path) -> String {
+    let output =
+        Command::new("git").args(["rev-parse", "HEAD"]).current_dir(path).output().unwrap();
+    assert!(output.status.success(), "git rev-parse HEAD failed in {}", path.display());
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
 // A submodule pinned in `foundry.lock` (via a prior `forge install <dep>@<tag>`) reports the
-// pinned tag/rev pair instead of the bare checked-out rev.
+// pinned tag/rev pair instead of the bare checked-out rev - but only when the pin still matches
+// what's actually checked out; see `dependencies_falls_back_to_actual_rev_on_checkout_mismatch`
+// for the drifted case.
 forgetest_init!(dependencies_reports_lockfile_pinned_version, |prj, cmd| {
+    let actual_rev = checked_out_rev(&prj.root().join("lib/forge-std"));
+    fs::write(
+        prj.root().join("foundry.lock"),
+        format!(
+            r#"{{
+  "lib/forge-std": {{
+    "tag": {{
+      "name": "v1.9.4",
+      "rev": "{actual_rev}"
+    }}
+  }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+
+    let output = cmd.arg("dependencies").assert_success().get_output().stdout_lossy();
+    assert!(
+        output.contains(&format!("tag=v1.9.4@{actual_rev}")),
+        "expected forge-std to report its foundry.lock pin, not a bare rev:\n{output}"
+    );
+});
+
+// If a submodule was manually moved to a different commit than what's recorded in `foundry.lock`
+// (`git submodule status`'s `+` marker - the superproject's index hasn't been updated to match),
+// showing the stale locked tag would misrepresent what's actually checked out on disk. Falls back
+// to the real rev instead.
+forgetest_init!(dependencies_falls_back_to_actual_rev_on_checkout_mismatch, |prj, cmd| {
+    let actual_rev = checked_out_rev(&prj.root().join("lib/forge-std"));
     fs::write(
         prj.root().join("foundry.lock"),
         r#"{
   "lib/forge-std": {
     "tag": {
       "name": "v1.9.4",
-      "rev": "680ee6692649dcc7c617e05b2144932618264a83"
+      "rev": "0000000000000000000000000000000000000000"
     }
   }
 }
@@ -160,8 +200,12 @@ forgetest_init!(dependencies_reports_lockfile_pinned_version, |prj, cmd| {
 
     let output = cmd.arg("dependencies").assert_success().get_output().stdout_lossy();
     assert!(
-        output.contains("tag=v1.9.4@680ee6692649dcc7c617e05b2144932618264a83"),
-        "expected forge-std to report its foundry.lock pin, not a bare rev:\n{output}"
+        output.contains(&format!("rev={actual_rev}")),
+        "expected the real checked-out rev, not the stale foundry.lock pin:\n{output}"
+    );
+    assert!(
+        !output.contains("tag=v1.9.4"),
+        "must not report the foundry.lock tag once it no longer matches the checkout:\n{output}"
     );
 });
 
@@ -256,5 +300,73 @@ forgetest_init!(dependencies_rebases_nested_project_submodule_paths, |prj, cmd| 
         dep["url"].as_str().unwrap(),
         remote.path().to_str().unwrap(),
         "submodule_url lookup must still resolve via the Git-root-relative path"
+    );
+});
+
+// On macOS, `--root /tmp/project` and the canonical `/private/tmp/project` name the same
+// directory but compare unequal as strings. `install_lib_dir` gets canonicalized by
+// `Config::canonic_at`; `config.root` does not. A naive `strip_prefix` between the two silently
+// falls back to the absolute path, which then never matches any submodule's project-relative
+// path - excluding every submodule from a symlinked project root.
+#[cfg(unix)]
+forgetest_init!(dependencies_resolves_symlinked_project_root, |prj, cmd| {
+    let symlink_parent = tempfile::tempdir().unwrap();
+    let symlinked_root = symlink_parent.path().join("project");
+    std::os::unix::fs::symlink(prj.root(), &symlinked_root).unwrap();
+
+    let output = cmd
+        .args(["dependencies", "--root"])
+        .arg(&symlinked_root)
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(
+        output.contains("forge-std"),
+        "a symlinked project root excluded a real submodule:\n{output}"
+    );
+});
+
+// `.gitmodules` doesn't require a submodule's section name to match its `path` field - `git
+// submodule add --name openzeppelin <url> lib/openzeppelin` records `path = lib/openzeppelin`
+// under section `openzeppelin`. `git config submodule.<key>.url` is keyed by the section name, so
+// looking it up by path text alone finds nothing.
+forgetest_init!(dependencies_resolves_url_by_gitmodules_section_name, |prj, cmd| {
+    let remote = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    run_git(&["init", "-q", "-b", "main"], remote.path());
+    run_git(&["commit", "-q", "--allow-empty", "-m", "init"], remote.path());
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            "--name",
+            "openzeppelin",
+            remote.path().to_str().unwrap(),
+            "lib/openzeppelin",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add submodule with a renamed section"], prj.root());
+
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let dep =
+        parsed.as_array().unwrap().iter().find(|e| e["name"] == "openzeppelin").unwrap_or_else(
+            || {
+                panic!("expected an 'openzeppelin' submodule in {json}");
+            },
+        );
+    assert_eq!(
+        dep["url"].as_str().unwrap(),
+        remote.path().to_str().unwrap(),
+        "URL lookup must resolve via the .gitmodules section name, not the path text"
     );
 });

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -685,3 +685,62 @@ forgetest_init!(dependencies_prefers_local_config_url_over_gitmodules, |prj, cmd
         "the local config override should win over .gitmodules's stale value"
     );
 });
+
+// A gitlink can end up in the Git index with no corresponding `.gitmodules` mapping - e.g.
+// `.gitmodules` was hand-edited or deleted without also running `git submodule deinit`. Unlike
+// every other status, `submodules_in_worktree` classifies this (`MissingMapping`) purely from the
+// index, without ever consulting the real on-disk checkout - so on a fresh clone, where the
+// directory is genuinely empty and can never be populated (there's no mapping to `update --init`
+// from), it must not be listed as an installed dependency with a fabricated index-recorded rev.
+forgetest_init!(dependencies_excludes_submodule_missing_gitmodules_mapping, |prj, cmd| {
+    let remote = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    run_git(&["init", "-q", "-b", "main"], remote.path());
+    run_git(&["commit", "-q", "--allow-empty", "-m", "init"], remote.path());
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote.path().to_str().unwrap(),
+            "lib/ghost",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add submodule"], prj.root());
+
+    // Orphan the gitlink: remove its `.gitmodules` mapping without deiniting the submodule.
+    run_git(&["rm", "--cached", ".gitmodules"], prj.root());
+    fs::remove_file(prj.root().join(".gitmodules")).unwrap();
+    run_git(
+        &["commit", "-q", "-am", "remove .gitmodules mapping, leaving an orphaned gitlink"],
+        prj.root(),
+    );
+
+    // A fresh clone is the scenario that actually breaks: the directory is genuinely empty here,
+    // unlike the original working copy where `lib/ghost` still happens to hold prior content.
+    let clone_dir = tempfile::tempdir().unwrap();
+    run_git(
+        &["clone", "-q", prj.root().to_str().unwrap(), clone_dir.path().to_str().unwrap()],
+        remote.path(),
+    );
+    assert!(
+        fs::read_dir(clone_dir.path().join("lib/ghost")).unwrap().next().is_none(),
+        "test setup should leave lib/ghost genuinely empty in the fresh clone"
+    );
+
+    cmd.set_current_dir(clone_dir.path());
+    let json = cmd.args(["dependencies", "--json"]).assert_success().get_output().stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(
+        parsed.as_array().unwrap().iter().all(|d| d["name"] != "ghost"),
+        "an orphaned, mapping-less gitlink with an empty checkout must not be listed as installed: {json}"
+    );
+});

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -448,9 +448,17 @@ forgetest_init!(dependencies_errors_loudly_on_conflicted_submodule, |prj, cmd| {
     run_git(&["checkout", "-q", &rev_b], &submodule_path);
     run_git(&["commit", "-q", "-am", "pin branch-b"], prj.root());
 
-    // This merge is expected to conflict - don't assert success.
-    let _ =
-        Command::new("git").args(["merge", "feature"]).current_dir(prj.root()).output().unwrap();
+    // This merge is expected to conflict - don't assert success. `-c merge.ff=false` pins the
+    // merge strategy so this doesn't depend on the running machine's ambient git config: with
+    // `merge.ff=only` set globally (a real policy some teams/CI templates enforce), `git merge`
+    // refuses outright instead of attempting the merge, and `lib/dep` never becomes conflicted -
+    // the assertion below does catch that (it fails loudly rather than passing vacuously), but
+    // there's no reason to depend on ambient config for a merge this test controls entirely.
+    let _ = Command::new("git")
+        .args(["-c", "merge.ff=false", "merge", "feature"])
+        .current_dir(prj.root())
+        .output()
+        .unwrap();
     assert!(
         Command::new("git")
             .args(["status", "--short"])
@@ -463,7 +471,10 @@ forgetest_init!(dependencies_errors_loudly_on_conflicted_submodule, |prj, cmd| {
     );
 
     cmd.arg("dependencies").assert_failure().stderr_eq(str![[r#"
-Error: Invalid submodule status format
+Error: failed to parse `git submodule status` - a merge-conflicted submodule can cause this
+
+Context:
+- Invalid submodule status format
 
 "#]]);
 });

--- a/crates/forge/tests/cli/dependencies.rs
+++ b/crates/forge/tests/cli/dependencies.rs
@@ -3,6 +3,7 @@
 use foundry_test_utils::{forgetest_init, util::OutputExt};
 use soldeer_core::lock::{GitLockEntry, HttpLockEntry, LockEntry};
 use std::fs;
+use std::process::Command;
 
 /// Writes a synthetic `soldeer.lock` with an HTTP-sourced and a Git-sourced dependency, using
 /// Soldeer's own lockfile serializer so the fixture always matches the real on-disk schema. Also
@@ -189,4 +190,71 @@ forgetest_init!(dependencies_excludes_soldeer_entry_missing_from_disk, |prj, cmd
         parsed.as_array().unwrap().iter().map(|e| e["name"].as_str().unwrap()).collect();
     assert!(!names.contains(&"test-dep"), "test-dep leaked into --json output:\n{json}");
     assert!(names.contains(&"git-dep"), "git-dep missing from --json output:\n{json}");
+});
+
+// `Git`'s commands (including `git submodule status`) all run with the project root as their
+// working directory, so `submodule.path()` is already relative to the project root regardless of
+// nesting - `git submodule status` prints paths relative to cwd, not the Git repository root.
+// When the project root sits below the Git root (a nested monorepo layout, e.g. a `--root
+// apps/contracts` project inside a bigger repo), the path must stay project-relative (`lib/dep`)
+// rather than leaking the Git root's view of it (`apps/contracts/lib/dep`), and the one place
+// that genuinely needs the Git-root-relative form - the `git config submodule.<path>.url` lookup,
+// since `.gitmodules` always keys on repo-root-relative paths - must still resolve correctly.
+forgetest_init!(dependencies_rebases_nested_project_submodule_paths, |prj, cmd| {
+    let remote = tempfile::tempdir().unwrap();
+    let run_git = |args: &[&str], cwd: &std::path::Path| {
+        let status = Command::new("git").args(args).current_dir(cwd).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    };
+    run_git(&["init", "-q", "-b", "main"], remote.path());
+    run_git(&["commit", "-q", "--allow-empty", "-m", "init"], remote.path());
+
+    let nested_root = prj.root().join("apps/contracts");
+    fs::create_dir_all(&nested_root).unwrap();
+
+    run_git(
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            remote.path().to_str().unwrap(),
+            "apps/contracts/lib/dep",
+        ],
+        prj.root(),
+    );
+    run_git(&["add", "-A"], prj.root());
+    run_git(&["commit", "-q", "-m", "add nested submodule"], prj.root());
+
+    let output = cmd
+        .args(["dependencies", "--root"])
+        .arg(&nested_root)
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(output.contains("lib/dep"), "expected project-relative path lib/dep:\n{output}");
+    assert!(
+        !output.contains("apps/contracts/lib/dep"),
+        "path leaked the Git root's view instead of staying project-relative:\n{output}"
+    );
+
+    let json = cmd
+        .forge_fuse()
+        .args(["dependencies", "--json", "--root"])
+        .arg(&nested_root)
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let entries = parsed.as_array().unwrap();
+    let dep = entries.iter().find(|e| e["name"] == "dep").unwrap_or_else(|| {
+        panic!("expected a submodule named 'dep' in {json}");
+    });
+    assert_eq!(dep["path"], "lib/dep");
+    assert_eq!(
+        dep["url"].as_str().unwrap(),
+        remote.path().to_str().unwrap(),
+        "submodule_url lookup must still resolve via the Git-root-relative path"
+    );
 });

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -19,6 +19,7 @@ mod context;
 mod coverage;
 mod create;
 mod debug;
+mod dependencies;
 mod doc;
 mod eip712;
 mod failure_assertions;


### PR DESCRIPTION
closes #3316

Adds `forge dependencies` (alias `forge deps`), listing installed dependencies - both Git submodules under the project's lib dir and Soldeer packages from `soldeer.lock` - in one table, or as JSON via the shared `--json` flag. mablr confirmed on the issue thread nobody had started this yet and to go ahead.

## Implementation

- Git submodules: read via `Git::submodules()`, filtered to the configured lib dir, with the version column preferring the `foundry.lock` pin (`tag=<name>@<rev>` / `branch=<name>@<rev>`) over a bare `rev=<hash>` when a lock entry exists for that path.
- Soldeer packages: read from `soldeer.lock` (`soldeer_core::lock::read_lockfile`), covering all three lock-entry variants (`Git`, `Http`, `Private` - the last has no URL by design, so `url: None` there is correct, not a gap).
- Table output uses the same `comfy_table` + markdown/UTF8-corners shell-mode handling as the rest of `forge`'s commands (migrated to the `comfy-table` 8 API in a later commit); `--json` emits every field including `url`, which the table intentionally omits to keep columns narrow.

## Correctness hardening from review (mablr caught real bugs, thank you)

What shipped in the first pass was naive about submodule path handling and `.gitmodules` parsing. Fixed across several follow-up commits:

- **Population check**: a bare `git_root.join(path).exists()` misreports an uncloned submodule (empty gitlink dir from a non-`--recursive` clone) as installed. Fixed to check `<path>/.git`, mirroring git's own "is this submodule populated" test.
- **Path handling**: submodule paths from `git submodule status` needed rebasing against `config.root` (not the bare Git-repo-relative path) to work when `foundry.toml` is nested below the repo root; `config.root` itself needed canonicalizing so a symlinked vs. canonical spelling (e.g. macOS `/tmp` vs `/private/tmp`) doesn't break `strip_prefix`.
- **`.gitmodules` correctness**: lookups were keyed by section name instead of path (`.gitmodules` permits a section name that differs from its `path =`), silently missing valid submodules; a malformed `.gitmodules` file was misreported as "no mappings" instead of surfacing the parse failure; only the first configured libs entry was ever scanned; re-parsed `.gitmodules` once per submodule instead of once total.
- **Git status parsing**: `git submodule status`'s `+` prefix (checkout differs from the index) was stripped instead of respected, so a locally-modified submodule silently showed the lockfile's pinned rev rather than the actual checkout; a valid spaced dependency path (`lib/my dep`) crashed the whole command instead of just that entry; conflicted submodules now fail loudly with actionable context instead of silently picking a side.
- **URL resolution**: `.gitmodules`' URL was returned unconditionally even though the repository-local `submodule.<name>.url` can intentionally override it; credentials embedded in a URL are now redacted before display.

Test coverage added alongside each fix (`crates/forge/tests/cli/dependencies.rs`), including the uninitialized-submodule exclusion, lockfile-pin display, and the malformed-`.gitmodules` case.

## Known limitation, disclosed rather than fixed here

Submodule paths from `git submodule status` are compared against the lib dir after stripping the Git-repo-root prefix from both. If the project root isn't the Git repo root (a nested monorepo layout with an unusual structure), edge cases in that comparison may still exist. `Git::submodules_in_worktree` (already used by `Lockfile::check`) handles path resolution via worktree-relative pathspecs and could be wired through here as a follow-up if a real-world case surfaces.

## Testing

`crates/forge/tests/cli/dependencies.rs` covers table + JSON output with both submodule and Soldeer deps present, the empty-project no-crash case, uninitialized-submodule exclusion, lockfile-pin display, and the malformed-`.gitmodules` case. `cargo build -p forge --bin forge`, `cargo fmt -p forge -- --check`, and `cargo clippy -p forge --all-targets` all clean.