### PR TITLE
feat(anvil): add built-in Tempo fee payer

### DIFF
--- a/.changelog/anvil-tempo-builtin-fee-payer.md
+++ b/.changelog/anvil-tempo-builtin-fee-payer.md
@@ -1,0 +1,5 @@
+---
+anvil: minor
+---
+
+Added a built-in Tempo fee payer to `anvil --network tempo`. `eth_signRawTransaction` sponsor-signs sender-signed Tempo AA transactions, and raw transactions carrying the sponsorship placeholder are sponsored automatically on submission, so `cast send --sponsor-url` and the Tempo SDK relay transport can point directly at anvil. The sponsor account defaults to the last dev account and is configurable via `--tempo.fee-payer`.

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -209,6 +209,10 @@ pub enum EthRequest {
     #[serde(rename = "eth_sendRawTransactionConditional")]
     EthSendRawTransactionConditional(Bytes, TransactionConditional),
 
+    /// Signs a raw Tempo transaction as the node's fee payer (sponsor) without broadcasting it.
+    #[serde(rename = "eth_signRawTransaction", with = "sequence")]
+    EthSignRawTransaction(Bytes),
+
     #[serde(rename = "anvil_classifyTransaction", with = "sequence")]
     AnvilClassifyTransaction(Bytes),
 

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -84,6 +84,14 @@ pub struct NodeArgs {
     #[arg(long)]
     pub derivation_path: Option<String>,
 
+    /// The account used to sponsor Tempo fee-payer requests (`eth_signRawTransaction` and raw
+    /// transactions carrying the sponsorship placeholder).
+    ///
+    /// Must be an unlocked account. Only used on Tempo networks; defaults to the last dev
+    /// account.
+    #[arg(long = "tempo.fee-payer", value_name = "ADDRESS")]
+    pub tempo_fee_payer: Option<Address>,
+
     /// The EVM hardfork to use.
     ///
     /// Choose the hardfork by name, e.g. `prague`, `cancun`, `shanghai`, `paris`, `london`, etc...
@@ -336,6 +344,7 @@ impl NodeArgs {
             // Restore the source-derived or explicitly selected network after applying the
             // execution chain ID. Fork source discovery can refine an unresolved network later.
             .with_networks(networks)
+            .with_tempo_fee_payer(self.tempo_fee_payer)
             .with_disable_default_create2_deployer(self.evm.disable_default_create2_deployer)
             .with_disable_pool_balance_checks(self.evm.disable_pool_balance_checks)
             .with_slots_in_an_epoch(self.slots_in_an_epoch)

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -271,6 +271,10 @@ pub struct NodeConfig {
     pub precompile_factory: Option<Arc<dyn PrecompileFactory>>,
     /// Networks to enable features for.
     pub networks: NetworkConfigs,
+    /// The account used to sponsor Tempo fee-payer requests.
+    ///
+    /// Must be an unlocked signer account. Defaults to the last dev account on Tempo networks.
+    pub tempo_fee_payer: Option<Address>,
     /// Do not print log messages.
     pub silent: bool,
     /// The path where persisted states are cached (used with `max_persisted_states`).
@@ -326,6 +330,18 @@ Derivation path:   {}
 "#,
                 generator.phrase,
                 generator.get_derivation_path()
+            );
+        }
+
+        if let Some(fee_payer) = self.tempo_fee_payer_address() {
+            let _ = write!(
+                s,
+                r#"
+
+Tempo Fee Payer
+==================
+{fee_payer}
+"#
             );
         }
 
@@ -598,6 +614,7 @@ impl Default for NodeConfig {
             memory_limit: None,
             precompile_factory: None,
             networks: Default::default(),
+            tempo_fee_payer: None,
             silent: false,
             cache_path: None,
             funded_accounts: HashMap::default(),
@@ -1234,6 +1251,25 @@ impl NodeConfig {
         self.inferred_fork_network = None;
         self.chain_id_network_base = None;
         self
+    }
+
+    /// Sets the account used to sponsor Tempo fee-payer requests.
+    #[must_use]
+    pub const fn with_tempo_fee_payer(mut self, fee_payer: Option<Address>) -> Self {
+        self.tempo_fee_payer = fee_payer;
+        self
+    }
+
+    /// Returns the effective account used to sponsor Tempo fee-payer requests.
+    ///
+    /// Defaults to the last dev account so it rarely collides with the sender accounts commonly
+    /// used in tests, mirroring the dedicated sponsor account of hosted fee payer services.
+    /// Returns `None` on non-Tempo networks.
+    pub fn tempo_fee_payer_address(&self) -> Option<Address> {
+        if !self.networks.is_tempo() {
+            return None;
+        }
+        self.tempo_fee_payer.or_else(|| self.genesis_accounts.last().map(|wallet| wallet.address()))
     }
 
     /// Enable Monad network features.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 use alloy_consensus::{
     Blob, BlockHeader, Transaction, TrieAccount, TxEip4844Variant, TxReceipt,
-    transaction::Recovered,
+    transaction::{Recovered, SignerRecoverable},
 };
 use alloy_dyn_abi::TypedData;
 use alloy_eips::{
@@ -56,6 +56,7 @@ use alloy_primitives::{
     Address, B64, B256, Bytes, TxHash, TxKind, U64, U256,
     map::{HashMap, HashSet},
 };
+use alloy_rlp::{Encodable, Header, PayloadView};
 use alloy_rpc_types::{
     AccessListResult, BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions,
     EIP1186AccountProofResponse, FeeHistory, Filter, FilteredParams, Index, Log, Work,
@@ -126,6 +127,7 @@ use revm::{
 };
 use std::{sync::Arc, time::Duration};
 use tempo_hardfork::TempoHardfork;
+use tempo_primitives::{AASigned, TEMPO_TX_TYPE_ID, transaction::FEE_PAYER_SIGNATURE_MARKER};
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver, unbounded_channel},
     try_join,
@@ -2031,6 +2033,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::EthSendRawTransactionConditional(tx, condition) => {
                 self.send_raw_transaction_conditional(tx, condition).await.to_rpc_result()
             }
+            EthRequest::EthSignRawTransaction(tx) => {
+                self.sign_raw_transaction(tx).await.to_rpc_result()
+            }
             EthRequest::AnvilClassifyTransaction(tx) => {
                 self.anvil_classify_transaction(tx).to_rpc_result()
             }
@@ -2926,18 +2931,38 @@ impl EthApi<FoundryNetwork> {
     /// Handler for ETH RPC call: `eth_sendRawTransaction`
     pub async fn send_raw_transaction(&self, tx: Bytes) -> Result<TxHash> {
         node_info!("eth_sendRawTransaction");
-        let mut data = tx.as_ref();
-        if data.is_empty() {
+        if tx.is_empty() {
             return Err(BlockchainError::EmptyRawTransactionData);
         }
 
+        // Built-in Tempo fee payer: raw transactions submitted in the fee payer service encoding
+        // or carrying the sponsorship placeholder ask the node to sponsor them before submission
+        // (the sign-and-relay mode of the fee payer service contract).
+        let service_encoded = if self.backend.is_tempo() {
+            normalize_fee_payer_service_encoding(tx.as_ref())
+        } else {
+            None
+        };
+        let raw = service_encoded.as_deref().unwrap_or(tx.as_ref());
+
+        let mut data = raw;
         let transaction = FoundryTxEnvelope::decode_2718(&mut data)
             .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?;
 
         self.ensure_typed_transaction_supported(&transaction)?;
 
+        let transaction = match transaction {
+            FoundryTxEnvelope::Tempo(aa_tx)
+                if self.backend.is_tempo()
+                    && aa_tx.tx().fee_payer_signature == Some(FEE_PAYER_SIGNATURE_MARKER) =>
+            {
+                FoundryTxEnvelope::Tempo(self.sponsor_sign_tempo_transaction(aa_tx).await?)
+            }
+            transaction => transaction,
+        };
+
         if self.backend.is_tempo() && TempoHardfork::from(self.backend.hardfork()).is_t5() {
-            let classification = classify_payment_lane(tx.as_ref());
+            let classification = classify_payment_lane(raw);
             trace!(target: "node", tx = ?transaction.hash(), ?classification, "classified transaction lane");
         }
 
@@ -3020,6 +3045,98 @@ impl EthApi<FoundryNetwork> {
         let receipt = self.check_transaction_inclusion(hash, timeout_ms).await?;
 
         Ok(receipt)
+    }
+
+    /// Signs a raw Tempo transaction as the node's fee payer (sponsor) and returns the fully
+    /// signed raw transaction without broadcasting it.
+    ///
+    /// This is the sign-only mode of the Tempo fee payer service contract, so
+    /// `cast send --sponsor-url` and the tempo SDK relay transport can point directly at this
+    /// node. Only available on Tempo networks.
+    ///
+    /// Handler for ETH RPC call: `eth_signRawTransaction`
+    pub async fn sign_raw_transaction(&self, tx: Bytes) -> Result<Bytes> {
+        node_info!("eth_signRawTransaction");
+        if !self.backend.is_tempo() {
+            return Err(BlockchainError::RpcUnimplemented);
+        }
+
+        if tx.is_empty() {
+            return Err(BlockchainError::EmptyRawTransactionData);
+        }
+
+        // Fee payer service clients submit the request in the service encoding, which carries a
+        // `0x00` placeholder in the fee payer signature field.
+        let service_encoded = normalize_fee_payer_service_encoding(tx.as_ref());
+        let mut data = service_encoded.as_deref().unwrap_or(tx.as_ref());
+
+        let transaction = FoundryTxEnvelope::decode_2718(&mut data)
+            .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?;
+
+        let FoundryTxEnvelope::Tempo(aa_tx) = transaction else {
+            return Err(RpcError::invalid_params(
+                "only Tempo (0x76) transactions can be fee-payer signed",
+            )
+            .into());
+        };
+
+        let signed = self.sponsor_sign_tempo_transaction(aa_tx).await?;
+        Ok(FoundryTxEnvelope::Tempo(signed).encoded_2718().into())
+    }
+
+    /// Fills the sponsor-owned fields of a sender-signed Tempo AA transaction.
+    ///
+    /// Mirrors the hosted Tempo fee payer service: the node's fee payer account selects the fee
+    /// token when the sender left it open and signs the fee payer digest. Only the fee token and
+    /// fee payer signature are touched, so the sender signature stays valid.
+    async fn sponsor_sign_tempo_transaction(&self, tx: AASigned) -> Result<AASigned> {
+        // The sender must have signed in the sponsored state (fee payer placeholder set): the
+        // sender signature commits to whether a fee payer is present, so sponsoring a
+        // transaction signed without the placeholder would invalidate it.
+        match tx.tx().fee_payer_signature {
+            Some(FEE_PAYER_SIGNATURE_MARKER) => {}
+            Some(_) => {
+                return Err(
+                    RpcError::invalid_params("transaction is already fee-payer signed").into()
+                );
+            }
+            None => {
+                return Err(RpcError::invalid_params(
+                    "transaction does not request sponsorship; sign it with the fee payer \
+                     signature placeholder",
+                )
+                .into());
+            }
+        }
+
+        let sender = tx.recover_signer().map_err(|_| {
+            BlockchainError::RpcError(RpcError::invalid_params(
+                "transaction must be signed by the sender before fee-payer signing",
+            ))
+        })?;
+
+        let Some(sponsor) = self.backend.tempo_fee_payer().await else {
+            return Err(RpcError::invalid_params("no Tempo fee payer account available").into());
+        };
+        if sponsor == sender {
+            return Err(RpcError::invalid_params(format!(
+                "Tempo fee payer {sponsor} must not equal the transaction sender"
+            ))
+            .into());
+        }
+        let signer = self.get_signer(sponsor).ok_or(BlockchainError::NoSignerAvailable)?;
+
+        let (mut tx, sender_signature, _) = tx.into_parts();
+        // The fee payer digest commits to the fee token, so it must be resolved first. The
+        // service encoding omits the sender's fee token preference, letting the sponsor pick the
+        // token it pays with.
+        if tx.fee_token.is_none() {
+            tx.fee_token = Some(self.backend.tempo_user_fee_token(sponsor).await?);
+        }
+        let digest = tx.fee_payer_signature_hash(sender);
+        tx.fee_payer_signature = Some(signer.sign_hash(sponsor, digest).await?);
+
+        Ok(tx.into_signed(sender_signature))
     }
 
     /// Call contract, returning the output data.
@@ -4914,6 +5031,53 @@ fn nonce_markers(
     tempo_parallel_nonce_markers(pending_transaction).unwrap_or_else(|| {
         (required_marker(nonce, on_chain_nonce, from), vec![to_marker(nonce, from)])
     })
+}
+
+/// Rewrites the Tempo fee payer service encoding of a raw transaction into the standard envelope
+/// encoding.
+///
+/// Fee payer service clients submit sponsorship requests with a `0x00` placeholder in the fee
+/// payer signature field (and the fee token left empty for the sponsor to fill), which the
+/// standard envelope decoder rejects. The placeholder is rewritten to the standard encoding of
+/// [`FEE_PAYER_SIGNATURE_MARKER`], preserving the sponsored signing state the sender committed
+/// to. Returns the normalized raw transaction when the input carries the placeholder and `None`
+/// for any other encoding.
+fn normalize_fee_payer_service_encoding(raw: &[u8]) -> Option<Vec<u8>> {
+    let (tx_type, mut encoded_fields) = raw.split_first()?;
+    if *tx_type != TEMPO_TX_TYPE_ID {
+        return None;
+    }
+    let PayloadView::List(fields) = Header::decode_raw(&mut encoded_fields).ok()? else {
+        return None;
+    };
+    if !encoded_fields.is_empty() {
+        return None;
+    }
+    // The fee payer signature is the twelfth field of a Tempo AA transaction.
+    if fields.get(11).is_none_or(|field| *field != [0x00]) {
+        return None;
+    }
+
+    // The standard encoding of the marker signature, mirroring the fee payer signature closure of
+    // `TempoTransaction::rlp_encode_fields_default`.
+    let marker = FEE_PAYER_SIGNATURE_MARKER;
+    let mut marker_field = Vec::new();
+    Header { list: true, payload_length: marker.rlp_rs_len() + marker.v().length() }
+        .encode(&mut marker_field);
+    marker.write_rlp_vrs(&mut marker_field, marker.v());
+
+    let mut payload = Vec::new();
+    for (index, field) in fields.into_iter().enumerate() {
+        if index == 11 {
+            payload.extend_from_slice(&marker_field);
+        } else {
+            payload.extend_from_slice(field);
+        }
+    }
+    let mut normalized = vec![TEMPO_TX_TYPE_ID];
+    Header { list: true, payload_length: payload.len() }.encode(&mut normalized);
+    normalized.extend_from_slice(&payload);
+    Some(normalized)
 }
 
 fn txpool_transaction_key(pending_transaction: &PendingTransaction<FoundryTxEnvelope>) -> String {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -121,6 +121,7 @@ use alloy_rpc_types::{
 use alloy_rpc_types_eth::{AccountInfo as RpcAccountInfo, Bundle, EthCallResponse};
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use alloy_serde::{OtherFields, WithOtherFields};
+use alloy_sol_types::SolCall;
 use alloy_trie::{HashBuilder, Nibbles, proof::ProofRetainer};
 use anvil_core::eth::{
     block::{Block, BlockInfo, canonical_block, create_block},
@@ -6189,6 +6190,46 @@ where
             Some(Output::Call(data)) if data.len() >= 32 => Ok(U256::from_be_slice(&data[..32])),
             _ => Ok(U256::ZERO),
         }
+    }
+
+    /// Returns the account used to sponsor Tempo fee-payer requests handled by this node.
+    ///
+    /// Returns `None` on non-Tempo networks.
+    pub async fn tempo_fee_payer(&self) -> Option<Address> {
+        if !self.is_tempo() {
+            return None;
+        }
+        self.node_config.read().await.tempo_fee_payer_address()
+    }
+
+    /// Returns the fee token an account pays with, as stored in the Tempo fee manager.
+    ///
+    /// Falls back to PathUSD when the account has no stored preference or the lookup fails.
+    pub async fn tempo_user_fee_token(&self, account: Address) -> Result<Address, BlockchainError> {
+        let calldata = IFeeManager::userTokensCall { user: account }.abi_encode();
+
+        let request = WithOtherFields::new(TransactionRequest {
+            from: Some(Address::ZERO),
+            to: Some(TxKind::Call(TIP_FEE_MANAGER_ADDRESS)),
+            input: calldata.into(),
+            ..Default::default()
+        });
+
+        let (exit, out, _, _) =
+            self.call(request, FeeDetails::zero(), None, Default::default()).await?;
+
+        let token = if exit == InstructionResult::Return
+            && let Some(Output::Call(data)) = out
+        {
+            IFeeManager::userTokensCall::abi_decode_returns(&data).unwrap_or(Address::ZERO)
+        } else {
+            Address::ZERO
+        };
+
+        if token.is_zero() {
+            return Ok(foundry_evm::core::tempo::PATH_USD_ADDRESS);
+        }
+        Ok(token)
     }
 
     /// Executes the [TransactionRequest] without writing to the DB

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -18,11 +18,11 @@ use std::{
 #[cfg(feature = "cli")]
 use crate::utils::http_provider;
 use alloy_consensus::{
-    BlockHeader, Eip658Value, Receipt, Sealable, Typed2718,
+    BlockHeader, Eip658Value, Receipt, Sealable, TxEip1559, Typed2718,
     proofs::{calculate_receipt_root, calculate_transaction_root},
-    transaction::SignerRecoverable,
+    transaction::{SignableTransaction, SignerRecoverable},
 };
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_genesis::Genesis;
 use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
 use alloy_primitives::{
@@ -67,7 +67,8 @@ use tempo_precompiles::{
 use tempo_primitives::{
     AASigned, TempoHeader, TempoSignature, TempoTransaction,
     transaction::{
-        Call, KeyAuthorization, KeychainSignature, PrimitiveSignature, SignatureType, TokenLimit,
+        Call, FEE_PAYER_SIGNATURE_MARKER, KeyAuthorization, KeychainSignature, PrimitiveSignature,
+        SignatureType, TokenLimit,
     },
 };
 
@@ -2361,6 +2362,298 @@ async fn test_tempo_send_transaction_preserves_signed_identity() {
     assert_eq!(transaction.recover_signer().unwrap(), from);
     assert_eq!(transaction.tx().fee_payer_signature, Some(fee_payer_signature));
     assert_eq!(transaction.tx().recover_fee_payer(from).unwrap(), fee_payer);
+}
+
+/// Builds a sender-signed Tempo AA PathUSD transfer that requests sponsorship through the fee
+/// payer signature marker.
+async fn sponsorship_requested_transfer(
+    chain_id: u64,
+    gas_price: u128,
+    sender_index: u32,
+    recipient: Address,
+    amount: U256,
+    fee_token: Option<Address>,
+    nonce: u64,
+) -> AASigned {
+    let tempo_tx = TempoTransaction {
+        chain_id,
+        fee_token,
+        max_priority_fee_per_gas: gas_price / 10,
+        max_fee_per_gas: gas_price * 2,
+        gas_limit: TIP20_TRANSFER_GAS,
+        calls: vec![tempo_transfer(recipient, amount)],
+        access_list: Default::default(),
+        nonce_key: U256::ZERO,
+        nonce,
+        fee_payer_signature: Some(FEE_PAYER_SIGNATURE_MARKER),
+        valid_before: None,
+        valid_after: None,
+        key_authorization: None,
+        tempo_authorization_list: vec![],
+    };
+    let signature = dev_key(sender_index).sign_hash(&tempo_tx.signature_hash()).await.unwrap();
+    AASigned::new_unhashed(
+        tempo_tx,
+        TempoSignature::Primitive(PrimitiveSignature::Secp256k1(signature)),
+    )
+}
+
+/// Encodes a Tempo AA transaction the way fee payer service clients submit it: the fee payer
+/// signature field carries the `0x00` placeholder and the fee token is omitted.
+fn fee_payer_service_encoded(tx: &AASigned) -> Bytes {
+    let mut buf = Vec::new();
+    tx.encode_for_fee_payer_service(&mut buf);
+    buf.into()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_sign_raw_transaction_sponsors_transaction() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let sender = accounts[0];
+    let sponsor = *accounts.last().unwrap();
+    let recipient = Address::random();
+    let amount = U256::from(100_000);
+
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+    let unsigned =
+        sponsorship_requested_transfer(chain_id, gas_price, 0, recipient, amount, None, 0).await;
+
+    let signed_raw = provider
+        .raw_request::<_, Bytes>(
+            "eth_signRawTransaction".into(),
+            (fee_payer_service_encoded(&unsigned),),
+        )
+        .await
+        .unwrap();
+
+    let TempoTxEnvelope::AA(signed) =
+        TempoTxEnvelope::decode_2718(&mut signed_raw.as_ref()).unwrap()
+    else {
+        panic!("expected a Tempo AA transaction");
+    };
+    assert_eq!(signed.signature(), unsigned.signature(), "sender signature must be preserved");
+    assert_eq!(signed.tx().calls, unsigned.tx().calls);
+    assert_eq!(signed.tx().fee_token, Some(PATH_USD), "sponsor pays with its stored fee token");
+    assert_eq!(signed.recover_signer().unwrap(), sender);
+    assert_eq!(signed.tx().recover_fee_payer(sender).unwrap(), sponsor);
+
+    // The returned transaction is fully signed and broadcasts through the regular path.
+    let token = IERC20::new(PATH_USD, &provider);
+    let sender_before = token.balanceOf(sender).call().await.unwrap();
+    let sponsor_before = token.balanceOf(sponsor).call().await.unwrap();
+
+    let receipt =
+        provider.send_raw_transaction(&signed_raw).await.unwrap().get_receipt().await.unwrap();
+    assert!(receipt.status(), "sponsored transaction should succeed");
+
+    assert_eq!(token.balanceOf(recipient).call().await.unwrap(), amount);
+    assert_eq!(
+        token.balanceOf(sender).call().await.unwrap(),
+        sender_before - amount,
+        "sender must only pay the transfer amount"
+    );
+    assert!(
+        token.balanceOf(sponsor).call().await.unwrap() < sponsor_before,
+        "sponsor must pay the transaction fee"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_send_raw_transaction_auto_sponsors_placeholder() {
+    let sponsor = dev_key(1).address();
+    let (_api, handle) = spawn(NodeConfig::test_tempo().with_tempo_fee_payer(Some(sponsor))).await;
+    let provider = handle.http_provider();
+    let sender = handle.dev_accounts().next().unwrap();
+    let recipient = Address::random();
+    let amount = U256::from(50_000);
+
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+
+    let token = IERC20::new(PATH_USD, &provider);
+    let sender_before = token.balanceOf(sender).call().await.unwrap();
+    let sponsor_token = IERC20::new(BETA_USD, &provider);
+    let sponsor_before = sponsor_token.balanceOf(sponsor).call().await.unwrap();
+
+    // Sign-and-relay mode: the placeholder-marked raw transaction is sponsored on submission.
+    let unsigned =
+        sponsorship_requested_transfer(chain_id, gas_price, 0, recipient, amount, None, 0).await;
+    let receipt = provider
+        .raw_request::<_, serde_json::Value>(
+            "eth_sendRawTransactionSync".into(),
+            (fee_payer_service_encoded(&unsigned),),
+        )
+        .await
+        .unwrap();
+    assert_eq!(receipt["status"], "0x1", "unexpected receipt: {receipt}");
+
+    let hash: B256 = serde_json::from_value(receipt["transactionHash"].clone()).unwrap();
+    let transaction = provider
+        .raw_request::<_, serde_json::Value>("eth_getTransactionByHash".into(), (hash,))
+        .await
+        .unwrap();
+    let transaction = serde_json::from_value::<AASigned>(transaction).unwrap();
+    assert_eq!(transaction.recover_signer().unwrap(), sender);
+    assert_eq!(transaction.tx().recover_fee_payer(sender).unwrap(), sponsor);
+    // The configured sponsor (dev account 1) pays with its stored fee token, BetaUSD.
+    assert_eq!(transaction.tx().fee_token, Some(BETA_USD));
+
+    // The same works for a placeholder signature in the standard encoding.
+    let unsigned =
+        sponsorship_requested_transfer(chain_id, gas_price, 0, recipient, amount, None, 1).await;
+    let receipt = provider
+        .send_raw_transaction(&TempoTxEnvelope::AA(unsigned).encoded_2718())
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(receipt.status(), "sponsored transaction should succeed");
+
+    assert_eq!(token.balanceOf(recipient).call().await.unwrap(), amount * U256::from(2));
+    assert_eq!(
+        token.balanceOf(sender).call().await.unwrap(),
+        sender_before - amount * U256::from(2),
+        "sender must only pay the transfer amounts"
+    );
+    assert!(
+        sponsor_token.balanceOf(sponsor).call().await.unwrap() < sponsor_before,
+        "sponsor must pay the transaction fees"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_sign_raw_transaction_preserves_fee_token() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+    let sender = handle.dev_accounts().next().unwrap();
+
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+    // The standard encoding keeps the sender's fee token choice, which the sponsor must honor.
+    let unsigned = sponsorship_requested_transfer(
+        chain_id,
+        gas_price,
+        0,
+        Address::random(),
+        U256::from(1),
+        Some(ALPHA_USD),
+        0,
+    )
+    .await;
+
+    let signed_raw = provider
+        .raw_request::<_, Bytes>(
+            "eth_signRawTransaction".into(),
+            (Bytes::from(TempoTxEnvelope::AA(unsigned).encoded_2718()),),
+        )
+        .await
+        .unwrap();
+
+    let TempoTxEnvelope::AA(signed) =
+        TempoTxEnvelope::decode_2718(&mut signed_raw.as_ref()).unwrap()
+    else {
+        panic!("expected a Tempo AA transaction");
+    };
+    assert_eq!(signed.tx().fee_token, Some(ALPHA_USD));
+    assert_eq!(
+        signed.tx().recover_fee_payer(sender).unwrap(),
+        dev_key(9).address(),
+        "default sponsor is the last dev account"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_sign_raw_transaction_rejects_invalid_requests() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+    let chain_id = provider.get_chain_id().await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+    let recipient = Address::random();
+
+    // The sponsor must not equal the transaction sender (the default sponsor is account 9).
+    let from_sponsor =
+        sponsorship_requested_transfer(chain_id, gas_price, 9, recipient, U256::from(1), None, 0)
+            .await;
+    let err = provider
+        .raw_request::<_, Bytes>(
+            "eth_signRawTransaction".into(),
+            (fee_payer_service_encoded(&from_sponsor),),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must not equal the transaction sender"),
+        "unexpected error: {err}"
+    );
+
+    // Transactions that already carry a real fee payer signature are rejected.
+    let mut sponsored =
+        sponsorship_requested_transfer(chain_id, gas_price, 0, recipient, U256::from(1), None, 0)
+            .await;
+    let (mut tx, signature, _) = sponsored.into_parts();
+    let sender = dev_key(0).address();
+    tx.fee_payer_signature =
+        Some(dev_key(2).sign_hash(&tx.fee_payer_signature_hash(sender)).await.unwrap());
+    sponsored = tx.into_signed(signature);
+    let err = provider
+        .raw_request::<_, Bytes>(
+            "eth_signRawTransaction".into(),
+            (Bytes::from(TempoTxEnvelope::AA(sponsored).encoded_2718()),),
+        )
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("already fee-payer signed"), "unexpected error: {err}");
+
+    // Transactions signed without the sponsorship placeholder are rejected: the sender signature
+    // commits to whether a fee payer is present, so sponsoring them would invalidate it.
+    let unsponsored =
+        sponsorship_requested_transfer(chain_id, gas_price, 0, recipient, U256::from(1), None, 0)
+            .await;
+    let (mut tx, signature, _) = unsponsored.into_parts();
+    tx.fee_payer_signature = None;
+    let unsponsored = tx.into_signed(signature);
+    let err = provider
+        .raw_request::<_, Bytes>(
+            "eth_signRawTransaction".into(),
+            (Bytes::from(TempoTxEnvelope::AA(unsponsored).encoded_2718()),),
+        )
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("does not request sponsorship"), "unexpected error: {err}");
+
+    // Non-Tempo transactions cannot be fee-payer signed.
+    let eip1559 = TxEip1559 {
+        chain_id,
+        nonce: 0,
+        gas_limit: 21_000,
+        max_fee_per_gas: gas_price * 2,
+        max_priority_fee_per_gas: gas_price / 10,
+        to: TxKind::Call(recipient),
+        ..Default::default()
+    };
+    let signature = dev_key(0).sign_hash(&eip1559.signature_hash()).await.unwrap();
+    let raw = FoundryTxEnvelope::Eip1559(eip1559.into_signed(signature)).encoded_2718();
+    let err = provider
+        .raw_request::<_, Bytes>("eth_signRawTransaction".into(), (Bytes::from(raw),))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("only Tempo (0x76) transactions"), "unexpected error: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sign_raw_transaction_unsupported_without_tempo() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let err = provider
+        .raw_request::<_, Bytes>("eth_signRawTransaction".into(), (Bytes::from_static(&[0x76]),))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("Not implemented"), "unexpected error: {err}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -985,6 +985,71 @@ casttest!(send_with_presigned_sponsor_signature_rejects_stale_digest, async |_pr
     assert!(stderr.contains("--tempo.print-sponsor-hash"), "{stderr}");
 });
 
+casttest!(send_with_sponsor_url_uses_anvil_builtin_fee_payer, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let provider = handle.http_provider();
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let sender = accounts[0];
+    let sponsor = *accounts.last().unwrap();
+    let recipient = accounts[3];
+    let sender_wallet = handle.dev_wallets().next().unwrap();
+    assert_eq!(sender_wallet.address(), sender);
+    let sender_pk = format!("0x{}", hex::encode(sender_wallet.credential().to_bytes()));
+    let token = PATH_USD_ADDRESS.to_string();
+    let recipient_arg = recipient.to_string();
+    let amount = U256::from(1000u64);
+
+    let tip20 = ITIP20::new(PATH_USD_ADDRESS, &provider);
+    let sender_before = tip20.balanceOf(sender).call().await.unwrap();
+    let sponsor_before = tip20.balanceOf(sponsor).call().await.unwrap();
+
+    // No local sponsor key or address: anvil's built-in fee payer signs the sponsorship request
+    // via `eth_signRawTransaction`, so the sponsor URL is simply the node itself.
+    let stdout = cmd
+        .cast_fuse()
+        .args([
+            "send",
+            &token,
+            "transfer(address,uint256)",
+            &recipient_arg,
+            "1000",
+            "--private-key",
+            &sender_pk,
+            "--rpc-url",
+            &rpc,
+            "--sponsor-url",
+            &rpc,
+            "--json",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    let receipt: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("receipt should be JSON");
+    assert_eq!(receipt["status"], "0x1", "unexpected receipt: {receipt}");
+    assert_eq!(
+        receipt["feePayer"],
+        serde_json::to_value(sponsor).unwrap(),
+        "fee payer should be anvil's default sponsor (last dev account): {receipt}"
+    );
+    assert_eq!(
+        receipt["feeToken"],
+        serde_json::to_value(PATH_USD_ADDRESS).unwrap(),
+        "sponsor pays with its stored fee token: {receipt}"
+    );
+
+    let sender_after = tip20.balanceOf(sender).call().await.unwrap();
+    let sponsor_after = tip20.balanceOf(sponsor).call().await.unwrap();
+    assert_eq!(
+        sender_after,
+        sender_before - amount,
+        "sender must only pay the transfer amount, fees are sponsored"
+    );
+    assert!(sponsor_after < sponsor_before, "sponsor must pay the transaction fee");
+});
+
 casttest!(tip20_logo_check_accepts_valid_values, |_prj, cmd| {
     for uri in ["", "https://example.com/logo.png", "HTTP://example.com/logo.png", "ipfs://token"] {
         cmd.cast_fuse().args(["tip20", "logo-check", uri]).assert_success();


### PR DESCRIPTION
Sponsored Tempo transactions could not be exercised against anvil without local sponsor key material: `--tempo.sponsor` needs a sponsor signer or signature on the client, and the remote path behind `--sponsor-url` needs a hosted fee payer service speaking `eth_signRawTransaction`.

Anvil in Tempo mode now serves the fee payer service contract itself, mirroring the hosted worker built on the Accounts relay handler ([tempoxyz/tempo-apps/apps/fee-payer](https://github.com/tempoxyz/tempo-apps/tree/main/apps/fee-payer)). `eth_signRawTransaction` accepts a sender-signed Tempo AA transaction, in both the standard encoding carrying the fee payer signature marker and the fee payer service encoding with the `0x00` placeholder, fills the two sponsor-owned fields (the fee token, when the sender left it open, and the fee payer signature) and returns the fully signed raw transaction without broadcasting it. Raw transactions submitted to `eth_sendRawTransaction`/`eth_sendRawTransactionSync` with the placeholder are sponsored automatically before submission, matching the sign-and-relay mode of the tempo-alloy `RelayTransport`. Transactions signed without the placeholder are rejected instead of sponsored, because the sender signature commits to whether a fee payer is present, and transactions that already carry a real fee payer signature are rejected as already sponsored.

The sponsor account defaults to the last dev account so it stays out of the way of commonly used sender accounts, can be overridden with the new `--tempo.fee-payer` flag, must differ from the transaction sender, and pays with its fee token stored in the fee manager (falling back to PathUSD). The startup banner shows the active fee payer in Tempo mode.

With this, `cast send --sponsor-url` and the tempo SDK relay transport can point directly at anvil:

```bash
cast send $TOKEN "transfer(address,uint256)" $RECIPIENT 1000 \
  --rpc-url http://127.0.0.1:8545 \
  --sponsor-url http://127.0.0.1:8545 \
  --private-key $PK
```

Docs: foundry-rs/book#2044.

> This PR was written primarily by Claude Code (implementation, tests, and PR text), reviewed by me.
