### PR TITLE
perf(symbolic): cache model evaluation

### DIFF
--- a/.changelog/symbolic-model-evaluation-cache.md
+++ b/.changelog/symbolic-model-evaluation-cache.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Reduced symbolic model validation overhead by caching shared expression results.

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -578,21 +578,7 @@ impl SymBoolExpr {
         &self,
         model: &M,
     ) -> Result<bool, SymbolicError> {
-        Ok(match self.kind() {
-            SymBoolExprKind::Const(value) => *value,
-            SymBoolExprKind::Not(value) => !value.eval_model(model)?,
-            SymBoolExprKind::And(values) => {
-                for value in values.iter() {
-                    if !value.eval_model(model)? {
-                        return Ok(false);
-                    }
-                }
-                true
-            }
-            SymBoolExprKind::Cmp(op, left, right) => {
-                op.eval(left.eval_model(model)?, right.eval_model(model)?)
-            }
-        })
+        ModelEvaluator::new(model).eval_bool(self)
     }
 
     pub(crate) fn eval_model_if_complete<M: SymbolicModelLookup + ?Sized>(

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -1389,52 +1389,7 @@ impl SymExpr {
         &self,
         model: &M,
     ) -> Result<U256, SymbolicError> {
-        let kind = self.kind();
-        if let Some(var) = kind.get_eval_var() {
-            return Ok(model.value(var).unwrap_or_default());
-        }
-        Ok(match kind {
-            SymExprKind::Const(value) => *value,
-            SymExprKind::Var(_) | SymExprKind::GasLeft(_) | SymExprKind::Hash { .. } => {
-                unreachable!("symbolic eval leaf handled above")
-            }
-            SymExprKind::Keccak { len, bytes, .. } => {
-                let len = len.eval_model(model)?;
-                let Ok(len) = usize::try_from(len) else {
-                    return Err(SymbolicError::Solver(
-                        "solver model uses an invalid keccak length".to_string(),
-                    ));
-                };
-                if len > bytes.len() {
-                    return Err(SymbolicError::Solver(
-                        "solver model uses an invalid keccak length".to_string(),
-                    ));
-                }
-
-                let mut input = Vec::with_capacity(len);
-                for byte in bytes.iter().take(len) {
-                    input.push((byte.eval_model(model)? & U256::from(0xff)).to::<u8>());
-                }
-
-                U256::from_be_bytes(keccak256(input).0)
-            }
-            SymExprKind::Not(value) => !value.eval_model(model)?,
-            SymExprKind::BinOp(op, left, right) => {
-                op.eval(left.eval_model(model)?, right.eval_model(model)?)
-            }
-            SymExprKind::TernOp(op, left, right, modulus) => op.eval(
-                left.eval_model(model)?,
-                right.eval_model(model)?,
-                modulus.eval_model(model)?,
-            ),
-            SymExprKind::Ite(cond, then_expr, else_expr) => {
-                if cond.eval_model(model)? {
-                    then_expr.eval_model(model)?
-                } else {
-                    else_expr.eval_model(model)?
-                }
-            }
-        })
+        ModelEvaluator::new(model).eval_word(self)
     }
 
     pub(crate) fn eval_model_if_complete<M: SymbolicModelLookup + ?Sized>(

--- a/crates/evm/symbolic/src/runtime/expr/mod.rs
+++ b/crates/evm/symbolic/src/runtime/expr/mod.rs
@@ -17,3 +17,112 @@ impl SymbolicModelLookup for NoopModel {
 pub(crate) use bool::*;
 pub(crate) use cx::*;
 pub(crate) use word::*;
+
+/// Evaluates hash-consed expressions once per model.
+///
+/// Symbolic expressions form a DAG, so recursively evaluating both operands without caching can
+/// revisit the same node exponentially many times.
+struct ModelEvaluator<'a, M: ?Sized> {
+    model: &'a M,
+    words: HashMap<SymExpr, U256>,
+    bools: HashMap<SymBoolExpr, bool>,
+}
+
+impl<'a, M: SymbolicModelLookup + ?Sized> ModelEvaluator<'a, M> {
+    fn new(model: &'a M) -> Self {
+        Self { model, words: HashMap::default(), bools: HashMap::default() }
+    }
+
+    fn eval_word(&mut self, expr: &SymExpr) -> Result<U256, SymbolicError> {
+        let kind = expr.kind();
+        if let Some(var) = kind.get_eval_var() {
+            return Ok(self.model.value(var).unwrap_or_default());
+        }
+        if let SymExprKind::Const(value) = kind {
+            return Ok(*value);
+        }
+        if let Some(value) = self.words.get(expr) {
+            return Ok(*value);
+        }
+
+        let value = match kind {
+            SymExprKind::Const(_)
+            | SymExprKind::Var(_)
+            | SymExprKind::GasLeft(_)
+            | SymExprKind::Hash { .. } => unreachable!("symbolic eval leaf handled above"),
+            SymExprKind::Keccak { len, bytes, .. } => {
+                let len = self.eval_word(len)?;
+                let Ok(len) = usize::try_from(len) else {
+                    return Err(SymbolicError::Solver(
+                        "solver model uses an invalid keccak length".to_string(),
+                    ));
+                };
+                if len > bytes.len() {
+                    return Err(SymbolicError::Solver(
+                        "solver model uses an invalid keccak length".to_string(),
+                    ));
+                }
+
+                let mut input = Vec::with_capacity(len);
+                for byte in bytes.iter().take(len) {
+                    input.push((self.eval_word(byte)? & U256::from(0xff)).to::<u8>());
+                }
+                U256::from_be_bytes(keccak256(input).0)
+            }
+            SymExprKind::Not(value) => !self.eval_word(value)?,
+            SymExprKind::BinOp(op, left, right) => {
+                op.eval(self.eval_word(left)?, self.eval_word(right)?)
+            }
+            SymExprKind::TernOp(op, left, right, modulus) => {
+                op.eval(self.eval_word(left)?, self.eval_word(right)?, self.eval_word(modulus)?)
+            }
+            SymExprKind::Ite(condition, then_expr, else_expr) => {
+                if self.eval_bool(condition)? {
+                    self.eval_word(then_expr)?
+                } else {
+                    self.eval_word(else_expr)?
+                }
+            }
+        };
+        self.words.insert(expr.clone(), value);
+        Ok(value)
+    }
+
+    fn eval_bool(&mut self, expr: &SymBoolExpr) -> Result<bool, SymbolicError> {
+        let kind = expr.kind();
+        if let SymBoolExprKind::Const(value) = kind {
+            return Ok(*value);
+        }
+        if let Some(value) = self.bools.get(expr) {
+            return Ok(*value);
+        }
+
+        let value = match kind {
+            SymBoolExprKind::Const(_) => unreachable!("symbolic eval leaf handled above"),
+            SymBoolExprKind::Not(value) => !self.eval_bool(value)?,
+            SymBoolExprKind::And(values) => {
+                let mut result = true;
+                for value in values.iter() {
+                    if !self.eval_bool(value)? {
+                        result = false;
+                        break;
+                    }
+                }
+                result
+            }
+            SymBoolExprKind::Cmp(op, left, right) => {
+                op.eval(self.eval_word(left)?, self.eval_word(right)?)
+            }
+        };
+        self.bools.insert(expr.clone(), value);
+        Ok(value)
+    }
+}
+
+pub(crate) fn eval_model_constraints<M: SymbolicModelLookup + ?Sized>(
+    constraints: &[SymBoolExpr],
+    model: &M,
+) -> bool {
+    let mut evaluator = ModelEvaluator::new(model);
+    constraints.iter().all(|constraint| evaluator.eval_bool(constraint).unwrap_or(false))
+}

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -823,7 +823,7 @@ fn model_satisfies_constraints(
     model: &(impl SymbolicModelLookup + ?Sized),
     constraints: &[SymBoolExpr],
 ) -> bool {
-    constraints.iter().all(|constraint| constraint.eval_model(model).unwrap_or(false))
+    eval_model_constraints(constraints, model)
 }
 
 #[derive(Clone, Debug, Default)]
@@ -1718,7 +1718,7 @@ pub(crate) fn parse_and_validate_model(
 ) -> Result<SymbolicModel, SymbolicError> {
     let symbols = model_symbols_for_constraints(cx, constraints);
     let model = parse_model_with_symbols(output, &symbols)?;
-    if constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap_or(false)) {
+    if eval_model_constraints(constraints, &model) {
         Ok(model)
     } else {
         let reason = if constraints.iter().any(SymBoolExpr::contains_keccak) {

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -533,7 +533,7 @@ fn fallback_model_satisfies_all_constraints(
     constraints: &[SymBoolExpr],
     model: &(impl SymbolicModelLookup + ?Sized),
 ) -> bool {
-    constraints.iter().all(|constraint| constraint.eval_model(model).unwrap_or(false))
+    eval_model_constraints(constraints, model)
 }
 
 fn complete_fallback_support_model(
@@ -886,7 +886,7 @@ pub(crate) fn fallback_single_var_model(constraints: &[SymBoolExpr]) -> Option<S
     for candidate in candidates {
         let mut model = SymbolicModel::default();
         model.insert(var, candidate);
-        if constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap_or(false)) {
+        if eval_model_constraints(constraints, &model) {
             return Some(model);
         }
     }


### PR DESCRIPTION
## Motivation

Symbolic expressions are hash-consed and therefore form DAGs, but model evaluation recursively walked them as trees. Shared arithmetic subexpressions could consequently be evaluated many times, with `SymExpr::eval_model` and `SymBinOp::eval` dominating Samply profiles on affected workloads.

## Solution

Add a private model evaluator that memoizes evaluated word and boolean nodes for the lifetime of one model evaluation. Reuse the same evaluator across complete constraint batches during solver-model and hard-arithmetic fallback validation.

This preserves leaf lookup, short-circuiting, error handling, and the existing model-validation behavior. It does not change solver selection, concurrency, configuration, or public APIs.

Profiling and benchmarks before rebasing onto the latest `master`:

| Workload | Baseline | Candidate | Result |
| --- | ---: | ---: | ---: |
| Shared-DAG stress case | 349.7 ms | 60.9 ms | 5.74x faster |
| Solady symbolic suite, 13 tests, one thread | 1.563 s | 1.435 s | 8.2% faster |
| Solady symbolic suite, default parallelism | 1.233 s | 1.215 s | 1.5% faster |
| Grandizzy 22-project corpus | 146.6 ms | 138.4 ms | 5.6% faster, with a noisier baseline |

Normalized symbolic results, counterexamples, path/query/model counts, and SMT byte counts were identical between baseline and candidate for the Solady and Grandizzy runs.

## AI assistance

Codex analyzed the Samply profiles, implemented the change, ran the benchmarks and validation, and drafted this PR description. I reviewed and approved the resulting patch.
