### PR TITLE
feat(cheatcodes): stabilize storage hooks

### DIFF
--- a/.changelog/stabilize-storage-hooks.md
+++ b/.changelog/stabilize-storage-hooks.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Stabilized the raw and mapping storage hook cheatcodes.

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -9825,7 +9825,7 @@
         ]
       },
       "group": "evm",
-      "status": "experimental",
+      "status": "stable",
       "safety": "unsafe"
     },
     {
@@ -9845,7 +9845,7 @@
         ]
       },
       "group": "evm",
-      "status": "experimental",
+      "status": "stable",
       "safety": "unsafe"
     },
     {
@@ -9865,7 +9865,7 @@
         ]
       },
       "group": "evm",
-      "status": "experimental",
+      "status": "stable",
       "safety": "unsafe"
     },
     {

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -429,7 +429,7 @@ interface Vm {
     /// staticness. The callback runs as an ordinary call frame and consumes one of the 1024
     /// protocol call-depth slots; a load at the maximum legal call depth can have its callback
     /// rejected as too deep, propagating as a failure of the load.
-    #[cheatcode(group = Evm, safety = Unsafe, status = Experimental)]
+    #[cheatcode(group = Evm, safety = Unsafe)]
     function registerSloadHook(address target, bytes4 callback) external;
 
     /// Registers a callback invoked after each SSTORE against `target`'s effective storage account,
@@ -445,7 +445,7 @@ interface Vm {
     /// staticness. The callback runs as an ordinary call frame and consumes one of the 1024
     /// protocol call-depth slots; a store at the maximum legal call depth can have its callback
     /// rejected as too deep, propagating as a failure of the store.
-    #[cheatcode(group = Evm, safety = Unsafe, status = Experimental)]
+    #[cheatcode(group = Evm, safety = Unsafe)]
     function registerSstoreHook(address target, bytes4 callback) external;
 
     /// Registers a callback after exact mapping-element SSTOREs rooted at `rootSlot` in `target`'s effective storage account.
@@ -463,7 +463,7 @@ interface Vm {
     /// callback subtrees. The callback must authenticate `msg.sender == address(vm)` to prevent
     /// external spoofing. Raw and mapping SSTORE hooks conflict per target, while multiple mapping
     /// roots may be registered.
-    #[cheatcode(group = Evm, safety = Unsafe, status = Experimental)]
+    #[cheatcode(group = Evm, safety = Unsafe)]
     function registerMappingSstoreHook(address target, bytes32 rootSlot, bytes4 callback) external;
 
     /// Record all account accesses as part of CREATE, CALL or SELFDESTRUCT opcodes in order,


### PR DESCRIPTION
Promotes `registerSloadHook`, `registerSstoreHook`, and `registerMappingSstoreHook` from experimental to stable. The hooks were introduced in #15954 and #15976 with concrete and symbolic execution coverage, and the mapping hook has since been exercised in clement-ux/weth-symbolic#1 to verify global WETH balance accounting.

The hooks remain classified as unsafe for scripts because their callbacks can mutate simulation state or cause execution to revert.
