### PR TITLE
fix(fmt): keep comments in the contract header

### DIFF
--- a/.changelog/fmt-contract-header-comments.md
+++ b/.changelog/fmt-contract-header-comments.md
@@ -1,0 +1,5 @@
+---
+forge-fmt: patch
+---
+
+Fixed `forge fmt` relocating a block comment between a contract header and its opening brace into the contract body.

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -309,6 +309,26 @@ impl State<'_, '_> {
         res.sf.src.get(res.pos.to_usize()..)?.chars().next()
     }
 
+    /// Returns the position of the first `{` within the span, ignoring the ones inside comments.
+    fn find_opening_brace(&self, span: Span) -> Option<BytePos> {
+        let snip = self.sm.span_to_snippet(span).ok()?;
+        let mut idx = 0;
+        while idx < snip.len() {
+            let rest = &snip[idx..];
+            if rest.starts_with('{') {
+                return Some(span.lo() + idx as u32);
+            }
+            idx += if let Some(line) = rest.strip_prefix("//") {
+                2 + line.find('\n').unwrap_or(line.len())
+            } else if let Some(block) = rest.strip_prefix("/*") {
+                2 + block.find("*/").map_or(block.len(), |end| end + 2)
+            } else {
+                rest.chars().next().map_or(1, char::len_utf8)
+            };
+        }
+        None
+    }
+
     fn print_span(&mut self, span: Span) {
         match self.sm.span_to_snippet(span) {
             Ok(s) => self.s.word(if matches!(self.config.style, IndentStyle::Tab) {
@@ -948,6 +968,14 @@ impl<'sess> State<'sess, '_> {
         'sess: 'b,
     {
         self.comments.iter().take_while(|c| c.pos() < pos).find(|c| !c.style.is_blank())
+    }
+
+    /// Returns `true` if the next comment is a mixed comment that starts before the given
+    /// position.
+    fn peek_mixed_comment_before(&self, pos: Option<BytePos>) -> bool {
+        pos.is_some_and(|pos| {
+            self.peek_comment().is_some_and(|cmnt| cmnt.pos() < pos && cmnt.style.is_mixed())
+        })
     }
 
     fn has_comment_before_with<F>(&self, pos: BytePos, f: F) -> bool

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -315,11 +315,12 @@ impl<'ast> State<'_, 'ast> {
         self.cursor.advance_to(span.lo(), true);
 
         // Position of the body's opening brace, needed to identify the comments that belong to
-        // the contract header.
+        // the contract header. The `is` and `layout` clauses can appear in either order, so the
+        // header ends at whichever clause ends last.
         let header_hi = bases
             .last()
             .map(|base| base.span().hi())
-            .or_else(|| layout.as_ref().map(|layout| layout.span.hi()))
+            .max(layout.as_ref().map(|layout| layout.span.hi()))
             .unwrap_or(name.span.hi());
         let body_lo = body.first().map_or(span.hi(), |item| item.span.lo());
         let brace = self.find_opening_brace(Span::new(header_hi, body_lo));

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -314,6 +314,16 @@ impl<'ast> State<'_, 'ast> {
         self.contract = Some(c);
         self.cursor.advance_to(span.lo(), true);
 
+        // Position of the body's opening brace, needed to identify the comments that belong to
+        // the contract header.
+        let header_hi = bases
+            .last()
+            .map(|base| base.span().hi())
+            .or_else(|| layout.as_ref().map(|layout| layout.span.hi()))
+            .unwrap_or(name.span.hi());
+        let body_lo = body.first().map_or(span.hi(), |item| item.span.lo());
+        let brace = self.find_opening_brace(Span::new(header_hi, body_lo));
+
         self.s.cbox(self.ind);
         self.ibox(0);
         self.cbox(0);
@@ -326,7 +336,8 @@ impl<'ast> State<'_, 'ast> {
         {
             self.word("layout at ");
             self.print_expr(layout.slot);
-            self.print_sep(Separator::Space);
+            let breaks = !bases.is_empty() || !self.peek_mixed_comment_before(brace);
+            self.print_sep(Separator::SpaceOrNbsp(breaks));
         }
 
         if let Some(first) = bases.first().map(|base| base.span())
@@ -355,10 +366,25 @@ impl<'ast> State<'_, 'ast> {
                     }
                 }
             }
-            if !self.print_trailing_comment(bases.last().unwrap().span().hi(), None) {
+            if self.print_trailing_comment(bases.last().unwrap().span().hi(), None) {
+                self.s.offset(-self.ind);
+            } else if self.peek_mixed_comment_before(brace) {
+                self.nbsp();
+            } else {
                 self.space();
+                self.s.offset(-self.ind);
             }
-            self.s.offset(-self.ind);
+        }
+
+        // Print the comments preceding the opening brace, otherwise they get relocated into the
+        // contract body. They are glued to both the header and the brace, as breaking them apart
+        // turns them into trailing comments, which are relocated again on the next run.
+        while self.peek_mixed_comment_before(brace) {
+            let cmnt = self.next_comment().unwrap();
+            if let Some(cmnt) = self.handle_comment(cmnt, true) {
+                self.print_comment(cmnt, CommentConfig::skip_ws().mixed_no_break());
+            }
+            self.nbsp();
         }
         self.end();
 

--- a/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
@@ -57,3 +57,26 @@ contract ERC7201Short layout at erc7201("s") is Base { }
 contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base { }
 
 contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max") is Base { }
+
+interface IERC721 /* is IERC165 */ {
+    function balanceOf(address owner) external view returns (uint256);
+}
+
+interface IERC721Empty /* is IERC165 */ { }
+
+contract WithBaseAndHeaderComment is Base /* base */ {
+    uint256 x;
+}
+
+contract WithLayoutAndHeaderComment layout at 69 /* layout */ { }
+
+contract MultipleHeaderComments /* one */ /* two */ { }
+
+contract VeryLongContractNameThatForcesTheHeaderToBreak is BaseOne, BaseTwo /* base */ {
+    uint256 x;
+}
+
+contract HeaderCommentOnItsOwnLine {
+    // isolated
+    uint256 x;
+}

--- a/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
@@ -70,6 +70,10 @@ contract WithBaseAndHeaderComment is Base /* base */ {
 
 contract WithLayoutAndHeaderComment layout at 69 /* layout */ { }
 
+contract WithLayoutAfterBase layout at erc7201("x{y") is Base /* layout */ {
+    uint256 x;
+}
+
 contract MultipleHeaderComments /* one */ /* two */ { }
 
 contract VeryLongContractNameThatForcesTheHeaderToBreak is BaseOne, BaseTwo /* base */ {

--- a/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
@@ -71,3 +71,36 @@ contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max")
     is
     Base
 {}
+
+interface IERC721 /* is IERC165 */ {
+
+    function balanceOf(address owner) external view returns (uint256);
+
+}
+
+interface IERC721Empty /* is IERC165 */ {}
+
+contract WithBaseAndHeaderComment is Base /* base */ {
+
+    uint256 x;
+
+}
+
+contract WithLayoutAndHeaderComment layout at 69 /* layout */ {}
+
+contract MultipleHeaderComments /* one */ /* two */ {}
+
+contract VeryLongContractNameThatForcesTheHeaderToBreak is
+    BaseOne,
+    BaseTwo /* base */ {
+
+    uint256 x;
+
+}
+
+contract HeaderCommentOnItsOwnLine {
+
+    // isolated
+    uint256 x;
+
+}

--- a/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
@@ -88,6 +88,12 @@ contract WithBaseAndHeaderComment is Base /* base */ {
 
 contract WithLayoutAndHeaderComment layout at 69 /* layout */ {}
 
+contract WithLayoutAfterBase layout at erc7201("x{y") is Base /* layout */ {
+
+    uint256 x;
+
+}
+
 contract MultipleHeaderComments /* one */ /* two */ {}
 
 contract VeryLongContractNameThatForcesTheHeaderToBreak is

--- a/crates/fmt/testdata/ContractDefinition/fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/fmt.sol
@@ -66,3 +66,28 @@ contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max")
     is
     Base
 {}
+
+interface IERC721 /* is IERC165 */ {
+    function balanceOf(address owner) external view returns (uint256);
+}
+
+interface IERC721Empty /* is IERC165 */ {}
+
+contract WithBaseAndHeaderComment is Base /* base */ {
+    uint256 x;
+}
+
+contract WithLayoutAndHeaderComment layout at 69 /* layout */ {}
+
+contract MultipleHeaderComments /* one */ /* two */ {}
+
+contract VeryLongContractNameThatForcesTheHeaderToBreak is
+    BaseOne,
+    BaseTwo /* base */ {
+    uint256 x;
+}
+
+contract HeaderCommentOnItsOwnLine {
+    // isolated
+    uint256 x;
+}

--- a/crates/fmt/testdata/ContractDefinition/fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/fmt.sol
@@ -79,6 +79,10 @@ contract WithBaseAndHeaderComment is Base /* base */ {
 
 contract WithLayoutAndHeaderComment layout at 69 /* layout */ {}
 
+contract WithLayoutAfterBase layout at erc7201("x{y") is Base /* layout */ {
+    uint256 x;
+}
+
 contract MultipleHeaderComments /* one */ /* two */ {}
 
 contract VeryLongContractNameThatForcesTheHeaderToBreak is

--- a/crates/fmt/testdata/ContractDefinition/original.sol
+++ b/crates/fmt/testdata/ContractDefinition/original.sol
@@ -53,3 +53,27 @@ contract WithLayoutAndBase layout at 69 is Base {}
 contract ERC7201Short layout at erc7201("s") is Base {}
 contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base {}
 contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max") is Base {}
+
+interface IERC721 /* is IERC165 */ {
+    function balanceOf(address owner) external view returns (uint256);
+}
+
+interface IERC721Empty /* is IERC165 */ {}
+
+contract WithBaseAndHeaderComment is Base /* base */ {
+    uint256 x;
+}
+
+contract WithLayoutAndHeaderComment layout at 69 /* layout */ {}
+
+contract MultipleHeaderComments /* one */ /* two */ {}
+
+contract VeryLongContractNameThatForcesTheHeaderToBreak is BaseOne, BaseTwo /* base */ {
+    uint256 x;
+}
+
+contract HeaderCommentOnItsOwnLine
+// isolated
+{
+    uint256 x;
+}

--- a/crates/fmt/testdata/ContractDefinition/original.sol
+++ b/crates/fmt/testdata/ContractDefinition/original.sol
@@ -66,6 +66,10 @@ contract WithBaseAndHeaderComment is Base /* base */ {
 
 contract WithLayoutAndHeaderComment layout at 69 /* layout */ {}
 
+contract WithLayoutAfterBase is Base layout at erc7201("x{y") /* layout */ {
+    uint256 x;
+}
+
 contract MultipleHeaderComments /* one */ /* two */ {}
 
 contract VeryLongContractNameThatForcesTheHeaderToBreak is BaseOne, BaseTwo /* base */ {


### PR DESCRIPTION
`forge fmt` moved a block comment written between a contract's header and its opening brace into the contract body, so `interface IERC721 /* is IERC165 */ {` became `interface IERC721 {` followed by `/* is IERC165 */` as the first line of the body. The header printer never consumed the comments sitting in front of the brace: with no bases they were simply left in the queue, and with bases `print_trailing_comment` skips mixed comments, so in both cases the body printer picked them up.

The contract printer now locates the body's opening brace by scanning the source between the end of the header and the first body item, skipping over comments so a brace inside one is not mistaken for it, and prints the mixed comments that precede it as part of the header. They are glued to both the header and the brace with hard spaces, which also required replacing the breakable separators after the layout specifier and after the last base when such a comment follows: if a break separated the comment from the brace it would become a trailing comment, and the next `forge fmt` run would relocate it again, tripping the idempotency check.

Only mixed comments (code on both sides) are kept in place. A comment on its own line, or one followed by a line break, still moves into the body, since keeping it would force the brace onto its own line.

Fixes https://github.com/foundry-rs/foundry/issues/16265
