### PR TITLE
fix(fmt): preserve item separation in disabled regions

### DIFF
--- a/.changelog/fmt-trailing-disable-start-cursor.md
+++ b/.changelog/fmt-trailing-disable-start-cursor.md
@@ -1,0 +1,5 @@
+---
+forge-fmt: patch
+---
+
+Fixed `forge fmt` corrupting output when a `forgefmt: disable-start` comment trails an enabled item on the same line.

--- a/.changelog/forgefmt-preserve-disabled-item-separation.md
+++ b/.changelog/forgefmt-preserve-disabled-item-separation.md
@@ -1,0 +1,5 @@
+---
+forge-fmt: patch
+---
+
+Preserved source blank lines between items inside `forgefmt: disable-start`/`disable-end` regions instead of inserting the formatter's item separation.

--- a/.changelog/forgefmt-preserve-disabled-item-separation.md
+++ b/.changelog/forgefmt-preserve-disabled-item-separation.md
@@ -1,5 +1,6 @@
 ---
 forge-fmt: patch
+foundry-common: patch
 ---
 
-Preserved source blank lines between items inside `forgefmt: disable-start`/`disable-end` regions instead of inserting the formatter's item separation.
+Preserved source blank lines between items inside `forgefmt: disable-start`/`disable-end` regions instead of inserting the formatter's item separation; line-based directives such as `disable-line` keep the isolation break.

--- a/crates/common/src/comments/inline_config.rs
+++ b/crates/common/src/comments/inline_config.rs
@@ -15,6 +15,8 @@ struct DisabledRange<T = BytePos> {
     lo: T,
     /// End position, inclusive.
     hi: T,
+    /// Whether the range stems from a `disable-start`/`disable-end` block.
+    block: bool,
 }
 
 impl DisabledRange<BytePos> {
@@ -172,7 +174,7 @@ impl<I: ItemIdIterator> InlineConfig<I> {
         }
 
         for (id, (_, lo, hi)) in disabled_blocks {
-            cfg.disable(id, DisabledRange { lo, hi });
+            cfg.disable(id, DisabledRange { lo, hi, block: true });
         }
 
         cfg
@@ -211,7 +213,7 @@ impl<I: ItemIdIterator> InlineConfig<I> {
                 if let Some(next_item) = find_next_item(span.hi()) {
                     self.disable_many(
                         ids,
-                        DisabledRange { lo: next_item.lo(), hi: next_item.hi() },
+                        DisabledRange { lo: next_item.lo(), hi: next_item.hi(), block: false },
                     );
                 }
             }
@@ -225,6 +227,7 @@ impl<I: ItemIdIterator> InlineConfig<I> {
                     DisabledRange {
                         lo: file.absolute_position(RelativeBytePos::from_usize(start)),
                         hi: file.absolute_position(RelativeBytePos::from_usize(end)),
+                        block: false,
                     },
                 );
             }
@@ -240,6 +243,7 @@ impl<I: ItemIdIterator> InlineConfig<I> {
                                     comment_range.start,
                                 )),
                                 hi: file.absolute_position(RelativeBytePos::from_usize(end)),
+                                block: false,
                             },
                         );
                     }
@@ -266,7 +270,7 @@ impl<I: ItemIdIterator> InlineConfig<I> {
                             let lo = *lo;
                             let (id, _) = entry.remove_entry();
 
-                            self.disable(id, DisabledRange { lo, hi: span.hi() });
+                            self.disable(id, DisabledRange { lo, hi: span.hi(), block: true });
                         }
                     }
                 }
@@ -280,6 +284,15 @@ impl InlineConfig<()> {
     pub fn is_disabled(&self, span: Span) -> bool {
         if let Some(ranges) = self.disabled_ranges.get(&()) {
             return ranges.iter().any(|range| range.includes(span));
+        }
+        false
+    }
+
+    /// Checks if a span is disabled by a `disable-start`/`disable-end` block, as opposed to a
+    /// line-based directive such as `disable-line`.
+    pub fn is_disabled_block(&self, span: Span) -> bool {
+        if let Some(ranges) = self.disabled_ranges.get(&()) {
+            return ranges.iter().any(|range| range.block && range.includes(span));
         }
         false
     }
@@ -372,6 +385,7 @@ mod tests {
             DisabledRange::<BytePos> {
                 lo: BytePos::from_usize(self.lo),
                 hi: BytePos::from_usize(self.hi),
+                block: self.block,
             }
         }
 
@@ -385,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_disabled_range_includes() {
-        let strict = DisabledRange { lo: 10, hi: 20 };
+        let strict = DisabledRange { lo: 10, hi: 20, block: false };
         assert!(strict.includes(10..20));
         assert!(strict.includes(12..18));
         assert!(!strict.includes(5..15)); // Partial overlap fails

--- a/crates/fmt/src/pp/convenience.rs
+++ b/crates/fmt/src/pp/convenience.rs
@@ -81,6 +81,8 @@ impl Printer {
 
     pub fn is_beginning_of_line(&self) -> bool {
         match self.last_token() {
+            // Verbatim-printed source can end with a line break. Regular tokens never contain one.
+            Some(Token::String(s)) => s.ends_with('\n'),
             Some(last_token) => last_token.is_hardbreak(),
             None => self.out.is_empty() || self.out.ends_with('\n'),
         }
@@ -96,6 +98,12 @@ impl Printer {
             let token = &self.buf[i].token;
             if token.is_hardbreak() {
                 return true;
+            }
+            // Verbatim-printed source can contain line breaks; judge by its last line.
+            if let Token::String(s) = token
+                && let Some(pos) = s.rfind('\n')
+            {
+                return s[pos + 1..].trim().is_empty();
             }
             if Self::token_has_non_whitespace_content(token) {
                 return false;

--- a/crates/fmt/src/pp/mod.rs
+++ b/crates/fmt/src/pp/mod.rs
@@ -299,10 +299,15 @@ impl Printer {
 
     #[track_caller]
     pub(crate) fn offset(&mut self, offset: isize) {
+        // Verbatim-printed source can leave a string (or a flushed buffer) where a break is
+        // normally expected; there is no break to adjust in that case.
+        if self.buf.is_empty() {
+            return;
+        }
         match &mut self.buf.last_mut().token {
             Token::Break(token) => token.offset += offset,
-            Token::Begin(_) => {}
-            Token::String(_) | Token::End => unreachable!(),
+            Token::Begin(_) | Token::String(_) => {}
+            Token::End => unreachable!(),
         }
     }
 

--- a/crates/fmt/src/state/common.rs
+++ b/crates/fmt/src/state/common.rs
@@ -695,7 +695,7 @@ impl<'ast> State<'_, 'ast> {
             CommentConfig::skip_trailing_ws().mixed_no_break().mixed_prev_space(),
         );
         if !block_format.breaks() {
-            if !self.last_token_is_break() {
+            if !self.last_token_is_break() && !self.is_beginning_of_line() {
                 self.hardbreak();
             }
             self.s.offset(-self.ind);

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -163,13 +163,19 @@ struct SourcePos {
 }
 
 impl SourcePos {
+    /// While `enabled`, the position is a loose lower bound that is resynced by `advance_to`.
+    /// While disabled, it is the exact start of the not-yet-printed source of a disabled region.
     pub(super) fn advance(&mut self, bytes: u32) {
         self.pos += BytePos(bytes);
     }
 
     pub(super) fn advance_to(&mut self, pos: BytePos, enabled: bool) {
-        self.pos = std::cmp::max(pos, self.pos);
-        self.enabled = enabled;
+        // Ignore stale updates while disabled, as the exact position must be preserved until the
+        // remainder of the disabled region has been printed.
+        if self.enabled || pos >= self.pos {
+            self.pos = std::cmp::max(pos, self.pos);
+            self.enabled = enabled;
+        }
     }
 
     pub(super) fn next_line(&mut self, is_at_crlf: bool) {
@@ -189,15 +195,13 @@ pub(super) enum Separator {
 }
 
 impl Separator {
-    fn print(&self, p: &mut pp::Printer, cursor: &mut SourcePos, is_at_crlf: bool) {
+    fn print(&self, p: &mut pp::Printer) {
         match self {
             Self::Nbsp => p.nbsp(),
             Self::Space => p.space(),
             Self::Hardbreak => p.hardbreak(),
             Self::SpaceOrNbsp(breaks) => p.space_or_nbsp(*breaks),
         }
-
-        cursor.next_line(is_at_crlf);
     }
 }
 
@@ -252,6 +256,17 @@ impl<'sess> State<'sess, '_> {
     /// The check is only meaningful if `self.has_crlf` is true.
     fn is_at_crlf(&self) -> bool {
         self.has_crlf && self.char_at(self.cursor.pos) == Some('\r')
+    }
+
+    /// Advances the cursor past the line break assumed to be represented by a printed separator.
+    ///
+    /// While the cursor is disabled it marks the exact start of not-yet-printed source, so it may
+    /// only advance if it actually sits at a line break; otherwise the separator does not consume
+    /// any source (e.g. it was already printed verbatim by a disabled trailing comment).
+    fn cursor_next_line(&mut self) {
+        if self.cursor.enabled || matches!(self.char_at(self.cursor.pos), Some('\n' | '\r')) {
+            self.cursor.next_line(self.is_at_crlf());
+        }
     }
 
     /// Computes the space left, bounded by the max space left.
@@ -383,8 +398,8 @@ impl State<'_, '_> {
     }
 
     fn print_sep_unhandled(&mut self, sep: Separator) {
-        let is_at_crlf = self.is_at_crlf();
-        sep.print(&mut self.s, &mut self.cursor, is_at_crlf);
+        sep.print(&mut self.s);
+        self.cursor_next_line();
     }
 
     fn print_ident(&mut self, ident: &ast::Ident) {

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -169,7 +169,7 @@ impl<'ast> State<'_, 'ast> {
         self.print_comments(span.hi(), CommentConfig::default());
         self.print_trailing_comment(span.hi(), None);
         self.hardbreak_if_not_bol();
-        self.cursor.next_line(self.is_at_crlf());
+        self.cursor_next_line();
     }
 
     fn print_pragma(&mut self, pragma: &'ast ast::PragmaDirective<'ast>) {
@@ -416,7 +416,13 @@ impl<'ast> State<'_, 'ast> {
             {
                 self.print_sep(Separator::Hardbreak);
             }
-            self.s.offset(-self.ind);
+            // With disabled regions the body can end with verbatim source instead of a break.
+            if !self.is_beginning_of_line() {
+                self.print_sep(Separator::Hardbreak);
+            }
+            if self.last_token_is_break() {
+                self.s.offset(-self.ind);
+            }
             self.end();
             if self.config.contract_new_lines {
                 self.hardbreak_if_nonempty();
@@ -425,7 +431,9 @@ impl<'ast> State<'_, 'ast> {
             // restore block depth
             self.block_depth -= 1;
         }
-        self.print_word("}");
+        // The cursor is updated with the actual span; a disabled trailing comment of the last item
+        // may have already consumed source beyond the closing brace.
+        self.word("}");
 
         self.cursor.advance_to(span.hi(), true);
         self.contract = None;

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -88,13 +88,15 @@ impl<'ast> State<'_, 'ast> {
         if !item_needs_iso(&next_item.kind) {
             return;
         }
-        // Never isolate items within a disabled region, where the source layout is preserved
-        // verbatim. The cursor sits right past the line break that follows the previous item, so
-        // check the byte that was last copied from the source.
+        // Never isolate items within a `disable-start`/`disable-end` region, where the source
+        // layout is preserved verbatim. The cursor sits right past the line break that follows the
+        // previous item, so check the byte that was last copied from the source. Line-based
+        // directives such as `disable-line` only opt out of formatting that line's contents, so
+        // they keep the isolation break.
         if self.cursor.pos > BytePos(0)
             && self
                 .inline_config
-                .is_disabled(Span::new(self.cursor.pos - BytePos(1), self.cursor.pos))
+                .is_disabled_block(Span::new(self.cursor.pos - BytePos(1), self.cursor.pos))
         {
             return;
         }

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -88,6 +88,16 @@ impl<'ast> State<'_, 'ast> {
         if !item_needs_iso(&next_item.kind) {
             return;
         }
+        // Never isolate items within a disabled region, where the source layout is preserved
+        // verbatim. The cursor sits right past the line break that follows the previous item, so
+        // check the byte that was last copied from the source.
+        if self.cursor.pos > BytePos(0)
+            && self
+                .inline_config
+                .is_disabled(Span::new(self.cursor.pos - BytePos(1), self.cursor.pos))
+        {
+            return;
+        }
         let span = next_item.span;
 
         let cmnts = self

--- a/crates/fmt/testdata/InlineDisable/fmt.sol
+++ b/crates/fmt/testdata/InlineDisable/fmt.sol
@@ -522,3 +522,21 @@ contract DisabledMemberSeparation {
         number = 3;
     }
 }
+
+contract TrailingDisableStart {
+    uint256 x;
+} // forgefmt: disable-start
+contract  DisabledSuffix {}
+// forgefmt: disable-end
+
+contract InlineTrailingDisableStart {
+    uint256 y; // forgefmt: disable-start
+}
+contract  DisabledSuffix2 {}
+// forgefmt: disable-end
+
+struct StructTrailingDisableStart {
+    uint256 a; // forgefmt: disable-start
+}
+contract  DisabledSuffix3 {}
+// forgefmt: disable-end

--- a/crates/fmt/testdata/InlineDisable/fmt.sol
+++ b/crates/fmt/testdata/InlineDisable/fmt.sol
@@ -502,3 +502,23 @@ function setNumber(uint256 newNumber, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdf
     number = newNumber;
     number1 =   newNumber1; // forgefmt: disable-line
 }
+
+// forgefmt: disable-start
+contract  DisabledItemA {}
+contract  DisabledItemB {}
+
+contract  DisabledItemC {}
+// forgefmt: disable-end
+contract EnabledAfterDisabled {
+    uint256 number;
+}
+
+contract DisabledMemberSeparation {
+    // forgefmt: disable-start
+    function  first() public { number  = 1; }
+    function  second() public { number  = 2; }
+    // forgefmt: disable-end
+    function third() public {
+        number = 3;
+    }
+}

--- a/crates/fmt/testdata/InlineDisable/fmt.sol
+++ b/crates/fmt/testdata/InlineDisable/fmt.sol
@@ -540,3 +540,7 @@ struct StructTrailingDisableStart {
 }
 contract  DisabledSuffix3 {}
 // forgefmt: disable-end
+
+contract IsolationBefore {}
+
+contract  IsolationDisabledLine {} // forgefmt: disable-line

--- a/crates/fmt/testdata/InlineDisable/original.sol
+++ b/crates/fmt/testdata/InlineDisable/original.sol
@@ -514,3 +514,6 @@ contract  DisabledSuffix2 {}
 struct StructTrailingDisableStart { uint256  a; } // forgefmt: disable-start
 contract  DisabledSuffix3 {}
 // forgefmt: disable-end
+
+contract IsolationBefore {}
+contract  IsolationDisabledLine {} // forgefmt: disable-line

--- a/crates/fmt/testdata/InlineDisable/original.sol
+++ b/crates/fmt/testdata/InlineDisable/original.sol
@@ -484,3 +484,19 @@ function setNumber(uint256 newNumber, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdf
     number = newNumber;
     number1 =   newNumber1; // forgefmt: disable-line
 }
+
+// forgefmt: disable-start
+contract  DisabledItemA {}
+contract  DisabledItemB {}
+
+contract  DisabledItemC {}
+// forgefmt: disable-end
+contract EnabledAfterDisabled { uint256  number; }
+
+contract DisabledMemberSeparation {
+    // forgefmt: disable-start
+    function  first() public { number  = 1; }
+    function  second() public { number  = 2; }
+    // forgefmt: disable-end
+    function  third() public { number  = 3; }
+}

--- a/crates/fmt/testdata/InlineDisable/original.sol
+++ b/crates/fmt/testdata/InlineDisable/original.sol
@@ -500,3 +500,17 @@ contract DisabledMemberSeparation {
     // forgefmt: disable-end
     function  third() public { number  = 3; }
 }
+
+contract TrailingDisableStart {
+    uint256   x;
+} // forgefmt: disable-start
+contract  DisabledSuffix {}
+// forgefmt: disable-end
+
+contract InlineTrailingDisableStart { uint256   y; } // forgefmt: disable-start
+contract  DisabledSuffix2 {}
+// forgefmt: disable-end
+
+struct StructTrailingDisableStart { uint256  a; } // forgefmt: disable-start
+contract  DisabledSuffix3 {}
+// forgefmt: disable-end


### PR DESCRIPTION
`forge fmt` did not preserve the source layout between items inside a `// forgefmt: disable-start` / `disable-end` region. Formatting

```solidity
// forgefmt: disable-start
contract  A {}
contract  B {}
// forgefmt: disable-end
```

inserted a blank line between the two contracts and another before the `disable-end` comment, even though the region opts out of formatting. Contract members in a disabled region were affected as well, where the `disable-end` comment additionally ended up over-indented because the printer emitted its own indentation on top of the verbatim source indent.

The item isolation policy in `separate_items` emitted a hardbreak without consulting the inline config, while the disabled-span machinery already copies inter-item whitespace verbatim from the source cursor. `separate_items` now returns early when the byte last copied from the source (the line break following the previous item) lies in a disabled region, so the source layout wins there. Boundary behavior is unchanged: an enabled item directly followed by a `disable-start` comment still gets its isolating blank line, since that gap precedes the disabled range.

The existing `InlineDisable` testdata only exercised item kinds that never receive isolation breaks (empty-body functions, errors, events), which is why this went unnoticed; the new cases cover contracts at the top level and members within a contract body.

This PR was written by Claude Code (Fable 5).
