### PR TITLE
refactor(anvil): unify hardfork resolution

### DIFF
--- a/.changelog/anvil-network-hardfork-selection.md
+++ b/.changelog/anvil-network-hardfork-selection.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Select Anvil's default hardfork from the configured network, chain ID, and genesis timestamp.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1,5 +1,5 @@
 use crate::{
-    EthereumHardfork, FeeManager, PrecompileFactory,
+    FeeManager, PrecompileFactory,
     eth::{
         backend::{
             db::{Db, SerializableState},
@@ -48,7 +48,6 @@ use foundry_evm::{
     backend::{BlockchainDb, BlockchainDbMeta, SharedBackend},
     constants::DEFAULT_CREATE2_DEPLOYER,
     hardfork::FoundryHardfork,
-    hardforks::latest_active_tempo_hardfork,
     utils::{apply_chain_and_block_specific_env_changes_for_chain, block_env_from_header},
 };
 use parking_lot::RwLock;
@@ -679,35 +678,9 @@ impl NodeConfig {
         if let Some(hardfork) = self.hardfork {
             return hardfork;
         }
-        if self.networks.is_tempo()
-            && let Some(hardfork) = TempoHardfork::from_chain_and_timestamp(
-                self.protocol_chain_id(),
-                self.get_genesis_timestamp(),
-            )
-        {
-            return hardfork.into();
-        }
-        #[cfg(feature = "monad")]
-        if self.networks.is_monad()
-            && let Some(hardfork) = MonadHardfork::from_chain_and_timestamp(
-                self.protocol_chain_id(),
-                self.get_genesis_timestamp(),
-            )
-        {
-            return hardfork.into();
-        }
-        #[cfg(feature = "optimism")]
-        if self.networks.is_optimism() {
-            return foundry_evm::hardforks::OpHardfork::default().into();
-        }
-        if self.networks.is_tempo() {
-            return latest_active_tempo_hardfork().into();
-        }
-        #[cfg(feature = "monad")]
-        if self.networks.is_monad() {
-            return MonadHardfork::default().into();
-        }
-        EthereumHardfork::default().into()
+        self.networks
+            .execution_network()
+            .hardfork_at(self.protocol_chain_id(), self.get_genesis_timestamp())
     }
 
     /// Sets a custom code size limit
@@ -2421,6 +2394,10 @@ async fn find_latest_fork_block<P: Provider<AnyNetwork>>(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "optimism")]
+    use foundry_evm::hardfork::OpHardfork;
+    use foundry_evm::{hardfork::EthereumHardfork, hardforks::latest_active_tempo_hardfork};
+
     use super::*;
 
     #[test]
@@ -2595,6 +2572,28 @@ mod tests {
 
         assert!(config.networks.is_tempo());
         assert!(matches!(config.get_hardfork(), FoundryHardfork::Tempo(_)));
+    }
+
+    #[test]
+    fn get_hardfork_on_ethereum_uses_genesis_timestamp() {
+        let timestamp = EthereumHardfork::Shanghai.mainnet_activation_timestamp().unwrap();
+        let config =
+            NodeConfig::test().with_chain_id(Some(1u64)).with_genesis_timestamp(Some(timestamp));
+
+        assert_eq!(config.get_hardfork(), FoundryHardfork::Ethereum(EthereumHardfork::Shanghai));
+    }
+
+    #[test]
+    #[cfg(feature = "optimism")]
+    fn get_hardfork_on_optimism_uses_genesis_timestamp() {
+        // OP Mainnet Canyon activation timestamp.
+        let timestamp = 1_704_992_401u64;
+        let config = NodeConfig::test()
+            .with_optimism()
+            .with_chain_id(Some(10u64))
+            .with_genesis_timestamp(Some(timestamp));
+
+        assert_eq!(config.get_hardfork(), FoundryHardfork::Optimism(OpHardfork::Canyon));
     }
 
     #[test]

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -664,6 +664,7 @@ async fn test_fork_reset_restores_explicit_genesis_base_fee() {
     let (api, handle) = spawn(
         NodeConfig::test()
             .with_no_storage_caching(true)
+            .with_hardfork(Some(EthereumHardfork::default().into()))
             .with_genesis(Some(Genesis { base_fee_per_gas: Some(0), ..Default::default() }))
             .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
             .with_fork_block_number(Some(0u64)),

--- a/crates/anvil/tests/it/gas.rs
+++ b/crates/anvil/tests/it/gas.rs
@@ -289,6 +289,7 @@ async fn test_fee_history_ignores_stale_cache_after_reset() {
 async fn test_memory_reset_restores_explicit_genesis_base_fee() {
     let (api, handle) = spawn(
         NodeConfig::test()
+            .with_hardfork(Some(EthereumHardfork::default().into()))
             .with_genesis(Some(Genesis { base_fee_per_gas: Some(0), ..Default::default() })),
     )
     .await;

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -15,7 +15,11 @@ use alloy_primitives::{Address, ChainId, address, map::AddressHashMap};
 use clap::Parser;
 #[cfg(feature = "monad")]
 use foundry_evm_hardforks::MonadHardfork;
-use foundry_evm_hardforks::{FoundryHardfork, TempoHardfork};
+#[cfg(feature = "optimism")]
+use foundry_evm_hardforks::OpHardfork;
+use foundry_evm_hardforks::{
+    EthereumHardfork, FoundryHardfork, TempoHardfork, latest_active_tempo_hardfork,
+};
 #[cfg(not(feature = "monad"))]
 type MonadHardfork = ();
 #[cfg(feature = "monad")]
@@ -281,6 +285,33 @@ impl NetworkVariant {
     /// Parses a hardfork name reported by an RPC endpoint in this network's namespace.
     pub fn parse_hardfork(self, hardfork: &str) -> Result<FoundryHardfork, String> {
         format!("{}:{hardfork}", self.name()).parse()
+    }
+
+    /// Returns the active hardfork for this network at the given chain and timestamp.
+    ///
+    /// Unknown chain IDs fall back to the network's default hardfork. The selected network owns
+    /// the lookup so an explicit network choice is not overridden by the chain ID's family.
+    pub fn hardfork_at(self, chain_id: ChainId, timestamp: u64) -> FoundryHardfork {
+        match self {
+            Self::Ethereum => {
+                EthereumHardfork::from_chain_and_timestamp(Chain::from_id(chain_id), timestamp)
+                    .unwrap_or_default()
+                    .into()
+            }
+            Self::Tempo => TempoHardfork::from_chain_and_timestamp(chain_id, timestamp)
+                .unwrap_or_else(latest_active_tempo_hardfork)
+                .into(),
+            #[cfg(feature = "optimism")]
+            Self::Optimism => {
+                OpHardfork::from_chain_and_timestamp(Chain::from_id(chain_id), timestamp)
+                    .unwrap_or_default()
+                    .into()
+            }
+            #[cfg(feature = "monad")]
+            Self::Monad => MonadHardfork::from_chain_and_timestamp(chain_id, timestamp)
+                .unwrap_or_default()
+                .into(),
+        }
     }
 
     /// Returns `true` if this is the Ethereum network variant.


### PR DESCRIPTION
Anvil previously selected hardforks through network-specific branches in `NodeConfig`, causing Ethereum and Optimism to use defaults while Tempo and Monad performed timestamp-based resolution.

This moves hardfork selection into `NetworkVariant::hardfork_at`, allowing each selected execution network to resolve its own chain and timestamp schedule while retaining network-specific fallbacks for unknown chains. Explicit hardfork overrides remain unchanged, and the selected network stays authoritative when execution and source chain families differ.

The base-fee reset fixtures now explicitly use Ethereum's current default hardfork because their default genesis represents mainnet at timestamp zero, which correctly resolves to Frontier under timestamp-aware selection and prevents the tests from exercising their intended reset behavior.
