### PR TITLE
fix(fmt): space comments inside an empty contract or struct body

### DIFF
--- a/.changelog/fmt-empty-body-comments.md
+++ b/.changelog/fmt-empty-body-comments.md
@@ -2,4 +2,4 @@
 forge-fmt: patch
 ---
 
-Fixed `forge fmt` dropping the space after the opening brace of an empty contract or struct body holding only comments, and crashing on a run of block comments at the end of a contract, struct, or enum body.
+Fixed `forge fmt` dropping the space after the opening brace of an empty contract or struct body holding only comments, crashing on a run of block comments at the end of a contract, struct, or enum body, and splitting such runs when `wrap_comments` is enabled.

--- a/.changelog/fmt-empty-body-comments.md
+++ b/.changelog/fmt-empty-body-comments.md
@@ -1,0 +1,5 @@
+---
+forge-fmt: patch
+---
+
+Fixed `forge fmt` dropping the space after the opening brace of an empty contract or struct body holding only comments, and crashing when it held more than one.

--- a/.changelog/fmt-empty-body-comments.md
+++ b/.changelog/fmt-empty-body-comments.md
@@ -2,4 +2,4 @@
 forge-fmt: patch
 ---
 
-Fixed `forge fmt` dropping the space after the opening brace of an empty contract or struct body holding only comments, and crashing when it held more than one.
+Fixed `forge fmt` dropping the space after the opening brace of an empty contract or struct body holding only comments, and crashing on a run of block comments at the end of a contract, struct, or enum body.

--- a/crates/fmt/src/state/common.rs
+++ b/crates/fmt/src/state/common.rs
@@ -765,11 +765,15 @@ impl<'ast> State<'_, 'ast> {
         let offset = if let BlockFormat::NoBraces(Some(off)) = block_format { off } else { 0 };
         self.print_comments(
             pos_hi,
-            self.cmnt_config().offset(offset).mixed_no_break().mixed_prev_space().mixed_post_nbsp(),
+            self.cmnt_config()
+                .offset(offset)
+                .mixed_no_break()
+                .mixed_prev_space()
+                .mixed_post_glued(),
         );
         self.print_comments(
             pos_hi,
-            CommentConfig::default().mixed_no_break().mixed_prev_space().mixed_post_nbsp(),
+            CommentConfig::default().mixed_no_break().mixed_prev_space().mixed_post_glued(),
         );
         if has_braces {
             self.word("}");

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -572,11 +572,16 @@ impl<'sess> State<'sess, '_> {
             }
 
             // Handle mixed with follow-up comment
+            let mut glue_next = false;
             if cmnt.style.is_mixed() {
                 if let Some(cmnt) = self.peek_comment_before(pos) {
                     config.mixed_no_break_prev = true;
                     config.mixed_no_break_post = true;
-                    config.mixed_post_nbsp = cmnt.style.is_mixed();
+                    config.mixed_post_nbsp = false;
+                    // The separator within a run of mixed comments must never break, even with
+                    // `wrap_comments`: a breakable space inside a broken consistent box always
+                    // breaks, which splits the run and reclassifies its comments on the next run.
+                    glue_next = cmnt.style.is_mixed();
                 }
 
                 // Ensure consecutive mixed comments don't have a double-space
@@ -594,6 +599,10 @@ impl<'sess> State<'sess, '_> {
 
             last_style = Some(cmnt.style);
             self.print_comment(cmnt, config);
+            if glue_next {
+                self.nbsp();
+                self.cursor.advance(1);
+            }
             config = config_cache;
         }
         last_style
@@ -787,7 +796,11 @@ impl<'sess> State<'sess, '_> {
                     }
                 }
                 if config.mixed_post_nbsp {
-                    config.nbsp_or_space(self.config.wrap_comments, &mut self.s);
+                    if config.mixed_post_glued {
+                        self.nbsp();
+                    } else {
+                        config.nbsp_or_space(self.config.wrap_comments, &mut self.s);
+                    }
                     self.cursor.advance(1);
                 } else if !config.mixed_no_break_post {
                     config.space(&mut self.s);
@@ -1071,6 +1084,10 @@ pub(crate) struct CommentConfig {
     // Config: mixed comments
     mixed_prev_space: bool,
     mixed_post_nbsp: bool,
+    /// Makes `mixed_post_nbsp` emit a hard space even with `wrap_comments`, which would
+    /// otherwise use a breakable one. Required when the comment is glued to a closing token, as
+    /// a break in between detaches it and reclassifies the comment on the next run.
+    mixed_post_glued: bool,
     mixed_no_break_prev: bool,
     mixed_no_break_post: bool,
 }
@@ -1083,7 +1100,7 @@ impl CommentConfig {
     /// Config for comments that are the sole content of an otherwise empty block, so that they
     /// are surrounded by spaces: `{ /* comment */ }`.
     pub(crate) fn empty_block() -> Self {
-        Self::skip_ws().mixed_no_break().mixed_prev_space().mixed_post_nbsp()
+        Self::skip_ws().mixed_no_break().mixed_prev_space().mixed_post_glued()
     }
 
     pub(crate) fn skip_leading_ws(resettable: bool) -> Self {
@@ -1130,6 +1147,12 @@ impl CommentConfig {
 
     pub(crate) const fn mixed_post_nbsp(mut self) -> Self {
         self.mixed_post_nbsp = true;
+        self
+    }
+
+    pub(crate) const fn mixed_post_glued(mut self) -> Self {
+        self.mixed_post_nbsp = true;
+        self.mixed_post_glued = true;
         self
     }
 

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -608,7 +608,6 @@ impl<'sess> State<'sess, '_> {
             }
 
             // Handle mixed with follow-up comment
-            let mut glue_next = false;
             if cmnt.style.is_mixed() {
                 if let Some(cmnt) = self.peek_comment_before(pos) {
                     config.mixed_no_break_prev = true;
@@ -617,7 +616,9 @@ impl<'sess> State<'sess, '_> {
                     // The separator within a run of mixed comments must never break, even with
                     // `wrap_comments`: a breakable space inside a broken consistent box always
                     // breaks, which splits the run and reclassifies its comments on the next run.
-                    glue_next = cmnt.style.is_mixed();
+                    if cmnt.style.is_mixed() {
+                        config = config.mixed_post_glued();
+                    }
                 }
 
                 // Ensure consecutive mixed comments don't have a double-space
@@ -635,10 +636,6 @@ impl<'sess> State<'sess, '_> {
 
             last_style = Some(cmnt.style);
             self.print_comment(cmnt, config);
-            if glue_next {
-                self.nbsp();
-                self.cursor.advance(1);
-            }
             config = config_cache;
         }
         last_style

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -1080,6 +1080,12 @@ impl CommentConfig {
         Self { skip_blanks: Some(Skip::All), ..Default::default() }
     }
 
+    /// Config for comments that are the sole content of an otherwise empty block, so that they
+    /// are surrounded by spaces: `{ /* comment */ }`.
+    pub(crate) fn empty_block() -> Self {
+        Self::skip_ws().mixed_no_break().mixed_prev_space().mixed_post_nbsp()
+    }
+
     pub(crate) fn skip_leading_ws(resettable: bool) -> Self {
         Self { skip_blanks: Some(Skip::Leading { resettable }), ..Default::default() }
     }

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -445,14 +445,9 @@ impl<'ast> State<'_, 'ast> {
                     self.print_sep(Separator::Hardbreak);
                 }
                 self.s.offset(-self.ind);
-            } else if !self.is_beginning_of_line() {
-                // A trailing run of mixed comments ends in a string token; glue the brace to it,
-                // as a break in between would reclassify the last comment on the next run.
-                glued = true;
-                self.nbsp();
+            } else {
+                glued = self.glue_brace_to_trailing_comments(cmnt.is_some());
             }
-            // Otherwise the body ended with verbatim source that already broke the line; print
-            // the brace as-is.
             self.end();
             if self.config.contract_new_lines && !glued {
                 self.hardbreak_if_nonempty();
@@ -467,6 +462,26 @@ impl<'ast> State<'_, 'ast> {
 
         self.cursor.advance_to(span.hi(), true);
         self.contract = None;
+    }
+
+    /// Glues the closing brace of an item body to a trailing run of mixed comments.
+    ///
+    /// A trailing run of mixed comments ends in a string token; a break in between would
+    /// reclassify the last comment on the next run, so the brace is glued with a hard space.
+    /// Bodies that end with a pending break (the caller adjusts its offset instead), an existing
+    /// space, or verbatim source that already broke the line are left unchanged.
+    ///
+    /// Returns `true` if the brace was glued.
+    fn glue_brace_to_trailing_comments(&mut self, printed: bool) -> bool {
+        if printed
+            && !self.last_token_is_break()
+            && !self.last_token_is_space()
+            && !self.is_beginning_of_line()
+        {
+            self.nbsp();
+            return true;
+        }
+        false
     }
 
     fn print_struct(&mut self, strukt: &'ast ast::ItemStruct<'ast>, span: Span) {
@@ -494,9 +509,8 @@ impl<'ast> State<'_, 'ast> {
             if ind == 0 {
                 self.s.offset(-self.ind);
             }
-        } else if printed && !self.last_token_is_space() {
-            // A trailing run of mixed comments ends in a string token; glue the brace to it.
-            self.nbsp();
+        } else {
+            self.glue_brace_to_trailing_comments(printed);
         }
         self.end();
         self.end();
@@ -510,22 +524,25 @@ impl<'ast> State<'_, 'ast> {
         self.print_ident(name);
         self.word(" {");
         self.hardbreak_if_nonempty();
+        let mut printed = false;
         for (pos, ident) in variants.iter().delimited() {
             self.print_comments(ident.span.lo(), CommentConfig::default());
             self.print_ident(ident);
             if !pos.is_last {
                 self.word(",");
             }
-            if !self.print_trailing_comment(ident.span.hi(), None) {
+            printed = self.print_trailing_comment(ident.span.hi(), None);
+            if !printed {
                 self.hardbreak();
             }
         }
-        self.print_comments(span.hi(), CommentConfig::skip_ws());
+        if self.print_comments(span.hi(), CommentConfig::skip_ws()).is_some() {
+            printed = true;
+        }
         if self.last_token_is_break() {
             self.s.offset(-self.ind);
         } else {
-            // A trailing run of mixed comments ends in a string token; glue the brace to it.
-            self.nbsp();
+            self.glue_brace_to_trailing_comments(printed);
         }
         self.end();
         self.word("}");

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -365,13 +365,14 @@ impl<'ast> State<'_, 'ast> {
         self.print_word("{");
         self.end();
         if body.is_empty() {
-            if self.print_comments(span.hi(), CommentConfig::skip_ws()).is_some() {
+            match self.print_comments(span.hi(), CommentConfig::empty_block()) {
                 // Adjust the offset of the trailing break from comment printing
                 // so the closing brace is not indented
-                self.s.offset(-self.ind);
-            } else if self.config.bracket_spacing {
-                self.nbsp();
-            };
+                Some(_) if self.last_token_is_break() => self.s.offset(-self.ind),
+                Some(_) => {}
+                None if self.config.bracket_spacing => self.nbsp(),
+                None => {}
+            }
             self.end();
         } else {
             // update block depth
@@ -439,8 +440,10 @@ impl<'ast> State<'_, 'ast> {
                 self.hardbreak();
             }
         }
-        self.print_comments(span.hi(), CommentConfig::skip_ws());
-        if ind == 0 {
+        let cmnt_config =
+            if fields.is_empty() { CommentConfig::empty_block() } else { CommentConfig::skip_ws() };
+        self.print_comments(span.hi(), cmnt_config);
+        if ind == 0 && self.last_token_is_break() {
             self.s.offset(-self.ind);
         }
         self.end();

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -401,15 +401,20 @@ impl<'ast> State<'_, 'ast> {
                 }
             }
 
-            if let Some(cmnt) = self.print_comments(span.hi(), CommentConfig::skip_trailing_ws())
-                && self.config.contract_new_lines
-                && !cmnt.is_blank()
-            {
-                self.print_sep(Separator::Hardbreak);
+            let cmnt = self.print_comments(span.hi(), CommentConfig::skip_trailing_ws());
+            let glued = !self.last_token_is_break();
+            if glued {
+                // A trailing run of mixed comments ends in a string token; glue the brace to it,
+                // as a break in between would reclassify the last comment on the next run.
+                self.nbsp();
+            } else {
+                if self.config.contract_new_lines && cmnt.is_some_and(|cmnt| !cmnt.is_blank()) {
+                    self.print_sep(Separator::Hardbreak);
+                }
+                self.s.offset(-self.ind);
             }
-            self.s.offset(-self.ind);
             self.end();
-            if self.config.contract_new_lines {
+            if self.config.contract_new_lines && !glued {
                 self.hardbreak_if_nonempty();
             }
 
@@ -442,9 +447,14 @@ impl<'ast> State<'_, 'ast> {
         }
         let cmnt_config =
             if fields.is_empty() { CommentConfig::empty_block() } else { CommentConfig::skip_ws() };
-        self.print_comments(span.hi(), cmnt_config);
-        if ind == 0 && self.last_token_is_break() {
-            self.s.offset(-self.ind);
+        let printed = self.print_comments(span.hi(), cmnt_config).is_some();
+        if self.last_token_is_break() {
+            if ind == 0 {
+                self.s.offset(-self.ind);
+            }
+        } else if printed && !self.last_token_is_space() {
+            // A trailing run of mixed comments ends in a string token; glue the brace to it.
+            self.nbsp();
         }
         self.end();
         self.end();
@@ -469,7 +479,12 @@ impl<'ast> State<'_, 'ast> {
             }
         }
         self.print_comments(span.hi(), CommentConfig::skip_ws());
-        self.s.offset(-self.ind);
+        if self.last_token_is_break() {
+            self.s.offset(-self.ind);
+        } else {
+            // A trailing run of mixed comments ends in a string token; glue the brace to it.
+            self.nbsp();
+        }
         self.end();
         self.word("}");
     }

--- a/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
@@ -6,6 +6,10 @@ contract EmptyBodyWithComment { /* body */ }
 
 contract EmptyBodyWithComments { /* one */ /* two */ }
 
+contract NonEmptyBodyTrailingComments {
+    uint256 x;
+    /* one */ /* two */ }
+
 // comment 7
 contract SampleContract {
     // spaced comment 1

--- a/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
@@ -2,6 +2,10 @@
 // config: bracket_spacing = true
 contract ContractDefinition is Contract1, Contract2, Contract3, Contract4, Contract5 { }
 
+contract EmptyBodyWithComment { /* body */ }
+
+contract EmptyBodyWithComments { /* one */ /* two */ }
+
 // comment 7
 contract SampleContract {
     // spaced comment 1

--- a/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
@@ -11,6 +11,11 @@ contract EmptyBodyWithComment { /* body */ }
 
 contract EmptyBodyWithComments { /* one */ /* two */ }
 
+contract NonEmptyBodyTrailingComments {
+
+    uint256 x;
+    /* one */ /* two */ }
+
 // comment 7
 contract SampleContract {
 

--- a/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
@@ -7,6 +7,10 @@ contract ContractDefinition is
     Contract5
 {}
 
+contract EmptyBodyWithComment { /* body */ }
+
+contract EmptyBodyWithComments { /* one */ /* two */ }
+
 // comment 7
 contract SampleContract {
 

--- a/crates/fmt/testdata/ContractDefinition/fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/fmt.sol
@@ -10,6 +10,10 @@ contract EmptyBodyWithComment { /* body */ }
 
 contract EmptyBodyWithComments { /* one */ /* two */ }
 
+contract NonEmptyBodyTrailingComments {
+    uint256 x;
+    /* one */ /* two */ }
+
 // comment 7
 contract SampleContract {
     // spaced comment 1

--- a/crates/fmt/testdata/ContractDefinition/fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/fmt.sol
@@ -6,6 +6,10 @@ contract ContractDefinition is
     Contract5
 {}
 
+contract EmptyBodyWithComment { /* body */ }
+
+contract EmptyBodyWithComments { /* one */ /* two */ }
+
 // comment 7
 contract SampleContract {
     // spaced comment 1

--- a/crates/fmt/testdata/ContractDefinition/original.sol
+++ b/crates/fmt/testdata/ContractDefinition/original.sol
@@ -1,6 +1,10 @@
 contract ContractDefinition is Contract1, Contract2, Contract3, Contract4, Contract5 {
 }
 
+contract EmptyBodyWithComment { /* body */ }
+
+contract EmptyBodyWithComments { /* one */ /* two */ }
+
 // comment 7
 contract SampleContract {
 

--- a/crates/fmt/testdata/ContractDefinition/original.sol
+++ b/crates/fmt/testdata/ContractDefinition/original.sol
@@ -5,6 +5,8 @@ contract EmptyBodyWithComment { /* body */ }
 
 contract EmptyBodyWithComments { /* one */ /* two */ }
 
+contract NonEmptyBodyTrailingComments { uint256 x; /* one */ /* two */ }
+
 // comment 7
 contract SampleContract {
 

--- a/crates/fmt/testdata/ContractDefinition/wrap-comments.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/wrap-comments.fmt.sol
@@ -75,3 +75,32 @@ contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max")
     is
     Base
 {}
+
+interface IERC721 /* is IERC165 */ {
+    function balanceOf(address owner) external view returns (uint256);
+}
+
+interface IERC721Empty /* is IERC165 */ {}
+
+contract WithBaseAndHeaderComment is Base /* base */ {
+    uint256 x;
+}
+
+contract WithLayoutAndHeaderComment layout at 69 /* layout */ {}
+
+contract WithLayoutAfterBase layout at erc7201("x{y") is Base /* layout */ {
+    uint256 x;
+}
+
+contract MultipleHeaderComments /* one */ /* two */ {}
+
+contract VeryLongContractNameThatForcesTheHeaderToBreak is
+    BaseOne,
+    BaseTwo /* base */ {
+    uint256 x;
+}
+
+contract HeaderCommentOnItsOwnLine {
+    // isolated
+    uint256 x;
+}

--- a/crates/fmt/testdata/ContractDefinition/wrap-comments.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/wrap-comments.fmt.sol
@@ -1,0 +1,77 @@
+// config: wrap_comments = true
+contract ContractDefinition is
+    Contract1,
+    Contract2,
+    Contract3,
+    Contract4,
+    Contract5
+{}
+
+contract EmptyBodyWithComment { /* body */ }
+
+contract EmptyBodyWithComments { /* one */ /* two */ }
+
+contract NonEmptyBodyTrailingComments {
+    uint256 x;
+    /* one */ /* two */ }
+
+// comment 7
+contract SampleContract {
+    // spaced comment 1
+
+    // spaced comment 2
+    // that spans multiple lines
+
+    // comment 8
+    constructor() { /* comment 9 */ } // comment 10
+
+    // comment 11
+    function max( /* comment 13 */
+        uint256 arg1,
+        uint256 /* comment 14 */ arg2,
+        uint256 /* comment 15 */
+    )
+        // comment 16
+        external /* comment 17 */
+        pure
+        returns (uint256)
+    // comment 18
+    {
+        // comment 19
+        return arg1 > arg2 ? arg1 : arg2;
+    }
+}
+
+// comment 20
+contract /* comment 21 */ ExampleContract is /* comment 22 */ SampleContract {}
+
+contract ERC20DecimalsMock is ERC20 {
+    uint8 private immutable _decimals;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_)
+        ERC20(name_, symbol_)
+    {
+        _decimals = decimals_;
+    }
+}
+
+contract SomeContract is
+    ERC165Upgradeable, // 1 inherited component
+    ISomeContract // 4 inherited components
+{}
+
+contract AnotherContract is
+    Adminable, /* 1 inherited components */
+    UUPSUpgradeable /* 1 inherited component */
+{}
+
+contract WithLayoutAndBase layout at 69 is Base {}
+
+contract ERC7201Short layout at erc7201("s") is Base {}
+
+contract ERC7201Mid layout at erc7201("openzeppelin.med") is Base {}
+
+contract ERC7201OverMax layout at erc7201("openzeppelin.storage.exceeds.max")
+    is
+    Base
+{}

--- a/crates/fmt/testdata/EnumDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/EnumDefinition/bracket-spacing.fmt.sol
@@ -7,6 +7,9 @@ contract EnumDefinitions {
         GoStraight,
         SitStill
     }
+    enum TrailingComments {
+        GoLeft
+        /* one */ /* two */ }
     enum States {
         State1,
         State2,

--- a/crates/fmt/testdata/EnumDefinition/fmt.sol
+++ b/crates/fmt/testdata/EnumDefinition/fmt.sol
@@ -6,6 +6,9 @@ contract EnumDefinitions {
         GoStraight,
         SitStill
     }
+    enum TrailingComments {
+        GoLeft
+        /* one */ /* two */ }
     enum States {
         State1,
         State2,

--- a/crates/fmt/testdata/EnumDefinition/original.sol
+++ b/crates/fmt/testdata/EnumDefinition/original.sol
@@ -3,5 +3,6 @@ contract EnumDefinitions {
 
     }
     enum ActionChoices { GoLeft, GoRight, GoStraight, SitStill }
+    enum TrailingComments { GoLeft /* one */ /* two */ }
     enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
 }

--- a/crates/fmt/testdata/EnumDefinition/wrap-comments.fmt.sol
+++ b/crates/fmt/testdata/EnumDefinition/wrap-comments.fmt.sol
@@ -1,0 +1,24 @@
+// config: wrap_comments = true
+contract EnumDefinitions {
+    enum Empty {}
+    enum ActionChoices {
+        GoLeft,
+        GoRight,
+        GoStraight,
+        SitStill
+    }
+    enum TrailingComments {
+        GoLeft
+        /* one */ /* two */ }
+    enum States {
+        State1,
+        State2,
+        State3,
+        State4,
+        State5,
+        State6,
+        State7,
+        State8,
+        State9
+    }
+}

--- a/crates/fmt/testdata/StructDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/StructDefinition/bracket-spacing.fmt.sol
@@ -8,6 +8,10 @@ struct Bar {
 
 struct EmptyStructWithComment { /* body */ }
 
+struct NonEmptyStructTrailingComments {
+    uint256 x;
+    /* one */ /* two */ }
+
 struct MyStruct {
     // first 1
     // first 2

--- a/crates/fmt/testdata/StructDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/StructDefinition/bracket-spacing.fmt.sol
@@ -6,6 +6,8 @@ struct Bar {
     string bar;
 }
 
+struct EmptyStructWithComment { /* body */ }
+
 struct MyStruct {
     // first 1
     // first 2

--- a/crates/fmt/testdata/StructDefinition/fmt.sol
+++ b/crates/fmt/testdata/StructDefinition/fmt.sol
@@ -7,6 +7,10 @@ struct Bar {
 
 struct EmptyStructWithComment { /* body */ }
 
+struct NonEmptyStructTrailingComments {
+    uint256 x;
+    /* one */ /* two */ }
+
 struct MyStruct {
     // first 1
     // first 2

--- a/crates/fmt/testdata/StructDefinition/fmt.sol
+++ b/crates/fmt/testdata/StructDefinition/fmt.sol
@@ -5,6 +5,8 @@ struct Bar {
     string bar;
 }
 
+struct EmptyStructWithComment { /* body */ }
+
 struct MyStruct {
     // first 1
     // first 2

--- a/crates/fmt/testdata/StructDefinition/original.sol
+++ b/crates/fmt/testdata/StructDefinition/original.sol
@@ -4,6 +4,8 @@ struct   Foo  {
 
 struct EmptyStructWithComment { /* body */ }
 
+struct NonEmptyStructTrailingComments { uint256 x; /* one */ /* two */ }
+
 struct MyStruct {
 // first 1
 // first 2

--- a/crates/fmt/testdata/StructDefinition/original.sol
+++ b/crates/fmt/testdata/StructDefinition/original.sol
@@ -2,6 +2,8 @@ struct   Foo  {
     
 } struct   Bar  {    uint foo ;string bar ;  }
 
+struct EmptyStructWithComment { /* body */ }
+
 struct MyStruct {
 // first 1
 // first 2

--- a/crates/fmt/testdata/StructDefinition/wrap-comments.fmt.sol
+++ b/crates/fmt/testdata/StructDefinition/wrap-comments.fmt.sol
@@ -1,0 +1,21 @@
+// config: wrap_comments = true
+struct Foo {}
+
+struct Bar {
+    uint256 foo;
+    string bar;
+}
+
+struct EmptyStructWithComment { /* body */ }
+
+struct NonEmptyStructTrailingComments {
+    uint256 x;
+    /* one */ /* two */ }
+
+struct MyStruct {
+    // first 1
+    // first 2
+    uint256 field1;
+    // second
+    uint256 field2;
+}


### PR DESCRIPTION
An empty contract or struct body whose only content is a block comment was printed as `contract C {/* body */ }`. The separator emitted before the comment is a zerobreak while the one after it is a space, so the brace ends up glued to the comment on one side only. Statement blocks go through `print_empty_block`, which surrounds the comment with hard spaces, so `function f() external { /* body */ }` was already correct and the same comment read differently depending on which body enclosed it. Both item bodies now use that same comment config, under `CommentConfig::empty_block`.

Two comments crashed outright:

```
contract C { /* a */ /* b */ }
```

```
internal error: entered unreachable code
Location: crates/fmt/src/state/sol.rs:371
```

`print_comments` ends a run of consecutive mixed comments with a non-breaking space or the comment itself, both string tokens, while `Printer::offset` assumes the last token is a break and panics otherwise. The same run also reaches the offsets at the end of a non-empty contract body and of an enum body, so all four `offset` calls that can follow a comment run are now guarded on the last token being a break. When the run ends in a string, the closing brace is glued to it with a space, since a break in between would reclassify the last comment as isolated and relocate it on the next run, tripping the idempotency check.

With `wrap_comments` enabled the same shapes were still unstable: the separator between the comments of a run, and the one an empty block emits before its closing brace, become breakable spaces under that setting, and a breakable space inside a broken consistent box always breaks, splitting the run apart. Those two separators are now always hard, while comments leading an expression keep the breakable space, which is stable and wraps better there. New `wrap-comments` testdata variants cover the contract, struct, and enum definitions.

Fixes https://github.com/foundry-rs/foundry/issues/16269

