### PR TITLE
refactor(traces): reuse hardfork conversions

### DIFF
--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -11,7 +11,7 @@ use foundry_evm::hardforks::EthereumHardfork;
 #[cfg(feature = "monad")]
 use foundry_evm::hardforks::MonadHardfork;
 use foundry_evm::{
-    hardforks::TempoHardfork,
+    hardforks::{ExecutionSpec, TempoHardfork},
     opts::ForkEndpointIdentity,
     traces::{
         CallTraceDecoderBuilder, DebugTraceIdentifier,
@@ -76,18 +76,12 @@ pub(crate) async fn handle_traces(
 
     let resolved_hardfork = hardfork.or(config.hardfork);
     let execution_network = networks.execution_network();
-    let tempo_hardfork = resolved_hardfork.and_then(|hardfork| match hardfork {
-        FoundryHardfork::Tempo(hardfork) => Some(hardfork),
-        _ => None,
-    });
+    let tempo_hardfork = resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork);
     let is_tempo = execution_network.is_tempo();
     #[cfg(feature = "monad")]
     let is_monad = execution_network.is_monad();
     #[cfg(feature = "monad")]
-    let monad_hardfork = resolved_hardfork.and_then(|hardfork| match hardfork {
-        FoundryHardfork::Monad(hardfork) => Some(hardfork),
-        _ => None,
-    });
+    let monad_hardfork = resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork);
     let mut builder = CallTraceDecoderBuilder::new()
         .with_tracing_config(tracing)
         .with_signature_identifier(SignaturesIdentifier::from_config(config)?)

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -12,10 +12,13 @@ use alloy_primitives::{Address, hex};
 use eyre::{Context, Result};
 use forge_fmt::FormatterConfig;
 use foundry_cli::utils::fetch_abi_from_etherscan;
-use foundry_config::{Chain, Config, FoundryHardfork, RpcEndpointUrl};
+use foundry_config::{Chain, Config, RpcEndpointUrl};
+#[cfg(feature = "monad")]
+use foundry_evm::hardforks::MonadHardfork;
 use foundry_evm::{
     core::evm::FoundryEvmNetwork,
     decode::decode_console_logs,
+    hardforks::{ExecutionSpec, TempoHardfork},
     traces::{
         CallTraceDecoder, CallTraceDecoderBuilder, TraceKind, decode_trace_arena,
         identifier::{SignaturesIdentifier, TraceIdentifiers},
@@ -179,19 +182,12 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
             )?)
             .with_networks(session_config.foundry_config.networks)
             .with_chain_id(chain_id.map(|c| c.id()))
-            .with_tempo_hardfork(resolved_hardfork.and_then(|hardfork| match hardfork {
-                FoundryHardfork::Tempo(hardfork) => Some(hardfork),
-                _ => None,
-            }));
+            .with_tempo_hardfork(resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork));
         #[cfg(feature = "monad")]
         {
-            builder =
-                builder.with_monad_hardfork(resolved_hardfork.and_then(
-                    |hardfork| match hardfork {
-                        FoundryHardfork::Monad(hardfork) => Some(hardfork),
-                        _ => None,
-                    },
-                ));
+            builder = builder.with_monad_hardfork(
+                resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork),
+            );
         }
         let mut decoder = builder.build();
 

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -12,7 +12,7 @@ use foundry_evm_core::{
 };
 #[cfg(feature = "monad")]
 use foundry_evm_hardforks::MonadHardfork;
-use foundry_evm_hardforks::{FoundryHardfork, TempoHardfork};
+use foundry_evm_hardforks::{ExecutionSpec, FoundryHardfork, TempoHardfork};
 use foundry_evm_networks::NetworkConfigs;
 use foundry_evm_traces::TraceRequirements;
 use revm::state::Bytecode;
@@ -127,15 +127,9 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         networks: NetworkConfigs,
         resolved_hardfork: Option<FoundryHardfork>,
     ) {
-        let tempo_hardfork = resolved_hardfork.and_then(|hardfork| match hardfork {
-            FoundryHardfork::Tempo(hardfork) => Some(hardfork),
-            _ => None,
-        });
+        let tempo_hardfork = resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork);
         #[cfg(feature = "monad")]
-        let monad_hardfork = resolved_hardfork.and_then(|hardfork| match hardfork {
-            FoundryHardfork::Monad(hardfork) => Some(hardfork),
-            _ => None,
-        });
+        let monad_hardfork = resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork);
         #[cfg(not(feature = "monad"))]
         let monad_hardfork = None;
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -50,7 +50,7 @@ use foundry_compilers::{
     utils::source_files_iter,
 };
 use foundry_config::{
-    Config, FoundryHardfork, InlineConfig, InvariantDepthMode, InvariantWorkers, figment,
+    Config, InlineConfig, InvariantDepthMode, InvariantWorkers, figment,
     figment::{
         Metadata, Profile, Provider,
         value::{Dict, Map, Value},
@@ -63,12 +63,15 @@ use foundry_debugger::{Debugger, DebuggerLayout};
 use foundry_evm::core::evm::MonadEvmNetwork;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
+#[cfg(feature = "monad")]
+use foundry_evm::hardforks::MonadHardfork;
 use foundry_evm::{
     core::evm::{
         BlockEnvFor, EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor,
     },
     executors::ShowmapDomain,
     fuzz::{BaseCounterExample, BasicTxDetails, CounterExample},
+    hardforks::{ExecutionSpec, TempoHardfork},
     opts::EvmOpts,
     traces::{
         backtrace::BacktraceBuilder, identifier::TraceIdentifiers, prune_trace_depth,
@@ -2948,19 +2951,12 @@ impl TestArgs {
             .with_known_contracts(&known_contracts)
             .with_networks(networks)
             .with_chain_id(remote_chain.map(|c| c.id()))
-            .with_tempo_hardfork(resolved_hardfork.and_then(|hardfork| match hardfork {
-                FoundryHardfork::Tempo(hardfork) => Some(hardfork),
-                _ => None,
-            }));
+            .with_tempo_hardfork(resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork));
         #[cfg(feature = "monad")]
         {
-            builder =
-                builder.with_monad_hardfork(resolved_hardfork.and_then(
-                    |hardfork| match hardfork {
-                        FoundryHardfork::Monad(hardfork) => Some(hardfork),
-                        _ => None,
-                    },
-                ));
+            builder = builder.with_monad_hardfork(
+                resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork),
+            );
         }
         // Signatures are of no value for gas reports.
         if !self.gas_report {

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -21,11 +21,14 @@ use foundry_common::{
     fmt::{format_token, format_token_raw},
     provider::ProviderBuilder,
 };
-use foundry_config::{Chain, FoundryHardfork, NamedChain};
+use foundry_config::{Chain, NamedChain};
 use foundry_debugger::Debugger;
+#[cfg(feature = "monad")]
+use foundry_evm::hardforks::MonadHardfork;
 use foundry_evm::{
     core::evm::FoundryEvmNetwork,
     decode::decode_console_logs,
+    hardforks::{ExecutionSpec, TempoHardfork},
     inspectors::cheatcodes::BroadcastableTransactions,
     traces::{
         CallTraceDecoder, CallTraceDecoderBuilder, DebugTraceIdentifier, TraceKind,
@@ -459,17 +462,11 @@ pub(crate) fn build_trace_decoder_for_context<FEN: FoundryEvmNetwork>(
         .with_signature_identifier(SignaturesIdentifier::from_config(&script_config.config)?)
         .with_networks(script_config.config.networks)
         .with_chain_id(chain_id.map(|chain| chain.id()))
-        .with_tempo_hardfork(resolved_hardfork.and_then(|hardfork| match hardfork {
-            FoundryHardfork::Tempo(hardfork) => Some(hardfork),
-            _ => None,
-        }));
+        .with_tempo_hardfork(resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork));
     #[cfg(feature = "monad")]
     {
-        builder =
-            builder.with_monad_hardfork(resolved_hardfork.and_then(|hardfork| match hardfork {
-                FoundryHardfork::Monad(hardfork) => Some(hardfork),
-                _ => None,
-            }));
+        builder = builder
+            .with_monad_hardfork(resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork));
     }
     let mut decoder = builder.build();
 


### PR DESCRIPTION
Replaces repeated Tempo and Monad hardfork variant matching with the existing `ExecutionSpec` conversions. This centralizes hardfork extraction across trace decoders and precompile-label setup while preserving existing behavior.