### PR TITLE
perf(debugger): render only visible opcodes

### DIFF
--- a/.changelog/debugger-visible-opcodes.md
+++ b/.changelog/debugger-visible-opcodes.md
@@ -1,0 +1,6 @@
+---
+foundry-debugger: patch
+---
+
+Reduced debugger memory use and redraw latency for long traces by formatting only visible opcode
+rows.

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -67,6 +67,12 @@ pub(crate) struct DrawMemory {
     pub(crate) active_internal_call: Option<ActiveInternalCallCache>,
 }
 
+#[derive(Default)]
+struct OpcodeListState {
+    inner_call_index: Option<usize>,
+    max_pc: usize,
+}
+
 pub(crate) struct TUIContext<'a> {
     pub(crate) debugger_context: &'a mut DebuggerContext,
 
@@ -87,8 +93,7 @@ pub(crate) struct TUIContext<'a> {
     /// Current step in the debug steps.
     pub(crate) current_step: usize,
     pub(crate) draw_memory: DrawMemory,
-    pub(crate) opcode_list: Vec<String>,
-    pub(crate) last_index: usize,
+    opcode_list: OpcodeListState,
 
     pub(crate) stack_labels: bool,
     /// Whether to decode active buffer as utf8 or not.
@@ -118,8 +123,7 @@ impl<'a> TUIContext<'a> {
             status: None,
             current_step: 0,
             draw_memory: DrawMemory::default(),
-            opcode_list: Vec::new(),
-            last_index: 0,
+            opcode_list: OpcodeListState::default(),
 
             stack_labels: false,
             buf_utf: false,
@@ -135,7 +139,7 @@ impl<'a> TUIContext<'a> {
     }
 
     pub(crate) fn init(&mut self) {
-        self.gen_opcode_list();
+        self.refresh_opcode_list_state();
     }
 
     pub(crate) fn debug_arena(&self) -> &[DebugNode] {
@@ -170,20 +174,19 @@ impl<'a> TUIContext<'a> {
         &self.debug_steps()[self.current_step]
     }
 
-    fn gen_opcode_list(&mut self) {
-        self.opcode_list.clear();
-        let debug_steps =
-            &self.debugger_context.debug_arena[self.draw_memory.inner_call_index].steps;
-        for step in debug_steps {
-            self.opcode_list.push(pretty_opcode(step));
-        }
+    pub(super) const fn opcode_max_pc(&self) -> usize {
+        self.opcode_list.max_pc
     }
 
-    fn gen_opcode_list_if_necessary(&mut self) {
-        if self.last_index != self.draw_memory.inner_call_index {
-            self.gen_opcode_list();
-            self.last_index = self.draw_memory.inner_call_index;
+    fn refresh_opcode_list_state(&mut self) {
+        let inner_call_index = self.draw_memory.inner_call_index;
+        if self.opcode_list.inner_call_index == Some(inner_call_index) {
+            return;
         }
+
+        let debug_steps = &self.debugger_context.debug_arena[inner_call_index].steps;
+        self.opcode_list.max_pc = debug_steps.iter().map(|step| step.pc).max().unwrap_or(0);
+        self.opcode_list.inner_call_index = Some(inner_call_index);
     }
 
     fn active_buffer(&self) -> &[u8] {
@@ -247,8 +250,7 @@ impl TUIContext<'_> {
             Event::Mouse(event) => self.handle_mouse_event(event),
             _ => ControlFlow::Continue(()),
         };
-        // Generate the list after the event has been handled.
-        self.gen_opcode_list_if_necessary();
+        self.refresh_opcode_list_state();
         ret
     }
 
@@ -1690,7 +1692,7 @@ fn find_opcode_match(
     target.map(|(node_index, step_index, _, _)| (node_index, step_index))
 }
 
-fn pretty_opcode(step: &CallTraceStep) -> String {
+pub(super) fn pretty_opcode(step: &CallTraceStep) -> String {
     if let Some(immediate) = step.immediate_bytes.as_ref().filter(|b| !b.is_empty()) {
         format!("{}(0x{})", step.op, hex::encode(immediate))
     } else {

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -1,7 +1,9 @@
 //! TUI draw implementation.
 
 use super::{
-    context::{ActiveInternalCallCache, ActiveInternalCallLocation, StatusKind, TUIContext},
+    context::{
+        ActiveInternalCallCache, ActiveInternalCallLocation, StatusKind, TUIContext, pretty_opcode,
+    },
     storage::{StorageAccess, StorageSpace, hex_u256, storage_access_at},
 };
 use crate::{DebuggerLayout, debugger::DebuggerStats, op::OpcodeParam};
@@ -513,21 +515,21 @@ impl TUIContext<'_> {
 
     fn draw_op_list(&self, f: &mut Frame<'_>, area: Rect) {
         let debug_steps = self.debug_steps();
-        let max_pc = debug_steps.iter().map(|step| step.pc).max().unwrap_or(0);
-        let max_pc_len = hex_digits(max_pc);
-
-        let items = debug_steps
-            .iter()
-            .enumerate()
-            .map(|(i, step)| {
-                let mut content = String::with_capacity(64);
-                write!(content, "{:0>max_pc_len$x}|", step.pc).unwrap();
-                if let Some(op) = self.opcode_list.get(i) {
-                    content.push_str(op);
-                }
-                ListItem::new(Span::styled(content, Style::new().fg(Color::White)))
-            })
-            .collect::<Vec<_>>();
+        // Opcode items are one line each; window them before `List::new` collects the iterator.
+        let visible_rows = area.height.saturating_sub(2) as usize;
+        let scroll_padding = usize::from(visible_rows >= 3);
+        let end = debug_steps
+            .len()
+            .min(visible_rows.max(self.current_step.saturating_add(scroll_padding + 1)));
+        let start = end.saturating_sub(visible_rows);
+        let pc_width = hex_digits(self.opcode_max_pc());
+        let items = debug_steps[start..end].iter().map(|step| {
+            let opcode = pretty_opcode(step);
+            let mut row = String::with_capacity(pc_width + 1 + opcode.len());
+            write!(row, "{:0>pc_width$x}|", step.pc).unwrap();
+            row.push_str(&opcode);
+            ListItem::new(Span::styled(row, Style::new().fg(Color::White)))
+        });
 
         let step = self.current_step();
         let call_gas_used = self.debug_call().gas_limit.saturating_sub(step.gas_remaining);
@@ -544,8 +546,9 @@ impl TUIContext<'_> {
             .block(block)
             .highlight_symbol("▶")
             .highlight_style(Style::new().fg(Color::White).bg(Color::DarkGray))
-            .scroll_padding(1);
-        let mut state = ListState::default().with_selected(Some(self.current_step));
+            .scroll_padding(scroll_padding);
+        let mut state =
+            ListState::default().with_selected(Some(self.current_step.saturating_sub(start)));
         f.render_stateful_widget(list, area, &mut state);
     }
 
@@ -1551,6 +1554,50 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(screen.contains("Memory (max expansion: 0 bytes)"));
+    }
+
+    #[test]
+    fn opcode_list_draws_visible_window() {
+        let steps = (0..64)
+            .chain([0x100])
+            .map(|pc| {
+                let mut step = trace_step(Vec::new());
+                step.pc = pc;
+                step.op = OpCode::ADD;
+                step
+            })
+            .collect();
+        let mut context = context_with_arena(vec![debug_node(0, 0, steps)]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.current_step = 50;
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|f| tui.draw_op_list(f, Rect::new(0, 0, 80, 20))).unwrap();
+
+        let lines = terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(80)
+            .map(|cells| cells.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect::<Vec<_>>();
+        assert!(lines[1].contains("022|ADD"));
+        assert!(lines[17].contains("▶032|ADD"));
+        assert!(lines[18].contains("033|ADD"));
+
+        let backend = TestBackend::new(80, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| tui.draw_op_list(f, Rect::new(0, 0, 80, 3))).unwrap();
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(screen.contains("▶032|ADD"));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

The debugger redraws after every terminal event. The opcode pane scanned the entire active call for program-counter width, formatted every executed opcode into a new row, and passed the complete list to Ratatui on every frame. Ratatui then collected that iterator and advanced a fresh list state from offset zero to the selected step. Each keypress therefore scaled with trace length, while the TUI also retained a separate formatted `String` for every step in the active call.

## Solution

Replace the per-step opcode string cache with private per-call state containing only the active call index and maximum program counter. Build Ratatui items from the terminal-visible `CallTraceStep` slice and preserve the existing selected-row padding, including minimal pane heights.

Navigation and search are unchanged; both already operate directly on `CallTraceStep`.

## Results

Local release-mode Ratatui `TestBackend` probe over a synthetic 50,000-step trace (temporary probe code removed):

| Workload | `master` | This PR | Result |
| --- | ---: | ---: | ---: |
| Enter call / initialize opcode state | 1.45 ms | 0.125 ms | 11.6x faster |
| Opcode pane, 50 redraws | 159.2 ms | 3.39 ms | 47.0x faster |
| Full 160x50 debugger frame, 50 redraws | 160.6 ms | 9.45 ms | 17.0x faster |

The change also removes one cached heap string per step in the active call. A live `forge test --debug` run over an approximately 50,000-step assembly loop covered call changes, a 20,000-step jump, and repeated 1,000-step forward/back jumps. The focused render test covers normal and one-row pane heights, and an exhaustive model comparison checked 1,628,100 list-length, viewport-height, and selection combinations against Ratatui scrolling behavior.

Stack, source, storage, and variable-pane redraw work remain out of scope. They have different ownership and invalidation requirements and should be measured independently rather than bundled into this change.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## AI assistance

Codex was used for repository exploration, implementation, test execution, benchmarking, live TUI validation, and drafting this description. I reviewed the resulting changes and measurements.