### PR TITLE
fix(fmt): handle trailing disable-start comments

### DIFF
--- a/.changelog/fmt-trailing-disable-start-cursor.md
+++ b/.changelog/fmt-trailing-disable-start-cursor.md
@@ -1,0 +1,5 @@
+---
+forge-fmt: patch
+---
+
+Fixed `forge fmt` corrupting output when a `forgefmt: disable-start` comment trails an enabled item on the same line.

--- a/crates/fmt/src/pp/convenience.rs
+++ b/crates/fmt/src/pp/convenience.rs
@@ -81,6 +81,8 @@ impl Printer {
 
     pub fn is_beginning_of_line(&self) -> bool {
         match self.last_token() {
+            // Verbatim-printed source can end with a line break. Regular tokens never contain one.
+            Some(Token::String(s)) => s.ends_with('\n'),
             Some(last_token) => last_token.is_hardbreak(),
             None => self.out.is_empty() || self.out.ends_with('\n'),
         }
@@ -96,6 +98,12 @@ impl Printer {
             let token = &self.buf[i].token;
             if token.is_hardbreak() {
                 return true;
+            }
+            // Verbatim-printed source can contain line breaks; judge by its last line.
+            if let Token::String(s) = token
+                && let Some(pos) = s.rfind('\n')
+            {
+                return s[pos + 1..].trim().is_empty();
             }
             if Self::token_has_non_whitespace_content(token) {
                 return false;

--- a/crates/fmt/src/pp/mod.rs
+++ b/crates/fmt/src/pp/mod.rs
@@ -299,10 +299,15 @@ impl Printer {
 
     #[track_caller]
     pub(crate) fn offset(&mut self, offset: isize) {
+        // Verbatim-printed source can leave a string (or a flushed buffer) where a break is
+        // normally expected; there is no break to adjust in that case.
+        if self.buf.is_empty() {
+            return;
+        }
         match &mut self.buf.last_mut().token {
             Token::Break(token) => token.offset += offset,
-            Token::Begin(_) => {}
-            Token::String(_) | Token::End => unreachable!(),
+            Token::Begin(_) | Token::String(_) => {}
+            Token::End => unreachable!(),
         }
     }
 

--- a/crates/fmt/src/state/common.rs
+++ b/crates/fmt/src/state/common.rs
@@ -695,7 +695,7 @@ impl<'ast> State<'_, 'ast> {
             CommentConfig::skip_trailing_ws().mixed_no_break().mixed_prev_space(),
         );
         if !block_format.breaks() {
-            if !self.last_token_is_break() {
+            if !self.last_token_is_break() && !self.is_beginning_of_line() {
                 self.hardbreak();
             }
             self.s.offset(-self.ind);

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -163,13 +163,19 @@ struct SourcePos {
 }
 
 impl SourcePos {
+    /// While `enabled`, the position is a loose lower bound that is resynced by `advance_to`.
+    /// While disabled, it is the exact start of the not-yet-printed source of a disabled region.
     pub(super) fn advance(&mut self, bytes: u32) {
         self.pos += BytePos(bytes);
     }
 
     pub(super) fn advance_to(&mut self, pos: BytePos, enabled: bool) {
-        self.pos = std::cmp::max(pos, self.pos);
-        self.enabled = enabled;
+        // Ignore stale updates while disabled, as the exact position must be preserved until the
+        // remainder of the disabled region has been printed.
+        if self.enabled || pos >= self.pos {
+            self.pos = std::cmp::max(pos, self.pos);
+            self.enabled = enabled;
+        }
     }
 
     pub(super) fn next_line(&mut self, is_at_crlf: bool) {
@@ -189,15 +195,13 @@ pub(super) enum Separator {
 }
 
 impl Separator {
-    fn print(&self, p: &mut pp::Printer, cursor: &mut SourcePos, is_at_crlf: bool) {
+    fn print(&self, p: &mut pp::Printer) {
         match self {
             Self::Nbsp => p.nbsp(),
             Self::Space => p.space(),
             Self::Hardbreak => p.hardbreak(),
             Self::SpaceOrNbsp(breaks) => p.space_or_nbsp(*breaks),
         }
-
-        cursor.next_line(is_at_crlf);
     }
 }
 
@@ -252,6 +256,17 @@ impl<'sess> State<'sess, '_> {
     /// The check is only meaningful if `self.has_crlf` is true.
     fn is_at_crlf(&self) -> bool {
         self.has_crlf && self.char_at(self.cursor.pos) == Some('\r')
+    }
+
+    /// Advances the cursor past the line break assumed to be represented by a printed separator.
+    ///
+    /// While the cursor is disabled it marks the exact start of not-yet-printed source, so it may
+    /// only advance if it actually sits at a line break; otherwise the separator does not consume
+    /// any source (e.g. it was already printed verbatim by a disabled trailing comment).
+    fn cursor_next_line(&mut self) {
+        if self.cursor.enabled || matches!(self.char_at(self.cursor.pos), Some('\n' | '\r')) {
+            self.cursor.next_line(self.is_at_crlf());
+        }
     }
 
     /// Computes the space left, bounded by the max space left.
@@ -383,8 +398,8 @@ impl State<'_, '_> {
     }
 
     fn print_sep_unhandled(&mut self, sep: Separator) {
-        let is_at_crlf = self.is_at_crlf();
-        sep.print(&mut self.s, &mut self.cursor, is_at_crlf);
+        sep.print(&mut self.s);
+        self.cursor_next_line();
     }
 
     fn print_ident(&mut self, ident: &ast::Ident) {

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -169,7 +169,7 @@ impl<'ast> State<'_, 'ast> {
         self.print_comments(span.hi(), CommentConfig::default());
         self.print_trailing_comment(span.hi(), None);
         self.hardbreak_if_not_bol();
-        self.cursor.next_line(self.is_at_crlf());
+        self.cursor_next_line();
     }
 
     fn print_pragma(&mut self, pragma: &'ast ast::PragmaDirective<'ast>) {
@@ -416,7 +416,13 @@ impl<'ast> State<'_, 'ast> {
             {
                 self.print_sep(Separator::Hardbreak);
             }
-            self.s.offset(-self.ind);
+            // With disabled regions the body can end with verbatim source instead of a break.
+            if !self.is_beginning_of_line() {
+                self.print_sep(Separator::Hardbreak);
+            }
+            if self.last_token_is_break() {
+                self.s.offset(-self.ind);
+            }
             self.end();
             if self.config.contract_new_lines {
                 self.hardbreak_if_nonempty();
@@ -425,7 +431,9 @@ impl<'ast> State<'_, 'ast> {
             // restore block depth
             self.block_depth -= 1;
         }
-        self.print_word("}");
+        // The cursor is updated with the actual span; a disabled trailing comment of the last item
+        // may have already consumed source beyond the closing brace.
+        self.word("}");
 
         self.cursor.advance_to(span.hi(), true);
         self.contract = None;

--- a/crates/fmt/testdata/InlineDisable/fmt.sol
+++ b/crates/fmt/testdata/InlineDisable/fmt.sol
@@ -522,3 +522,21 @@ contract DisabledMemberSeparation {
         number = 3;
     }
 }
+
+contract TrailingDisableStart {
+    uint256 x;
+} // forgefmt: disable-start
+contract  DisabledSuffix {}
+// forgefmt: disable-end
+
+contract InlineTrailingDisableStart {
+    uint256 y; // forgefmt: disable-start
+}
+contract  DisabledSuffix2 {}
+// forgefmt: disable-end
+
+struct StructTrailingDisableStart {
+    uint256 a; // forgefmt: disable-start
+}
+contract  DisabledSuffix3 {}
+// forgefmt: disable-end

--- a/crates/fmt/testdata/InlineDisable/original.sol
+++ b/crates/fmt/testdata/InlineDisable/original.sol
@@ -500,3 +500,17 @@ contract DisabledMemberSeparation {
     // forgefmt: disable-end
     function  third() public { number  = 3; }
 }
+
+contract TrailingDisableStart {
+    uint256   x;
+} // forgefmt: disable-start
+contract  DisabledSuffix {}
+// forgefmt: disable-end
+
+contract InlineTrailingDisableStart { uint256   y; } // forgefmt: disable-start
+contract  DisabledSuffix2 {}
+// forgefmt: disable-end
+
+struct StructTrailingDisableStart { uint256  a; } // forgefmt: disable-start
+contract  DisabledSuffix3 {}
+// forgefmt: disable-end


### PR DESCRIPTION
`forge fmt` corrupted output when a `forgefmt: disable-start` comment trailed an enabled item on the same line. Formatting

```solidity
contract X { uint  x; } // forgefmt: disable-start
contract  Y {}
// forgefmt: disable-end
```

dropped the first bytes of the disabled region (`tract  Y {}`), and the struct variant of the same layout panicked in `Printer::offset`.

The trailing comment is printed before the enclosing item finishes, so the verbatim machinery consumes source (the comment and its line break) ahead of the printer. The source cursor then kept advancing for output that consumed no source: the item epilogue emitted a hardbreak plus `next_line` for a line break that had already been copied verbatim, the contract's closing brace advanced it past a byte that lies behind it, and `print_contract` re-marked the mid-region cursor as enabled through a stale `advance_to`. Once the cursor overshot, the next disabled span was printed from the wrong offset.

While the cursor is disabled it now marks the exact start of not-yet-printed source: `advance_to` ignores stale updates, and separators only advance it past a line break it actually sits on. The printer additionally treats verbatim strings ending in a newline as beginning-of-line, which stops spurious breaks after disabled trailing comments, and `Printer::offset` no longer panics when verbatim output leaves a string where a break is normally expected.

Based on #16274 because both change how disabled regions interact with item separation and extend the same `InlineDisable` fixtures; with both applied, the isolation guard from that PR also preserves the source layout between the trailing comment's line and the following disabled item.

This PR was written by Claude Code (Fable 5).
