### PR TITLE
feat(cheatcodes): add typed FFI outputs

### DIFF
--- a/.changelog/typed-ffi-output.md
+++ b/.changelog/typed-ffi-output.md
@@ -1,0 +1,7 @@
+---
+forge: minor
+foundry-cheatcodes: minor
+foundry-cheatcodes-spec: minor
+---
+
+Added `vm.ffiUint`, `vm.ffiString`, and `vm.ffiBytes` for unambiguous FFI output decoding.

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -6166,6 +6166,66 @@
     },
     {
       "func": {
+        "id": "ffiBytes",
+        "description": "Performs a foreign function call via the terminal and decodes the output as hex bytes.",
+        "declaration": "function ffiBytes(string[] calldata commandInput) external returns (bytes memory result);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "ffiBytes(string[])",
+        "selector": "0x32730d81",
+        "selectorBytes": [
+          50,
+          115,
+          13,
+          129
+        ]
+      },
+      "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "ffiString",
+        "description": "Performs a foreign function call via the terminal and returns the output as a string.",
+        "declaration": "function ffiString(string[] calldata commandInput) external returns (string memory result);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "ffiString(string[])",
+        "selector": "0x0d0d2f41",
+        "selectorBytes": [
+          13,
+          13,
+          47,
+          65
+        ]
+      },
+      "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "ffiUint",
+        "description": "Performs a foreign function call via the terminal and parses the output as a `uint256`.",
+        "declaration": "function ffiUint(string[] calldata commandInput) external returns (uint256 result);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "ffiUint(string[])",
+        "selector": "0xcdf7c6c4",
+        "selectorBytes": [
+          205,
+          247,
+          198,
+          196
+        ]
+      },
+      "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "foundryVersionAtLeast",
         "description": "Returns true if the current Foundry version is greater than or equal to the given version.\nThe given version string must be in the format `major.minor.patch`.\nThis is equivalent to `foundryVersionCmp(version) >= 0`.",
         "declaration": "function foundryVersionAtLeast(string calldata version) external view returns (bool);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2228,6 +2228,18 @@ interface Vm {
     #[cheatcode(group = Filesystem)]
     function ffi(string[] calldata commandInput) external returns (bytes memory result);
 
+    /// Performs a foreign function call via the terminal and parses the output as a `uint256`.
+    #[cheatcode(group = Filesystem)]
+    function ffiUint(string[] calldata commandInput) external returns (uint256 result);
+
+    /// Performs a foreign function call via the terminal and returns the output as a string.
+    #[cheatcode(group = Filesystem)]
+    function ffiString(string[] calldata commandInput) external returns (string memory result);
+
+    /// Performs a foreign function call via the terminal and decodes the output as hex bytes.
+    #[cheatcode(group = Filesystem)]
+    function ffiBytes(string[] calldata commandInput) external returns (bytes memory result);
+
     /// Performs a foreign function call via terminal and returns the exit code, stdout, and stderr.
     #[cheatcode(group = Filesystem)]
     function tryFfi(string[] calldata commandInput) external returns (FfiResult memory result);

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -742,28 +742,32 @@ fn get_artifact_code<FEN: FoundryEvmNetwork>(
 impl Cheatcode for ffiCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
         let Self { commandInput: input } = self;
+        let stdout = ffi_stdout(state, input)?;
+        Ok(decode_ffi_stdout(&stdout).abi_encode())
+    }
+}
 
-        let output = ffi(state, input)?;
+impl Cheatcode for ffiUintCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { commandInput: input } = self;
+        parse(&ffi_stdout(state, input)?, &DynSolType::Uint(256))
+    }
+}
 
-        // Check the exit code of the command.
-        if output.exitCode != 0 {
-            // If the command failed, return an error with the exit code and stderr.
-            return Err(fmt_err!(
-                "ffi command {:?} exited with code {}. stderr: {}",
-                input,
-                output.exitCode,
-                String::from_utf8_lossy(&output.stderr)
-            ));
-        }
+impl Cheatcode for ffiStringCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { commandInput: input } = self;
+        Ok(ffi_stdout(state, input)?.abi_encode())
+    }
+}
 
-        // If the command succeeded but still wrote to stderr, log it as a warning.
-        if !output.stderr.is_empty() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            warn!(target: "cheatcodes", ?input, ?stderr, "ffi command wrote to stderr");
-        }
-
-        // We already hex-decoded the stdout in the `ffi` helper function.
-        Ok(output.stdout.abi_encode())
+impl Cheatcode for ffiBytesCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { commandInput: input } = self;
+        let stdout = ffi_stdout(state, input)?;
+        Ok(hex::decode(&stdout)
+            .map_err(|err| fmt_err!("failed parsing ffi stdout as bytes: {err}"))?
+            .abi_encode())
     }
 }
 
@@ -861,6 +865,43 @@ fn read_dir<FEN: FoundryEvmNetwork>(
 }
 
 fn ffi<FEN: FoundryEvmNetwork>(state: &Cheatcodes<FEN>, input: &[String]) -> Result<FfiResult> {
+    let output = ffi_command(state, input)?;
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let stdout = stdout.trim();
+    Ok(FfiResult {
+        exitCode: output.status.code().unwrap_or(69),
+        stdout: decode_ffi_stdout(stdout),
+        stderr: output.stderr.into(),
+    })
+}
+
+fn ffi_stdout<FEN: FoundryEvmNetwork>(state: &Cheatcodes<FEN>, input: &[String]) -> Result<String> {
+    let output = ffi_command(state, input)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    if !output.status.success() {
+        return Err(fmt_err!(
+            "ffi command {:?} exited with code {}. stderr: {}",
+            input,
+            output.status.code().unwrap_or(69),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    if !output.stderr.is_empty() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!(target: "cheatcodes", ?input, ?stderr, "ffi command wrote to stderr");
+    }
+    Ok(stdout.trim().to_string())
+}
+
+fn decode_ffi_stdout(stdout: &str) -> Bytes {
+    hex::decode(stdout).unwrap_or_else(|_| stdout.as_bytes().to_vec()).into()
+}
+
+fn ffi_command<FEN: FoundryEvmNetwork>(
+    state: &Cheatcodes<FEN>,
+    input: &[String],
+) -> Result<std::process::Output> {
     ensure!(
         state.config.ffi,
         "FFI is disabled; add the `--ffi` flag to allow tests to call external commands"
@@ -871,25 +912,9 @@ fn ffi<FEN: FoundryEvmNetwork>(state: &Cheatcodes<FEN>, input: &[String]) -> Res
 
     debug!(target: "cheatcodes", ?cmd, "invoking ffi");
 
-    let output = cmd
-        .current_dir(&state.config.root)
+    cmd.current_dir(&state.config.root)
         .output()
-        .map_err(|err| fmt_err!("failed to execute command {cmd:?}: {err}"))?;
-
-    // The stdout might be encoded on valid hex, or it might just be a string,
-    // so we need to determine which it is to avoid improperly encoding later.
-    let trimmed_stdout = String::from_utf8(output.stdout)?;
-    let trimmed_stdout = trimmed_stdout.trim();
-    let encoded_stdout = if let Ok(hex) = hex::decode(trimmed_stdout) {
-        hex
-    } else {
-        trimmed_stdout.as_bytes().to_vec()
-    };
-    Ok(FfiResult {
-        exitCode: output.status.code().unwrap_or(69),
-        stdout: encoded_stdout.into(),
-        stderr: output.stderr.into(),
-    })
+        .map_err(|err| fmt_err!("failed to execute command {cmd:?}: {err}"))
 }
 
 fn prompt_input(prompt_text: &str) -> Result<String, dialoguer::Error> {

--- a/testdata/default/cheats/Ffi.t.sol
+++ b/testdata/default/cheats/Ffi.t.sol
@@ -25,4 +25,33 @@ contract FfiTest is Test {
         bytes memory res = vm.ffi(inputs);
         assertEq(string(res), "gm");
     }
+
+    function testTypedFfiOutput() public {
+        string[] memory inputs = new string[](3);
+        inputs[0] = "echo";
+        inputs[1] = "-n";
+        inputs[2] = "42";
+
+        assertEq(vm.ffiUint(inputs), 42);
+        assertEq(vm.ffiString(inputs), "42");
+        assertEq(vm.ffiBytes(inputs), hex"42");
+
+        inputs[2] = "123";
+        assertEq(vm.ffiUint(inputs), 123);
+        assertEq(vm.ffiString(inputs), "123");
+    }
+
+    function testFfiBytesRejectsNonHexOutput() public {
+        string[] memory inputs = new string[](3);
+        inputs[0] = "echo";
+        inputs[1] = "-n";
+        inputs[2] = "gm";
+
+        vm.expectRevert();
+        this.ffiBytes(inputs);
+    }
+
+    function ffiBytes(string[] memory inputs) external returns (bytes memory) {
+        return vm.ffiBytes(inputs);
+    }
 }

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -301,6 +301,9 @@ interface Vm {
     function expectTip20LogoURIUpdated(address token, address updater, string calldata newLogoURI) external;
     function fee(uint256 newBasefee) external;
     function ffi(string[] calldata commandInput) external returns (bytes memory result);
+    function ffiBytes(string[] calldata commandInput) external returns (bytes memory result);
+    function ffiString(string[] calldata commandInput) external returns (string memory result);
+    function ffiUint(string[] calldata commandInput) external returns (uint256 result);
     function foundryVersionAtLeast(string calldata version) external view returns (bool);
     function foundryVersionCmp(string calldata version) external view returns (int256);
     function fromRlp(bytes calldata rlp) external pure returns (bytes[] memory data);


### PR DESCRIPTION
## Motivation

`vm.ffi` heuristically decodes valid even-length output as hex and falls back to UTF-8 otherwise. This makes numeric command output ambiguous: for example, `42` becomes a single hex byte while `123` remains the string `"123"`.

Closes #5988.

## Solution

Add `vm.ffiUint`, `vm.ffiString`, and `vm.ffiBytes` so callers can choose the expected output type explicitly. The legacy `vm.ffi` behavior remains unchanged, while the typed variants reuse the existing uint parser, return UTF-8 directly, or require valid hex respectively. The generated cheatcode metadata and interface are updated, and focused Solidity tests cover both the original ambiguity and strict bytes decoding.