### PR TITLE
refactor(evm): remove foundry replay hook

### DIFF
--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -1,6 +1,8 @@
 //! A wrapper around `Backend` that is clone-on-write used for fuzzing.
 
 use super::BackendError;
+#[cfg(feature = "monad")]
+use crate::evm::protocol_system_call;
 use crate::{
     FoundryInspectorExt,
     backend::{
@@ -132,6 +134,10 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         chain_context: ChainFor<FEN>,
         inspector: I,
     ) -> eyre::Result<Option<ResultAndState<HaltReasonFor<FEN>>>> {
+        if !self.backend.networks().is_monad() || protocol_system_call(tx_env)?.is_none() {
+            return Ok(None);
+        }
+
         self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind()));
 
         let factory = FEN::EvmFactory::default();
@@ -141,14 +147,14 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
             chain_context,
             inspector,
         );
-        let result = factory.try_transact_foundry_system_replay(&mut evm, tx_env)?;
+        let result = evm.transact_raw(tx_env.clone())?;
 
         // A successful specialized replay replaces the EVM transaction with its synthetic system
         // call. Keep the canonical envelope in `tx_env`; ordinary execution uses
         // `inspect_with_context` above and copies inspector mutations back normally.
         *evm_env = evm.finish().1;
 
-        Ok(result)
+        Ok(Some(result))
     }
 
     /// Returns whether there was a state snapshot failure in the backend.

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -24,7 +24,7 @@ use revm::{
     Database, DatabaseCommit,
     bytecode::Bytecode,
     context::{ContextTr, Transaction},
-    context_interface::result::ResultAndState,
+    context_interface::result::{HaltReason, ResultAndState},
     database::DatabaseRef,
     primitives::AddressMap,
     state::{Account, AccountInfo, EvmState},
@@ -133,7 +133,7 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         tx_env: &mut TxEnvFor<FEN>,
         chain_context: ChainFor<FEN>,
         inspector: I,
-    ) -> eyre::Result<Option<ResultAndState<HaltReasonFor<FEN>>>> {
+    ) -> eyre::Result<Option<ResultAndState<HaltReason>>> {
         if !self.backend.networks().is_monad() || protocol_system_call(tx_env)?.is_none() {
             return Ok(None);
         }
@@ -141,18 +141,15 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind()));
 
         let factory = FEN::EvmFactory::default();
-        let mut evm = factory.create_foundry_evm_with_inspector(
-            self,
-            evm_env.clone(),
-            chain_context,
-            inspector,
-        );
+        let mut inspector = inspector;
+        let mut evm =
+            factory.create_foundry_nested_evm(self, evm_env.clone(), chain_context, &mut inspector);
         let result = evm.transact_raw(tx_env.clone())?;
 
         // A successful specialized replay replaces the EVM transaction with its synthetic system
         // call. Keep the canonical envelope in `tx_env`; ordinary execution uses
         // `inspect_with_context` above and copies inspector mutations back normally.
-        *evm_env = evm.finish().1;
+        *evm_env = evm.to_evm_env();
 
         Ok(Some(result))
     }

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -192,9 +192,6 @@ pub trait FoundryEvmFactory:
     /// Returning `Ok(None)` means the transaction was not recognized. Implementations must not
     /// mutate the EVM, its database, or inspector before returning `Ok(None)`, because callers may
     /// fall back to ordinary execution using the same EVM instance.
-    ///
-    /// Implementations that recognize a transaction here must provide equivalent recognition in
-    /// [`Self::try_transact_foundry_system_replay`].
     #[cfg(feature = "monad")]
     fn try_transact_system_replay<DB, I>(
         &self,
@@ -205,26 +202,6 @@ pub trait FoundryEvmFactory:
         DB: alloy_evm::Database,
         I: Inspector<Self::Context<DB>>,
     {
-        Ok(None)
-    }
-
-    /// Tries to execute a canonical system transaction on a Foundry-wrapped EVM with an inspector.
-    ///
-    /// Returning `Ok(None)` means the transaction was not recognized. Implementations must not
-    /// mutate the EVM, its database, or inspector before returning `Ok(None)`, because callers may
-    /// fall back to ordinary execution using the same EVM instance.
-    ///
-    /// Implementations that recognize a transaction here must provide equivalent recognition in
-    /// [`Self::try_transact_system_replay`].
-    #[cfg(feature = "monad")]
-    fn try_transact_foundry_system_replay<
-        'db,
-        I: FoundryInspectorExt<Self::FoundryContext<'db>>,
-    >(
-        &self,
-        _evm: &mut Self::FoundryEvm<'db, I>,
-        _tx: &Self::Tx,
-    ) -> eyre::Result<Option<ResultAndState<Self::HaltReason>>> {
         Ok(None)
     }
 

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -171,7 +171,7 @@ impl ProtocolSystemCall {
 ///
 /// Returns an error when the transaction uses Monad's reserved protocol sender but does not
 /// satisfy the canonical envelope rules.
-pub fn protocol_system_call(tx: &TxEnv) -> eyre::Result<Option<ProtocolSystemCall>> {
+pub fn protocol_system_call<T: Transaction>(tx: &T) -> eyre::Result<Option<ProtocolSystemCall>> {
     if tx.caller() != SYSTEM_ADDRESS {
         return Ok(None);
     }
@@ -193,23 +193,23 @@ pub fn protocol_system_call(tx: &TxEnv) -> eyre::Result<Option<ProtocolSystemCal
         "invalid Monad protocol system transaction: gas price must be zero"
     );
     eyre::ensure!(
-        tx.gas_priority_fee.is_none(),
+        tx.max_priority_fee_per_gas().is_none(),
         "invalid Monad protocol system transaction: priority fee must be absent"
     );
     eyre::ensure!(
-        tx.access_list.0.is_empty(),
+        tx.access_list().is_none_or(|mut list| list.next().is_none()),
         "invalid Monad protocol system transaction: access list must be empty"
     );
     eyre::ensure!(
-        tx.blob_hashes.is_empty(),
+        tx.blob_versioned_hashes().is_empty(),
         "invalid Monad protocol system transaction: blob hashes must be empty"
     );
     eyre::ensure!(
-        tx.max_fee_per_blob_gas == 0,
+        tx.max_fee_per_blob_gas() == 0,
         "invalid Monad protocol system transaction: blob gas fee must be zero"
     );
     eyre::ensure!(
-        tx.authorization_list.is_empty(),
+        tx.authorization_list_len() == 0,
         "invalid Monad protocol system transaction: authorization list must be empty"
     );
 
@@ -401,17 +401,6 @@ impl FoundryEvmFactory for MonadEvmFactory {
         DB: alloy_evm::Database,
         I: Inspector<Self::Context<DB>>,
     {
-        try_transact_monad_system_replay(evm, tx)
-    }
-
-    fn try_transact_foundry_system_replay<
-        'db,
-        I: FoundryInspectorExt<Self::FoundryContext<'db>>,
-    >(
-        &self,
-        evm: &mut Self::FoundryEvm<'db, I>,
-        tx: &Self::Tx,
-    ) -> eyre::Result<Option<ResultAndState<Self::HaltReason>>> {
         try_transact_monad_system_replay(evm, tx)
     }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -36,7 +36,7 @@ use foundry_evm_core::{
     },
     evm::{
         BlockContext, ChainFor, EthEvmNetwork, EvmEnvFor, FoundryEvmFactory, FoundryEvmNetwork,
-        HaltReasonFor, IntoInstructionResult, SpecFor, TxEnvFor,
+        IntoInstructionResult, SpecFor, TxEnvFor,
     },
     utils::StateChangeset,
 };
@@ -1545,11 +1545,11 @@ fn calculate_stipend(tx_env: &impl Transaction, spec: SpecId, eip2780_enabled: b
 }
 
 /// Converts the data aggregated in the `inspector` and `call` to a `RawCallResult`.
-fn convert_executed_result<FEN: FoundryEvmNetwork>(
+fn convert_executed_result<FEN: FoundryEvmNetwork, H: IntoInstructionResult>(
     evm_env: EvmEnvFor<FEN>,
     tx_env: TxEnvFor<FEN>,
     mut inspector: InspectorStack<FEN>,
-    ResultAndState { result, state: state_changeset }: ResultAndState<HaltReasonFor<FEN>>,
+    ResultAndState { result, state: state_changeset }: ResultAndState<H>,
     db: &dyn DatabaseRef<Error = DatabaseError>,
     has_state_snapshot_failure: bool,
     fork_block_number: Option<u64>,


### PR DESCRIPTION
Stacked on #16292.

Removes `FoundryEvmFactory::try_transact_foundry_system_replay`. The Monad-gated Cow backend now recognizes canonical protocol envelopes only when the active runtime network is Monad, then executes them through the network-owned `NestedEvm::transact_raw` path while preserving the existing optional recognition contract.

AI assistance was used.
