### PR TITLE
fix(doc): preserve longer code fences

### DIFF
--- a/.changelog/fix-longer-mdx-fences.md
+++ b/.changelog/fix-longer-mdx-fences.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-doc: patch
+---
+
+Preserve Markdown code blocks that use longer backtick or tilde fences when generating MDX documentation.

--- a/crates/doc/src/vocs.rs
+++ b/crates/doc/src/vocs.rs
@@ -324,25 +324,37 @@ fn build_source_to_url(pages: &[PathBuf]) -> SourceToUrl {
 /// HTML-like tokens like `<TOKEN>` would be interpreted as MDX expressions/JSX
 /// and break `vocs dev` / `vocs build`.
 fn escape_mdx_outside_code_fences(text: &str) -> String {
+    struct Fence {
+        marker: char,
+        len: usize,
+    }
+
     let mut out = String::with_capacity(text.len());
-    let mut in_fence = false;
-    let mut fence_marker = "";
+    let mut fence: Option<Fence> = None;
     for line in text.split_inclusive('\n') {
         let trimmed = line.trim_start();
-        if in_fence {
+        if let Some(open) = fence.as_ref() {
             out.push_str(line);
-            if trimmed.starts_with(fence_marker) {
-                in_fence = false;
+            let marker_len = trimmed.chars().take_while(|&ch| ch == open.marker).count();
+            // Fence markers are ASCII, so their character count is also the byte index.
+            let suffix = &trimmed[marker_len..];
+            if marker_len >= open.len && suffix.trim().is_empty() {
+                fence = None;
             }
-        } else if trimmed.starts_with("```") {
-            in_fence = true;
-            fence_marker = "```";
-            out.push_str(line);
-        } else if trimmed.starts_with("~~~") {
-            in_fence = true;
-            fence_marker = "~~~";
-            out.push_str(line);
         } else {
+            let opening = trimmed.chars().next().and_then(|marker| {
+                if !matches!(marker, '`' | '~') {
+                    return None;
+                }
+                let len = trimmed.chars().take_while(|&ch| ch == marker).count();
+                (len >= 3).then_some(Fence { marker, len })
+            });
+            if let Some(opening) = opening {
+                fence = Some(opening);
+                out.push_str(line);
+                continue;
+            }
+
             // Escape `{` and bare `<` (not already `&lt;` or a known entity).
             let mut inline_code_ticks = 0usize;
             let mut pending_ticks = 0usize;
@@ -628,6 +640,22 @@ End {brace}.
 
         // Inside ~~~ fences: untouched.
         assert!(out.contains("echo {not escaped}"), "~~~ fence content must be unchanged");
+    }
+
+    #[test]
+    fn escape_mdx_supports_longer_backtick_fences() {
+        let input = "````markdown\n```solidity\ncontract Test {\n    function value() external returns (uint256) {\n        return 1;\n    }\n}\n```\n````\n\nOutside {text}.\n";
+        let out = escape_mdx_outside_code_fences(input);
+
+        assert_eq!(out, input.replace("Outside {text}", r"Outside \{text}"));
+    }
+
+    #[test]
+    fn escape_mdx_supports_longer_tilde_fences() {
+        let input = "~~~~markdown\n~~~solidity\ncontract Test {\n    function value() external returns (uint256) {\n        return 1;\n    }\n}\n~~~\n~~~~\n\nOutside {text}.\n";
+        let out = escape_mdx_outside_code_fences(input);
+
+        assert_eq!(out, input.replace("Outside {text}", r"Outside \{text}"));
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`escape_mdx_outside_code_fences` previously tracked fenced code blocks using a fixed three-character marker. A four-character fence was therefore closed by an inner three-character sequence, even though CommonMark requires a closing fence to use the same marker and contain at least as many characters as the opening fence.

This caused content inside longer fences to be processed as regular MDX text, potentially escaping Solidity braces and less-than signs or producing invalid generated documentation. PR #15842 handles code ranges in the NatSpec rendering path, but does not cover homepage content processed by this function.



## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Track each opening fence's marker character and length. A line now closes the fence only when it uses the same marker, contains at least the opening number of marker characters, and has only whitespace after the marker sequence.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
