### PR TITLE
perf(symbolic): speed up constraint normalization

### DIFF
--- a/.changelog/symbolic-constraint-hash-ordering.md
+++ b/.changelog/symbolic-constraint-hash-ordering.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Sped up symbolic tests with large path-constraint sets by reusing cached structural hashes during normalization.

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -25,6 +25,11 @@ pub(in crate::runtime) enum SymBoolExprKind {
 }
 
 impl SymBoolExpr {
+    #[inline]
+    pub(in crate::runtime) fn stable_hash_cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.kind.stable_hash_cmp(&other.kind)
+    }
+
     pub(in crate::runtime) fn kind(&self) -> &SymBoolExprKind {
         self.kind.value()
     }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -49,7 +49,15 @@ fn normalize_constraint_batch(
 }
 
 fn sort_dedup_bool_exprs(exprs: &mut Vec<SymBoolExpr>) {
-    exprs.sort_by_cached_key(bool_structural_key);
+    // Hash-consing already caches deterministic structural hashes. Only render full structural
+    // keys for the exceedingly rare case where two distinct expressions collide.
+    exprs.sort_unstable_by(|left, right| {
+        if left == right {
+            return std::cmp::Ordering::Equal;
+        }
+        left.stable_hash_cmp(right)
+            .then_with(|| bool_structural_key(left).cmp(&bool_structural_key(right)))
+    });
     exprs.dedup();
 }
 

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3381,8 +3381,13 @@ fn solver_normalizes_constraint_batches_by_flattening_and_deduping() {
     ];
 
     let normalized = normalize_constraints_for_solver(&mut cx, &grouped);
+    let reversed =
+        normalize_constraints_for_solver(&mut cx, &grouped.into_iter().rev().collect::<Vec<_>>());
 
-    assert_eq!(normalized, vec![b, a]);
+    assert_eq!(normalized.len(), 2);
+    assert_eq!(normalized, reversed);
+    assert!(normalized.contains(&a));
+    assert!(normalized.contains(&b));
 
     let x_eq_y = SymBoolExpr::eq(&mut cx, x, y);
     let false_expr = SymBoolExpr::constant(&mut cx, false);


### PR DESCRIPTION
## Summary

- Order normalized solver constraints by the deterministic structural hashes already cached by hash-consing instead of rendering every expression into a `String`.
- Keep the existing structural key as the collision fallback, preserving a deterministic total order and canonical solver-cache keys.
- Extend the existing normalization regression test to cover permutation-independent ordering and deduplication.
- The internal order changes and may select a different valid counterexample, but repeated runs remain deterministic; the 22-case symbolic bug suite retained identical statuses and path/query counters.
- Validated with the symbolic crate's full 310-test nextest suite, clippy with warnings denied, Forge and symbolic crate checks, nightly formatting, and `git diff --check`.

## Benchmarks

Measured with `hyperfine` against a symbolic test containing sequential equality branches, using release Forge binaries and `--offline`:

| Scenario | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| 1,024 branches, warm (20 runs) | 2.808s | 1.682s | 1.67x, 1.126s saved |
| 2,048 branches, warm (8 runs) | 9.984s | 6.085s | 1.64x, 3.899s saved |
| 2,048 branches, `forge clean` before each run (5 runs) | 13.169s | 7.616s | 1.73x, 5.553s saved |

Samply attributed 27.9% of CPU samples before the change to rendering structural sort keys. That rendering is absent from the normal comparison path after the change.
