### PR TITLE
fix(anvil): key trace cache by options

### DIFF
--- a/.changelog/anvil-trace-cache-options.md
+++ b/.changelog/anvil-trace-cache-options.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed forked debug trace requests returning cached results produced with different tracing options.

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -341,14 +341,23 @@ impl<N: Network> ClientFork<N> {
         hash: B256,
         opts: GethDebugTracingOptions,
     ) -> Result<GethTrace, TransportError> {
-        if let Some(traces) = self.storage_read().geth_transaction_traces.get(&hash).cloned() {
-            return Ok(traces);
+        if let Some(trace) = self
+            .storage_read()
+            .geth_transaction_traces
+            .get(&hash)
+            .and_then(|traces| traces.iter().find(|(cached_opts, _)| cached_opts == &opts))
+            .map(|(_, trace)| trace.clone())
+        {
+            return Ok(trace);
         }
 
-        let trace = self.provider().debug_trace_transaction(hash, opts).await?;
+        let trace = self.provider().debug_trace_transaction(hash, opts.clone()).await?;
 
         let mut storage = self.storage_write();
-        storage.geth_transaction_traces.insert(hash, trace.clone());
+        let traces = storage.geth_transaction_traces.entry(hash).or_default();
+        if !traces.iter().any(|(cached_opts, _)| cached_opts == &opts) {
+            traces.push((opts, trace.clone()));
+        }
 
         Ok(trace)
     }
@@ -386,14 +395,24 @@ impl<N: Network> ClientFork<N> {
         block_hash: B256,
         opts: GethDebugTracingOptions,
     ) -> Result<Vec<TraceResult>, TransportError> {
-        if let Some(traces) = self.storage_read().geth_block_traces.get(&block_hash).cloned() {
+        if let Some(traces) = self
+            .storage_read()
+            .geth_block_traces
+            .get(&block_hash)
+            .and_then(|traces| traces.iter().find(|(cached_opts, _)| cached_opts == &opts))
+            .map(|(_, traces)| traces.clone())
+        {
             return Ok(traces);
         }
 
-        let trace_results = self.provider().debug_trace_block_by_hash(block_hash, opts).await?;
+        let trace_results =
+            self.provider().debug_trace_block_by_hash(block_hash, opts.clone()).await?;
 
         let mut storage = self.storage_write();
-        storage.geth_block_traces.insert(block_hash, trace_results.clone());
+        let traces = storage.geth_block_traces.entry(block_hash).or_default();
+        if !traces.iter().any(|(cached_opts, _)| cached_opts == &opts) {
+            traces.push((opts, trace_results.clone()));
+        }
 
         Ok(trace_results)
     }
@@ -903,8 +922,8 @@ pub struct ForkedStorage<N: Network = AnyNetwork> {
     pub transaction_receipts: FbHashMap<32, FoundryTxReceipt>,
     pub transaction_traces: FbHashMap<32, Vec<Trace>>,
     pub logs: HashMap<Filter, Vec<Log>>,
-    pub geth_transaction_traces: FbHashMap<32, GethTrace>,
-    pub geth_block_traces: FbHashMap<32, Vec<TraceResult>>,
+    pub geth_transaction_traces: FbHashMap<32, Vec<(GethDebugTracingOptions, GethTrace)>>,
+    pub geth_block_traces: FbHashMap<32, Vec<(GethDebugTracingOptions, Vec<TraceResult>)>>,
     pub block_traces: HashMap<u64, Vec<Trace>>,
     pub block_receipts: HashMap<u64, Vec<FoundryTxReceipt>>,
     pub code_at: HashMap<(Address, u64), Bytes>,

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -17,13 +17,19 @@ use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder, Transac
 use alloy_primitives::{
     Address, B256, Bytes, TxHash, TxKind, U64, U256, address, b256, bytes, hex, uint,
 };
-use alloy_provider::{Provider, ext::TxPoolApi};
+use alloy_provider::{
+    Provider,
+    ext::{DebugApi, TxPoolApi},
+};
 use alloy_rpc_types::{
     AccountInfo, BlockId, BlockNumberOrTag, Index,
     anvil::Forking,
     request::{TransactionInput, TransactionRequest},
     state::EvmOverrides,
-    trace::parity::{Action, TraceResultsWithTransactionHash, TraceType},
+    trace::{
+        geth::{CallConfig, GethDebugTracingOptions, GethTrace, TraceResult},
+        parity::{Action, TraceResultsWithTransactionHash, TraceType},
+    },
 };
 use alloy_serde::WithOtherFields;
 use alloy_signer_local::PrivateKeySigner;
@@ -880,6 +886,86 @@ async fn test_fork_trace_replay_block_transactions_forwards_trace_types() {
     }
     // `StateDiff` was also requested, so it must be honored, not just `Trace`.
     assert!(full_trace.state_diff.is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_debug_trace_cache_includes_options() {
+    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let origin_provider = origin_handle.http_provider();
+    let from = origin_handle.dev_wallets().next().unwrap().address();
+    let receipt = origin_provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default().from(from).to(Address::random()).value(U256::from(1)),
+        ))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    let fork_url = spawn_rpc_proxy_rejecting_method_after(
+        origin_handle.http_endpoint(),
+        "debug_traceTransaction",
+        2,
+    )
+    .await;
+    let fork_url =
+        spawn_rpc_proxy_rejecting_method_after(fork_url, "debug_traceBlockByHash", 2).await;
+    let (_fork_api, fork_handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
+    let fork_provider = fork_handle.http_provider();
+    let call_tracer = GethDebugTracingOptions::call_tracer(CallConfig::default());
+
+    let default_trace = fork_provider
+        .debug_trace_transaction(receipt.transaction_hash, GethDebugTracingOptions::default())
+        .await
+        .unwrap();
+    let call_trace = fork_provider
+        .debug_trace_transaction(receipt.transaction_hash, call_tracer.clone())
+        .await
+        .unwrap();
+    assert!(matches!(default_trace, GethTrace::Default(_)));
+    assert!(matches!(call_trace, GethTrace::CallTracer(_)));
+    assert_eq!(
+        fork_provider
+            .debug_trace_transaction(receipt.transaction_hash, GethDebugTracingOptions::default())
+            .await
+            .unwrap(),
+        default_trace
+    );
+    assert_eq!(
+        fork_provider
+            .debug_trace_transaction(receipt.transaction_hash, call_tracer.clone())
+            .await
+            .unwrap(),
+        call_trace
+    );
+
+    let block_hash = receipt.block_hash.unwrap();
+    let default_traces = fork_provider
+        .debug_trace_block_by_hash(block_hash, GethDebugTracingOptions::default())
+        .await
+        .unwrap();
+    let call_traces =
+        fork_provider.debug_trace_block_by_hash(block_hash, call_tracer.clone()).await.unwrap();
+    assert!(matches!(
+        &default_traces[0],
+        TraceResult::Success { result: GethTrace::Default(_), .. }
+    ));
+    assert!(matches!(
+        &call_traces[0],
+        TraceResult::Success { result: GethTrace::CallTracer(_), .. }
+    ));
+    assert_eq!(
+        fork_provider
+            .debug_trace_block_by_hash(block_hash, GethDebugTracingOptions::default())
+            .await
+            .unwrap(),
+        default_traces
+    );
+    assert_eq!(
+        fork_provider.debug_trace_block_by_hash(block_hash, call_tracer).await.unwrap(),
+        call_traces
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Anvil’s fork cache keyed debug traces only by transaction or block hash, causing requests with different tracing options to reuse whichever result was cached first. Cache traces by both hash and options while preserving repeated-request caching.