### PR TITLE
perf(symbolic): speed up single-var witnesses

### DIFF
--- a/.changelog/symbolic-single-var-witnesses.md
+++ b/.changelog/symbolic-single-var-witnesses.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Sped up symbolic tests with large single-variable branch sets.

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -854,7 +854,15 @@ pub(crate) fn fallback_single_var_model(constraints: &[SymBoolExpr]) -> Option<S
         return None;
     }
 
-    let mut candidates = HashSet::<U256>::default();
+    let mut model = SymbolicModel::default();
+    let mut remaining_support_visits = usize::MAX;
+    if complete_fallback_support_model(constraints, &mut model, &mut remaining_support_visits)
+        && model.len() == 1
+        && model.contains_key(&var)
+    {
+        return Some(model);
+    }
+
     for candidate in [
         U256::ZERO,
         U256::from(1),
@@ -863,9 +871,14 @@ pub(crate) fn fallback_single_var_model(constraints: &[SymBoolExpr]) -> Option<S
         U256::MAX - U256::from(1),
         U256::MAX - U256::from(2),
     ] {
-        push_fallback_candidate(&mut candidates, candidate, hints);
+        let mut model = SymbolicModel::default();
+        model.insert(var, (candidate | hints.one) & !hints.zero);
+        if eval_model_constraints(constraints, &model) {
+            return Some(model);
+        }
     }
 
+    let mut candidates = HashSet::<U256>::default();
     for constant in constants.iter().copied() {
         push_fallback_candidate(&mut candidates, constant, hints);
         push_fallback_candidate(&mut candidates, constant.wrapping_add(U256::from(1)), hints);

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2584,6 +2584,34 @@ fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
 }
 
 #[test]
+fn fallback_model_uses_direct_bound_witness() {
+    let mut cx = SymCx::new();
+    let calldata = SymExpr::var(&mut cx, "calldata_0");
+    let upper_bound = SymExpr::constant(&mut cx, U256::from(512));
+    let constraint = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, calldata, upper_bound);
+
+    let model = fallback_single_var_model(&[constraint]).unwrap();
+
+    assert_eq!(model_value(&cx, &model, "calldata_0"), Some(U256::from(512)));
+}
+
+#[test]
+fn fallback_model_uses_boundary_witness() {
+    let mut cx = SymCx::new();
+    let calldata = SymExpr::var(&mut cx, "calldata_0");
+    let mut constraints = Vec::new();
+    for excluded in 0..3 {
+        let value = SymExpr::constant(&mut cx, U256::from(excluded));
+        let equals = SymBoolExpr::eq(&mut cx, calldata.clone(), value);
+        constraints.push(equals.not(&mut cx));
+    }
+
+    let model = fallback_single_var_model(&constraints).unwrap();
+
+    assert_eq!(model_value(&cx, &model, "calldata_0"), Some(U256::MAX));
+}
+
+#[test]
 fn fallback_model_keeps_multi_bit_nonzero_masks_weak() {
     let mut cx = SymCx::new();
     let calldata = SymExpr::var(&mut cx, "calldata_0");


### PR DESCRIPTION
## Summary

Reuses the existing support-model completion and boundary candidates before generating and sorting the full single-variable witness set. Every early model is evaluated against all constraints, and misses continue through the existing exhaustive fallback.

## Benchmarks

Measured with profiling builds over 20 runs of `forge test --symbolic --offline --match-test checkDispatch --json` on a 512-way equality dispatch.

| Benchmark | master | this PR | delta |
| --- | ---: | ---: | ---: |
| Dispatch wall time | 3.354s ± 0.012s | 953.4ms ± 22.4ms | 3.52x faster |
| Samply total samples | 3,433 | 947 | -72.4% |
| `fallback_single_var_model` samples | 2,850 | 387 | -86.4% |
| Ordinary symbolic bug-suite wall time | 173.4ms ± 2.0ms | 174.1ms ± 3.1ms | neutral |

The dispatch result remained unchanged at 513 paths, 1,026 solver queries, one SMT query, and 22,561 SMT input bytes.
