### PR TITLE
perf(symbolic): reduce path clone overhead

### DIFF
--- a/.changelog/symbolic-path-state-sharing.md
+++ b/.changelog/symbolic-path-state-sharing.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Reduced symbolic path-fork memory and clone overhead by sharing unchanged world state and moving consumed call outcomes.

--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -986,7 +986,6 @@ impl SymbolicExecutor {
                 let mut frame = CallFrame::new(
                     &mut self.cx,
                     to,
-                    code_address,
                     to,
                     call_caller,
                     value.clone(),
@@ -999,16 +998,8 @@ impl SymbolicExecutor {
             }
             CallKind::StaticCall => {
                 let value = SymExpr::zero(&mut self.cx);
-                let mut frame = CallFrame::new(
-                    &mut self.cx,
-                    to,
-                    code_address,
-                    to,
-                    call_caller,
-                    value,
-                    true,
-                    calldata,
-                );
+                let mut frame =
+                    CallFrame::new(&mut self.cx, to, to, call_caller, value, true, calldata);
                 frame.address_word = callee_address_word;
                 frame.caller_word = call_caller_word;
                 frame
@@ -1017,7 +1008,6 @@ impl SymbolicExecutor {
                 let mut frame = CallFrame::new(
                     &mut self.cx,
                     state.address,
-                    code_address,
                     state.storage_address,
                     state.caller,
                     state.callvalue.clone(),
@@ -1032,7 +1022,6 @@ impl SymbolicExecutor {
                 let mut frame = CallFrame::new(
                     &mut self.cx,
                     state.address,
-                    code_address,
                     state.storage_address,
                     call_caller,
                     value.clone(),
@@ -1055,29 +1044,22 @@ impl SymbolicExecutor {
         child.expected_revert = None;
         child.assume_no_revert_next_call = None;
         let outcomes = self.execute_external_call(executor, child, &child_code, completed_paths)?;
-        let Some((first, rest)) = outcomes.split_first() else {
+        if outcomes.is_empty() {
             return Ok(StepOutcome::AssumeRejected);
-        };
+        }
 
         let mut parents = VecDeque::with_capacity(outcomes.len());
-        for outcome in std::iter::once(first).chain(rest.iter()) {
+        for mut outcome in outcomes {
             let mut parent = state.clone();
-            parent.constraints = outcome.state.constraints.clone();
-            parent.next_symbol = outcome.state.next_symbol;
-            parent.inherit_branch_target_progress(&outcome.state);
-            parent.storage_load_hooks = outcome.state.storage_load_hooks.clone();
-            parent.storage_store_hooks = outcome.state.storage_store_hooks.clone();
-            parent.mapping_storage_store_hooks = outcome.state.mapping_storage_store_hooks.clone();
-            parent.inherit_mapping_hook_provenance(&outcome.state);
-            parent.inherit_inspector_recordings(&outcome.state);
+            parent.take_call_outcome_state(&mut outcome.state);
 
             if let Some(assumption) = parent.assume_no_revert_next_call.take()
-                && matches!(outcome.status, TopLevelCallStatus::Revert)
+                && matches!(outcome.status, CallStatus::Revert)
                 && self.assume_no_revert_rejects(
                     &mut parent,
                     &assumption,
                     to,
-                    &outcome.return_data,
+                    &outcome.state.frame.return_data,
                 )?
             {
                 continue;
@@ -1085,16 +1067,16 @@ impl SymbolicExecutor {
 
             if let Some(mut expected) = parent.expected_revert.clone() {
                 match outcome.status {
-                    TopLevelCallStatus::Success => {
+                    CallStatus::Success => {
                         *state = parent;
                         return Ok(StepOutcome::Failure);
                     }
-                    TopLevelCallStatus::Revert | TopLevelCallStatus::Failure => {
+                    CallStatus::Revert | CallStatus::Failure => {
                         if !self.expected_revert_matches(
                             &mut parent,
                             &expected,
                             to,
-                            &outcome.return_data,
+                            &outcome.state.frame.return_data,
                         )? {
                             *state = parent;
                             return Ok(StepOutcome::Failure);
@@ -1104,10 +1086,10 @@ impl SymbolicExecutor {
                         } else {
                             parent.expected_revert = Some(expected);
                         }
-                        parent.expected_calls = outcome.state.expected_calls.clone();
-                        parent.expected_creates = outcome.state.expected_creates.clone();
-                        parent.call_mocks = outcome.state.call_mocks.clone();
-                        parent.function_mocks = outcome.state.function_mocks.clone();
+                        parent.expected_calls = outcome.state.expected_calls;
+                        parent.expected_creates = outcome.state.expected_creates;
+                        parent.call_mocks = outcome.state.call_mocks;
+                        parent.function_mocks = outcome.state.function_mocks;
                         parent.world = original_world.clone();
                         parent.return_data = SymReturnData::empty(&mut self.cx);
                         parent.copy_call_output_offset(
@@ -1122,31 +1104,31 @@ impl SymbolicExecutor {
                 }
             }
 
-            parent.world = if matches!(outcome.status, TopLevelCallStatus::Success) {
-                outcome.state.world.clone()
+            parent.world = if matches!(outcome.status, CallStatus::Success) {
+                outcome.state.world
             } else {
                 original_world.clone()
             };
             match outcome.status {
-                TopLevelCallStatus::Success => {
-                    parent.block = outcome.state.block.clone();
-                    parent.expected_emit = outcome.state.expected_emit.clone();
-                    parent.expected_calls = outcome.state.expected_calls.clone();
-                    parent.expected_creates = outcome.state.expected_creates.clone();
-                    parent.call_mocks = outcome.state.call_mocks.clone();
-                    parent.function_mocks = outcome.state.function_mocks.clone();
+                CallStatus::Success => {
+                    parent.block = outcome.state.block;
+                    parent.expected_emit = outcome.state.expected_emit;
+                    parent.expected_calls = outcome.state.expected_calls;
+                    parent.expected_creates = outcome.state.expected_creates;
+                    parent.call_mocks = outcome.state.call_mocks;
+                    parent.function_mocks = outcome.state.function_mocks;
                 }
-                TopLevelCallStatus::Failure => {
+                CallStatus::Failure => {
                     *state = parent;
                     return Ok(StepOutcome::Failure);
                 }
-                TopLevelCallStatus::Revert => {}
+                CallStatus::Revert => {}
             }
-            parent.return_data = outcome.return_data.clone();
+            parent.return_data = outcome.state.frame.return_data;
             parent.copy_call_output_offset(&mut self.cx, out_offset.clone(), &out_size)?;
             let success = SymExpr::constant(
                 &mut self.cx,
-                U256::from(matches!(outcome.status, TopLevelCallStatus::Success)),
+                U256::from(matches!(outcome.status, CallStatus::Success)),
             );
             parent.stack.push(success)?;
             parents.push_back(parent);

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -167,16 +167,8 @@ impl SymbolicExecutor {
         let zero = SymExpr::zero(&mut self.cx);
         let calldata = SymBytes::empty(&mut self.cx);
         let calldata = SymCalldata::from_bytes(&mut self.cx, calldata);
-        let mut frame = CallFrame::new(
-            &mut self.cx,
-            created,
-            created,
-            created,
-            state.address,
-            zero,
-            false,
-            calldata,
-        );
+        let mut frame =
+            CallFrame::new(&mut self.cx, created, created, state.address, zero, false, calldata);
         frame.address_word = created_word.clone();
         frame.caller_word = state.address_word.clone();
         let mut child = state.child(frame);
@@ -188,29 +180,22 @@ impl SymbolicExecutor {
         child.assume_no_revert_next_call = None;
 
         let outcomes = self.execute_external_call(executor, child, &initcode, completed_paths)?;
-        let Some((first, rest)) = outcomes.split_first() else {
+        if outcomes.is_empty() {
             return Ok(StepOutcome::AssumeRejected);
-        };
+        }
 
         let mut parents = VecDeque::with_capacity(outcomes.len());
-        for outcome in std::iter::once(first).chain(rest.iter()) {
+        for mut outcome in outcomes {
             let mut parent = state.clone();
-            parent.constraints = outcome.state.constraints.clone();
-            parent.next_symbol = outcome.state.next_symbol;
-            parent.inherit_branch_target_progress(&outcome.state);
-            parent.storage_load_hooks = outcome.state.storage_load_hooks.clone();
-            parent.storage_store_hooks = outcome.state.storage_store_hooks.clone();
-            parent.mapping_storage_store_hooks = outcome.state.mapping_storage_store_hooks.clone();
-            parent.inherit_mapping_hook_provenance(&outcome.state);
-            parent.inherit_inspector_recordings(&outcome.state);
+            parent.take_call_outcome_state(&mut outcome.state);
 
             if let Some(assumption) = parent.assume_no_revert_next_call.take()
-                && matches!(outcome.status, TopLevelCallStatus::Revert)
+                && matches!(outcome.status, CallStatus::Revert)
                 && self.assume_no_revert_rejects(
                     &mut parent,
                     &assumption,
                     created,
-                    &outcome.return_data,
+                    &outcome.state.frame.return_data,
                 )?
             {
                 continue;
@@ -218,16 +203,16 @@ impl SymbolicExecutor {
 
             if let Some(mut expected) = parent.expected_revert.clone() {
                 match outcome.status {
-                    TopLevelCallStatus::Success => {
+                    CallStatus::Success => {
                         *state = parent;
                         return Ok(StepOutcome::Failure);
                     }
-                    TopLevelCallStatus::Revert | TopLevelCallStatus::Failure => {
+                    CallStatus::Revert | CallStatus::Failure => {
                         if !self.expected_revert_matches(
                             &mut parent,
                             &expected,
                             created,
-                            &outcome.return_data,
+                            &outcome.state.frame.return_data,
                         )? {
                             *state = parent;
                             return Ok(StepOutcome::Failure);
@@ -237,10 +222,10 @@ impl SymbolicExecutor {
                         } else {
                             parent.expected_revert = Some(expected);
                         }
-                        parent.expected_calls = outcome.state.expected_calls.clone();
+                        parent.expected_calls = outcome.state.expected_calls;
                         parent.expected_creates = pending_expected_creates.clone();
-                        parent.call_mocks = outcome.state.call_mocks.clone();
-                        parent.function_mocks = outcome.state.function_mocks.clone();
+                        parent.call_mocks = outcome.state.call_mocks;
+                        parent.function_mocks = outcome.state.function_mocks;
                         parent.world = failure_world.clone();
                         let zero = SymExpr::zero(&mut self.cx);
                         let return_data = SymReturnData::from_words(&mut self.cx, vec![zero]);
@@ -258,24 +243,25 @@ impl SymbolicExecutor {
             }
 
             match outcome.status {
-                TopLevelCallStatus::Success => {
-                    parent.world = outcome.state.world.clone();
-                    parent.block = outcome.state.block.clone();
-                    parent.expected_emit = outcome.state.expected_emit.clone();
-                    parent.expected_calls = outcome.state.expected_calls.clone();
+                CallStatus::Success => {
+                    parent.world = outcome.state.world;
+                    parent.block = outcome.state.block;
+                    parent.expected_emit = outcome.state.expected_emit;
+                    parent.expected_calls = outcome.state.expected_calls;
                     parent.expected_creates = pending_expected_creates.clone();
-                    parent.call_mocks = outcome.state.call_mocks.clone();
-                    parent.function_mocks = outcome.state.function_mocks.clone();
+                    parent.call_mocks = outcome.state.call_mocks;
+                    parent.function_mocks = outcome.state.function_mocks;
                     self.observe_expected_create(
                         &mut parent,
                         state.address,
                         CreateKind::Create,
-                        &outcome.return_data,
+                        &outcome.state.frame.return_data,
                     )?;
                     if !parent.world.is_destroyed(created) {
-                        parent
-                            .world
-                            .install_code(created, outcome.return_data.to_code(&mut self.cx)?);
+                        parent.world.install_code(
+                            created,
+                            outcome.state.frame.return_data.to_code(&mut self.cx)?,
+                        );
                         parent.world.set_nonce(created, 1);
                     }
                     let return_data =
@@ -288,13 +274,13 @@ impl SymbolicExecutor {
                         return_data,
                     )?;
                 }
-                TopLevelCallStatus::Revert => {
+                CallStatus::Revert => {
                     parent.world = failure_world.clone();
-                    parent.return_data = outcome.return_data.clone();
+                    parent.return_data = outcome.state.frame.return_data;
                     parent.copy_call_output_offset(&mut self.cx, out_offset.clone(), out_size)?;
                     parent.stack.push(SymExpr::zero(&mut self.cx))?;
                 }
-                TopLevelCallStatus::Failure => {
+                CallStatus::Failure => {
                     *state = parent;
                     return Ok(StepOutcome::Failure);
                 }

--- a/crates/evm/symbolic/src/executor/create.rs
+++ b/crates/evm/symbolic/src/executor/create.rs
@@ -96,7 +96,6 @@ impl SymbolicExecutor {
             &mut self.cx,
             created,
             created,
-            created,
             state.address,
             value.clone(),
             false,
@@ -114,30 +113,23 @@ impl SymbolicExecutor {
         child.assume_no_revert_next_call = None;
 
         let outcomes = self.execute_external_call(executor, child, &initcode, completed_paths)?;
-        let Some((first, rest)) = outcomes.split_first() else {
+        if outcomes.is_empty() {
             return Ok(StepOutcome::AssumeRejected);
-        };
+        }
 
         let mut parents = VecDeque::with_capacity(outcomes.len());
-        for outcome in std::iter::once(first).chain(rest.iter()) {
+        for mut outcome in outcomes {
             let mut parent = state.clone();
-            parent.constraints = outcome.state.constraints.clone();
-            parent.next_symbol = outcome.state.next_symbol;
-            parent.inherit_branch_target_progress(&outcome.state);
-            parent.storage_load_hooks = outcome.state.storage_load_hooks.clone();
-            parent.storage_store_hooks = outcome.state.storage_store_hooks.clone();
-            parent.mapping_storage_store_hooks = outcome.state.mapping_storage_store_hooks.clone();
-            parent.inherit_mapping_hook_provenance(&outcome.state);
-            parent.inherit_inspector_recordings(&outcome.state);
+            parent.take_call_outcome_state(&mut outcome.state);
             parent.return_data = SymReturnData::empty(&mut self.cx);
 
             if let Some(assumption) = parent.assume_no_revert_next_call.take()
-                && matches!(outcome.status, TopLevelCallStatus::Revert)
+                && matches!(outcome.status, CallStatus::Revert)
                 && self.assume_no_revert_rejects(
                     &mut parent,
                     &assumption,
                     created,
-                    &outcome.return_data,
+                    &outcome.state.frame.return_data,
                 )?
             {
                 continue;
@@ -145,16 +137,16 @@ impl SymbolicExecutor {
 
             if let Some(mut expected) = parent.expected_revert.clone() {
                 match outcome.status {
-                    TopLevelCallStatus::Success => {
+                    CallStatus::Success => {
                         *state = parent;
                         return Ok(StepOutcome::Failure);
                     }
-                    TopLevelCallStatus::Revert | TopLevelCallStatus::Failure => {
+                    CallStatus::Revert | CallStatus::Failure => {
                         if !self.expected_revert_matches(
                             &mut parent,
                             &expected,
                             created,
-                            &outcome.return_data,
+                            &outcome.state.frame.return_data,
                         )? {
                             *state = parent;
                             return Ok(StepOutcome::Failure);
@@ -164,10 +156,10 @@ impl SymbolicExecutor {
                         } else {
                             parent.expected_revert = Some(expected);
                         }
-                        parent.expected_calls = outcome.state.expected_calls.clone();
+                        parent.expected_calls = outcome.state.expected_calls;
                         parent.expected_creates = pending_expected_creates.clone();
-                        parent.call_mocks = outcome.state.call_mocks.clone();
-                        parent.function_mocks = outcome.state.function_mocks.clone();
+                        parent.call_mocks = outcome.state.call_mocks;
+                        parent.function_mocks = outcome.state.function_mocks;
                         parent.world = failure_world.clone();
                         parent.stack.push(created_word.clone())?;
                         parents.push_back(parent);
@@ -177,34 +169,35 @@ impl SymbolicExecutor {
             }
 
             match outcome.status {
-                TopLevelCallStatus::Success => {
-                    parent.world = outcome.state.world.clone();
-                    parent.block = outcome.state.block.clone();
-                    parent.expected_emit = outcome.state.expected_emit.clone();
-                    parent.expected_calls = outcome.state.expected_calls.clone();
+                CallStatus::Success => {
+                    parent.world = outcome.state.world;
+                    parent.block = outcome.state.block;
+                    parent.expected_emit = outcome.state.expected_emit;
+                    parent.expected_calls = outcome.state.expected_calls;
                     parent.expected_creates = pending_expected_creates.clone();
-                    parent.call_mocks = outcome.state.call_mocks.clone();
-                    parent.function_mocks = outcome.state.function_mocks.clone();
+                    parent.call_mocks = outcome.state.call_mocks;
+                    parent.function_mocks = outcome.state.function_mocks;
                     self.observe_expected_create(
                         &mut parent,
                         state.address,
                         kind,
-                        &outcome.return_data,
+                        &outcome.state.frame.return_data,
                     )?;
                     if !parent.world.is_destroyed(created) {
-                        parent
-                            .world
-                            .install_code(created, outcome.return_data.to_code(&mut self.cx)?);
+                        parent.world.install_code(
+                            created,
+                            outcome.state.frame.return_data.to_code(&mut self.cx)?,
+                        );
                         parent.world.set_nonce(created, 1);
                     }
                     parent.stack.push(created_word.clone())?;
                 }
-                TopLevelCallStatus::Revert => {
+                CallStatus::Revert => {
                     parent.world = failure_world.clone();
-                    parent.return_data = outcome.return_data.clone();
+                    parent.return_data = outcome.state.frame.return_data;
                     parent.stack.push(SymExpr::zero(&mut self.cx))?;
                 }
-                TopLevelCallStatus::Failure => {
+                CallStatus::Failure => {
                     *state = parent;
                     return Ok(StepOutcome::Failure);
                 }
@@ -227,7 +220,7 @@ impl SymbolicExecutor {
         initial: PathState,
         code: &SymCode,
         completed_paths: &mut usize,
-    ) -> Result<Vec<ExternalCallOutcome>, SymbolicError> {
+    ) -> Result<Vec<CallOutcome>, SymbolicError> {
         let mut worklist = VecDeque::from([initial]);
         let mut outcomes = Vec::new();
         let path_limit = self.config.path_width() as usize;
@@ -239,11 +232,7 @@ impl SymbolicExecutor {
             }
             if std::mem::take(&mut state.pending_storage_hook_revert) {
                 *completed_paths += 1;
-                outcomes.push(ExternalCallOutcome {
-                    status: TopLevelCallStatus::Revert,
-                    return_data: state.return_data.clone(),
-                    state,
-                });
+                outcomes.push(CallOutcome { status: CallStatus::Revert, state });
                 continue;
             }
 
@@ -257,13 +246,12 @@ impl SymbolicExecutor {
                 let op = match code.guarded_opcode(&mut self.cx, state.pc)? {
                     GuardedOpcode::End => {
                         *completed_paths += 1;
-                        outcomes.push(ExternalCallOutcome {
+                        outcomes.push(CallOutcome {
                             status: if state.storage_hook_active || state.expectations_satisfied() {
-                                TopLevelCallStatus::Success
+                                CallStatus::Success
                             } else {
-                                TopLevelCallStatus::Failure
+                                CallStatus::Failure
                             },
-                            return_data: state.return_data.clone(),
                             state,
                         });
                         break;
@@ -281,15 +269,14 @@ impl SymbolicExecutor {
                             let mut halted = state.clone();
                             halted.constraints = out_of_bounds_constraints;
                             *completed_paths += 1;
-                            outcomes.push(ExternalCallOutcome {
+                            outcomes.push(CallOutcome {
                                 status: if halted.storage_hook_active
                                     || halted.expectations_satisfied()
                                 {
-                                    TopLevelCallStatus::Success
+                                    CallStatus::Success
                                 } else {
-                                    TopLevelCallStatus::Failure
+                                    CallStatus::Failure
                                 },
-                                return_data: halted.return_data.clone(),
                                 state: halted,
                             });
                         }
@@ -315,33 +302,24 @@ impl SymbolicExecutor {
                     StepOutcome::Continue => {}
                     StepOutcome::Halt => {
                         *completed_paths += 1;
-                        outcomes.push(ExternalCallOutcome {
+                        outcomes.push(CallOutcome {
                             status: if state.storage_hook_active || state.expectations_satisfied() {
-                                TopLevelCallStatus::Success
+                                CallStatus::Success
                             } else {
-                                TopLevelCallStatus::Failure
+                                CallStatus::Failure
                             },
-                            return_data: state.return_data.clone(),
                             state,
                         });
                         break;
                     }
                     StepOutcome::Revert => {
                         *completed_paths += 1;
-                        outcomes.push(ExternalCallOutcome {
-                            status: TopLevelCallStatus::Revert,
-                            return_data: state.return_data.clone(),
-                            state,
-                        });
+                        outcomes.push(CallOutcome { status: CallStatus::Revert, state });
                         break;
                     }
                     StepOutcome::Failure => {
                         *completed_paths += 1;
-                        outcomes.push(ExternalCallOutcome {
-                            status: TopLevelCallStatus::Failure,
-                            return_data: state.return_data.clone(),
-                            state,
-                        });
+                        outcomes.push(CallOutcome { status: CallStatus::Failure, state });
                         break;
                     }
                     StepOutcome::AssumeRejected | StepOutcome::Forked => break,

--- a/crates/evm/symbolic/src/executor/invariant.rs
+++ b/crates/evm/symbolic/src/executor/invariant.rs
@@ -28,13 +28,12 @@ impl SymbolicExecutor {
 
         let mut checked = Vec::new();
         for mut outcome in outcomes {
-            if !matches!(outcome.status, TopLevelCallStatus::Success) {
-                outcome.status = TopLevelCallStatus::Failure;
+            if !matches!(outcome.status, CallStatus::Success) {
                 checked.push(InvariantCheckOutcome { failed: true, state: outcome.state });
                 continue;
             }
 
-            if self.invariant_return_failed(invariant, &outcome.return_data, &mut outcome.state)? {
+            if self.invariant_return_failed(invariant, &mut outcome.state)? {
                 checked.push(InvariantCheckOutcome { failed: true, state: outcome.state });
                 continue;
             }
@@ -49,7 +48,7 @@ impl SymbolicExecutor {
             let constraints = after_calldata.constraints().to_vec();
             for after_outcome in self.execute_sequence_call(
                 executor,
-                outcome.state.clone(),
+                outcome.state,
                 invariant_address,
                 sender,
                 after_invariant,
@@ -58,7 +57,7 @@ impl SymbolicExecutor {
                 completed_paths,
             )? {
                 checked.push(InvariantCheckOutcome {
-                    failed: !matches!(after_outcome.status, TopLevelCallStatus::Success),
+                    failed: !matches!(after_outcome.status, CallStatus::Success),
                     state: after_outcome.state,
                 });
             }
@@ -69,7 +68,6 @@ impl SymbolicExecutor {
     pub(super) fn invariant_return_failed(
         &mut self,
         invariant: &Function,
-        return_data: &SymReturnData,
         state: &mut PathState,
     ) -> Result<bool, SymbolicError> {
         if invariant.outputs.is_empty() {
@@ -78,11 +76,11 @@ impl SymbolicExecutor {
         if invariant.outputs.len() != 1 || invariant.outputs[0].selector_type().as_ref() != "bool" {
             return Ok(false);
         }
-        if return_data.len() < 32 {
+        if state.return_data.len() < 32 {
             return Ok(true);
         }
 
-        let pass = return_data.load_word(&mut self.cx, 0)?.nonzero_bool(&mut self.cx);
+        let pass = state.return_data.load_word(&mut self.cx, 0)?.nonzero_bool(&mut self.cx);
         let fail = pass.clone().not(&mut self.cx);
         match fail.as_const() {
             Some(true) => Ok(true),
@@ -112,7 +110,7 @@ impl SymbolicExecutor {
         calldata: SymCalldata,
         constraints: Vec<SymBoolExpr>,
         completed_paths: &mut usize,
-    ) -> Result<Vec<TopLevelCallOutcome>, SymbolicError> {
+    ) -> Result<Vec<CallOutcome>, SymbolicError> {
         state.world.clear_transaction_scoped_state();
         state.mapping_hook_keccak_preimages.clear();
         let code = state.world.extcode(&mut self.cx, executor, target)?;
@@ -120,16 +118,8 @@ impl SymbolicExecutor {
         state.origin = sender;
         state.origin_word = SymExpr::constant(&mut self.cx, address_word(sender));
         let callvalue = SymExpr::zero(&mut self.cx);
-        state.frame = CallFrame::new(
-            &mut self.cx,
-            target,
-            target,
-            target,
-            sender,
-            callvalue,
-            false,
-            calldata,
-        );
+        state.frame =
+            CallFrame::new(&mut self.cx, target, target, sender, callvalue, false, calldata);
         state.constraints.extend(constraints);
 
         let mut worklist = VecDeque::from([state]);
@@ -143,11 +133,7 @@ impl SymbolicExecutor {
             }
             if std::mem::take(&mut state.pending_storage_hook_revert) {
                 *completed_paths += 1;
-                outcomes.push(TopLevelCallOutcome {
-                    status: TopLevelCallStatus::Revert,
-                    return_data: state.return_data.clone(),
-                    state,
-                });
+                outcomes.push(CallOutcome { status: CallStatus::Revert, state });
                 continue;
             }
             let _path_span =
@@ -164,13 +150,12 @@ impl SymbolicExecutor {
 
                 let Some(op) = code.opcode(&mut self.cx, state.pc)? else {
                     *completed_paths += 1;
-                    outcomes.push(TopLevelCallOutcome {
+                    outcomes.push(CallOutcome {
                         status: if state.expectations_satisfied() {
-                            TopLevelCallStatus::Success
+                            CallStatus::Success
                         } else {
-                            TopLevelCallStatus::Failure
+                            CallStatus::Failure
                         },
-                        return_data: state.return_data.clone(),
                         state,
                     });
                     break;
@@ -189,33 +174,24 @@ impl SymbolicExecutor {
                     StepOutcome::Continue => {}
                     StepOutcome::Halt => {
                         *completed_paths += 1;
-                        outcomes.push(TopLevelCallOutcome {
+                        outcomes.push(CallOutcome {
                             status: if state.expectations_satisfied() {
-                                TopLevelCallStatus::Success
+                                CallStatus::Success
                             } else {
-                                TopLevelCallStatus::Failure
+                                CallStatus::Failure
                             },
-                            return_data: state.return_data.clone(),
                             state,
                         });
                         break;
                     }
                     StepOutcome::Revert => {
                         *completed_paths += 1;
-                        outcomes.push(TopLevelCallOutcome {
-                            status: TopLevelCallStatus::Revert,
-                            return_data: state.return_data.clone(),
-                            state,
-                        });
+                        outcomes.push(CallOutcome { status: CallStatus::Revert, state });
                         break;
                     }
                     StepOutcome::Failure => {
                         *completed_paths += 1;
-                        outcomes.push(TopLevelCallOutcome {
-                            status: TopLevelCallStatus::Failure,
-                            return_data: state.return_data.clone(),
-                            state,
-                        });
+                        outcomes.push(CallOutcome { status: CallStatus::Failure, state });
                         break;
                     }
                     StepOutcome::AssumeRejected | StepOutcome::Forked => break,

--- a/crates/evm/symbolic/src/executor/mod.rs
+++ b/crates/evm/symbolic/src/executor/mod.rs
@@ -8,6 +8,40 @@ mod invariant;
 mod opcodes;
 mod run;
 
+#[derive(Debug)]
+struct CallOutcome {
+    status: CallStatus,
+    state: PathState,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CallStatus {
+    Success,
+    Revert,
+    Failure,
+}
+
+#[derive(Debug)]
+struct SequencePath {
+    state: PathState,
+    steps: Vec<SequenceStepTemplate>,
+}
+
+#[derive(Clone, Debug)]
+struct SequenceStepTemplate {
+    sender: Address,
+    address: Address,
+    contract_name: Option<String>,
+    function: Function,
+    calldata: SymbolicCalldata,
+}
+
+#[derive(Debug)]
+struct InvariantCheckOutcome {
+    failed: bool,
+    state: PathState,
+}
+
 impl SymbolicExecutor {
     pub(super) fn pop_next_path(&self, paths: &mut VecDeque<PathState>) -> Option<PathState> {
         match self.config.exploration_order {

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -198,7 +198,6 @@ impl SymbolicExecutor {
             &mut self.cx,
             hook.callback_target,
             hook.callback_target,
-            hook.callback_target,
             CHEATCODE_ADDRESS,
             callvalue,
             false,
@@ -211,23 +210,25 @@ impl SymbolicExecutor {
         }
 
         let mut parents = VecDeque::with_capacity(outcomes.len());
-        for outcome in outcomes {
+        for mut outcome in outcomes {
             let mut parent = state.clone();
-            parent.constraints = outcome.state.constraints.clone();
+            parent.constraints = std::mem::take(&mut outcome.state.constraints);
             parent.next_symbol = outcome.state.next_symbol;
-            parent.storage_load_hooks = outcome.state.storage_load_hooks.clone();
-            parent.storage_store_hooks = outcome.state.storage_store_hooks.clone();
-            parent.mapping_storage_store_hooks = outcome.state.mapping_storage_store_hooks.clone();
-            parent.inherit_mapping_hook_provenance(&outcome.state);
+            parent.storage_load_hooks = std::mem::take(&mut outcome.state.storage_load_hooks);
+            parent.storage_store_hooks = std::mem::take(&mut outcome.state.storage_store_hooks);
+            parent.mapping_storage_store_hooks =
+                std::mem::take(&mut outcome.state.mapping_storage_store_hooks);
+            parent.mapping_hook_keccak_preimages =
+                std::mem::take(&mut outcome.state.mapping_hook_keccak_preimages);
             parent.storage_hook_active = false;
 
             match outcome.status {
-                TopLevelCallStatus::Success => {
-                    parent.world = outcome.state.world.clone();
-                    parent.block = outcome.state.block.clone();
+                CallStatus::Success => {
+                    parent.world = outcome.state.world;
+                    parent.block = outcome.state.block;
                 }
-                TopLevelCallStatus::Revert | TopLevelCallStatus::Failure => {
-                    parent.return_data = outcome.return_data.clone();
+                CallStatus::Revert | CallStatus::Failure => {
+                    parent.return_data = outcome.state.frame.return_data;
                     parent.pending_storage_hook_revert = true;
                 }
             }

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -593,7 +593,7 @@ impl SymbolicExecutor {
                                 steps.push(step.clone());
 
                                 match outcome.status {
-                                    TopLevelCallStatus::Failure => {
+                                    CallStatus::Failure => {
                                         let (sequence, storage) =
                                             self.materialize_sequence(&steps, &outcome.state)?;
                                         return Ok(SymbolicInvariantRunResult::Counterexample {
@@ -603,7 +603,7 @@ impl SymbolicExecutor {
                                             stats: self.stats_with_paths(completed_paths),
                                         });
                                     }
-                                    TopLevelCallStatus::Revert => {
+                                    CallStatus::Revert => {
                                         if input.fail_on_revert {
                                             let (sequence, storage) =
                                                 self.materialize_sequence(&steps, &outcome.state)?;
@@ -624,21 +624,23 @@ impl SymbolicExecutor {
                                         // concrete campaign.
                                         let mut reverted_state = sequence.state.clone();
                                         reverted_state
-                                            .merge_reverted_top_level_effects(&outcome.state);
+                                            .take_reverted_top_level_effects(outcome.state);
                                         if symbolic_invariant_should_check(
                                             steps.len(),
                                             input.depth,
                                             input.check_interval,
                                         ) {
-                                            for invariant_outcome in self.execute_invariant_check(
-                                                input.executor,
-                                                reverted_state.clone(),
-                                                input.invariant_address,
-                                                input.sender,
-                                                input.invariant,
-                                                after_invariant_for(steps.len()),
-                                                &mut completed_paths,
-                                            )? {
+                                            for mut invariant_outcome in self
+                                                .execute_invariant_check(
+                                                    input.executor,
+                                                    reverted_state.clone(),
+                                                    input.invariant_address,
+                                                    input.sender,
+                                                    input.invariant,
+                                                    after_invariant_for(steps.len()),
+                                                    &mut completed_paths,
+                                                )?
+                                            {
                                                 if invariant_outcome.failed {
                                                     let (sequence, storage) = self
                                                         .materialize_sequence(
@@ -656,8 +658,8 @@ impl SymbolicExecutor {
                                                     );
                                                 }
                                                 let mut state = reverted_state.clone();
-                                                state.merge_noncommitting_check_constraints(
-                                                    &invariant_outcome.state,
+                                                state.take_noncommitting_check_state(
+                                                    &mut invariant_outcome.state,
                                                 );
                                                 next_frontier.push(SequencePath {
                                                     state,
@@ -671,21 +673,23 @@ impl SymbolicExecutor {
                                             });
                                         }
                                     }
-                                    TopLevelCallStatus::Success => {
+                                    CallStatus::Success => {
                                         if symbolic_invariant_should_check(
                                             steps.len(),
                                             input.depth,
                                             input.check_interval,
                                         ) {
-                                            for invariant_outcome in self.execute_invariant_check(
-                                                input.executor,
-                                                outcome.state.clone(),
-                                                input.invariant_address,
-                                                input.sender,
-                                                input.invariant,
-                                                after_invariant_for(steps.len()),
-                                                &mut completed_paths,
-                                            )? {
+                                            for mut invariant_outcome in self
+                                                .execute_invariant_check(
+                                                    input.executor,
+                                                    outcome.state.clone(),
+                                                    input.invariant_address,
+                                                    input.sender,
+                                                    input.invariant,
+                                                    after_invariant_for(steps.len()),
+                                                    &mut completed_paths,
+                                                )?
+                                            {
                                                 if invariant_outcome.failed {
                                                     let (sequence, storage) = self
                                                         .materialize_sequence(
@@ -703,8 +707,8 @@ impl SymbolicExecutor {
                                                     );
                                                 }
                                                 let mut state = outcome.state.clone();
-                                                state.merge_noncommitting_check_constraints(
-                                                    &invariant_outcome.state,
+                                                state.take_noncommitting_check_state(
+                                                    &mut invariant_outcome.state,
                                                 );
                                                 next_frontier.push(SequencePath {
                                                     state,

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -55,8 +55,7 @@ impl PathState {
         let gas_price = SymExpr::zero(cx);
         let block = SymbolicBlock::new(cx);
         let callvalue = SymExpr::constant(cx, callvalue);
-        let frame =
-            CallFrame::new(cx, address, address, address, caller, callvalue, false, call_data);
+        let frame = CallFrame::new(cx, address, address, caller, callvalue, false, call_data);
         Self {
             depth: 0,
             call_depth: 0,
@@ -109,8 +108,7 @@ impl PathState {
         let callvalue = SymExpr::zero(cx);
         let calldata = SymBytes::empty(cx);
         let calldata = SymCalldata::from_bytes(cx, calldata);
-        let frame =
-            CallFrame::new(cx, address, address, address, caller, callvalue, false, calldata);
+        let frame = CallFrame::new(cx, address, address, caller, callvalue, false, calldata);
         Self {
             depth: 0,
             call_depth: 0,
@@ -204,46 +202,14 @@ impl PathState {
     }
 
     pub(crate) fn child(&self, frame: CallFrame) -> Self {
-        Self {
-            depth: self.depth,
-            call_depth: self.call_depth + 1,
-            origin: self.origin,
-            origin_word: self.origin_word.clone(),
-            gas_price: self.gas_price.clone(),
-            ffi_enabled: self.ffi_enabled,
-            block: self.block.clone(),
-            frame,
-            world: self.world.clone(),
-            // A prank changes the call being entered; calls made by the callee use
-            // normal EVM caller semantics unless the callee sets its own prank.
-            prank: SymbolicPrank::default(),
-            constraints: self.constraints.clone(),
-            next_symbol: self.next_symbol,
-            recorded_logs: self.recorded_logs.clone(),
-            access_record: self.access_record.clone(),
-            root_calldata: self.root_calldata.clone(),
-            corpus_seed_models: self.corpus_seed_models.clone(),
-            branch_target: self.branch_target,
-            branch_target_reached: self.branch_target_reached,
-            needs_feasibility_check: self.needs_feasibility_check,
-            loop_jumps: HashMap::default(),
-            expected_revert: self.expected_revert.clone(),
-            assume_no_revert_next_call: self.assume_no_revert_next_call.clone(),
-            expected_emit: self.expected_emit.clone(),
-            expected_calls: self.expected_calls.clone(),
-            expected_creates: self.expected_creates.clone(),
-            call_mocks: self.call_mocks.clone(),
-            function_mocks: self.function_mocks.clone(),
-            persistent_accounts: self.persistent_accounts.clone(),
-            wallets: self.wallets.clone(),
-            labels: self.labels.clone(),
-            storage_load_hooks: self.storage_load_hooks.clone(),
-            storage_store_hooks: self.storage_store_hooks.clone(),
-            mapping_storage_store_hooks: self.mapping_storage_store_hooks.clone(),
-            mapping_hook_keccak_preimages: self.mapping_hook_keccak_preimages.clone(),
-            storage_hook_active: self.storage_hook_active,
-            pending_storage_hook_revert: self.pending_storage_hook_revert,
-        }
+        let mut child = self.clone();
+        child.call_depth += 1;
+        child.frame = frame;
+        // A prank changes the call being entered; calls made by the callee use normal EVM caller
+        // semantics unless the callee sets its own prank.
+        child.prank = SymbolicPrank::default();
+        child.loop_jumps.clear();
+        child
     }
 
     pub(crate) fn storage_hook_child(&self, frame: CallFrame) -> Self {
@@ -417,38 +383,40 @@ impl PathState {
         }
     }
 
-    pub(crate) fn merge_noncommitting_check_constraints(&mut self, check: &Self) {
-        self.constraints = check.constraints.clone();
+    pub(crate) fn take_noncommitting_check_state(&mut self, check: &mut Self) {
+        self.constraints = std::mem::take(&mut check.constraints);
         self.next_symbol = self.next_symbol.max(check.next_symbol);
         self.world.merge_replay_metadata_from(&check.world);
-        self.storage_load_hooks = check.storage_load_hooks.clone();
-        self.storage_store_hooks = check.storage_store_hooks.clone();
-        self.mapping_storage_store_hooks = check.mapping_storage_store_hooks.clone();
+        self.storage_load_hooks = std::mem::take(&mut check.storage_load_hooks);
+        self.storage_store_hooks = std::mem::take(&mut check.storage_store_hooks);
+        self.mapping_storage_store_hooks = std::mem::take(&mut check.mapping_storage_store_hooks);
     }
 
-    pub(crate) fn inherit_mapping_hook_provenance(&mut self, child: &Self) {
-        self.mapping_hook_keccak_preimages = child.mapping_hook_keccak_preimages.clone();
+    pub(crate) fn take_call_outcome_state(&mut self, child: &mut Self) {
+        self.constraints = std::mem::take(&mut child.constraints);
+        self.next_symbol = child.next_symbol;
+        self.inherit_branch_target_progress(child);
+        self.storage_load_hooks = std::mem::take(&mut child.storage_load_hooks);
+        self.storage_store_hooks = std::mem::take(&mut child.storage_store_hooks);
+        self.mapping_storage_store_hooks = std::mem::take(&mut child.mapping_storage_store_hooks);
+        self.mapping_hook_keccak_preimages =
+            std::mem::take(&mut child.mapping_hook_keccak_preimages);
+        self.recorded_logs = child.recorded_logs.take();
+        self.access_record = child.access_record.take();
     }
 
-    pub(crate) fn inherit_inspector_recordings(&mut self, child: &Self) {
-        self.recorded_logs = child.recorded_logs.clone();
-        self.access_record = child.access_record.clone();
-    }
-
-    pub(crate) fn merge_reverted_top_level_effects(&mut self, reverted: &Self) {
-        self.merge_noncommitting_check_constraints(reverted);
-        self.block = reverted.block.clone();
-        self.inherit_inspector_recordings(reverted);
-        self.expected_revert = reverted.expected_revert.clone();
-        self.assume_no_revert_next_call = reverted.assume_no_revert_next_call.clone();
-        self.expected_emit = reverted.expected_emit.clone();
-        self.expected_calls = reverted.expected_calls.clone();
-        self.expected_creates = reverted.expected_creates.clone();
-        self.call_mocks = reverted.call_mocks.clone();
-        self.function_mocks = reverted.function_mocks.clone();
-        self.storage_load_hooks = reverted.storage_load_hooks.clone();
-        self.storage_store_hooks = reverted.storage_store_hooks.clone();
-        self.mapping_storage_store_hooks = reverted.mapping_storage_store_hooks.clone();
+    pub(crate) fn take_reverted_top_level_effects(&mut self, mut reverted: Self) {
+        self.take_noncommitting_check_state(&mut reverted);
+        self.block = reverted.block;
+        self.recorded_logs = reverted.recorded_logs;
+        self.access_record = reverted.access_record;
+        self.expected_revert = reverted.expected_revert;
+        self.assume_no_revert_next_call = reverted.assume_no_revert_next_call;
+        self.expected_emit = reverted.expected_emit;
+        self.expected_calls = reverted.expected_calls;
+        self.expected_creates = reverted.expected_creates;
+        self.call_mocks = reverted.call_mocks;
+        self.function_mocks = reverted.function_mocks;
     }
 
     pub(crate) const fn satisfies_branch_target(&self) -> bool {
@@ -1433,8 +1401,6 @@ pub(crate) struct CallFrame {
     pub(crate) pc: usize,
     pub(crate) address: Address,
     pub(crate) address_word: SymExpr,
-    #[allow(dead_code)]
-    pub(crate) code_address: Address,
     pub(crate) storage_address: Address,
     pub(crate) caller: Address,
     pub(crate) caller_word: SymExpr,
@@ -1447,11 +1413,9 @@ pub(crate) struct CallFrame {
 }
 
 impl CallFrame {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         cx: &mut SymCx,
         address: Address,
-        code_address: Address,
         storage_address: Address,
         caller: Address,
         callvalue: SymExpr,
@@ -1462,7 +1426,6 @@ impl CallFrame {
             pc: 0,
             address,
             address_word: SymExpr::constant(cx, address_word(address)),
-            code_address,
             storage_address,
             caller,
             caller_word: SymExpr::constant(cx, address_word(caller)),
@@ -1474,48 +1437,6 @@ impl CallFrame {
             return_data: SymReturnData::empty(cx),
         }
     }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct ExternalCallOutcome {
-    pub(crate) status: TopLevelCallStatus,
-    pub(crate) return_data: SymReturnData,
-    pub(crate) state: PathState,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct SequencePath {
-    pub(crate) state: PathState,
-    pub(crate) steps: Vec<SequenceStepTemplate>,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct SequenceStepTemplate {
-    pub(crate) sender: Address,
-    pub(crate) address: Address,
-    pub(crate) contract_name: Option<String>,
-    pub(crate) function: Function,
-    pub(crate) calldata: SymbolicCalldata,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct InvariantCheckOutcome {
-    pub(crate) failed: bool,
-    pub(crate) state: PathState,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum TopLevelCallStatus {
-    Success,
-    Revert,
-    Failure,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct TopLevelCallOutcome {
-    pub(crate) status: TopLevelCallStatus,
-    pub(crate) return_data: SymReturnData,
-    pub(crate) state: PathState,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -1593,8 +1514,9 @@ impl StorageWrite {
     }
 }
 
+/// World data shared copy-on-write by branched paths and snapshots.
 #[derive(Clone, Debug, Default)]
-struct SymbolicWorldSnapshot {
+pub(crate) struct SymbolicWorldState {
     storage: Vec<StorageWrite>,
     transient_storage: Vec<StorageWrite>,
     created_accounts: HashSet<Address>,
@@ -1610,30 +1532,6 @@ struct SymbolicWorldSnapshot {
     zero_init_symbolic_storage: bool,
     symbolic_address_aliases: HashMap<SymExpr, Address>,
     replay_storage_slots: HashMap<Symbol, Vec<SymbolicReplayStorageSlot>>,
-}
-
-impl From<&SymbolicWorld> for SymbolicWorldSnapshot {
-    fn from(world: &SymbolicWorld) -> Self {
-        Self {
-            storage: world.storage.clone(),
-            transient_storage: world.transient_storage.clone(),
-            created_accounts: world.created_accounts.clone(),
-            current_transaction_created_accounts: world
-                .current_transaction_created_accounts
-                .clone(),
-            balances: world.balances.clone(),
-            code_cache: world.code_cache.clone(),
-            nonces: world.nonces.clone(),
-            existing_accounts: world.existing_accounts.clone(),
-            destroyed_accounts: world.destroyed_accounts.clone(),
-            arbitrary_storage_accounts: world.arbitrary_storage_accounts.clone(),
-            arbitrary_storage_copies: world.arbitrary_storage_copies.clone(),
-            arbitrary_storage_all: world.arbitrary_storage_all,
-            zero_init_symbolic_storage: world.zero_init_symbolic_storage,
-            symbolic_address_aliases: world.symbolic_address_aliases.clone(),
-            replay_storage_slots: world.replay_storage_slots.clone(),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -1644,26 +1542,24 @@ struct SymbolicReplayStorageSlot {
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SymbolicWorld {
-    storage: Vec<StorageWrite>,
-    transient_storage: Vec<StorageWrite>,
-    created_accounts: HashSet<Address>,
-    current_transaction_created_accounts: HashSet<Address>,
-    balances: HashMap<Address, SymExpr>,
-    code_cache: HashMap<Address, SymCode>,
-    nonces: HashMap<Address, u64>,
-    existing_accounts: HashSet<Address>,
-    destroyed_accounts: HashSet<Address>,
-    arbitrary_storage_accounts: HashMap<Address, bool>,
-    arbitrary_storage_copies: HashMap<Address, Address>,
-    arbitrary_storage_all: bool,
-    zero_init_symbolic_storage: bool,
-    symbolic_address_aliases: HashMap<SymExpr, Address>,
-    replay_storage_slots: HashMap<Symbol, Vec<SymbolicReplayStorageSlot>>,
-    snapshots: HashMap<U256, SymbolicWorldSnapshot>,
+    state: Arc<SymbolicWorldState>,
+    snapshots: HashMap<U256, Arc<SymbolicWorldState>>,
     next_snapshot_id: u64,
 }
 
+impl Deref for SymbolicWorld {
+    type Target = SymbolicWorldState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
 impl SymbolicWorld {
+    fn state_mut(&mut self) -> &mut SymbolicWorldState {
+        Arc::make_mut(&mut self.state)
+    }
+
     pub(crate) fn is_destroyed(&self, address: Address) -> bool {
         self.destroyed_accounts.contains(&address)
     }
@@ -1679,7 +1575,7 @@ impl SymbolicWorld {
     }
 
     #[cfg(test)]
-    pub(crate) const fn storage_len(&self) -> usize {
+    pub(crate) fn storage_len(&self) -> usize {
         self.storage.len()
     }
 
@@ -1688,9 +1584,10 @@ impl SymbolicWorld {
         self.storage.get(index).map(StorageWrite::value)
     }
 
-    pub(crate) const fn set_storage_layout(&mut self, layout: SymbolicStorageLayout) {
-        self.arbitrary_storage_all = matches!(layout, SymbolicStorageLayout::Generic);
-        self.zero_init_symbolic_storage = matches!(layout, SymbolicStorageLayout::ZeroInit);
+    pub(crate) fn set_storage_layout(&mut self, layout: SymbolicStorageLayout) {
+        let state = self.state_mut();
+        state.arbitrary_storage_all = matches!(layout, SymbolicStorageLayout::Generic);
+        state.zero_init_symbolic_storage = matches!(layout, SymbolicStorageLayout::ZeroInit);
     }
 
     pub(crate) fn sload<FEN: FoundryEvmNetwork>(
@@ -1707,7 +1604,7 @@ impl SymbolicWorld {
     }
 
     pub(crate) fn sstore(&mut self, address: Address, key: SymExpr, value: SymExpr) {
-        self.storage.push(StorageWrite::new(address, key, value));
+        self.state_mut().storage.push(StorageWrite::new(address, key, value));
     }
 
     pub(crate) fn tload(&self, cx: &mut SymCx, address: Address, key: SymExpr) -> SymExpr {
@@ -1716,18 +1613,20 @@ impl SymbolicWorld {
     }
 
     pub(crate) fn tstore(&mut self, address: Address, key: SymExpr, value: SymExpr) {
-        self.transient_storage.push(StorageWrite::new(address, key, value));
+        self.state_mut().transient_storage.push(StorageWrite::new(address, key, value));
     }
 
     /// Clears transaction-scoped state at a top-level call boundary.
     pub(crate) fn clear_transaction_scoped_state(&mut self) {
-        self.transient_storage.clear();
-        self.current_transaction_created_accounts.clear();
+        let state = self.state_mut();
+        state.transient_storage.clear();
+        state.current_transaction_created_accounts.clear();
     }
 
     pub(crate) fn mark_current_transaction_created(&mut self, address: Address) {
-        self.created_accounts.insert(address);
-        self.current_transaction_created_accounts.insert(address);
+        let state = self.state_mut();
+        state.created_accounts.insert(address);
+        state.current_transaction_created_accounts.insert(address);
     }
 
     /// Returns whether `address` was created in the current top-level symbolic transaction.
@@ -1736,11 +1635,11 @@ impl SymbolicWorld {
     }
 
     pub(crate) fn enable_arbitrary_storage(&mut self, address: Address, overwrite: bool) {
-        self.arbitrary_storage_accounts.insert(address, overwrite);
+        self.state_mut().arbitrary_storage_accounts.insert(address, overwrite);
     }
 
     pub(crate) fn enable_arbitrary_storage_copy(&mut self, source: Address, target: Address) {
-        self.arbitrary_storage_copies.insert(target, source);
+        self.state_mut().arbitrary_storage_copies.insert(target, source);
     }
 
     pub(crate) fn replay_storage_symbols(&self) -> SymbolicVars {
@@ -1790,7 +1689,7 @@ impl SymbolicWorld {
             return address;
         }
         let address = expr.representative_symbolic_address();
-        self.symbolic_address_aliases.insert(expr, address);
+        self.state_mut().symbolic_address_aliases.insert(expr, address);
         address
     }
 
@@ -1803,29 +1702,15 @@ impl SymbolicWorld {
     pub(crate) fn snapshot_state(&mut self) -> U256 {
         let id = U256::from(self.next_snapshot_id);
         self.next_snapshot_id = self.next_snapshot_id.saturating_add(1);
-        self.snapshots.insert(id, SymbolicWorldSnapshot::from(&*self));
+        self.snapshots.insert(id, Arc::clone(&self.state));
         id
     }
 
     pub(crate) fn restore_snapshot(&mut self, id: U256) -> bool {
-        let Some(snapshot) = self.snapshots.get(&id).cloned() else {
+        let Some(snapshot) = self.snapshots.get(&id) else {
             return false;
         };
-        self.storage = snapshot.storage;
-        self.transient_storage = snapshot.transient_storage;
-        self.created_accounts = snapshot.created_accounts;
-        self.current_transaction_created_accounts = snapshot.current_transaction_created_accounts;
-        self.balances = snapshot.balances;
-        self.code_cache = snapshot.code_cache;
-        self.nonces = snapshot.nonces;
-        self.existing_accounts = snapshot.existing_accounts;
-        self.destroyed_accounts = snapshot.destroyed_accounts;
-        self.arbitrary_storage_accounts = snapshot.arbitrary_storage_accounts;
-        self.arbitrary_storage_copies = snapshot.arbitrary_storage_copies;
-        self.arbitrary_storage_all = snapshot.arbitrary_storage_all;
-        self.zero_init_symbolic_storage = snapshot.zero_init_symbolic_storage;
-        self.symbolic_address_aliases = snapshot.symbolic_address_aliases;
-        self.replay_storage_slots = snapshot.replay_storage_slots;
+        self.state = Arc::clone(snapshot);
         true
     }
 
@@ -1939,10 +1824,16 @@ impl SymbolicWorld {
     }
 
     fn record_replay_storage_slot(&mut self, symbol: Symbol, address: Address, slot: U256) {
-        let slots = self.replay_storage_slots.entry(symbol).or_default();
-        if !slots.iter().any(|existing| existing.address == address && existing.slot == slot) {
-            slots.push(SymbolicReplayStorageSlot { address, slot });
+        if self.replay_storage_slots.get(&symbol).is_some_and(|slots| {
+            slots.iter().any(|existing| existing.address == address && existing.slot == slot)
+        }) {
+            return;
         }
+        self.state_mut()
+            .replay_storage_slots
+            .entry(symbol)
+            .or_default()
+            .push(SymbolicReplayStorageSlot { address, slot });
     }
 
     fn merge_replay_metadata_from(&mut self, other: &Self) {
@@ -1951,8 +1842,9 @@ impl SymbolicWorld {
                 self.record_replay_storage_slot(*symbol, slot.address, slot.slot);
             }
         }
+        let state = self.state_mut();
         for (expr, address) in &other.symbolic_address_aliases {
-            self.symbolic_address_aliases.entry(expr.clone()).or_insert(*address);
+            state.symbolic_address_aliases.entry(expr.clone()).or_insert(*address);
         }
     }
 
@@ -2011,10 +1903,12 @@ impl SymbolicWorld {
     }
 
     pub(crate) fn set_balance_word(&mut self, address: Address, value: SymExpr) {
-        self.balances.insert(address, value.clone());
-        if !value.as_const().is_some_and(|value| value.is_zero()) {
-            self.existing_accounts.insert(address);
-            self.destroyed_accounts.remove(&address);
+        let account_exists = !value.as_const().is_some_and(|value| value.is_zero());
+        let state = self.state_mut();
+        state.balances.insert(address, value);
+        if account_exists {
+            state.existing_accounts.insert(address);
+            state.destroyed_accounts.remove(&address);
         }
     }
 
@@ -2056,10 +1950,11 @@ impl SymbolicWorld {
     }
 
     pub(crate) fn set_nonce(&mut self, address: Address, nonce: u64) {
-        self.nonces.insert(address, nonce);
+        let state = self.state_mut();
+        state.nonces.insert(address, nonce);
         if nonce != 0 {
-            self.existing_accounts.insert(address);
-            self.destroyed_accounts.remove(&address);
+            state.existing_accounts.insert(address);
+            state.destroyed_accounts.remove(&address);
         }
     }
 
@@ -2086,9 +1981,10 @@ impl SymbolicWorld {
     }
 
     pub(crate) fn install_code(&mut self, address: Address, code: SymCode) {
-        self.code_cache.insert(address, code);
-        self.existing_accounts.insert(address);
-        self.destroyed_accounts.remove(&address);
+        let state = self.state_mut();
+        state.code_cache.insert(address, code);
+        state.existing_accounts.insert(address);
+        state.destroyed_accounts.remove(&address);
     }
 
     /// Implements legacy `SELFDESTRUCT` semantics.
@@ -2106,18 +2002,25 @@ impl SymbolicWorld {
                 SymExpr::binop(cx, SymBinOp::Add, beneficiary_balance, balance);
             self.set_balance_word(beneficiary, beneficiary_balance);
         }
-        self.balances.insert(address, SymExpr::zero(cx));
-        self.code_cache.insert(address, SymCode::empty(cx));
-        if !self.nonces.contains_key(&address) {
-            let nonce = self.nonce(executor, address)?;
-            self.nonces.insert(address, nonce);
+        let nonce = if self.nonces.contains_key(&address) {
+            None
+        } else {
+            Some(self.nonce(executor, address)?)
+        };
+        let zero = SymExpr::zero(cx);
+        let empty_code = SymCode::empty(cx);
+        let state = self.state_mut();
+        state.balances.insert(address, zero);
+        state.code_cache.insert(address, empty_code);
+        if let Some(nonce) = nonce {
+            state.nonces.insert(address, nonce);
         }
-        self.storage.retain(|write| write.address() != address);
-        self.transient_storage.retain(|write| write.address() != address);
-        self.created_accounts.remove(&address);
-        self.current_transaction_created_accounts.remove(&address);
-        self.existing_accounts.remove(&address);
-        self.destroyed_accounts.insert(address);
+        state.storage.retain(|write| write.address() != address);
+        state.transient_storage.retain(|write| write.address() != address);
+        state.created_accounts.remove(&address);
+        state.current_transaction_created_accounts.remove(&address);
+        state.existing_accounts.remove(&address);
+        state.destroyed_accounts.insert(address);
         Ok(())
     }
 
@@ -2137,7 +2040,8 @@ impl SymbolicWorld {
             let beneficiary_balance =
                 SymExpr::binop(cx, SymBinOp::Add, beneficiary_balance, balance);
             self.set_balance_word(beneficiary, beneficiary_balance);
-            self.balances.insert(address, SymExpr::zero(cx));
+            let zero = SymExpr::zero(cx);
+            self.state_mut().balances.insert(address, zero);
         }
     }
 
@@ -2164,7 +2068,7 @@ impl SymbolicWorld {
             || self.nonces.get(&address).is_some_and(|nonce| *nonce != 0)
             || self.code_cache.get(&address).is_some_and(|code| !code.is_empty())
         {
-            self.existing_accounts.insert(address);
+            self.state_mut().existing_accounts.insert(address);
             return Ok(true);
         }
 
@@ -2177,15 +2081,17 @@ impl SymbolicWorld {
         };
 
         if account.nonce != 0 || !account.balance.is_zero() {
-            self.existing_accounts.insert(address);
+            self.state_mut().existing_accounts.insert(address);
             return Ok(true);
         }
 
         if let Some(code) = account.code.as_ref()
             && !code.is_empty()
         {
-            self.code_cache.insert(address, SymCode::from_bytecode(cx, code));
-            self.existing_accounts.insert(address);
+            let code = SymCode::from_bytecode(cx, code);
+            let state = self.state_mut();
+            state.code_cache.insert(address, code);
+            state.existing_accounts.insert(address);
             return Ok(true);
         }
 
@@ -2220,13 +2126,13 @@ impl SymbolicWorld {
                 || !account.balance.is_zero()
                 || account.code.as_ref().is_some_and(|code| !code.is_empty()))
         {
-            self.existing_accounts.insert(address);
+            self.state_mut().existing_accounts.insert(address);
         }
         let bytecode = account.as_ref().and_then(|account| account.code.as_ref());
         let code = bytecode
             .map(|bytecode| SymCode::from_bytecode(cx, bytecode))
             .unwrap_or_else(|| SymCode::empty(cx));
-        self.code_cache.insert(address, code.clone());
+        self.state_mut().code_cache.insert(address, code.clone());
         Ok(code)
     }
 
@@ -2389,7 +2295,7 @@ mod tests {
         reverted.storage_store_hooks.insert(target, hook);
         reverted.mapping_storage_store_hooks.insert((target, U256::from(2)), hook);
 
-        state.merge_reverted_top_level_effects(&reverted);
+        state.take_reverted_top_level_effects(reverted);
 
         assert_eq!(state.storage_load_hooks.get(&target), Some(&hook));
         assert_eq!(state.storage_store_hooks.get(&target), Some(&hook));
@@ -2413,6 +2319,30 @@ mod tests {
     }
 
     #[test]
+    fn cloned_world_shares_state_until_mutated() {
+        let mut cx = SymCx::new();
+        let address = Address::repeat_byte(0x11);
+        let mut world = SymbolicWorld::default();
+        world.sstore(
+            address,
+            SymExpr::constant(&mut cx, U256::from(1)),
+            SymExpr::constant(&mut cx, U256::from(2)),
+        );
+        let mut branch = world.clone();
+
+        assert!(Arc::ptr_eq(&world.state, &branch.state));
+        branch.sstore(
+            address,
+            SymExpr::constant(&mut cx, U256::from(3)),
+            SymExpr::constant(&mut cx, U256::from(4)),
+        );
+
+        assert!(!Arc::ptr_eq(&world.state, &branch.state));
+        assert_eq!(world.storage_len(), 1);
+        assert_eq!(branch.storage_len(), 2);
+    }
+
+    #[test]
     fn noncommitting_checks_preserve_new_storage_hook_registrations() {
         let mut cx = SymCx::new();
         let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
@@ -2426,7 +2356,7 @@ mod tests {
         check.storage_store_hooks.insert(target, hook);
         check.mapping_storage_store_hooks.insert((target, U256::from(2)), hook);
 
-        state.merge_noncommitting_check_constraints(&check);
+        state.take_noncommitting_check_state(&mut check);
 
         assert_eq!(state.storage_load_hooks.get(&target), Some(&hook));
         assert_eq!(state.storage_store_hooks.get(&target), Some(&hook));
@@ -2454,7 +2384,7 @@ mod tests {
         check.storage_store_hooks.insert(target, hook);
         check.mapping_storage_store_hooks.insert((target, U256::from(2)), hook);
 
-        state.merge_noncommitting_check_constraints(&check);
+        state.take_noncommitting_check_state(&mut check);
 
         assert_eq!(state.storage_load_hooks.get(&target), Some(&hook));
         assert_eq!(state.storage_store_hooks.get(&target), Some(&hook));

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1817,7 +1817,6 @@ fn path_state_child_replaces_frame_and_resets_local_loop_state() {
         &mut cx,
         child_address,
         child_address,
-        child_address,
         Address::ZERO,
         callvalue,
         false,


### PR DESCRIPTION
## Motivation

Symbolic path forks eagerly cloned the full world overlay, including storage, account, code, and replay metadata collections. Nested call outcomes were also borrowed after execution even though they were immediately discarded, forcing clones of constraints, hooks, recordings, expectations, mocks, world state, and return data.

## Solution

Share world overlays and snapshots copy-on-write until a branch mutates them, and consume nested call, create, deploy, storage-hook, and invariant outcomes by value. The change also consolidates the duplicate call outcome types inside the executor, removes duplicate return-data storage and the unused call-frame code address, and expresses child-state creation as a clone followed by the three intentional per-call resets.

The existing propagation policies remain explicit: successful calls commit their world and inspector state, reverted calls preserve only the effects already selected by the invariant runner, and snapshots still restore the world atomically. Storage ordering and symbolic alias selection are unchanged.

## Results

| Benchmark | `master` | This PR | Change |
| --- | ---: | ---: | ---: |
| Official `forge_symbolic_test`, Solady v0.1.26, 5 runs | 0.381s ± 0.010s | 0.339s ± 0.012s | -10.8% |
| Deterministic 513-path populated-world stress, 80 runs | 151.9ms ± 1.9ms | 143.1ms ± 1.5ms | -5.8% |
| `PathState` inline size | 1,928 B | 1,416 B | -26.6% |
| Stress-case maximum RSS | 75.0 MB | 64.2 MB | -14.4% |
| Stress-case peak footprint | 45.2 MB | 34.2 MB | -24.4% |
| Grandizzy 22-case median | 552.7ms | 554.1ms | neutral (+0.3%) |

The official comparison executed identical work on both revisions: 13/13 tests, 35 paths, 148 solver queries, 68 SMT queries, and identical cache and query-volume counts.

Path-level parallelism is intentionally out of scope: each executor owns a mutable expression interner, while Forge already parallelizes independent tests and solver portfolios already use scoped threads and a channel. Locking or splitting the interner would trade away locality without evidence of a gain. Solver process reuse remains in #16252, symbolic memory behavior remains with #16183 and the merged #16240, and Anvil Monad isolation remains behind the #16251 stack. Copy-on-write block state was also tested and removed after making the targeted workload about 1.6% slower.

AI assistance disclosure: Codex was used for repository exploration, implementation, test execution, benchmarking, and drafting this description. I reviewed the resulting changes and measurements.
