### PR TITLE
refactor(evm): move extra cheatcodes to network config

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -34,7 +34,7 @@ use foundry_evm_core::{
         history_storage_slot, history_storage_value,
     },
     env::FoundryContextExt,
-    evm::{FoundryEvmFactory, FoundryEvmNetwork, TxEnvFor, TxEnvelopeFor},
+    evm::{FoundryEvmNetwork, TxEnvFor, TxEnvelopeFor},
     utils::get_blob_base_fee_update_fraction_by_spec_id,
 };
 use foundry_evm_traces::TraceRequirements;
@@ -45,7 +45,7 @@ use revm::{
     bytecode::Bytecode,
     context::{Block, Cfg, ContextTr, Host, JournalTr, Transaction, result::ExecutionResult},
     inspector::JournalExt,
-    primitives::{KECCAK_EMPTY, hardfork::SpecId},
+    primitives::{KECCAK_EMPTY, eip3860::MAX_INITCODE_SIZE, hardfork::SpecId},
     state::{Account, AccountStatus},
 };
 use std::{
@@ -1356,8 +1356,14 @@ impl Cheatcode for executeTransactionCall {
         ccx.ecx.cfg_env_mut().disable_nonce_check = false;
 
         // Enforce the active EVM's initcode size limit.
-        ccx.ecx.cfg_env_mut().limit_contract_initcode_size =
-            Some(FEN::EvmFactory::CONTRACT_INITCODE_SIZE_LIMIT);
+        let initcode_size_limit = ccx
+            .state
+            .config
+            .evm_opts
+            .networks
+            .contract_size_limits()
+            .map_or(MAX_INITCODE_SIZE, |limits| limits.initcode);
+        ccx.ecx.cfg_env_mut().limit_contract_initcode_size = Some(initcode_size_limit);
 
         // Reset the tx gas limit cap so revm applies the spec-defined default (EIP-7825).
         // Normal test execution sets `Some(u64::MAX)` to disable the cap; clearing it here

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1448,7 +1448,10 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         }
 
         #[cfg(feature = "monad")]
-        if is_monad_cheatcode_call::<FEN>(call.target_address) {
+        if is_monad_cheatcode_call(
+            self.config.evm_opts.networks.extra_cheatcode_addresses(),
+            call.target_address,
+        ) {
             let checkpoint = ecx.journal_mut().checkpoint();
             return match self.apply_monad_cheatcode(ecx, call) {
                 Ok(retdata) => {
@@ -2354,7 +2357,11 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         let cheatcode_call = call.target_address == CHEATCODE_ADDRESS
             || call.target_address == HARDHAT_CONSOLE_ADDRESS;
         #[cfg(feature = "monad")]
-        let cheatcode_call = cheatcode_call || is_monad_cheatcode_call::<FEN>(call.target_address);
+        let cheatcode_call = cheatcode_call
+            || is_monad_cheatcode_call(
+                self.config.evm_opts.networks.extra_cheatcode_addresses(),
+                call.target_address,
+            );
         let curr_depth = ecx.journal().depth();
 
         self.finish_created_accounts_frame(

--- a/crates/cheatcodes/src/monad.rs
+++ b/crates/cheatcodes/src/monad.rs
@@ -3,10 +3,7 @@
 use crate::{CheatsCtxt, Result};
 use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolInterface;
-use foundry_evm_core::{
-    constants::MONAD_CHEATCODE_ADDRESS,
-    evm::{FoundryEvmFactory, FoundryEvmNetwork},
-};
+use foundry_evm_core::{constants::MONAD_CHEATCODE_ADDRESS, evm::FoundryEvmNetwork};
 use monad_revm::{
     api::block::{
         syscall_on_epoch_change_calldata, syscall_reward_calldata, syscall_snapshot_calldata,
@@ -53,9 +50,11 @@ alloy_sol_types::sol! {
     }
 }
 
-pub(crate) fn is_monad_cheatcode_call<FEN: FoundryEvmNetwork>(target: Address) -> bool {
-    target == MONAD_CHEATCODE_ADDRESS
-        && FEN::EvmFactory::EXTRA_CHEATCODE_ADDRESSES.contains(&target)
+pub(crate) fn is_monad_cheatcode_call(
+    extra_cheatcode_addresses: &[Address],
+    target: Address,
+) -> bool {
+    target == MONAD_CHEATCODE_ADDRESS && extra_cheatcode_addresses.contains(&target)
 }
 
 pub(crate) fn apply_monad_cheatcode<FEN: FoundryEvmNetwork>(

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -624,8 +624,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
     ) -> eyre::Result<Self> {
         trace!(target: "backend", forking_mode=?fork.is_some(), "creating executor backend");
         // Note: this will take of registering the `fork`
-        let mut persistent_accounts = HashSet::from(DEFAULT_PERSISTENT_ACCOUNTS);
-        persistent_accounts.extend(FEN::EvmFactory::EXTRA_CHEATCODE_ADDRESSES);
+        let persistent_accounts = HashSet::from(DEFAULT_PERSISTENT_ACCOUNTS);
         let inner = BackendInner { persistent_accounts, ..Default::default() };
 
         let mut backend = Self {
@@ -3033,7 +3032,6 @@ mod tests {
     use crate::fork::CreateFork;
     use crate::{
         backend::{Backend, ForkPosition},
-        constants::MONAD_CHEATCODE_ADDRESS,
         evm::EthEvmNetwork,
         fork::ForkId,
         opts::EvmOpts,
@@ -3148,18 +3146,6 @@ mod tests {
             journaled_state.state[&address].storage[&missing_slot].present_value(),
             U256::from(7)
         );
-    }
-
-    #[test]
-    fn persistent_accounts_follow_the_active_network() {
-        let ethereum = Backend::<EthEvmNetwork>::spawn(None).unwrap();
-        assert!(!ethereum.inner.persistent_accounts.contains(&MONAD_CHEATCODE_ADDRESS));
-
-        #[cfg(feature = "monad")]
-        {
-            let monad = Backend::<MonadEvmNetwork>::spawn(None).unwrap();
-            assert!(monad.inner.persistent_accounts.contains(&MONAD_CHEATCODE_ADDRESS));
-        }
     }
 
     #[test]

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -1,5 +1,7 @@
 use alloy_primitives::{Address, B256, address, b256, hex};
 
+pub use foundry_evm_networks::MONAD_CHEATCODE_ADDRESS;
+
 /// The cheatcode handler address.
 ///
 /// This is the same address as the one used in DappTools's HEVM.
@@ -14,9 +16,6 @@ pub const CHEATCODE_ADDRESS: Address = address!("0x7109709ECfa91a80626fF3989D68f
 /// `keccak256(abi.encodePacked(CHEATCODE_ADDRESS))`.
 pub const CHEATCODE_CONTRACT_HASH: B256 =
     b256!("0xb0450508e5a2349057c3b4c9c84524d62be4bb17e565dbe2df34725a26872291");
-
-/// The Monad cheatcode handler address.
-pub const MONAD_CHEATCODE_ADDRESS: Address = address!("0xc0FFeeCD43A10e1C2b0De63c6CDCFe5B7d0e0CEA");
 
 /// The Hardhat console address.
 ///

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -139,9 +139,6 @@ pub trait FoundryEvmFactory:
     /// Chain context required to execute at an exact transaction position.
     type Chain: FoundryChain;
 
-    /// Additional network-specific cheatcode contract addresses.
-    const EXTRA_CHEATCODE_ADDRESSES: &'static [Address] = &[];
-
     /// Whether transaction execution needs metadata from surrounding blocks.
     const NEEDS_BLOCK_CONTEXT: bool = false;
 

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -30,7 +30,7 @@ use revm::{
     interpreter::{
         CallInput, CallInputs, CallScheme, CallValue, CreateInputs, FrameInput, InstructionResult,
     },
-    primitives::{eip3860::MAX_INITCODE_SIZE, hardfork::SpecId},
+    primitives::hardfork::SpecId,
 };
 use serde::{Deserialize, Serialize};
 use tempo_alloy::TempoNetwork;
@@ -141,9 +141,6 @@ pub trait FoundryEvmFactory:
 
     /// Additional network-specific cheatcode contract addresses.
     const EXTRA_CHEATCODE_ADDRESSES: &'static [Address] = &[];
-
-    /// Maximum initcode size enforced during nested transaction execution.
-    const CONTRACT_INITCODE_SIZE_LIMIT: usize = MAX_INITCODE_SIZE;
 
     /// Whether transaction execution needs metadata from surrounding blocks.
     const NEEDS_BLOCK_CONTEXT: bool = false;
@@ -395,21 +392,5 @@ impl IntoInstructionResult for TempoHaltReason {
             Self::Ethereum(eth) => eth.into(),
             _ => InstructionResult::PrecompileError,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn factories_define_nested_initcode_size_limit() {
-        assert_eq!(EthEvmFactory::CONTRACT_INITCODE_SIZE_LIMIT, MAX_INITCODE_SIZE);
-        assert_eq!(TempoEvmFactory::CONTRACT_INITCODE_SIZE_LIMIT, MAX_INITCODE_SIZE);
-        #[cfg(feature = "monad")]
-        assert_eq!(
-            MonadEvmFactory::CONTRACT_INITCODE_SIZE_LIMIT,
-            monad_revm::MONAD_MAX_INITCODE_SIZE
-        );
     }
 }

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -331,7 +331,6 @@ where
 
 impl FoundryEvmFactory for MonadEvmFactory {
     const EXTRA_CHEATCODE_ADDRESSES: &'static [Address] = &[MONAD_CHEATCODE_ADDRESS];
-    const CONTRACT_INITCODE_SIZE_LIMIT: usize = monad_revm::MONAD_MAX_INITCODE_SIZE;
 
     const NEEDS_BLOCK_CONTEXT: bool = true;
 

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -36,7 +36,6 @@ use revm::{
 use crate::{
     FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
-    constants::MONAD_CHEATCODE_ADDRESS,
     evm::{FoundryEvmFactory, NestedEvm, NestedEvmFor},
 };
 
@@ -330,8 +329,6 @@ where
 }
 
 impl FoundryEvmFactory for MonadEvmFactory {
-    const EXTRA_CHEATCODE_ADDRESSES: &'static [Address] = &[MONAD_CHEATCODE_ADDRESS];
-
     const NEEDS_BLOCK_CONTEXT: bool = true;
 
     type Chain = MonadChainContext;

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -337,9 +337,12 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             call.cheatcodes.as_ref().map_or_else(Default::default, |cheats| {
                 (cheats.breakpoints.clone(), cheats.deprecated.clone())
             });
-        let success =
-            should_ignore_revert::<FEN>(self.config.fail_on_revert, address, call.reverter)
-                || self.executor_f.is_raw_call_mut_success(address, &mut call, false);
+        let success = should_ignore_revert(
+            self.config.fail_on_revert,
+            address,
+            call.reverter,
+            self.executor_f.inspector().networks.extra_cheatcode_addresses(),
+        ) || self.executor_f.is_raw_call_mut_success(address, &mut call, false);
 
         let mut result = FuzzTestResult {
             success,
@@ -464,9 +467,12 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
 
         // Consider call success if test should not fail on reverts and reverter is not the test
         // address or one of the network's cheatcode contracts.
-        let success =
-            should_ignore_revert::<FEN>(self.config.fail_on_revert, address, call.reverter)
-                || state.0.is_raw_call_mut_success(address, &mut call, false);
+        let success = should_ignore_revert(
+            self.config.fail_on_revert,
+            address,
+            call.reverter,
+            state.0.inspector().networks.extra_cheatcode_addresses(),
+        ) || state.0.is_raw_call_mut_success(address, &mut call, false);
 
         if success {
             Ok(FuzzOutcome::Case(CaseOutcome {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -28,7 +28,7 @@ use foundry_evm_core::{
     constants::{
         CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME,
     },
-    evm::{FoundryEvmFactory, FoundryEvmNetwork},
+    evm::FoundryEvmNetwork,
     precompiles::PRECOMPILES,
 };
 use foundry_evm_fuzz::{
@@ -1741,9 +1741,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // Set up fuzzer WITHOUT call_generator initially.
         // We defer call_override until after the initial invariant check to avoid
         // injecting random calls during setup which would break the invariant assertion.
+        let extra_cheatcode_addresses = executor.inspector().networks.extra_cheatcode_addresses();
         executor.inspector_mut().set_fuzzer(
             Fuzzer::new(config.dictionary.max_fuzz_dictionary_values, mapping_slots)
-                .with_extra_cheatcode_addresses(FEN::EvmFactory::EXTRA_CHEATCODE_ADDRESSES)
+                .with_extra_cheatcode_addresses(extra_cheatcode_addresses)
                 .with_call_recording(config.corpus.is_coverage_guided()),
         );
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -97,16 +97,17 @@ const DURATION_BETWEEN_METRICS_REPORT: Duration = Duration::from_secs(5);
 
 /// Returns whether a nested revert can be ignored when fail-on-revert is disabled.
 #[inline]
-pub fn should_ignore_revert<FEN: FoundryEvmNetwork>(
+pub fn should_ignore_revert(
     fail_on_revert: bool,
     target: Address,
     reverter: Option<Address>,
+    extra_cheatcode_addresses: &[Address],
 ) -> bool {
     !fail_on_revert
         && reverter.is_some_and(|reverter| {
             reverter != target
                 && reverter != CHEATCODE_ADDRESS
-                && !FEN::EvmFactory::EXTRA_CHEATCODE_ADDRESSES.contains(&reverter)
+                && !extra_cheatcode_addresses.contains(&reverter)
         })
 }
 
@@ -167,6 +168,9 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         gas_limit: u64,
         legacy_assertions: bool,
     ) -> Self {
+        let extra_cheatcode_addresses = inspector.networks.extra_cheatcode_addresses();
+        backend.extend_persistent_accounts(extra_cheatcode_addresses.iter().copied());
+
         // Need to create a non-empty contract on the cheatcodes address so `extcodesize` checks
         // do not fail.
         backend.insert_account_info(
@@ -180,7 +184,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             },
         );
 
-        for &address in FEN::EvmFactory::EXTRA_CHEATCODE_ADDRESSES {
+        for &address in extra_cheatcode_addresses {
             backend.insert_account_info(
                 address,
                 revm::state::AccountInfo {
@@ -1781,6 +1785,8 @@ mod tests {
     use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
     #[cfg(feature = "monad")]
     use foundry_evm_core::{constants::MONAD_CHEATCODE_ADDRESS, evm::MonadEvmNetwork};
+    #[cfg(feature = "monad")]
+    use foundry_evm_networks::NetworkConfigs;
     use foundry_evm_traces::InternalTraceMode;
     use revm::context::TxEnv;
     use std::{sync::mpsc, thread};
@@ -1797,11 +1803,11 @@ mod tests {
         let target = Address::from([0x11; 20]);
         let nested = Address::from([0x22; 20]);
 
-        assert!(should_ignore_revert::<EthEvmNetwork>(false, target, Some(nested)));
-        assert!(!should_ignore_revert::<EthEvmNetwork>(true, target, Some(nested)));
-        assert!(!should_ignore_revert::<EthEvmNetwork>(false, target, Some(target)));
-        assert!(!should_ignore_revert::<EthEvmNetwork>(false, target, Some(CHEATCODE_ADDRESS)));
-        assert!(!should_ignore_revert::<EthEvmNetwork>(false, target, None));
+        assert!(should_ignore_revert(false, target, Some(nested), &[]));
+        assert!(!should_ignore_revert(true, target, Some(nested), &[]));
+        assert!(!should_ignore_revert(false, target, Some(target), &[]));
+        assert!(!should_ignore_revert(false, target, Some(CHEATCODE_ADDRESS), &[]));
+        assert!(!should_ignore_revert(false, target, None, &[]));
     }
 
     #[cfg(feature = "monad")]
@@ -1809,16 +1815,33 @@ mod tests {
     fn network_cheatcode_revert_handling_is_monad_specific() {
         let target = Address::from([0x11; 20]);
 
-        assert!(should_ignore_revert::<EthEvmNetwork>(
+        assert!(should_ignore_revert(false, target, Some(MONAD_CHEATCODE_ADDRESS), &[]));
+        assert!(!should_ignore_revert(
             false,
             target,
             Some(MONAD_CHEATCODE_ADDRESS),
+            NetworkConfigs::with_monad().extra_cheatcode_addresses(),
         ));
-        assert!(!should_ignore_revert::<MonadEvmNetwork>(
-            false,
-            target,
-            Some(MONAD_CHEATCODE_ADDRESS),
-        ));
+    }
+
+    #[cfg(feature = "monad")]
+    #[test]
+    fn extra_cheatcode_accounts_follow_the_active_network() {
+        let default_network = ExecutorBuilder::<MonadEvmNetwork>::default().build(
+            EvmEnvFor::<MonadEvmNetwork>::default(),
+            TxEnvFor::<MonadEvmNetwork>::default(),
+            Backend::spawn(None).unwrap(),
+        );
+        assert!(!default_network.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
+
+        let monad = ExecutorBuilder::<MonadEvmNetwork>::default()
+            .inspectors(|stack| stack.networks(NetworkConfigs::with_monad()))
+            .build(
+                EvmEnvFor::<MonadEvmNetwork>::default(),
+                TxEnvFor::<MonadEvmNetwork>::default(),
+                Backend::spawn(None).unwrap(),
+            );
+        assert!(monad.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/showmap.rs
+++ b/crates/evm/evm/src/executors/showmap.rs
@@ -711,8 +711,12 @@ fn fuzz_replay_call_succeeded<FEN: FoundryEvmNetwork>(
     call_result: &mut crate::executors::RawCallResult<FEN>,
     fail_on_revert: bool,
 ) -> bool {
-    should_ignore_revert::<FEN>(fail_on_revert, target_addr, call_result.reverter)
-        || executor.is_raw_call_mut_success(target_addr, call_result, false)
+    should_ignore_revert(
+        fail_on_revert,
+        target_addr,
+        call_result.reverter,
+        executor.inspector().networks.extra_cheatcode_addresses(),
+    ) || executor.is_raw_call_mut_success(target_addr, call_result, false)
 }
 
 fn newly_broken_invariants<FEN: FoundryEvmNetwork>(

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -37,6 +37,12 @@ use tempo_contracts::precompiles::{
     VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
 
+/// The Monad cheatcode handler address.
+pub const MONAD_CHEATCODE_ADDRESS: Address = address!("0xc0FFeeCD43A10e1C2b0De63c6CDCFe5B7d0e0CEA");
+
+#[cfg(feature = "monad")]
+const MONAD_CHEATCODE_ADDRESSES: &[Address] = &[MONAD_CHEATCODE_ADDRESS];
+
 pub mod arbitrum;
 pub mod celo;
 
@@ -473,6 +479,15 @@ impl NetworkConfigs {
     #[cfg(not(feature = "monad"))]
     pub const fn is_monad(&self) -> bool {
         false
+    }
+
+    /// Returns additional cheatcode contract addresses for the active network.
+    pub const fn extra_cheatcode_addresses(&self) -> &'static [Address] {
+        #[cfg(feature = "monad")]
+        if self.is_monad() {
+            return MONAD_CHEATCODE_ADDRESSES;
+        }
+        &[]
     }
 
     pub const fn is_celo(&self) -> bool {
@@ -1468,6 +1483,7 @@ mod tests {
         let cfg = NetworkConfigs::with_monad();
         assert_eq!(cfg.active_network_name(), Some("monad"));
         assert!(cfg.is_monad());
+        assert_eq!(cfg.extra_cheatcode_addresses(), &[MONAD_CHEATCODE_ADDRESS]);
     }
 
     #[test]
@@ -1481,7 +1497,9 @@ mod tests {
 
     #[test]
     fn active_network_name_default_is_none() {
-        assert_eq!(NetworkConfigs::default().active_network_name(), None);
+        let cfg = NetworkConfigs::default();
+        assert_eq!(cfg.active_network_name(), None);
+        assert!(cfg.extra_cheatcode_addresses().is_empty());
     }
 
     // --- Serde round-trip ---

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -65,8 +65,7 @@ use foundry_evm::core::evm::MonadEvmNetwork;
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
     core::evm::{
-        BlockEnvFor, EthEvmNetwork, FoundryEvmFactory, FoundryEvmNetwork, SpecFor, TempoEvmNetwork,
-        TxEnvFor,
+        BlockEnvFor, EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor,
     },
     executors::ShowmapDomain,
     fuzz::{BaseCounterExample, BasicTxDetails, CounterExample},
@@ -2981,7 +2980,7 @@ impl TestArgs {
                 config.gas_reports.clone(),
                 config.gas_reports_ignore.clone(),
                 config.gas_reports_include_tests,
-                FEN::EvmFactory::EXTRA_CHEATCODE_ADDRESSES.iter().copied(),
+                config.networks.extra_cheatcode_addresses().iter().copied(),
             )
         });
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -3335,10 +3335,11 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             return SymbolicFuzzSeedReplay::Rejected;
         }
 
-        let success = should_ignore_revert::<FEN>(
+        let success = should_ignore_revert(
             fuzz_config.fail_on_revert,
             self.address,
             raw_call_result.reverter,
+            self.executor.inspector().networks.extra_cheatcode_addresses(),
         ) || self.executor.is_raw_call_success(
             self.address,
             Cow::Borrowed(&raw_call_result.state_changeset),


### PR DESCRIPTION
Stacked on #16282.

Additional cheatcode addresses were associated with `FoundryEvmFactory`, causing Monad-specific behavior to follow the generic EVM type even when the active runtime network was not Monad.

Resolve these addresses from `NetworkConfigs` instead. Backend persistence, cheatcode account installation and dispatch, revert handling, fuzzing, invariant execution, and gas reporting now use the active network configuration. This removes `EXTRA_CHEATCODE_ADDRESSES` from `FoundryEvmFactory` and keeps the Monad cheatcode address inactive unless Monad is the resolved network.

> AI-assisted.
