### PR TITLE
refactor(evm): resolve initcode limit by network

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -34,7 +34,7 @@ use foundry_evm_core::{
         history_storage_slot, history_storage_value,
     },
     env::FoundryContextExt,
-    evm::{FoundryEvmFactory, FoundryEvmNetwork, TxEnvFor, TxEnvelopeFor},
+    evm::{FoundryEvmNetwork, TxEnvFor, TxEnvelopeFor},
     utils::get_blob_base_fee_update_fraction_by_spec_id,
 };
 use foundry_evm_traces::TraceRequirements;
@@ -45,7 +45,7 @@ use revm::{
     bytecode::Bytecode,
     context::{Block, Cfg, ContextTr, Host, JournalTr, Transaction, result::ExecutionResult},
     inspector::JournalExt,
-    primitives::{KECCAK_EMPTY, hardfork::SpecId},
+    primitives::{KECCAK_EMPTY, eip3860::MAX_INITCODE_SIZE, hardfork::SpecId},
     state::{Account, AccountStatus},
 };
 use std::{
@@ -1356,8 +1356,14 @@ impl Cheatcode for executeTransactionCall {
         ccx.ecx.cfg_env_mut().disable_nonce_check = false;
 
         // Enforce the active EVM's initcode size limit.
-        ccx.ecx.cfg_env_mut().limit_contract_initcode_size =
-            Some(FEN::EvmFactory::CONTRACT_INITCODE_SIZE_LIMIT);
+        let initcode_size_limit = ccx
+            .state
+            .config
+            .evm_opts
+            .networks
+            .contract_size_limits()
+            .map_or(MAX_INITCODE_SIZE, |limits| limits.initcode);
+        ccx.ecx.cfg_env_mut().limit_contract_initcode_size = Some(initcode_size_limit);
 
         // Reset the tx gas limit cap so revm applies the spec-defined default (EIP-7825).
         // Normal test execution sets `Some(u64::MAX)` to disable the cap; clearing it here

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -30,7 +30,7 @@ use revm::{
     interpreter::{
         CallInput, CallInputs, CallScheme, CallValue, CreateInputs, FrameInput, InstructionResult,
     },
-    primitives::{eip3860::MAX_INITCODE_SIZE, hardfork::SpecId},
+    primitives::hardfork::SpecId,
 };
 use serde::{Deserialize, Serialize};
 use tempo_alloy::TempoNetwork;
@@ -141,9 +141,6 @@ pub trait FoundryEvmFactory:
 
     /// Additional network-specific cheatcode contract addresses.
     const EXTRA_CHEATCODE_ADDRESSES: &'static [Address] = &[];
-
-    /// Maximum initcode size enforced during nested transaction execution.
-    const CONTRACT_INITCODE_SIZE_LIMIT: usize = MAX_INITCODE_SIZE;
 
     /// Whether transaction execution needs metadata from surrounding blocks.
     const NEEDS_BLOCK_CONTEXT: bool = false;
@@ -395,21 +392,5 @@ impl IntoInstructionResult for TempoHaltReason {
             Self::Ethereum(eth) => eth.into(),
             _ => InstructionResult::PrecompileError,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn factories_define_nested_initcode_size_limit() {
-        assert_eq!(EthEvmFactory::CONTRACT_INITCODE_SIZE_LIMIT, MAX_INITCODE_SIZE);
-        assert_eq!(TempoEvmFactory::CONTRACT_INITCODE_SIZE_LIMIT, MAX_INITCODE_SIZE);
-        #[cfg(feature = "monad")]
-        assert_eq!(
-            MonadEvmFactory::CONTRACT_INITCODE_SIZE_LIMIT,
-            monad_revm::MONAD_MAX_INITCODE_SIZE
-        );
     }
 }

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -331,7 +331,6 @@ where
 
 impl FoundryEvmFactory for MonadEvmFactory {
     const EXTRA_CHEATCODE_ADDRESSES: &'static [Address] = &[MONAD_CHEATCODE_ADDRESS];
-    const CONTRACT_INITCODE_SIZE_LIMIT: usize = monad_revm::MONAD_MAX_INITCODE_SIZE;
 
     const NEEDS_BLOCK_CONTEXT: bool = true;
 


### PR DESCRIPTION
## Description
Stacked on #16262.

Nested `executeTransaction` previously obtained its initcode size limit from a `FoundryEvmFactory` constant, making the generic factory interface carry a capability used only to select Monad’s override.

Resolve the limit from the active network configuration instead. Monad’s limit is now selected only when Monad support is compiled and the resolved runtime network is Monad; other networks fall back to revm’s EIP-3860 default. This also removes the factory constant, its Monad implementation, and the associated factory-level tests.