### PR TITLE
ci: fix tempo sponsor-signature check flakiness

### DIFF
--- a/.changelog/tempo-sponsor-signature-mismatch-hint.md
+++ b/.changelog/tempo-sponsor-signature-mismatch-hint.md
@@ -1,0 +1,6 @@
+---
+cast: patch
+forge: patch
+---
+
+Improved the Tempo sponsor signature mismatch error to explain that the signed digest must match the transaction being sent and which transaction flags to pin.

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -581,9 +581,25 @@ echo -e "\n=== CAST SEND WITH SPONSOR (--tempo.sponsor-signature) ==="
 # Step 2: Sign it with the sponsor's private key
 # Step 3: Send with --tempo.sponsor and --tempo.sponsor-signature
 
+# The sponsor digest commits to the full transaction, including nonce, gas limit and
+# fees. Pin those fields explicitly so `cast mktx` and `cast send` build the identical
+# transaction: refilling them from live chain state (basefee moves, gas estimates change)
+# between the two invocations changes the digest and invalidates the pre-signed sponsor
+# signature. The gas limit is pinned to a padded estimate; a limit below actual usage
+# would make the transaction run out of gas during Tempo AA validation and be dropped
+# without a receipt.
+SPONSOR_TX_NONCE=$(cast nonce "$ADDR" --rpc-url "$ETH_RPC_URL")
+SPONSOR_TX_GAS=$(cast estimate --rpc-url "$ETH_RPC_URL" \
+  0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --from "$ADDR")
+SPONSOR_TX_ARGS=(
+  0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()'
+  --nonce "$SPONSOR_TX_NONCE" --gas-limit $((2 * SPONSOR_TX_GAS))
+  --gas-price 20gwei --priority-gas-price 1gwei
+)
+
 # Step 1: Get the hash that the sponsor needs to sign
 FEE_PAYER_HASH=$(cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-  0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" \
+  "${SPONSOR_TX_ARGS[@]}" --private-key "$PK" \
   --tempo.print-sponsor-hash)
 printf "Fee payer signature hash: %s\n" "$FEE_PAYER_HASH"
 
@@ -591,10 +607,16 @@ printf "Fee payer signature hash: %s\n" "$FEE_PAYER_HASH"
 SPONSOR_SIG=$(cast wallet sign --private-key "$SPONSOR_PK" "$FEE_PAYER_HASH" --no-hash)
 printf "Sponsor signature: %s\n" "$SPONSOR_SIG"
 
-# Step 3: Send the sponsored transaction with the signature
-RECEIPT=$(cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-  0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" \
-  --tempo.sponsor "$SPONSOR_ADDR" --tempo.sponsor-signature "$SPONSOR_SIG" --json)
+# Step 3: Send the sponsored transaction with the signature. With --json, cast reports
+# errors as a JSON envelope on stdout, which the command substitution captures; print the
+# captured output on failure so the error is visible in CI logs.
+if ! RECEIPT=$(cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  "${SPONSOR_TX_ARGS[@]}" --private-key "$PK" \
+  --tempo.sponsor "$SPONSOR_ADDR" --tempo.sponsor-signature "$SPONSOR_SIG" --json); then
+  echo "ERROR: sponsored cast send failed"
+  echo "Output: $RECEIPT"
+  exit 1
+fi
 
 # Verify the fee_payer in the receipt matches the sponsor address
 RECEIPT_FEE_PAYER=$(echo "$RECEIPT" | jq -r '.feePayer // .fee_payer // empty')

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -778,6 +778,213 @@ casttest!(mktx_rejects_remote_sponsor_instead_of_ignoring_it, |_prj, cmd| {
     assert!(stderr.contains("--sponsor-url is not supported by cast mktx"), "{stderr}");
 });
 
+casttest!(send_with_presigned_sponsor_signature_keeps_digest_stable, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let provider = handle.http_provider();
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let sender = accounts[0];
+    let sponsor = accounts[1];
+    let filler = accounts[2];
+    let recipient = accounts[3];
+    let sender_wallet = handle.dev_wallets().next().unwrap();
+    assert_eq!(sender_wallet.address(), sender);
+    let sender_pk = format!("0x{}", hex::encode(sender_wallet.credential().to_bytes()));
+    let sponsor_wallet = handle.dev_wallets().nth(1).unwrap();
+    assert_eq!(sponsor_wallet.address(), sponsor);
+    let sponsor_pk = format!("0x{}", hex::encode(sponsor_wallet.credential().to_bytes()));
+    let token = PATH_USD_ADDRESS.to_string();
+    let recipient_arg = recipient.to_string();
+    let sponsor_arg = sponsor.to_string();
+
+    // The sponsor digest commits to the full transaction, so nonce, gas limit and fees must be
+    // pinned for `cast mktx` and `cast send` to build the identical transaction. The gas limit
+    // must cover actual usage: a Tempo transaction that runs out of gas during AA validation is
+    // dropped without a receipt.
+    let nonce = provider.get_transaction_count(sender).await.unwrap().to_string();
+    let pinned = [
+        "--nonce",
+        nonce.as_str(),
+        "--gas-limit",
+        "1000000",
+        "--gas-price",
+        "40gwei",
+        "--priority-gas-price",
+        "1gwei",
+    ];
+
+    let mut mktx_args = vec![
+        "mktx",
+        &token,
+        "transfer(address,uint256)",
+        &recipient_arg,
+        "1",
+        "--private-key",
+        &sender_pk,
+        "--rpc-url",
+        &rpc,
+        "--tempo.print-sponsor-hash",
+    ];
+    mktx_args.extend(pinned);
+    let hash = cmd
+        .cast_fuse()
+        .args(&mktx_args)
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+    assert!(hash.starts_with("0x") && hash.len() == 66, "unexpected sponsor hash: {hash}");
+
+    let sig = cmd
+        .cast_fuse()
+        .args(["wallet", "sign", "--private-key", &sponsor_pk, "--no-hash", &hash])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    // Mine an unrelated transaction between hash generation and send; the pinned fields must
+    // keep the digest stable across the chain-state change.
+    let tip20 = ITIP20::new(PATH_USD_ADDRESS, &provider);
+    let filler_tx = TransactionRequest::default()
+        .from(filler)
+        .to(PATH_USD_ADDRESS)
+        .with_input(tip20.transfer(recipient, U256::from(5u64)).calldata().clone())
+        .with_gas_limit(10_000_000);
+    let filler_receipt = provider
+        .send_transaction(WithOtherFields::new(filler_tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(filler_receipt.status(), "filler transfer should succeed");
+
+    let mut send_args = vec![
+        "send",
+        &token,
+        "transfer(address,uint256)",
+        &recipient_arg,
+        "1",
+        "--private-key",
+        &sender_pk,
+        "--rpc-url",
+        &rpc,
+        "--tempo.sponsor",
+        &sponsor_arg,
+        "--tempo.sponsor-signature",
+        &sig,
+        "--json",
+    ];
+    send_args.extend(pinned);
+    let send_assert = cmd.cast_fuse().args(&send_args).assert_success();
+    let output = send_assert.get_output();
+
+    let stderr = output.stderr_lossy();
+    assert!(
+        stderr.to_lowercase().contains(&format!("tempo sponsor digest: {}", hash.to_lowercase())),
+        "sponsor digest drifted from the pre-signed hash {hash}:\n{stderr}"
+    );
+
+    let receipt: serde_json::Value =
+        serde_json::from_str(output.stdout_lossy().trim()).expect("receipt should be JSON");
+    assert_eq!(receipt["status"], "0x1", "unexpected receipt: {receipt}");
+    let fee_payer: Address =
+        receipt["feePayer"].as_str().expect("receipt has feePayer").parse().unwrap();
+    assert_eq!(fee_payer, sponsor, "receipt fee payer should be the sponsor");
+});
+
+casttest!(send_with_presigned_sponsor_signature_rejects_stale_digest, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let provider = handle.http_provider();
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let sender = accounts[0];
+    let sponsor = accounts[1];
+    let recipient = accounts[2];
+    let sender_wallet = handle.dev_wallets().next().unwrap();
+    assert_eq!(sender_wallet.address(), sender);
+    let sender_pk = format!("0x{}", hex::encode(sender_wallet.credential().to_bytes()));
+    let sponsor_wallet = handle.dev_wallets().nth(1).unwrap();
+    assert_eq!(sponsor_wallet.address(), sponsor);
+    let sponsor_pk = format!("0x{}", hex::encode(sponsor_wallet.credential().to_bytes()));
+    let token = PATH_USD_ADDRESS.to_string();
+    let recipient_arg = recipient.to_string();
+    let sponsor_arg = sponsor.to_string();
+
+    // Without pinned fields, both commands fill nonce and fees from live chain state.
+    let hash = cmd
+        .cast_fuse()
+        .args([
+            "mktx",
+            &token,
+            "transfer(address,uint256)",
+            &recipient_arg,
+            "1",
+            "--private-key",
+            &sender_pk,
+            "--rpc-url",
+            &rpc,
+            "--tempo.print-sponsor-hash",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    let sig = cmd
+        .cast_fuse()
+        .args(["wallet", "sign", "--private-key", &sponsor_pk, "--no-hash", &hash])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    // Consume the sender nonce so the refilled transaction no longer matches the signed digest.
+    let tip20 = ITIP20::new(PATH_USD_ADDRESS, &provider);
+    let bump_tx = TransactionRequest::default()
+        .from(sender)
+        .to(PATH_USD_ADDRESS)
+        .with_input(tip20.transfer(recipient, U256::from(1u64)).calldata().clone())
+        .with_gas_limit(10_000_000);
+    let bump_receipt = provider
+        .send_transaction(WithOtherFields::new(bump_tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(bump_receipt.status(), "nonce bump transfer should succeed");
+
+    let stderr = cmd
+        .cast_fuse()
+        .args([
+            "send",
+            &token,
+            "transfer(address,uint256)",
+            &recipient_arg,
+            "1",
+            "--private-key",
+            &sender_pk,
+            "--rpc-url",
+            &rpc,
+            "--tempo.sponsor",
+            &sponsor_arg,
+            "--tempo.sponsor-signature",
+            &sig,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("Tempo sponsor signature recovered"), "{stderr}");
+    assert!(stderr.contains("--tempo.print-sponsor-hash"), "{stderr}");
+});
+
 casttest!(tip20_logo_check_accepts_valid_values, |_prj, cmd| {
     for uri in ["", "https://example.com/logo.png", "HTTP://example.com/logo.png", "ipfs://token"] {
         cmd.cast_fuse().args(["tip20", "logo-check", uri]).assert_success();

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -352,7 +352,13 @@ impl TempoSponsor {
             .recover_address_from_prehash(&digest)
             .context("failed to recover Tempo sponsor signature")?;
         if recovered != self.sponsor {
-            eyre::bail!("Tempo sponsor signature recovered {recovered}, expected {}", self.sponsor);
+            eyre::bail!(
+                "Tempo sponsor signature recovered {recovered}, expected {}; the signature must \
+                 cover this exact transaction's sponsor digest — when signing a digest produced \
+                 with `--tempo.print-sponsor-hash`, pin --nonce, --gas-limit, --gas-price and \
+                 --priority-gas-price on both commands so the digest does not change in between",
+                self.sponsor
+            );
         }
         if recovered == sender {
             eyre::bail!(


### PR DESCRIPTION
The `tempo-check` job failed twice on master at the `CAST SEND WITH SPONSOR (--tempo.sponsor-signature)` step ([run 32297723694](https://github.com/foundry-rs/foundry/actions/runs/32297723694/job/96212864658), [run 32281026643](https://github.com/foundry-rs/foundry/actions/runs/32281026643)). The logs of the earlier run show the root cause: `cast mktx --tempo.print-sponsor-hash` printed `0x6359e51f...` while `cast send` computed sponsor digest `0x2b7ba688...`. The sponsor digest commits to the full transaction, and both commands refill nonce, gas limit and fees from live chain state, so a basefee or gas-estimate change between the two invocations changes the digest and the pre-signed sponsor signature no longer recovers to the sponsor. This is a race in the check, not network flakiness: the two-command flow is only sound when the transaction fields are pinned. The check now resolves the nonce and a padded gas estimate once and passes `--nonce`, `--gas-limit`, `--gas-price` and `--priority-gas-price` to both commands, which also removes the estimate call from the send path. The gas limit is a padded estimate rather than a constant because a limit below actual usage makes the transaction run out of gas during Tempo AA validation and get dropped without a receipt.

Both failures were also invisible in the CI logs: with `--json`, cast reports errors as a JSON envelope on stdout, which `RECEIPT=$(cast send ...)` captured and discarded when `set -e` aborted the script. The send is now guarded and prints the captured output on failure, so the second run's still-unknown error will be diagnosable if it recurs.

Since the mismatch error is cryptic for anyone hitting this outside CI, it now explains that the signature must cover the exact transaction being sent and which flags to pin:

```
Tempo sponsor signature recovered 0xf4fA...82Cf, expected 0x7099...79C8; the signature must cover this exact transaction's sponsor digest — when signing a digest produced with `--tempo.print-sponsor-hash`, pin --nonce, --gas-limit, --gas-price and --priority-gas-price on both commands so the digest does not change in between
```

The pinned flow was verified against `anvil --network tempo`: the digest stays identical across both commands with blocks mined in between, the sponsored transaction mines with the sponsor as fee payer, and the drifted-digest case reproduces the CI failure and the new error message.


Two `casttest!` tests now cover the presigned sponsor flow against an in-process `anvil --network tempo` node: the pinned flow keeps the digest stable across a chain-state change and produces a receipt with the sponsor as fee payer, and a stale digest is rejected with the new error message.

Written with AI assistance (Claude Code).
