### PR TITLE
feat(cheatcodes): match EVM errors in expectRevert

### DIFF
--- a/.changelog/expect-revert-evm-errors.md
+++ b/.changelog/expect-revert-evm-errors.md
@@ -1,0 +1,6 @@
+---
+forge: minor
+foundry-cheatcodes: minor
+---
+
+Allowed `vm.expectRevert` to match status-derived EVM errors such as `EvmError: OutOfGas`.

--- a/crates/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/cheatcodes/src/test/revert_handlers.rs
@@ -81,6 +81,9 @@ fn handle_revert(
     };
 
     let mut actual_revert = if retdata.is_empty() && !expected_reason.is_empty() {
+        if status == InstructionResult::Revert {
+            bail!("call reverted as expected, but without data");
+        }
         RevertDecoder::new().decode(retdata, Some(status)).into_bytes()
     } else {
         retdata.to_vec()

--- a/crates/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/cheatcodes/src/test/revert_handlers.rs
@@ -80,11 +80,11 @@ fn handle_revert(
         return Ok(());
     };
 
-    if !expected_reason.is_empty() && retdata.is_empty() {
-        bail!("call reverted as expected, but without data");
-    }
-
-    let mut actual_revert: Vec<u8> = retdata.to_vec();
+    let mut actual_revert = if retdata.is_empty() && !expected_reason.is_empty() {
+        RevertDecoder::new().decode(retdata, Some(status)).into_bytes()
+    } else {
+        retdata.to_vec()
+    };
 
     // Compare only the first 4 bytes if partial match.
     if revert_params.partial_match() && actual_revert.get(..4) == expected_reason.get(..4) {

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -36,6 +36,12 @@ contract Reverter {
     function revertWithoutReason() public pure {
         revert();
     }
+
+    function outOfGas() public pure {
+        assembly {
+            for {} 1 {} {}
+        }
+    }
 }
 
 contract ConstructorReverter {
@@ -134,6 +140,12 @@ contract ExpectRevertTest is Test {
         Reverter reverter = new Reverter();
         vm.expectRevert(bytes(""));
         reverter.revertWithoutReason();
+    }
+
+    function testExpectRevertEvmError() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert(bytes("EvmError: OutOfGas"));
+        reverter.outOfGas{gas: 10_000}();
     }
 
     function testExpectRevertAnyRevert() public {


### PR DESCRIPTION
`expectRevert` rejected any non-empty expected reason when a halt returned no bytes, so status-derived failures such as `OutOfGas` could only be matched with `bytes("")`. This decodes empty-data halt statuses through the existing `RevertDecoder` before comparison, allowing explicit `EvmError: OutOfGas` expectations while preserving `bytes("")` matching for ordinary empty reverts.

Closes #4012.

This PR was prepared with AI assistance.
