### PR TITLE
feat(fuzz): seed bytes32 from literals

### DIFF
--- a/.changelog/fuzz-bytes32-literals.md
+++ b/.changelog/fuzz-bytes32-literals.md
@@ -1,0 +1,5 @@
+---
+foundry-evm-fuzz: patch
+---
+
+Seed `bytes32` fuzz inputs from numeric Solidity literals with the same ABI word representation.

--- a/crates/evm/fuzz/src/strategies/literals.rs
+++ b/crates/evm/fuzz/src/strategies/literals.rs
@@ -241,6 +241,7 @@ impl LiteralsCollector {
                 self.insert_word(DynSolType::Uint(bits), word);
             }
         }
+        self.insert_word(DynSolType::FixedBytes(32), word);
     }
 
     /// Seeds a signed value under all `intN` sizes that can represent it.
@@ -806,6 +807,7 @@ mod tests {
 
         assert_word(&map, DynSolType::Address, addr, "Expected DAI in address set");
         assert_word(&map, DynSolType::Uint(64), num, "Expected MAGIC_NUMBER in uint64 set");
+        assert_word(&map, DynSolType::FixedBytes(32), num, "Expected MAGIC_NUMBER in bytes32 set");
         assert_word(&map, DynSolType::Int(32), int, "Expected MAGIC_INT in int32 set");
         assert_word(&map, DynSolType::FixedBytes(32), word, "Expected MAGIC_WORD in bytes32 set");
         assert!(map.strings.contains("xyzzy"), "Expected MAGIC_STRING to be collected");
@@ -872,12 +874,13 @@ mod tests {
         // - MAGIC_WORD
         // - String literals (hashed and right-padded versions)
         // - The folded EIP-1967 slot `K - 1` (`K` itself dedups with the hashed string literal)
-        assert_eq!(count(DynSolType::FixedBytes(32)), 7, "FixedBytes(32) count mismatch");
+        // - Unsigned numeric values, which use the same ABI word representation
+        assert_eq!(count(DynSolType::FixedBytes(32)), 14, "FixedBytes(32) count mismatch");
 
         // Total count check
         assert_eq!(
             literals.words.values().map(|set| set.len()).sum::<usize>(),
-            49,
+            56,
             "Total word values count mismatch"
         );
     }


### PR DESCRIPTION
Solidity numeric literals are currently inserted into the typed fuzz dictionary for integer parameters but not for `bytes32`, even though `uint256` and `bytes32` use the same 32-byte ABI word representation. This also seeds those words for `bytes32` while deliberately leaving smaller fixed-byte types unchanged because they are left-aligned.

On a branch requiring two `bytes32` arguments to equal the source literal `0x69`, master found the branch in 1 of 50 independent 5,000-run campaigns; this change found it in 50 of 50. Paired 200,000-run measurements were neutral: 682.5ms to 685.6ms for a no-op `bytes32` target and 1.913s to 1.920s for the full campaign.

The implementation and analysis were developed with AI assistance.
