### PR TITLE
refactor(anvil): centralize Monad replay context

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -514,13 +514,23 @@ struct PreparedMonadExecution {
 }
 
 #[cfg(feature = "monad")]
-fn exact_monad_context_at(
-    context: &MonadReplayContext,
+fn monad_execution_context_at(
+    context: Option<&MonadReplayContext>,
     current_tx_index: usize,
-) -> MonadExecutionContext<'static> {
-    let mut context = context.clone();
-    context.current_tx_index = current_tx_index;
-    MonadExecutionContext::Exact(Box::new(context))
+) -> Option<MonadExecutionContext<'static>> {
+    context.map(|context| {
+        let mut context = context.clone();
+        context.current_tx_index = current_tx_index;
+        MonadExecutionContext::Exact(Box::new(context))
+    })
+}
+
+#[cfg(not(feature = "monad"))]
+const fn monad_execution_context_at(
+    _context: Option<&MonadReplayContext>,
+    _current_tx_index: usize,
+) -> Option<MonadExecutionContext<'static>> {
+    None
 }
 
 #[cfg(feature = "monad")]
@@ -1569,6 +1579,22 @@ impl<N: Network> Backend<N> {
         Ok(monad_context_from_participants(grandparent, parent, &current, 0))
     }
 
+    #[cfg(feature = "monad")]
+    fn active_monad_context_for_mined_block(
+        &self,
+        block: &Block,
+    ) -> Result<Option<MonadReplayContext>, BlockchainError> {
+        self.is_monad().then(|| self.monad_context_for_mined_block(block)).transpose()
+    }
+
+    #[cfg(not(feature = "monad"))]
+    fn active_monad_context_for_mined_block(
+        &self,
+        _block: &Block,
+    ) -> Result<Option<MonadReplayContext>, BlockchainError> {
+        Ok(None)
+    }
+
     /// Builds context immediately before a synthetic transaction at `current_tx_index`.
     #[cfg(feature = "monad")]
     fn monad_context_before_mined_transaction(
@@ -2045,19 +2071,11 @@ impl<N: Network> Backend<N> {
     where
         DB: DatabaseRef<Error = DatabaseError> + Debug,
     {
-        #[cfg(feature = "monad")]
-        let monad_context =
-            self.is_monad().then(|| self.monad_context_for_mined_block(block)).transpose()?;
+        let monad_context = self.active_monad_context_for_mined_block(block)?;
         for (index, transaction) in block.body.transactions[..end].iter().enumerate() {
-            #[cfg(not(feature = "monad"))]
-            let _ = index;
             let pending = self.pending_mined_transaction(transaction.clone())?;
             let mut inspector = AnvilInspector::default();
-            #[cfg(feature = "monad")]
-            let transaction_context =
-                monad_context.as_ref().map(|context| exact_monad_context_at(context, index));
-            #[cfg(not(feature = "monad"))]
-            let transaction_context = None;
+            let transaction_context = monad_execution_context_at(monad_context.as_ref(), index);
             let (result, _) = self.replay_envelope_with_inspector_ref_and_context(
                 cache_db,
                 evm_env,
@@ -4134,9 +4152,7 @@ impl<N: Network> Backend<N> {
     ) -> Result<Vec<TraceResultsWithTransactionHash>, BlockchainError> {
         let (mut cache_db, evm_env, hardfork) = self.prepare_block_replay(block, parent_state)?;
         let mut results = Vec::new();
-        #[cfg(feature = "monad")]
-        let monad_context =
-            self.is_monad().then(|| self.monad_context_for_mined_block(block)).transpose()?;
+        let monad_context = self.active_monad_context_for_mined_block(block)?;
 
         // Execute each transaction in the block with tracing
         for tx_envelope in &block.body.transactions {
@@ -4147,12 +4163,8 @@ impl<N: Network> Backend<N> {
 
             // Prepare transaction environment and execute
             let pending_tx = self.pending_mined_transaction(tx_envelope.clone())?;
-            #[cfg(feature = "monad")]
-            let transaction_context = monad_context
-                .as_ref()
-                .map(|context| exact_monad_context_at(context, results.len()));
-            #[cfg(not(feature = "monad"))]
-            let transaction_context = None;
+            let transaction_context =
+                monad_execution_context_at(monad_context.as_ref(), results.len());
             let (result, _) = self.replay_envelope_with_inspector_ref_and_context(
                 &cache_db,
                 &evm_env,
@@ -6842,14 +6854,8 @@ where
 
             let target_tx = block.body.transactions[index].clone();
             let target_tx = self.pending_mined_transaction(target_tx)?;
-            #[cfg(feature = "monad")]
-            let monad_context =
-                self.is_monad().then(|| self.monad_context_for_mined_block(&block)).transpose()?;
-            #[cfg(feature = "monad")]
-            let transaction_context =
-                monad_context.as_ref().map(|context| exact_monad_context_at(context, index));
-            #[cfg(not(feature = "monad"))]
-            let transaction_context = None;
+            let monad_context = self.active_monad_context_for_mined_block(&block)?;
+            let transaction_context = monad_execution_context_at(monad_context.as_ref(), index);
             let (result, base_tx_env) = self.replay_envelope_with_inspector_ref_and_context(
                 &cache_db,
                 &evm_env,
@@ -7027,19 +7033,13 @@ where
             let (mut cache_db, evm_env, hardfork) =
                 self.prepare_block_replay(block, parent_state)?;
             let mut transactions = Vec::with_capacity(block.body.transactions.len());
-            #[cfg(feature = "monad")]
-            let monad_context =
-                self.is_monad().then(|| self.monad_context_for_mined_block(block)).transpose()?;
+            let monad_context = self.active_monad_context_for_mined_block(block)?;
 
             for tx_envelope in &block.body.transactions {
                 let mut inspector = OpcodeGasInspector::default();
                 let pending_tx = self.pending_mined_transaction(tx_envelope.clone())?;
-                #[cfg(feature = "monad")]
-                let transaction_context = monad_context
-                    .as_ref()
-                    .map(|context| exact_monad_context_at(context, transactions.len()));
-                #[cfg(not(feature = "monad"))]
-                let transaction_context = None;
+                let transaction_context =
+                    monad_execution_context_at(monad_context.as_ref(), transactions.len());
                 let (result, _) = self.replay_envelope_with_inspector_ref_and_context(
                     &cache_db,
                     &evm_env,


### PR DESCRIPTION
Centralizes optional Monad replay-context preparation and per-transaction context selection behind feature-paired helpers. This removes repeated conditional-compilation branches from block replay, transaction tracing, and opcode-gas paths while preserving existing behavior.