### PR TITLE
fix(cast): decode call revert errors

### DIFF
--- a/.changelog/cast-call-decode-reverts.md
+++ b/.changelog/cast-call-decode-reverts.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Decoded revert data in `cast call` error output when the error signature is known.

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -42,7 +42,7 @@ use foundry_common::{
     tempo::classify_payment_lane,
 };
 use foundry_config::Chain;
-use foundry_evm::core::bytecode::InstIter;
+use foundry_evm::core::{bytecode::InstIter, decode::RevertDecoder};
 use foundry_primitives::FoundryTxEnvelope;
 use futures::{FutureExt, StreamExt, TryStreamExt, future::Either};
 #[cfg(feature = "optimism")]
@@ -164,7 +164,22 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
             call = call.overrides(state_override)
         }
 
-        let res = call.await?;
+        let res = match call.await {
+            Ok(res) => res,
+            Err(err) => {
+                if let Some(data) = err.as_error_resp().and_then(|payload| payload.as_revert_data())
+                {
+                    let decoded = match RevertDecoder::new().maybe_decode_known(&data) {
+                        Some(decoded) => Some(decoded),
+                        None => tx::decode_custom_error(&data).await.ok().flatten(),
+                    };
+                    if let Some(decoded) = decoded {
+                        return Err(err).wrap_err(format!("execution reverted: {decoded}"));
+                    }
+                }
+                return Err(err.into());
+            }
+        };
         let decoded = if let Some(func) = func {
             // decode args into tokens
             match func.abi_decode_output(res.as_ref()) {

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -952,14 +952,18 @@ where
 
 /// Helper function that tries to decode custom error name and inputs from error payload data.
 async fn decode_execution_revert(data: &RawValue) -> Result<Option<String>> {
-    let err_data = serde_json::from_str::<Bytes>(data.get())?;
-    let Some(selector) = err_data.get(..4) else { return Ok(None) };
+    let data = serde_json::from_str::<Bytes>(data.get())?;
+    decode_custom_error(&data).await
+}
+
+pub(crate) async fn decode_custom_error(data: &[u8]) -> Result<Option<String>> {
+    let Some(selector) = data.get(..4) else { return Ok(None) };
     if let Some(known_error) =
         SignaturesIdentifier::new(false)?.identify_error(selector.try_into().unwrap()).await
     {
         let mut decoded_error = known_error.name.clone();
         if !known_error.inputs.is_empty()
-            && let Ok(error) = known_error.decode_error(&err_data)
+            && let Ok(error) = known_error.decode_error(data)
         {
             write!(decoded_error, "({})", format_tokens(&error.body).format(", "))?;
         }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -7021,6 +7021,86 @@ forgetest_async!(cast_call_debug_trace_call_local_artifacts_json_stdout, |prj, c
     });
 });
 
+casttest!(cast_call_decodes_custom_error, async |prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    let signature = "RequestLimitExceeded(uint256,uint256)";
+    let selector = keccak256(signature);
+    let mut revert_data = selector[..4].to_vec();
+    revert_data.extend((U256::from(5), U256::from(3)).abi_encode());
+
+    // Runtime bytecode that copies the appended revert payload into memory and reverts with it.
+    let payload_len = u8::try_from(revert_data.len()).unwrap();
+    let mut runtime =
+        vec![0x60, payload_len, 0x60, 0x0a, 0x5f, 0x39, 0x60, payload_len, 0x5f, 0xfd];
+    runtime.extend(revert_data);
+
+    // Isolate and seed the signature cache so decoding is deterministic and offline.
+    let home = prj.root().join("home");
+    let cache_dir = home.join(".foundry/cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let selector = format!("0x{}", hex::encode(&selector[..4]));
+    let mut errors = serde_json::Map::new();
+    errors.insert(selector, json!(signature));
+    fs::write(
+        cache_dir.join("signatures"),
+        serde_json::to_vec(&json!({
+            "functions": {},
+            "errors": errors,
+            "events": {},
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let target = "0x000000000000000000000000000000000000dead";
+    let code_override = format!("{target}:0x{}", hex::encode(runtime));
+    let endpoint = handle.http_endpoint();
+
+    cmd.env("HOME", &home);
+    cmd.env("FOUNDRY_OFFLINE", "true");
+    cmd.args([
+        "call",
+        target,
+        "--data",
+        "0x",
+        "--override-code",
+        &code_override,
+        "--rpc-url",
+        &endpoint,
+    ])
+    .assert_failure()
+    .stdout_eq(str![""])
+    .stderr_eq(str![[r#"
+Error: execution reverted: RequestLimitExceeded(5, 3)
+
+Context:
+- server returned an error response:[..]
+
+"#]]);
+
+    cmd.cast_fuse();
+    cmd.env("HOME", &home);
+    cmd.env("FOUNDRY_OFFLINE", "true");
+    cmd.args([
+            "call",
+            target,
+            "--data",
+            "0x",
+            "--override-code",
+            &code_override,
+            "--rpc-url",
+            &endpoint,
+            "--json",
+        ])
+        .assert_failure()
+        .stdout_eq(str![[r#"
+{"schema_version":1,"success":false,"data":null,"errors":[{"level":"error","code":"cast.error","message":"execution reverted: RequestLimitExceeded(5, 3)"},{"level":"error","code":"cast.error.context","message":"server returned an error response:[..]"}],"warnings":[]}
+
+"#]])
+        .stderr_eq(str![""]);
+});
+
 // `cast call --trace` decodes custom errors through the local signatures cache that `forge build`
 // populates, without requiring `--with-local-artifacts`.
 // <https://github.com/foundry-rs/foundry/issues/11085>


### PR DESCRIPTION
## Summary

Decode revert payloads returned by ordinary `cast call` RPC requests before rendering the error.

Built-in Solidity errors use the same revert decoder as trace output, while custom errors reuse Cast’s existing signature identifier. The original RPC error remains attached as context, so human output retains the raw provider response and JSON output exposes the decoded error first without changing the CLI or output schema.

## Impact

Known reverts now surface as readable errors in both text and JSON modes. Unknown or undecodable payloads keep the existing error output unchanged.