### PR TITLE
fix(anvil): preserve fork node info errors

### DIFF
--- a/.changelog/preserve-anvil-node-info-errors.md
+++ b/.changelog/preserve-anvil-node-info-errors.md
@@ -1,0 +1,8 @@
+---
+anvil: patch
+cast: patch
+chisel: patch
+forge: patch
+---
+
+Preserved non-method-not-found `anvil_nodeInfo` errors during fork endpoint detection.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -124,7 +124,7 @@ impl AnvilNodeInfoProbe {
                 self.identified = true;
                 Ok(Some(node_info))
             }
-            Err(_) if !self.identified => Ok(None),
+            Err(error) if !self.identified && is_rpc_method_not_found(&error) => Ok(None),
             Err(error) => {
                 Err(error).wrap_err("failed to determine network family from fork endpoint")
             }

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -38,7 +38,7 @@ use foundry_evm_networks::NetworkConfigs;
 use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope};
 use foundry_test_utils::rpc::{
     self, next_http_rpc_endpoint, next_rpc_endpoint, spawn_rpc_proxy_erroring_method_after,
-    spawn_rpc_proxy_rejecting_method_after, spawn_rpc_proxy_rejecting_method_before,
+    spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
 };
 use futures::StreamExt;
 use revm::{
@@ -144,7 +144,7 @@ async fn test_fork_reset_keeps_node_info_probe_strict_after_identification_durin
 async fn test_fork_retries_when_anvil_node_info_becomes_available() {
     let (_api, origin) = spawn(NodeConfig::test()).await;
     let fork_url =
-        spawn_rpc_proxy_rejecting_method_before(origin.http_endpoint(), "anvil_nodeInfo", 1).await;
+        spawn_rpc_proxy_method_not_found_before(origin.http_endpoint(), "anvil_nodeInfo", 1).await;
 
     try_spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await.unwrap();
 }

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -89,13 +89,19 @@ pub fn fork_config() -> NodeConfig {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_fork_allows_unavailable_anvil_node_info() {
+async fn test_fork_rejects_anvil_node_info_rpc_error() {
     let (_api, origin) =
         spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
     let fork_url =
         spawn_rpc_proxy_erroring_method_after(origin.http_endpoint(), "anvil_nodeInfo", 0).await;
 
-    try_spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await.unwrap();
+    let result = try_spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
+    let Err(error) = result else { panic!("expected fork startup to fail") };
+
+    assert!(
+        error.to_string().contains("failed to determine network family from fork endpoint"),
+        "{error}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -1545,7 +1545,7 @@ mod tests {
     use alloy_rpc_types::anvil::Forking;
     use alloy_serde::WithOtherFields;
     use foundry_test_utils::rpc::{
-        spawn_rpc_proxy_rejecting_method_after, spawn_rpc_proxy_rejecting_method_before,
+        spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
     };
     #[cfg(feature = "optimism")]
     use op_revm::OpSpecId;
@@ -2258,7 +2258,7 @@ mod tests {
     async fn fork_node_info_probe_becomes_strict_after_initial_failure() {
         let (_api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
         let fork_url =
-            spawn_rpc_proxy_rejecting_method_before(handle.http_endpoint(), "anvil_nodeInfo", 1)
+            spawn_rpc_proxy_method_not_found_before(handle.http_endpoint(), "anvil_nodeInfo", 1)
                 .await;
         let evm_opts = EvmOpts { fork_url: Some(fork_url), ..Default::default() };
 

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -197,7 +197,7 @@ impl AnvilNodeInfoProbe {
                 self.identified = true;
                 Ok(Some(node_info))
             }
-            Err(_) if !self.identified => Ok(None),
+            Err(error) if !self.identified && is_rpc_method_not_found(&error) => Ok(None),
             Err(error) => Err(error).wrap_err("failed to determine network family from endpoint"),
         }
     }
@@ -2221,32 +2221,21 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn fork_non_anvil_node_info_failure_is_optional() {
+    async fn fork_non_anvil_node_info_rpc_error_is_visible() {
         let (_api, handle) =
             anvil::spawn(anvil::NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64)))
                 .await;
         let fork_url =
             spawn_rpc_proxy_rejecting_method_after(handle.http_endpoint(), "anvil_nodeInfo", 0)
                 .await;
-        let networks = NetworkConfigs::with_ethereum();
-        let mut evm_opts =
-            EvmOpts { fork_url: Some(fork_url.clone()), networks, ..Default::default() };
+        let mut evm_opts = EvmOpts { fork_url: Some(fork_url), ..Default::default() };
 
-        evm_opts.infer_network_from_fork().await.unwrap();
+        let error = evm_opts.infer_network_from_fork().await.unwrap_err();
 
-        assert_eq!(evm_opts.env.chain_id, Some(NamedChain::Mainnet as u64));
-        assert_eq!(evm_opts.networks, networks);
-        assert_eq!(evm_opts.fork_endpoint.as_ref().unwrap().reported_hardfork, None);
-        let (_, _, fork) = evm_opts.env_resolved::<SpecId, BlockEnv, TxEnv>().await.unwrap();
-        assert_eq!(fork.unwrap().context().network, NetworkVariant::Ethereum);
-
-        #[cfg(feature = "optimism")]
-        {
-            let networks = NetworkConfigs::with_optimism();
-            let mut evm_opts = EvmOpts { fork_url: Some(fork_url), networks, ..Default::default() };
-            evm_opts.infer_network_from_fork().await.unwrap();
-            assert_eq!(evm_opts.networks, networks);
-        }
+        assert!(
+            error.to_string().contains("failed to determine network family from endpoint"),
+            "{error}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -286,6 +286,8 @@ pub async fn spawn_rpc_proxy_rejecting_method_after(
         method,
         RpcMethodRejection::After(successful_calls),
         StatusCode::FORBIDDEN,
+        -32004,
+        "method is not allowed",
     )
     .await
 }
@@ -301,6 +303,26 @@ pub async fn spawn_rpc_proxy_rejecting_method_before(
         method,
         RpcMethodRejection::Before(rejected_calls),
         StatusCode::FORBIDDEN,
+        -32004,
+        "method is not allowed",
+    )
+    .await
+}
+
+/// Spawns an RPC proxy that returns method-not-found for the first `unavailable_calls` requests to
+/// `method`.
+pub async fn spawn_rpc_proxy_method_not_found_before(
+    endpoint: String,
+    method: &'static str,
+    unavailable_calls: usize,
+) -> String {
+    spawn_rpc_proxy_rejecting_method(
+        endpoint,
+        method,
+        RpcMethodRejection::Before(unavailable_calls),
+        StatusCode::OK,
+        -32601,
+        "method not found",
     )
     .await
 }
@@ -317,6 +339,8 @@ pub async fn spawn_rpc_proxy_erroring_method_after(
         method,
         RpcMethodRejection::After(successful_calls),
         StatusCode::OK,
+        -32004,
+        "method is not allowed",
     )
     .await
 }
@@ -341,6 +365,8 @@ async fn spawn_rpc_proxy_rejecting_method(
     method: &'static str,
     rejection: RpcMethodRejection,
     rejection_status: StatusCode,
+    error_code: i64,
+    error_message: &'static str,
 ) -> String {
     let client = reqwest::Client::new();
     let calls = std::sync::Arc::new(AtomicUsize::new(0));
@@ -361,8 +387,8 @@ async fn spawn_rpc_proxy_rejecting_method(
                             "jsonrpc": "2.0",
                             "id": id,
                             "error": {
-                                "code": -32004,
-                                "message": "method is not allowed",
+                                "code": error_code,
+                                "message": error_message,
                             },
                         })),
                     )


### PR DESCRIPTION
This keeps `anvil_nodeInfo` optional only when the endpoint returns an exact method-not-found response. Authentication, transport, rate-limit, and vendor RPC errors are now preserved instead of being silently treated as evidence that the endpoint is not Anvil.

AI assistance was used in preparing this change.