### PR TITLE
refactor(anvil): centralize Monad block metadata

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -7359,12 +7359,25 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
     ) -> Result<SerializableState, BlockchainError> {
         let at = self.evm_env.read().block_env.clone();
         #[cfg(feature = "monad")]
-        let monad_block_metadata;
+        let mut monad_block_participants = BTreeMap::new();
+        #[cfg(feature = "monad")]
+        let mut monad_block_replay_profiles = BTreeMap::new();
         let (best_number, blocks, transactions) = {
             let storage = self.blockchain.storage.read();
             #[cfg(feature = "monad")]
-            {
-                monad_block_metadata = self.serialized_monad_block_metadata(&storage);
+            if self.is_monad() {
+                monad_block_participants = storage
+                    .monad_block_participants
+                    .iter()
+                    .filter(|(hash, _)| storage.blocks.contains_key(*hash))
+                    .map(|(hash, participants)| (*hash, participants.iter().copied().collect()))
+                    .collect();
+                monad_block_replay_profiles = storage
+                    .monad_block_replay_profiles
+                    .iter()
+                    .filter(|(hash, _)| storage.blocks.contains_key(*hash))
+                    .map(|(hash, profile)| (*hash, *profile))
+                    .collect();
             }
             (storage.best_number, storage.serialized_blocks(), storage.serialized_transactions())
         };
@@ -7384,7 +7397,8 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         #[cfg(feature = "monad")]
         let state = {
             let mut state = state;
-            monad_block_metadata.apply(&mut state);
+            state.monad_block_participants = monad_block_participants;
+            state.monad_block_replay_profiles = monad_block_replay_profiles;
             state
         };
         Ok(state)
@@ -7517,7 +7531,24 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         }
 
         #[cfg(feature = "monad")]
-        self.restore_monad_block_metadata(&mut storage, &state)?;
+        if self.is_monad() {
+            for (hash, profile) in &state.monad_block_replay_profiles {
+                if storage.blocks.contains_key(hash) {
+                    storage.monad_block_replay_profiles.insert(*hash, *profile);
+                }
+            }
+            for (hash, participants) in &state.monad_block_participants {
+                if storage.blocks.contains_key(hash) {
+                    storage
+                        .monad_block_participants
+                        .insert(*hash, participants.iter().copied().collect());
+                }
+            }
+            self.rebuild_monad_block_participant_cache(&mut storage)?;
+            // Reject state that cannot supply the ancestor metadata required by the next block
+            // before changing the live chain, EVM environment, or database.
+            self.monad_context_for_child_of_in_storage(&storage, storage.best_hash)?;
+        }
 
         // Re-anchor block time to the canonical head selected above so the next blocks continue
         // its timeline: the saved one when the loaded head stays canonical, the fork's when the

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4769,9 +4769,7 @@ impl<N: Network> Backend<N> {
                     }
                 }
                 #[cfg(feature = "monad")]
-                storage.monad_block_participants.remove(&hash);
-                #[cfg(feature = "monad")]
-                storage.monad_block_replay_profiles.remove(&hash);
+                storage.remove_monad_block_metadata(&hash);
             }
 
             storage.best_number = num;
@@ -5179,13 +5177,12 @@ where
             storage.hashes.insert(block_number, block_hash);
             #[cfg(feature = "monad")]
             if let Some(participants) = monad_participants {
-                storage.monad_block_participants.insert(block_hash, participants);
-                storage.monad_block_replay_profiles.insert(
+                monad::store_block_metadata(
+                    &mut storage,
                     block_hash,
-                    MonadBlockReplayProfile {
-                        execution_chain_id,
-                        hardfork: MonadHardfork::from(hardfork),
-                    },
+                    participants,
+                    execution_chain_id,
+                    hardfork,
                 );
             }
             for (info, receipt) in transactions.into_iter().zip(receipts) {
@@ -5578,13 +5575,12 @@ where
             storage.hashes.insert(block_number, block_hash);
             #[cfg(feature = "monad")]
             if let Some(participants) = monad_participants {
-                storage.monad_block_participants.insert(block_hash, participants);
-                storage.monad_block_replay_profiles.insert(
+                monad::store_block_metadata(
+                    &mut storage,
                     block_hash,
-                    MonadBlockReplayProfile {
-                        execution_chain_id: evm_env.cfg_env.chain_id,
-                        hardfork: hardfork.into(),
-                    },
+                    participants,
+                    evm_env.cfg_env.chain_id,
+                    hardfork,
                 );
             }
 
@@ -7363,25 +7359,12 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
     ) -> Result<SerializableState, BlockchainError> {
         let at = self.evm_env.read().block_env.clone();
         #[cfg(feature = "monad")]
-        let mut monad_block_participants = BTreeMap::new();
-        #[cfg(feature = "monad")]
-        let mut monad_block_replay_profiles = BTreeMap::new();
+        let monad_block_metadata;
         let (best_number, blocks, transactions) = {
             let storage = self.blockchain.storage.read();
             #[cfg(feature = "monad")]
-            if self.is_monad() {
-                monad_block_participants = storage
-                    .monad_block_participants
-                    .iter()
-                    .filter(|(hash, _)| storage.blocks.contains_key(*hash))
-                    .map(|(hash, participants)| (*hash, participants.iter().copied().collect()))
-                    .collect();
-                monad_block_replay_profiles = storage
-                    .monad_block_replay_profiles
-                    .iter()
-                    .filter(|(hash, _)| storage.blocks.contains_key(*hash))
-                    .map(|(hash, profile)| (*hash, *profile))
-                    .collect();
+            {
+                monad_block_metadata = self.serialized_monad_block_metadata(&storage);
             }
             (storage.best_number, storage.serialized_blocks(), storage.serialized_transactions())
         };
@@ -7401,8 +7384,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         #[cfg(feature = "monad")]
         let state = {
             let mut state = state;
-            state.monad_block_participants = monad_block_participants;
-            state.monad_block_replay_profiles = monad_block_replay_profiles;
+            monad_block_metadata.apply(&mut state);
             state
         };
         Ok(state)
@@ -7535,24 +7517,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         }
 
         #[cfg(feature = "monad")]
-        if self.is_monad() {
-            for (hash, profile) in &state.monad_block_replay_profiles {
-                if storage.blocks.contains_key(hash) {
-                    storage.monad_block_replay_profiles.insert(*hash, *profile);
-                }
-            }
-            for (hash, participants) in &state.monad_block_participants {
-                if storage.blocks.contains_key(hash) {
-                    storage
-                        .monad_block_participants
-                        .insert(*hash, participants.iter().copied().collect());
-                }
-            }
-            self.rebuild_monad_block_participant_cache(&mut storage)?;
-            // Reject state that cannot supply the ancestor metadata required by the next block
-            // before changing the live chain, EVM environment, or database.
-            self.monad_context_for_child_of_in_storage(&storage, storage.best_hash)?;
-        }
+        self.restore_monad_block_metadata(&mut storage, &state)?;
 
         // Re-anchor block time to the canonical head selected above so the next blocks continue
         // its timeline: the saved one when the loaded head stays canonical, the fork's when the

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -6,8 +6,7 @@ use super::{
 };
 use crate::eth::{
     backend::{
-        db::{MonadBlockReplayProfile, SerializableState},
-        executor::build_tx_env_for_pending,
+        db::MonadBlockReplayProfile, executor::build_tx_env_for_pending,
         replay::HistoricalReplayTransaction,
     },
     error::BlockchainError,
@@ -16,7 +15,7 @@ use alloy_consensus::{BlockHeader, constants::EMPTY_ROOT_HASH};
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, RecoveredTx};
 use alloy_monad_evm::{MonadContext, MonadEvm, MonadEvmFactory};
 use alloy_network::{BlockResponse, Network};
-use alloy_primitives::{Address, B256};
+use alloy_primitives::B256;
 use alloy_rpc_types::{BlockNumberOrTag as BlockNumber, BlockTransactions};
 use anvil_core::eth::{
     block::Block,
@@ -44,7 +43,6 @@ use revm::{
     },
     database_interface::WrapDatabaseRef,
 };
-use std::collections::{BTreeMap, BTreeSet};
 
 pub(super) fn store_block_metadata<N: Network>(
     storage: &mut BlockchainStorage<N>,
@@ -58,19 +56,6 @@ pub(super) fn store_block_metadata<N: Network>(
         block_hash,
         MonadBlockReplayProfile { execution_chain_id, hardfork: MonadHardfork::from(hardfork) },
     );
-}
-
-#[derive(Default)]
-pub(super) struct SerializedBlockMetadata {
-    participants: BTreeMap<B256, BTreeSet<Address>>,
-    replay_profiles: BTreeMap<B256, MonadBlockReplayProfile>,
-}
-
-impl SerializedBlockMetadata {
-    pub(super) fn apply(self, state: &mut SerializableState) {
-        state.monad_block_participants = self.participants;
-        state.monad_block_replay_profiles = self.replay_profiles;
-    }
 }
 
 pub(super) struct PreparedExecution {
@@ -146,56 +131,6 @@ pub(super) fn rollback_transaction<DB: alloy_evm::Database>(
 }
 
 impl<N: Network> Backend<N> {
-    pub(super) fn serialized_monad_block_metadata(
-        &self,
-        storage: &BlockchainStorage<N>,
-    ) -> SerializedBlockMetadata {
-        if !self.is_monad() {
-            return SerializedBlockMetadata::default();
-        }
-        SerializedBlockMetadata {
-            participants: storage
-                .monad_block_participants
-                .iter()
-                .filter(|(hash, _)| storage.blocks.contains_key(*hash))
-                .map(|(hash, participants)| (*hash, participants.iter().copied().collect()))
-                .collect(),
-            replay_profiles: storage
-                .monad_block_replay_profiles
-                .iter()
-                .filter(|(hash, _)| storage.blocks.contains_key(*hash))
-                .map(|(hash, profile)| (*hash, *profile))
-                .collect(),
-        }
-    }
-
-    pub(super) fn restore_monad_block_metadata(
-        &self,
-        storage: &mut BlockchainStorage<N>,
-        state: &SerializableState,
-    ) -> Result<(), BlockchainError> {
-        if !self.is_monad() {
-            return Ok(());
-        }
-        for (hash, profile) in &state.monad_block_replay_profiles {
-            if storage.blocks.contains_key(hash) {
-                storage.monad_block_replay_profiles.insert(*hash, *profile);
-            }
-        }
-        for (hash, participants) in &state.monad_block_participants {
-            if storage.blocks.contains_key(hash) {
-                storage
-                    .monad_block_participants
-                    .insert(*hash, participants.iter().copied().collect());
-            }
-        }
-        self.rebuild_monad_block_participant_cache(storage)?;
-        // Reject state that cannot supply the ancestor metadata required by the next block before
-        // changing the live chain, EVM environment, or database.
-        self.monad_context_for_child_of_in_storage(storage, storage.best_hash)?;
-        Ok(())
-    }
-
     /// Reconstructs a locally mined transaction using its authoritative stored sender.
     pub(super) fn monad_pending_mined_transaction_from_storage(
         storage: &BlockchainStorage<N>,

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -5,14 +5,18 @@ use super::{
     storage::BlockchainStorage,
 };
 use crate::eth::{
-    backend::{executor::build_tx_env_for_pending, replay::HistoricalReplayTransaction},
+    backend::{
+        db::{MonadBlockReplayProfile, SerializableState},
+        executor::build_tx_env_for_pending,
+        replay::HistoricalReplayTransaction,
+    },
     error::BlockchainError,
 };
 use alloy_consensus::{BlockHeader, constants::EMPTY_ROOT_HASH};
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, RecoveredTx};
 use alloy_monad_evm::{MonadContext, MonadEvm, MonadEvmFactory};
 use alloy_network::{BlockResponse, Network};
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use alloy_rpc_types::{BlockNumberOrTag as BlockNumber, BlockTransactions};
 use anvil_core::eth::{
     block::Block,
@@ -27,6 +31,7 @@ use foundry_evm::{
             monad_block_participants, monad_context_from_participants,
         },
     },
+    hardfork::FoundryHardfork,
 };
 use foundry_primitives::FoundryTxEnvelope;
 use monad_revm::{MonadChainContext, MonadHardfork, instructions::monad_gas_params};
@@ -39,6 +44,34 @@ use revm::{
     },
     database_interface::WrapDatabaseRef,
 };
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(super) fn store_block_metadata<N: Network>(
+    storage: &mut BlockchainStorage<N>,
+    block_hash: B256,
+    participants: MonadBlockParticipants,
+    execution_chain_id: u64,
+    hardfork: FoundryHardfork,
+) {
+    storage.monad_block_participants.insert(block_hash, participants);
+    storage.monad_block_replay_profiles.insert(
+        block_hash,
+        MonadBlockReplayProfile { execution_chain_id, hardfork: MonadHardfork::from(hardfork) },
+    );
+}
+
+#[derive(Default)]
+pub(super) struct SerializedBlockMetadata {
+    participants: BTreeMap<B256, BTreeSet<Address>>,
+    replay_profiles: BTreeMap<B256, MonadBlockReplayProfile>,
+}
+
+impl SerializedBlockMetadata {
+    pub(super) fn apply(self, state: &mut SerializableState) {
+        state.monad_block_participants = self.participants;
+        state.monad_block_replay_profiles = self.replay_profiles;
+    }
+}
 
 pub(super) struct PreparedExecution {
     pub(super) context: Option<MonadChainContext>,
@@ -113,6 +146,56 @@ pub(super) fn rollback_transaction<DB: alloy_evm::Database>(
 }
 
 impl<N: Network> Backend<N> {
+    pub(super) fn serialized_monad_block_metadata(
+        &self,
+        storage: &BlockchainStorage<N>,
+    ) -> SerializedBlockMetadata {
+        if !self.is_monad() {
+            return SerializedBlockMetadata::default();
+        }
+        SerializedBlockMetadata {
+            participants: storage
+                .monad_block_participants
+                .iter()
+                .filter(|(hash, _)| storage.blocks.contains_key(*hash))
+                .map(|(hash, participants)| (*hash, participants.iter().copied().collect()))
+                .collect(),
+            replay_profiles: storage
+                .monad_block_replay_profiles
+                .iter()
+                .filter(|(hash, _)| storage.blocks.contains_key(*hash))
+                .map(|(hash, profile)| (*hash, *profile))
+                .collect(),
+        }
+    }
+
+    pub(super) fn restore_monad_block_metadata(
+        &self,
+        storage: &mut BlockchainStorage<N>,
+        state: &SerializableState,
+    ) -> Result<(), BlockchainError> {
+        if !self.is_monad() {
+            return Ok(());
+        }
+        for (hash, profile) in &state.monad_block_replay_profiles {
+            if storage.blocks.contains_key(hash) {
+                storage.monad_block_replay_profiles.insert(*hash, *profile);
+            }
+        }
+        for (hash, participants) in &state.monad_block_participants {
+            if storage.blocks.contains_key(hash) {
+                storage
+                    .monad_block_participants
+                    .insert(*hash, participants.iter().copied().collect());
+            }
+        }
+        self.rebuild_monad_block_participant_cache(storage)?;
+        // Reject state that cannot supply the ancestor metadata required by the next block before
+        // changing the live chain, EVM environment, or database.
+        self.monad_context_for_child_of_in_storage(storage, storage.best_hash)?;
+        Ok(())
+    }
+
     /// Reconstructs a locally mined transaction using its authoritative stored sender.
     pub(super) fn monad_pending_mined_transaction_from_storage(
         storage: &BlockchainStorage<N>,

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -328,6 +328,13 @@ pub struct BlockchainStorage<N: Network> {
 }
 
 impl<N: Network> BlockchainStorage<N> {
+    /// Removes all metadata associated with a locally stored Monad block.
+    #[cfg(feature = "monad")]
+    pub(super) fn remove_monad_block_metadata(&mut self, block_hash: &B256) {
+        self.monad_block_participants.remove(block_hash);
+        self.monad_block_replay_profiles.remove(block_hash);
+    }
+
     /// Creates a new storage with a genesis block
     pub fn new(
         evm_env: &EvmEnv,
@@ -421,9 +428,7 @@ impl<N: Network> BlockchainStorage<N> {
                     removed.push(block);
                 }
                 #[cfg(feature = "monad")]
-                self.monad_block_participants.remove(&hash);
-                #[cfg(feature = "monad")]
-                self.monad_block_replay_profiles.remove(&hash);
+                self.remove_monad_block_metadata(&hash);
                 self.hashes.remove(&i);
             }
         }


### PR DESCRIPTION
Centralizes the insertion, removal, serialization, and restoration of Monad block metadata. This keeps its lifecycle coordinated and reduces Monad-specific bookkeeping in the generic backend without changing state compatibility or behavior.