### PR TITLE
refactor(anvil): isolate Monad backend helpers

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -77,7 +77,7 @@ use alloy_evm::{
 #[cfg(feature = "monad")]
 use alloy_evm::{RecoveredTx, block::BlockExecutionError};
 #[cfg(feature = "monad")]
-use alloy_monad_evm::{MonadContext, MonadEvm, MonadEvmFactory};
+use alloy_monad_evm::{MonadContext, MonadEvmFactory};
 #[cfg(feature = "monad")]
 use alloy_network::BlockResponse;
 use alloy_network::{
@@ -134,7 +134,7 @@ use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use foundry_evm::core::{
     FromAnyRpcTransaction,
     evm::{
-        FoundryEvmFactory, MonadBlockParticipants, MonadEvmNetwork,
+        FoundryEvmFactory, MonadBlockParticipants,
         monad_block_participants as collect_monad_block_participants,
         monad_context_from_participants, protocol_system_call,
     },
@@ -178,6 +178,8 @@ use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, POST_EXEC_TX_TYPE_ID};
 #[cfg(feature = "optimism")]
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
+#[cfg(feature = "monad")]
+use revm::context_interface::result::InvalidTransaction;
 use revm::{
     Database as RevmDatabase, DatabaseCommit, Inspector,
     context::{Block as RevmBlock, BlockEnv, Cfg, CfgEnv, ContextSetters, ContextTr, TxEnv},
@@ -195,11 +197,6 @@ use revm::{
     precompile::{PrecompileSpecId, Precompiles},
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
     state::{Account, AccountInfo, EvmState, EvmStorageSlot, TransactionId},
-};
-#[cfg(feature = "monad")]
-use revm::{
-    context::Transaction as RevmTransaction,
-    context_interface::{result::InvalidTransaction, transaction::AuthorizationTr},
 };
 use revm_inspectors::opcode::OpcodeGasInspector;
 use std::{
@@ -507,13 +504,6 @@ impl<'a> EnvelopeExecution<'a> {
 }
 
 #[cfg(feature = "monad")]
-struct PreparedMonadExecution {
-    context: Option<MonadChainContext>,
-    kind: EnvelopeExecutionKind,
-    hardfork: MonadHardfork,
-}
-
-#[cfg(feature = "monad")]
 fn monad_execution_context_at(
     context: Option<&MonadReplayContext>,
     current_tx_index: usize,
@@ -546,76 +536,6 @@ const fn next_monad_context(_context: &mut MonadReplayContext) -> MonadExecution
 const fn noop_before_transaction<E, T>(_evm: &mut E, _tx: &T) {}
 
 const fn noop_on_execution_error<E>(_evm: &mut E) {}
-
-/// Caches the fork blocks needed to construct the next Monad block's ancestor context.
-#[cfg(feature = "monad")]
-async fn cache_monad_fork_context(fork: &ClientFork) -> Result<(), BlockchainError> {
-    let block_number = fork.block_number();
-    let block =
-        fork.block_by_number_full(block_number).await?.ok_or(BlockchainError::BlockNotFound)?;
-    let parent_hash = block.header().parent_hash();
-    if !parent_hash.is_zero() {
-        fork.block_by_hash_full(parent_hash).await?.ok_or(BlockchainError::BlockNotFound)?;
-    }
-    Ok(())
-}
-
-/// Adds a candidate transaction to the current Monad block context.
-#[cfg(feature = "monad")]
-fn append_monad_transaction(chain: &mut MonadChainContext, tx: &TxEnv) {
-    chain.current_tx_index = chain.current_block_senders.len();
-    chain.current_block_senders.push(tx.caller());
-    chain.current_block_authorities.push(
-        tx.authorization_list().filter_map(|authorization| authorization.authority()).collect(),
-    );
-}
-
-#[cfg(feature = "monad")]
-fn prepare_monad_transaction<DB: alloy_evm::Database>(
-    evm: &mut MonadEvm<DB, AnvilInspector>,
-    tx: &TxEnv,
-) {
-    append_monad_transaction(&mut evm.ctx_mut().chain, tx);
-}
-
-#[cfg(feature = "monad")]
-fn resolve_monad_execution_context(
-    context: Option<MonadExecutionContext<'_>>,
-    tx: &TxEnv,
-) -> Option<MonadChainContext> {
-    match context {
-        Some(MonadExecutionContext::Exact(context)) => Some(*context),
-        Some(MonadExecutionContext::Next(context)) => {
-            append_monad_transaction(context, tx);
-            Some(context.clone())
-        }
-        None => None,
-    }
-}
-
-#[cfg(feature = "monad")]
-fn advance_monad_block(context: &mut MonadChainContext) {
-    let current = context
-        .current_block_senders
-        .iter()
-        .copied()
-        .chain(context.current_block_authorities.iter().flatten().copied())
-        .collect();
-    context.grandparent_senders_and_authorities =
-        std::mem::replace(&mut context.parent_senders_and_authorities, current);
-    context.current_block_senders.clear();
-    context.current_block_authorities.clear();
-    context.current_tx_index = 0;
-}
-
-/// Removes a candidate transaction that failed before block inclusion.
-#[cfg(feature = "monad")]
-fn rollback_monad_transaction<DB: alloy_evm::Database>(evm: &mut MonadEvm<DB, AnvilInspector>) {
-    let chain = &mut evm.ctx_mut().chain;
-    chain.current_block_senders.pop();
-    chain.current_block_authorities.pop();
-    chain.current_tx_index = chain.current_block_senders.len();
-}
 
 /// Maximum cumulative gas available to one `eth_simulateV1` request.
 const SIMULATE_GAS_CAP: u64 = 50_000_000;
@@ -848,6 +768,8 @@ pub mod cache;
 pub mod fork_db;
 pub mod in_memory_db;
 pub mod inspector;
+#[cfg(feature = "monad")]
+mod monad;
 #[cfg(feature = "optimism")]
 pub mod optimism;
 pub mod state;
@@ -2854,13 +2776,13 @@ impl<N: Network> Backend<N> {
         let base = tx_env.clone();
         #[cfg(feature = "monad")]
         let result = if self.is_monad() {
-            let context = resolve_monad_execution_context(execution.monad_context, &tx_env);
+            let context = monad::resolve_execution_context(execution.monad_context, &tx_env);
             self.transact_monad_with_inspector_ref(
                 db,
                 evm_env,
                 inspector,
                 tx_env,
-                PreparedMonadExecution {
+                monad::PreparedExecution {
                     context,
                     kind: execution.kind,
                     hardfork: MonadHardfork::from(execution.hardfork),
@@ -2885,18 +2807,6 @@ impl<N: Network> Backend<N> {
                 timestamp_millis_part: 0,
                 ..Default::default()
             },
-        )
-    }
-
-    /// Builds the Monad [`EvmEnv`] (spec and gas params) from a base env.
-    #[cfg(feature = "monad")]
-    fn build_monad_evm_env(
-        evm_env: &EvmEnv,
-        hardfork: MonadHardfork,
-    ) -> EvmEnvFor<MonadEvmNetwork> {
-        EvmEnv::new(
-            evm_env.cfg_env.clone().with_spec_and_gas_params(hardfork, monad_gas_params(hardfork)),
-            evm_env.block_env.clone(),
         )
     }
 
@@ -2928,46 +2838,6 @@ impl<N: Network> Backend<N> {
             }),
             state: result.state,
         })
-    }
-
-    /// Monad path of [`Backend::transact_call_with_inspector_ref`].
-    #[cfg(feature = "monad")]
-    fn transact_monad_with_inspector_ref<'db, I, DB>(
-        &self,
-        db: &'db DB,
-        evm_env: &EvmEnv,
-        inspector: &mut I,
-        tx_env: TxEnv,
-        execution: PreparedMonadExecution,
-    ) -> Result<ResultAndState<HaltReason>, BlockchainError>
-    where
-        DB: DatabaseRef + ?Sized,
-        I: Inspector<MonadContext<WrapDatabaseRef<&'db DB>>>,
-        WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
-    {
-        let monad_env = Self::build_monad_evm_env(evm_env, execution.hardfork);
-        let factory = MonadEvmFactory::default();
-        let context = execution.context.unwrap_or_else(|| {
-            monad_context_from_participants(
-                Default::default(),
-                Default::default(),
-                std::slice::from_ref(&tx_env),
-                0,
-            )
-        });
-        let mut evm = factory.create_evm_with_inspector(WrapDatabaseRef(db), monad_env, inspector);
-        evm.ctx_mut().chain = context;
-        self.inject_precompiles(evm.precompiles_mut(), evm_env);
-        match execution.kind {
-            EnvelopeExecutionKind::Transaction => Ok(evm.transact(tx_env)?),
-            EnvelopeExecutionKind::Replay => {
-                if let Some(result) = factory.try_transact_system_replay(&mut evm, &tx_env)? {
-                    Ok(result)
-                } else {
-                    Ok(evm.transact(tx_env)?)
-                }
-            }
-        }
     }
 
     /// Creates a concrete EVM + [`AnvilBlockExecutor`], runs pre-execution changes, and
@@ -3074,7 +2944,7 @@ impl<N: Network> Backend<N> {
             evm.ctx_mut().chain = transaction_context;
             return run!(
                 evm,
-                prepare_monad_transaction,
+                monad::prepare_transaction,
                 |executor: &mut AnvilBlockExecutor<_>,
                  tx_env: TxEnv,
                  recovered: Recovered<FoundryTxEnvelope>,
@@ -3110,7 +2980,7 @@ impl<N: Network> Backend<N> {
                         },
                     )
                 },
-                rollback_monad_transaction
+                monad::rollback_transaction
             );
         }
         let mut evm =
@@ -3561,13 +3431,13 @@ impl<N: Network> Backend<N> {
             }
             #[cfg(feature = "monad")]
             CallTxEnv::Monad(tx_env) => {
-                let context = resolve_monad_execution_context(monad_context, &tx_env);
+                let context = monad::resolve_execution_context(monad_context, &tx_env);
                 self.transact_monad_with_inspector_ref(
                     db,
                     evm_env,
                     inspector,
                     tx_env,
-                    PreparedMonadExecution {
+                    monad::PreparedExecution {
                         context,
                         kind: EnvelopeExecutionKind::Transaction,
                         hardfork: MonadHardfork::from(hardfork),
@@ -4420,7 +4290,7 @@ impl<N: Network> Backend<N> {
             if backend.networks.is_monad() { backend.fork.read().clone() } else { None };
         #[cfg(feature = "monad")]
         if let Some(fork) = monad_fork {
-            cache_monad_fork_context(&fork).await?;
+            monad::cache_fork_context(&fork).await?;
         }
 
         if let Some(interval_block_time) = automine_block_time {
@@ -4794,7 +4664,7 @@ impl<N: Network> Backend<N> {
 
             #[cfg(feature = "monad")]
             if self.is_monad() {
-                cache_monad_fork_context(&staged_fork).await?;
+                monad::cache_fork_context(&staged_fork).await?;
             }
 
             if !staged_config
@@ -5720,7 +5590,7 @@ where
                     transactions,
                     inspector_tx_config,
                     |evm, tx_env, _transaction_hash| {
-                        prepare_monad_transaction(evm, &tx_env);
+                        monad::prepare_transaction(evm, &tx_env);
                         let result = match MonadEvmFactory::default()
                             .try_transact_system_replay(evm, &tx_env)
                             .map_err(BlockExecutionError::msg)
@@ -5730,7 +5600,7 @@ where
                             Err(err) => Err(err),
                         };
                         if result.is_err() {
-                            rollback_monad_transaction(evm);
+                            monad::rollback_transaction(evm);
                         }
                         result
                     },
@@ -8213,7 +8083,7 @@ impl Backend<FoundryNetwork> {
                     block_env.timestamp = block_env.timestamp.saturating_add(U256::ONE);
                     #[cfg(feature = "monad")]
                     if let Some(context) = monad_context.as_mut() {
-                        advance_monad_block(context);
+                        monad::advance_block(context);
                     }
                 }
 
@@ -8821,7 +8691,7 @@ impl Backend<FoundryNetwork> {
 
                 #[cfg(feature = "monad")]
                 if let Some(context) = monad_context.as_mut() {
-                    advance_monad_block(context);
+                    monad::advance_block(context);
                 }
             }
 
@@ -8843,7 +8713,7 @@ impl Backend<FoundryNetwork> {
                             &block.block,
                             block.block.body.transactions.len(),
                         )?;
-                        advance_monad_block(&mut context);
+                        monad::advance_block(&mut context);
                         Some(context)
                     } else {
                         None

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -49,8 +49,6 @@ use crate::{
     },
 };
 use alloy_chains::NamedChain;
-#[cfg(feature = "monad")]
-use alloy_consensus::constants::EMPTY_ROOT_HASH;
 use alloy_consensus::{
     Blob, BlockHeader, EnvKzgSettings, Header, Signed, Transaction as TransactionTrait,
     TransactionEnvelope, TrieAccount, TxEip4844Variant, TxEnvelope, TxReceipt, Typed2718,
@@ -67,6 +65,8 @@ use alloy_eips::{
     eip7840::BlobParams,
     eip7910::SystemContract,
 };
+#[cfg(feature = "monad")]
+use alloy_evm::block::BlockExecutionError;
 use alloy_evm::{
     Database, EthEvmFactory, Evm, EvmEnv, EvmFactory, FromTxWithEncoded,
     block::{BlockExecutionResult, BlockExecutor, StateDB},
@@ -75,11 +75,7 @@ use alloy_evm::{
     precompiles::{DynPrecompile, MovePrecompileError, Precompile, PrecompilesMap},
 };
 #[cfg(feature = "monad")]
-use alloy_evm::{RecoveredTx, block::BlockExecutionError};
-#[cfg(feature = "monad")]
 use alloy_monad_evm::{MonadContext, MonadEvmFactory};
-#[cfg(feature = "monad")]
-use alloy_network::BlockResponse;
 use alloy_network::{
     AnyHeader, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction, AnyTxEnvelope, AnyTxType, Network,
     NetworkTransactionBuilder, ReceiptResponse, UnknownTxEnvelope, UnknownTypedTransaction,
@@ -131,13 +127,9 @@ use chrono::Datelike;
 use eyre::{Context, Result};
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 #[cfg(feature = "monad")]
-use foundry_evm::core::{
-    FromAnyRpcTransaction,
-    evm::{
-        FoundryEvmFactory, MonadBlockParticipants,
-        monad_block_participants as collect_monad_block_participants,
-        monad_context_from_participants, protocol_system_call,
-    },
+use foundry_evm::core::evm::{
+    FoundryEvmFactory, monad_block_participants as collect_monad_block_participants,
+    protocol_system_call,
 };
 #[cfg(feature = "optimism")]
 use foundry_evm::hardfork::OpHardfork;
@@ -1276,237 +1268,18 @@ impl<N: Network> Backend<N> {
     }
 
     /// Reconstructs a locally mined transaction using its authoritative stored sender.
-    #[cfg(feature = "monad")]
-    fn pending_mined_transaction_from_storage(
-        storage: &BlockchainStorage<N>,
-        transaction: MaybeImpersonatedTransaction<FoundryTxEnvelope>,
-    ) -> Result<PendingTransaction<FoundryTxEnvelope>, BlockchainError> {
-        let transaction_hash = transaction.hash();
-        let mined =
-            storage.transactions.get(&transaction_hash).ok_or(BlockchainError::DataUnavailable)?;
-        Ok(PendingTransaction::with_sender(transaction, mined.info.from))
-    }
-
-    /// Reconstructs a locally mined transaction using its authoritative stored sender.
     fn pending_mined_transaction(
         &self,
         transaction: MaybeImpersonatedTransaction<FoundryTxEnvelope>,
     ) -> Result<PendingTransaction<FoundryTxEnvelope>, BlockchainError> {
         #[cfg(feature = "monad")]
         if self.is_monad() {
-            return Self::pending_mined_transaction_from_storage(
+            return Self::monad_pending_mined_transaction_from_storage(
                 &self.blockchain.storage.read(),
                 transaction,
             );
         }
         Ok(PendingTransaction::from_maybe_impersonated(transaction)?)
-    }
-
-    /// Converts retained local Monad transactions using their authoritative mined senders.
-    #[cfg(feature = "monad")]
-    fn monad_tx_envs_from_storage(
-        &self,
-        storage: &BlockchainStorage<N>,
-        transactions: &[MaybeImpersonatedTransaction<FoundryTxEnvelope>],
-    ) -> Result<Vec<TxEnv>, BlockchainError> {
-        transactions
-            .iter()
-            .map(|transaction| {
-                let pending =
-                    Self::pending_mined_transaction_from_storage(storage, transaction.clone())?;
-                Ok(build_tx_env_for_pending::<FoundryTxEnvelope, TxEnv>(&pending, self.cheats()))
-            })
-            .collect()
-    }
-
-    /// Converts a historical Monad prefix using its prepared authoritative senders.
-    #[cfg(feature = "monad")]
-    fn monad_historical_replay_tx_envs(
-        &self,
-        transactions: &[HistoricalReplayTransaction],
-    ) -> Vec<TxEnv> {
-        transactions
-            .iter()
-            .map(|replay| {
-                let pending = PendingTransaction::with_sender(
-                    MaybeImpersonatedTransaction::new(replay.transaction.tx().clone()),
-                    replay.transaction.signer(),
-                );
-                build_tx_env_for_pending::<FoundryTxEnvelope, TxEnv>(&pending, self.cheats())
-            })
-            .collect()
-    }
-
-    /// Returns a block's number, parent hash, and cached Monad participants.
-    #[cfg(feature = "monad")]
-    fn monad_block_participants_from_storage(
-        &self,
-        storage: &BlockchainStorage<N>,
-        hash: B256,
-    ) -> Result<(u64, B256, MonadBlockParticipants), BlockchainError> {
-        let local = storage.blocks.get(&hash).cloned().map(|block| {
-            let participants = storage.monad_block_participants.get(&hash).cloned();
-            (block, participants)
-        });
-        if let Some((block, participants)) = local {
-            let participants = if let Some(participants) = participants {
-                participants
-            } else if block.body.transactions.is_empty()
-                && block.header.transactions_root() != EMPTY_ROOT_HASH
-            {
-                return Err(BlockchainError::DataUnavailable);
-            } else {
-                collect_monad_block_participants(
-                    &self.monad_tx_envs_from_storage(storage, &block.body.transactions)?,
-                )
-            };
-            return Ok((block.header.number(), block.header.parent_hash, participants));
-        }
-
-        let fork = self.get_fork().ok_or(BlockchainError::BlockNotFound)?;
-        let block = fork
-            .storage
-            .read()
-            .blocks
-            .get(&hash)
-            .cloned()
-            .ok_or(BlockchainError::DataUnavailable)?;
-        let BlockTransactions::Full(transactions) = block.transactions() else {
-            return Err(BlockchainError::DataUnavailable);
-        };
-        let tx_envs = transactions
-            .iter()
-            .map(TxEnv::from_any_rpc_transaction)
-            .collect::<eyre::Result<Vec<_>>>()?;
-        Ok((
-            block.header().number(),
-            block.header().parent_hash(),
-            collect_monad_block_participants(&tx_envs),
-        ))
-    }
-
-    /// Returns a block's number, parent hash, and cached Monad participants.
-    #[cfg(feature = "monad")]
-    fn monad_block_participants(
-        &self,
-        hash: B256,
-    ) -> Result<(u64, B256, MonadBlockParticipants), BlockchainError> {
-        self.monad_block_participants_from_storage(&self.blockchain.storage.read(), hash)
-    }
-
-    /// Rebuilds Monad participant metadata for locally stored blocks with transaction bodies.
-    #[cfg(feature = "monad")]
-    fn rebuild_monad_block_participant_cache(
-        &self,
-        storage: &mut BlockchainStorage<N>,
-    ) -> Result<(), BlockchainError> {
-        let participants = storage
-            .blocks
-            .iter()
-            .filter(|(hash, block)| {
-                !storage.monad_block_participants.contains_key(*hash)
-                    && (!block.body.transactions.is_empty()
-                        || block.header.transactions_root() == EMPTY_ROOT_HASH)
-            })
-            .map(|(hash, block)| (*hash, block.body.transactions.clone()))
-            .map(|(hash, transactions)| {
-                let tx_envs = self.monad_tx_envs_from_storage(storage, &transactions)?;
-                Ok((hash, collect_monad_block_participants(&tx_envs)))
-            })
-            .collect::<Result<Vec<_>, BlockchainError>>()?;
-
-        for (hash, participants) in participants {
-            if storage.blocks.contains_key(&hash) {
-                storage.monad_block_participants.insert(hash, participants);
-            }
-        }
-        Ok(())
-    }
-
-    /// Builds the initial Monad context for a block whose parent is `parent_hash`.
-    #[cfg(feature = "monad")]
-    fn monad_context_for_child_of(
-        &self,
-        parent_hash: B256,
-    ) -> Result<MonadChainContext, BlockchainError> {
-        self.monad_context_for_child_of_in_storage(&self.blockchain.storage.read(), parent_hash)
-    }
-
-    /// Builds the initial Monad context from staged storage.
-    #[cfg(feature = "monad")]
-    fn monad_context_for_child_of_in_storage(
-        &self,
-        storage: &BlockchainStorage<N>,
-        parent_hash: B256,
-    ) -> Result<MonadChainContext, BlockchainError> {
-        let (_, grandparent_hash, parent) =
-            self.monad_block_participants_from_storage(storage, parent_hash)?;
-        let grandparent = if grandparent_hash.is_zero() {
-            MonadBlockParticipants::default()
-        } else {
-            self.monad_block_participants_from_storage(storage, grandparent_hash)?.2
-        };
-        Ok(monad_context_from_participants(grandparent, parent, &[], 0))
-    }
-
-    /// Fetches the full blocks required to build context on top of `block_number`.
-    #[cfg(feature = "monad")]
-    async fn monad_context_for_child_of_block_number(
-        &self,
-        block_number: u64,
-    ) -> Result<MonadChainContext, BlockchainError> {
-        let block = self
-            .block_by_number_full(BlockNumber::Number(block_number))
-            .await?
-            .ok_or(BlockchainError::BlockNotFound)?;
-        let parent_hash = block.header().parent_hash();
-        if !parent_hash.is_zero() {
-            self.block_by_hash_full(parent_hash).await?.ok_or(BlockchainError::DataUnavailable)?;
-        }
-        self.monad_context_for_child_of(block.header().hash)
-    }
-
-    /// Fetches the full blocks required to build context on top of `block_hash`.
-    #[cfg(feature = "monad")]
-    async fn monad_context_for_child_of_block_hash(
-        &self,
-        block_hash: B256,
-    ) -> Result<MonadChainContext, BlockchainError> {
-        let block =
-            self.block_by_hash_full(block_hash).await?.ok_or(BlockchainError::BlockNotFound)?;
-        let parent_hash = block.header().parent_hash();
-        if !parent_hash.is_zero() {
-            self.block_by_hash_full(parent_hash).await?.ok_or(BlockchainError::DataUnavailable)?;
-        }
-        self.monad_context_for_child_of(block_hash)
-    }
-
-    /// Builds reusable Monad context for a locally stored block.
-    #[cfg(feature = "monad")]
-    fn monad_context_for_mined_block(
-        &self,
-        block: &Block,
-    ) -> Result<MonadChainContext, BlockchainError> {
-        let current = self.monad_tx_envs_from_storage(
-            &self.blockchain.storage.read(),
-            &block.body.transactions,
-        )?;
-        let (_, grandparent_hash, parent) =
-            self.monad_block_participants(block.header.parent_hash)?;
-        let grandparent = if grandparent_hash.is_zero() {
-            MonadBlockParticipants::default()
-        } else {
-            self.monad_block_participants(grandparent_hash)?.2
-        };
-        Ok(monad_context_from_participants(grandparent, parent, &current, 0))
-    }
-
-    #[cfg(feature = "monad")]
-    fn active_monad_context_for_mined_block(
-        &self,
-        block: &Block,
-    ) -> Result<Option<MonadReplayContext>, BlockchainError> {
-        self.is_monad().then(|| self.monad_context_for_mined_block(block)).transpose()
     }
 
     #[cfg(not(feature = "monad"))]
@@ -1515,35 +1288,6 @@ impl<N: Network> Backend<N> {
         _block: &Block,
     ) -> Result<Option<MonadReplayContext>, BlockchainError> {
         Ok(None)
-    }
-
-    /// Builds context immediately before a synthetic transaction at `current_tx_index`.
-    #[cfg(feature = "monad")]
-    fn monad_context_before_mined_transaction(
-        &self,
-        block: &Block,
-        current_tx_index: usize,
-    ) -> Result<MonadChainContext, BlockchainError> {
-        let current = self.monad_tx_envs_from_storage(
-            &self.blockchain.storage.read(),
-            &block.body.transactions,
-        )?;
-        if current_tx_index > current.len() {
-            return Err(BlockchainError::DataUnavailable);
-        }
-        let (_, grandparent_hash, parent) =
-            self.monad_block_participants(block.header.parent_hash)?;
-        let grandparent = if grandparent_hash.is_zero() {
-            MonadBlockParticipants::default()
-        } else {
-            self.monad_block_participants(grandparent_hash)?.2
-        };
-        Ok(monad_context_from_participants(
-            grandparent,
-            parent,
-            &current[..current_tx_index],
-            current_tx_index,
-        ))
     }
 
     /// Returns the active hardfork.

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -1,17 +1,34 @@
-//! Monad-specific execution helpers for the in-memory backend.
+//! Monad-specific execution and context helpers for the in-memory backend.
 
 use super::{
     AnvilInspector, Backend, ClientFork, DatabaseRef, EnvelopeExecutionKind, MonadExecutionContext,
+    storage::BlockchainStorage,
 };
-use crate::eth::error::BlockchainError;
-use alloy_consensus::BlockHeader;
-use alloy_evm::{Database, Evm, EvmEnv, EvmFactory};
+use crate::eth::{
+    backend::{executor::build_tx_env_for_pending, replay::HistoricalReplayTransaction},
+    error::BlockchainError,
+};
+use alloy_consensus::{BlockHeader, constants::EMPTY_ROOT_HASH};
+use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, RecoveredTx};
 use alloy_monad_evm::{MonadContext, MonadEvm, MonadEvmFactory};
 use alloy_network::{BlockResponse, Network};
+use alloy_primitives::B256;
+use alloy_rpc_types::{BlockNumberOrTag as BlockNumber, BlockTransactions};
+use anvil_core::eth::{
+    block::Block,
+    transaction::{MaybeImpersonatedTransaction, PendingTransaction},
+};
 use foundry_evm::{
     backend::DatabaseError,
-    core::evm::{EvmEnvFor, FoundryEvmFactory, MonadEvmNetwork},
+    core::{
+        FromAnyRpcTransaction,
+        evm::{
+            EvmEnvFor, FoundryEvmFactory, MonadBlockParticipants, MonadEvmNetwork,
+            monad_block_participants, monad_context_from_participants,
+        },
+    },
 };
+use foundry_primitives::FoundryTxEnvelope;
 use monad_revm::{MonadChainContext, MonadHardfork, instructions::monad_gas_params};
 use revm::{
     Inspector,
@@ -96,6 +113,246 @@ pub(super) fn rollback_transaction<DB: alloy_evm::Database>(
 }
 
 impl<N: Network> Backend<N> {
+    /// Reconstructs a locally mined transaction using its authoritative stored sender.
+    pub(super) fn monad_pending_mined_transaction_from_storage(
+        storage: &BlockchainStorage<N>,
+        transaction: MaybeImpersonatedTransaction<FoundryTxEnvelope>,
+    ) -> Result<PendingTransaction<FoundryTxEnvelope>, BlockchainError> {
+        let transaction_hash = transaction.hash();
+        let mined =
+            storage.transactions.get(&transaction_hash).ok_or(BlockchainError::DataUnavailable)?;
+        Ok(PendingTransaction::with_sender(transaction, mined.info.from))
+    }
+
+    /// Converts retained local transactions using their authoritative mined senders.
+    fn monad_tx_envs_from_storage(
+        &self,
+        storage: &BlockchainStorage<N>,
+        transactions: &[MaybeImpersonatedTransaction<FoundryTxEnvelope>],
+    ) -> Result<Vec<TxEnv>, BlockchainError> {
+        transactions
+            .iter()
+            .map(|transaction| {
+                let pending = Self::monad_pending_mined_transaction_from_storage(
+                    storage,
+                    transaction.clone(),
+                )?;
+                Ok(build_tx_env_for_pending::<FoundryTxEnvelope, TxEnv>(&pending, self.cheats()))
+            })
+            .collect()
+    }
+
+    /// Converts a historical replay prefix using its prepared authoritative senders.
+    pub(super) fn monad_historical_replay_tx_envs(
+        &self,
+        transactions: &[HistoricalReplayTransaction],
+    ) -> Vec<TxEnv> {
+        transactions
+            .iter()
+            .map(|replay| {
+                let pending = PendingTransaction::with_sender(
+                    MaybeImpersonatedTransaction::new(replay.transaction.tx().clone()),
+                    replay.transaction.signer(),
+                );
+                build_tx_env_for_pending::<FoundryTxEnvelope, TxEnv>(&pending, self.cheats())
+            })
+            .collect()
+    }
+
+    /// Returns a block's number, parent hash, and cached participants.
+    fn monad_block_participants_from_storage(
+        &self,
+        storage: &BlockchainStorage<N>,
+        hash: B256,
+    ) -> Result<(u64, B256, MonadBlockParticipants), BlockchainError> {
+        let local = storage.blocks.get(&hash).cloned().map(|block| {
+            let participants = storage.monad_block_participants.get(&hash).cloned();
+            (block, participants)
+        });
+        if let Some((block, participants)) = local {
+            let participants = if let Some(participants) = participants {
+                participants
+            } else if block.body.transactions.is_empty()
+                && block.header.transactions_root() != EMPTY_ROOT_HASH
+            {
+                return Err(BlockchainError::DataUnavailable);
+            } else {
+                monad_block_participants(
+                    &self.monad_tx_envs_from_storage(storage, &block.body.transactions)?,
+                )
+            };
+            return Ok((block.header.number(), block.header.parent_hash, participants));
+        }
+
+        let fork = self.get_fork().ok_or(BlockchainError::BlockNotFound)?;
+        let block = fork
+            .storage
+            .read()
+            .blocks
+            .get(&hash)
+            .cloned()
+            .ok_or(BlockchainError::DataUnavailable)?;
+        let BlockTransactions::Full(transactions) = block.transactions() else {
+            return Err(BlockchainError::DataUnavailable);
+        };
+        let tx_envs = transactions
+            .iter()
+            .map(TxEnv::from_any_rpc_transaction)
+            .collect::<eyre::Result<Vec<_>>>()?;
+        Ok((
+            block.header().number(),
+            block.header().parent_hash(),
+            monad_block_participants(&tx_envs),
+        ))
+    }
+
+    fn monad_block_participants(
+        &self,
+        hash: B256,
+    ) -> Result<(u64, B256, MonadBlockParticipants), BlockchainError> {
+        self.monad_block_participants_from_storage(&self.blockchain.storage.read(), hash)
+    }
+
+    /// Rebuilds participant metadata for locally stored blocks with transaction bodies.
+    pub(super) fn rebuild_monad_block_participant_cache(
+        &self,
+        storage: &mut BlockchainStorage<N>,
+    ) -> Result<(), BlockchainError> {
+        let participants = storage
+            .blocks
+            .iter()
+            .filter(|(hash, block)| {
+                !storage.monad_block_participants.contains_key(*hash)
+                    && (!block.body.transactions.is_empty()
+                        || block.header.transactions_root() == EMPTY_ROOT_HASH)
+            })
+            .map(|(hash, block)| (*hash, block.body.transactions.clone()))
+            .map(|(hash, transactions)| {
+                let tx_envs = self.monad_tx_envs_from_storage(storage, &transactions)?;
+                Ok((hash, monad_block_participants(&tx_envs)))
+            })
+            .collect::<Result<Vec<_>, BlockchainError>>()?;
+
+        for (hash, participants) in participants {
+            if storage.blocks.contains_key(&hash) {
+                storage.monad_block_participants.insert(hash, participants);
+            }
+        }
+        Ok(())
+    }
+
+    /// Builds the initial context for a block whose parent is `parent_hash`.
+    pub(super) fn monad_context_for_child_of(
+        &self,
+        parent_hash: B256,
+    ) -> Result<MonadChainContext, BlockchainError> {
+        self.monad_context_for_child_of_in_storage(&self.blockchain.storage.read(), parent_hash)
+    }
+
+    /// Builds the initial context from staged storage.
+    pub(super) fn monad_context_for_child_of_in_storage(
+        &self,
+        storage: &BlockchainStorage<N>,
+        parent_hash: B256,
+    ) -> Result<MonadChainContext, BlockchainError> {
+        let (_, grandparent_hash, parent) =
+            self.monad_block_participants_from_storage(storage, parent_hash)?;
+        let grandparent = if grandparent_hash.is_zero() {
+            MonadBlockParticipants::default()
+        } else {
+            self.monad_block_participants_from_storage(storage, grandparent_hash)?.2
+        };
+        Ok(monad_context_from_participants(grandparent, parent, &[], 0))
+    }
+
+    async fn monad_context_for_child_of_block(
+        &self,
+        block: alloy_network::AnyRpcBlock,
+        block_hash: B256,
+    ) -> Result<MonadChainContext, BlockchainError> {
+        let parent_hash = block.header().parent_hash();
+        if !parent_hash.is_zero() {
+            self.block_by_hash_full(parent_hash).await?.ok_or(BlockchainError::DataUnavailable)?;
+        }
+        self.monad_context_for_child_of(block_hash)
+    }
+
+    /// Fetches the full blocks required to build context on top of `block_number`.
+    pub(super) async fn monad_context_for_child_of_block_number(
+        &self,
+        block_number: u64,
+    ) -> Result<MonadChainContext, BlockchainError> {
+        let block = self
+            .block_by_number_full(BlockNumber::Number(block_number))
+            .await?
+            .ok_or(BlockchainError::BlockNotFound)?;
+        let block_hash = block.header().hash;
+        self.monad_context_for_child_of_block(block, block_hash).await
+    }
+
+    /// Fetches the full blocks required to build context on top of `block_hash`.
+    pub(super) async fn monad_context_for_child_of_block_hash(
+        &self,
+        block_hash: B256,
+    ) -> Result<MonadChainContext, BlockchainError> {
+        let block =
+            self.block_by_hash_full(block_hash).await?.ok_or(BlockchainError::BlockNotFound)?;
+        self.monad_context_for_child_of_block(block, block_hash).await
+    }
+
+    fn monad_context_for_mined_transactions(
+        &self,
+        block: &Block,
+        current: &[TxEnv],
+        current_tx_index: usize,
+    ) -> Result<MonadChainContext, BlockchainError> {
+        let (_, grandparent_hash, parent) =
+            self.monad_block_participants(block.header.parent_hash)?;
+        let grandparent = if grandparent_hash.is_zero() {
+            MonadBlockParticipants::default()
+        } else {
+            self.monad_block_participants(grandparent_hash)?.2
+        };
+        Ok(monad_context_from_participants(grandparent, parent, current, current_tx_index))
+    }
+
+    fn monad_context_for_mined_block(
+        &self,
+        block: &Block,
+    ) -> Result<MonadChainContext, BlockchainError> {
+        let current = self.monad_tx_envs_from_storage(
+            &self.blockchain.storage.read(),
+            &block.body.transactions,
+        )?;
+        self.monad_context_for_mined_transactions(block, &current, 0)
+    }
+
+    pub(super) fn active_monad_context_for_mined_block(
+        &self,
+        block: &Block,
+    ) -> Result<Option<MonadChainContext>, BlockchainError> {
+        self.is_monad().then(|| self.monad_context_for_mined_block(block)).transpose()
+    }
+
+    pub(super) fn monad_context_before_mined_transaction(
+        &self,
+        block: &Block,
+        current_tx_index: usize,
+    ) -> Result<MonadChainContext, BlockchainError> {
+        let current = self.monad_tx_envs_from_storage(
+            &self.blockchain.storage.read(),
+            &block.body.transactions,
+        )?;
+        if current_tx_index > current.len() {
+            return Err(BlockchainError::DataUnavailable);
+        }
+        self.monad_context_for_mined_transactions(
+            block,
+            &current[..current_tx_index],
+            current_tx_index,
+        )
+    }
+
     /// Builds the Monad [`EvmEnv`] (spec and gas params) from a base env.
     pub(super) fn build_monad_evm_env(
         evm_env: &EvmEnv,

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -165,21 +165,17 @@ impl<N: Network> Backend<N> {
         storage: &BlockchainStorage<N>,
         hash: B256,
     ) -> Result<(u64, B256, MonadBlockParticipants), BlockchainError> {
-        let local = storage.blocks.get(&hash).cloned().map(|block| {
-            let participants = storage.monad_block_participants.get(&hash).cloned();
-            (block, participants)
-        });
-        if let Some((block, participants)) = local {
-            let participants = if let Some(participants) = participants {
-                participants
-            } else if block.body.transactions.is_empty()
-                && block.header.transactions_root() != EMPTY_ROOT_HASH
-            {
-                return Err(BlockchainError::DataUnavailable);
-            } else {
-                monad_block_participants(
+        if let Some(block) = storage.blocks.get(&hash) {
+            let participants = match storage.monad_block_participants.get(&hash) {
+                Some(participants) => participants.clone(),
+                None if block.body.transactions.is_empty()
+                    && block.header.transactions_root() != EMPTY_ROOT_HASH =>
+                {
+                    return Err(BlockchainError::DataUnavailable);
+                }
+                None => monad_block_participants(
                     &self.monad_tx_envs_from_storage(storage, &block.body.transactions)?,
-                )
+                ),
             };
             return Ok((block.header.number(), block.header.parent_hash, participants));
         }

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -1,0 +1,142 @@
+//! Monad-specific execution helpers for the in-memory backend.
+
+use super::{
+    AnvilInspector, Backend, ClientFork, DatabaseRef, EnvelopeExecutionKind, MonadExecutionContext,
+};
+use crate::eth::error::BlockchainError;
+use alloy_consensus::BlockHeader;
+use alloy_evm::{Database, Evm, EvmEnv, EvmFactory};
+use alloy_monad_evm::{MonadContext, MonadEvm, MonadEvmFactory};
+use alloy_network::{BlockResponse, Network};
+use foundry_evm::{
+    backend::DatabaseError,
+    core::evm::{EvmEnvFor, FoundryEvmFactory, MonadEvmNetwork},
+};
+use monad_revm::{MonadChainContext, MonadHardfork, instructions::monad_gas_params};
+use revm::{
+    Inspector,
+    context::{Transaction, TxEnv},
+    context_interface::{
+        result::{HaltReason, ResultAndState},
+        transaction::AuthorizationTr,
+    },
+    database_interface::WrapDatabaseRef,
+};
+
+pub(super) struct PreparedExecution {
+    pub(super) context: Option<MonadChainContext>,
+    pub(super) kind: EnvelopeExecutionKind,
+    pub(super) hardfork: MonadHardfork,
+}
+
+/// Caches the fork blocks needed to construct the next Monad block's ancestor context.
+pub(super) async fn cache_fork_context(fork: &ClientFork) -> Result<(), BlockchainError> {
+    let block_number = fork.block_number();
+    let block =
+        fork.block_by_number_full(block_number).await?.ok_or(BlockchainError::BlockNotFound)?;
+    let parent_hash = block.header().parent_hash();
+    if !parent_hash.is_zero() {
+        fork.block_by_hash_full(parent_hash).await?.ok_or(BlockchainError::BlockNotFound)?;
+    }
+    Ok(())
+}
+
+/// Adds a candidate transaction to the current Monad block context.
+fn append_transaction(chain: &mut MonadChainContext, tx: &TxEnv) {
+    chain.current_tx_index = chain.current_block_senders.len();
+    chain.current_block_senders.push(tx.caller());
+    chain.current_block_authorities.push(
+        tx.authorization_list().filter_map(|authorization| authorization.authority()).collect(),
+    );
+}
+
+pub(super) fn prepare_transaction<DB: alloy_evm::Database>(
+    evm: &mut MonadEvm<DB, AnvilInspector>,
+    tx: &TxEnv,
+) {
+    append_transaction(&mut evm.ctx_mut().chain, tx);
+}
+
+pub(super) fn resolve_execution_context(
+    context: Option<MonadExecutionContext<'_>>,
+    tx: &TxEnv,
+) -> Option<MonadChainContext> {
+    match context {
+        Some(MonadExecutionContext::Exact(context)) => Some(*context),
+        Some(MonadExecutionContext::Next(context)) => {
+            append_transaction(context, tx);
+            Some(context.clone())
+        }
+        None => None,
+    }
+}
+
+pub(super) fn advance_block(context: &mut MonadChainContext) {
+    let current = context
+        .current_block_senders
+        .iter()
+        .copied()
+        .chain(context.current_block_authorities.iter().flatten().copied())
+        .collect();
+    context.grandparent_senders_and_authorities =
+        std::mem::replace(&mut context.parent_senders_and_authorities, current);
+    context.current_block_senders.clear();
+    context.current_block_authorities.clear();
+    context.current_tx_index = 0;
+}
+
+/// Removes a candidate transaction that failed before block inclusion.
+pub(super) fn rollback_transaction<DB: alloy_evm::Database>(
+    evm: &mut MonadEvm<DB, AnvilInspector>,
+) {
+    let chain = &mut evm.ctx_mut().chain;
+    chain.current_block_senders.pop();
+    chain.current_block_authorities.pop();
+    chain.current_tx_index = chain.current_block_senders.len();
+}
+
+impl<N: Network> Backend<N> {
+    /// Builds the Monad [`EvmEnv`] (spec and gas params) from a base env.
+    pub(super) fn build_monad_evm_env(
+        evm_env: &EvmEnv,
+        hardfork: MonadHardfork,
+    ) -> EvmEnvFor<MonadEvmNetwork> {
+        EvmEnv::new(
+            evm_env.cfg_env.clone().with_spec_and_gas_params(hardfork, monad_gas_params(hardfork)),
+            evm_env.block_env.clone(),
+        )
+    }
+
+    /// Monad path of [`Backend::transact_call_with_inspector_ref`].
+    pub(super) fn transact_monad_with_inspector_ref<'db, I, DB>(
+        &self,
+        db: &'db DB,
+        evm_env: &EvmEnv,
+        inspector: &mut I,
+        tx_env: TxEnv,
+        execution: PreparedExecution,
+    ) -> Result<ResultAndState<HaltReason>, BlockchainError>
+    where
+        DB: DatabaseRef + ?Sized,
+        I: Inspector<MonadContext<WrapDatabaseRef<&'db DB>>>,
+        WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
+    {
+        let monad_env = Self::build_monad_evm_env(evm_env, execution.hardfork);
+        let factory = MonadEvmFactory::default();
+        let context =
+            execution.context.unwrap_or_else(|| factory.chain_context_for_transaction(&tx_env));
+        let mut evm = factory.create_evm_with_inspector(WrapDatabaseRef(db), monad_env, inspector);
+        evm.ctx_mut().chain = context;
+        self.inject_precompiles(evm.precompiles_mut(), evm_env);
+        match execution.kind {
+            EnvelopeExecutionKind::Transaction => Ok(evm.transact(tx_env)?),
+            EnvelopeExecutionKind::Replay => {
+                if let Some(result) = factory.try_transact_system_replay(&mut evm, &tx_env)? {
+                    Ok(result)
+                } else {
+                    Ok(evm.transact(tx_env)?)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Moves Monad-specific execution and context lifecycle helpers into a dedicated feature-gated backend module. This keeps shared dispatch and storage reconstruction in the main backend while giving Monad environment construction, transaction execution, context advancement, rollback, and fork caching one clear owner. It also reuses the generic EVM factory hook for standalone transaction context.