### PR TITLE
fix(fmt): keep the comments preceding a disabled item

### DIFF
--- a/.changelog/fmt-disabled-item-comments.md
+++ b/.changelog/fmt-disabled-item-comments.md
@@ -1,0 +1,5 @@
+---
+forge-fmt: patch
+---
+
+Fixed `forge fmt` deleting the comments that precede an item excluded from formatting with a `forgefmt: disable-*` directive.

--- a/crates/fmt/src/lib.rs
+++ b/crates/fmt/src/lib.rs
@@ -236,7 +236,13 @@ pub fn format_ast<'ast>(
     let ast = source.ast.as_ref()?;
     let inline_config = parse_inline_config(gcx.sess, &comments, ast);
 
-    let mut state = state::State::new(gcx.sess.source_map(), config, inline_config, comments);
+    let mut state = state::State::new(
+        gcx.sess.source_map(),
+        source.file.start_pos,
+        config,
+        inline_config,
+        comments,
+    );
     state.print_source_unit(ast);
     Some(state.s.eof())
 }

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -205,6 +205,7 @@ impl Separator {
 impl<'sess> State<'sess, '_> {
     pub(super) fn new(
         sm: &'sess SourceMap,
+        start_pos: BytePos,
         config: Arc<FormatterConfig>,
         inline_config: InlineConfig<()>,
         comments: Comments,
@@ -219,7 +220,7 @@ impl<'sess> State<'sess, '_> {
             comments,
             config,
             inline_config,
-            cursor: SourcePos { pos: BytePos::from_u32(0), enabled: true },
+            cursor: SourcePos { pos: start_pos, enabled: true },
             has_crlf: false,
             contract: None,
             single_line_stmt: None,

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -120,24 +120,22 @@ impl<'ast> State<'_, 'ast> {
         let ast::Item { ref docs, span, ref kind } = *item;
         self.print_docs(docs);
 
-        if self.handle_span(item.span, skip_ws) {
+        // The comments preceding the item are printed before checking whether it is disabled,
+        // because printing a disabled item copies the source verbatim and drops every comment
+        // that ends before it.
+        let cmnt = self.print_comments(
+            span.lo(),
+            if skip_ws { CommentConfig::skip_leading_ws(false) } else { CommentConfig::default() },
+        );
+
+        if self.print_span_if_disabled(span) {
             if !self.print_trailing_comment(span.hi(), None) {
                 self.print_sep(Separator::Hardbreak);
             }
             return;
         }
 
-        if self
-            .print_comments(
-                span.lo(),
-                if skip_ws {
-                    CommentConfig::skip_leading_ws(false)
-                } else {
-                    CommentConfig::default()
-                },
-            )
-            .is_some_and(|cmnt| cmnt.is_mixed())
-        {
+        if cmnt.is_some_and(|cmnt| cmnt.is_mixed()) {
             self.zerobreak();
         }
 
@@ -3314,7 +3312,13 @@ mod tests {
                     Comments::new(&source_obj.file, gcx.sess.source_map(), true, false, None);
                 let config = Arc::new(FormatterConfig::default());
                 let inline_config = InlineConfig::default();
-                let mut state = State::new(gcx.sess.source_map(), config, inline_config, comments);
+                let mut state = State::new(
+                    gcx.sess.source_map(),
+                    source_obj.file.start_pos,
+                    config,
+                    inline_config,
+                    comments,
+                );
 
                 // Extract the first function header (either top-level or inside a contract)
                 let func = ast

--- a/crates/fmt/testdata/InlineDisable/fmt.sol
+++ b/crates/fmt/testdata/InlineDisable/fmt.sol
@@ -1,7 +1,7 @@
-pragma solidity ^0.5.2;
-
 // forgefmt: disable-next-line
 pragma    solidity     ^0.5.2;
+
+pragma solidity ^0.5.2;
 
 import {
     symbol1 as alias1,
@@ -10,6 +10,7 @@ import {
     symbol4
 } from "File2.sol";
 
+// comment before the directive
 // forgefmt: disable-next-line
 import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from 'File2.sol';
 

--- a/crates/fmt/testdata/InlineDisable/original.sol
+++ b/crates/fmt/testdata/InlineDisable/original.sol
@@ -1,10 +1,11 @@
+// forgefmt: disable-next-line
 pragma    solidity     ^0.5.2;
 
-// forgefmt: disable-next-line
 pragma    solidity     ^0.5.2;
 
 import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from 'File2.sol';
 
+// comment before the directive
 // forgefmt: disable-next-line
 import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from 'File2.sol';
 

--- a/crates/forge/tests/cli/fmt.rs
+++ b/crates/forge/tests/cli/fmt.rs
@@ -267,3 +267,23 @@ forgetest_init!(fmt_only_cmnts_file, |prj, cmd| {
     cmd.forge_fuse().args(["fmt", "--check", "src/FmtTest.sol"]);
     cmd.assert_success();
 });
+
+// <https://github.com/foundry-rs/foundry/issues/16268>
+forgetest_init!(fmt_keeps_disable_directive_in_every_file, |prj, cmd| {
+    const NAMES: [&str; 4] = ["A", "B", "C", "D"];
+    const SOURCE: &str = "// forgefmt: disable-next-line\ncontract  Disabled {}\n";
+
+    for name in NAMES {
+        prj.add_raw_source(&format!("Fmt{name}.sol"), SOURCE);
+    }
+
+    cmd.args(["fmt", "src"]).assert_success();
+
+    // Only the first file in the source map used to keep its directive.
+    for name in NAMES {
+        assert_data_eq!(
+            std::fs::read_to_string(prj.root().join(format!("src/Fmt{name}.sol"))).unwrap(),
+            SOURCE,
+        );
+    }
+});


### PR DESCRIPTION
A disabled item is printed by copying its source verbatim, and that copy also discards every comment ending before the item. `print_item` flushed the preceding comments first only for items that were not the first of their scope, so a `forgefmt: disable-*` directive at the top of a file was consumed by the raw span and never printed. The directive still took effect on that run, but it was gone from the output, so the next `forge fmt` reformatted exactly the code the author had excluded. Any other leading comment was lost the same way. The comments are now printed before the disabled check, so they are emitted in place rather than swallowed.

The formatter cursor also started at `BytePos(0)` instead of the start position of the file being formatted. That only coincides for the first file in the source map, and `forge fmt` loads an entire project into a single one, so for every other file the span between the cursor and the first item resolved into a different source. It now starts at the file's own `start_pos`.

Fixes https://github.com/foundry-rs/foundry/issues/16268
