### PR TITLE
feat(chisel): inspect inline assembly expressions

### DIFF
--- a/.changelog/chisel-inline-assembly.md
+++ b/.changelog/chisel-inline-assembly.md
@@ -1,0 +1,5 @@
+---
+chisel: minor
+---
+
+Allowed Chisel to inspect the final expression in an inline assembly block.

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -141,8 +141,13 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         // Create new source with exact input appended and parse
         let (new_source, do_execute) = source.clone_with_new_line(input.to_string())?;
 
-        let InspectResult { control_flow, formatted_output, last_result } =
+        let InspectResult { control_flow, formatted_output, last_result, replay_input } =
             source.inspect(input).await?;
+        let (new_source, do_execute) = if let Some(input) = replay_input {
+            source.clone_with_new_line(input)?
+        } else {
+            (new_source, do_execute)
+        };
         if let Some(last_result) = last_result {
             self.last_result = Some(last_result);
         }

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -37,15 +37,22 @@ pub struct InspectResult {
     pub formatted_output: Option<String>,
     /// An expression that recreates the inspected value, if any.
     pub last_result: Option<String>,
+    /// Input to execute and persist after inspection, if it differs from the original input.
+    pub replay_input: Option<String>,
 }
 
 impl InspectResult {
     const fn empty(control_flow: ControlFlow<()>) -> Self {
-        Self { control_flow, formatted_output: None, last_result: None }
+        Self { control_flow, formatted_output: None, last_result: None, replay_input: None }
     }
 }
 
-fn yul_inspector_line(input: &str) -> Option<String> {
+struct YulInspection {
+    inspector_input: String,
+    replay_input: String,
+}
+
+fn yul_inspection(input: &str, session_source: &str) -> Option<YulInspection> {
     let sess = Session::builder().with_buffer_emitter(Default::default()).build();
     sess.enter_sequential(|| {
         let arena = solar::ast::Arena::new();
@@ -57,22 +64,28 @@ fn yul_inspector_line(input: &str) -> Option<String> {
         )
         .ok()?;
         let stmt = parser.parse_stmt().map_err(|err| err.emit()).ok()?;
+        if !parser.token.is_eof() {
+            return None;
+        }
         let AstStmtKind::Assembly(assembly) = &stmt.kind else { return None };
         let last = assembly.block.stmts.last()?;
         let yul::StmtKind::Expr(expr) = &last.kind else { return None };
 
-        let stmt_range = sess.source_map().span_to_source(stmt.span).ok()?.data;
-        if !input.get(stmt_range.end..)?.trim().is_empty() {
-            return None;
-        }
         let expr_range = sess.source_map().span_to_source(expr.span).ok()?.data;
         let expression = input.get(expr_range.clone())?;
+        let result_var = std::iter::once("__chisel_yul_result".to_string())
+            .chain((1..).map(|suffix| format!("__chisel_yul_result_{suffix}")))
+            .find(|name| !input.contains(name) && !session_source.contains(name))?;
 
         let mut assembly = input.to_string();
-        assembly.replace_range(expr_range, &format!("__chisel_yul_result := {expression}"));
-        Some(format!(
-            "uint256 __chisel_yul_result; {assembly} bytes memory inspectoor = abi.encode(__chisel_yul_result);"
-        ))
+        assembly.replace_range(expr_range.clone(), &format!("{result_var} := {expression}"));
+        let inspector_input = format!(
+            "uint256 {result_var}; {assembly}\nbytes memory inspectoor = abi.encode({result_var});"
+        );
+
+        let mut replay_input = input.to_string();
+        replay_input.replace_range(expr_range, &format!("pop({expression})"));
+        Some(YulInspection { inspector_input, replay_input })
     })
 }
 
@@ -109,11 +122,11 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
     /// If the input is valid, returns its [`InspectResult`].
     pub async fn inspect(&self, input: &str) -> Result<InspectResult> {
         let line = format!("bytes memory inspectoor = abi.encode({input});");
-        let mut source = match self.clone_with_new_line(line) {
-            Ok((source, _)) => source,
+        let (mut source, replay_input) = match self.clone_with_new_line(line) {
+            Ok((source, _)) => (source, None),
             Err(err) => {
                 debug!(%err, "failed to build new source for inspection");
-                let Some(line) = yul_inspector_line(input) else {
+                let Some(inspection) = yul_inspection(input, &self.to_repl_source()) else {
                     return Ok(InspectResult::empty(ControlFlow::Continue(())));
                 };
                 if self
@@ -122,10 +135,10 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                 {
                     return Ok(InspectResult::empty(ControlFlow::Continue(())));
                 }
-                let Ok((source, _)) = self.clone_with_new_line(line) else {
+                let Ok((source, _)) = self.clone_with_new_line(inspection.inspector_input) else {
                     return Ok(InspectResult::empty(ControlFlow::Continue(())));
                 };
-                source
+                (source, Some(inspection.replay_input))
             }
         };
 
@@ -182,6 +195,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                     control_flow: ControlFlow::Break(()),
                     formatted_output: Some(formatted_event?),
                     last_result: None,
+                    replay_input: None,
                 });
             }
 
@@ -253,11 +267,16 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
         };
         let last_result = format!("abi.decode(hex\"{}\", ({ty}))", hex::encode(data));
         let token = ty.abi_decode(data).wrap_err("Could not decode inspected values")?;
-        let c = if cont { ControlFlow::Continue(()) } else { ControlFlow::Break(()) };
+        let c = if cont || replay_input.is_some() {
+            ControlFlow::Continue(())
+        } else {
+            ControlFlow::Break(())
+        };
         Ok(InspectResult {
             control_flow: c,
             formatted_output: Some(format_token(token)),
             last_result: Some(last_result),
+            replay_input,
         })
     }
 

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -18,7 +18,8 @@ use foundry_evm::{
     traces::TraceRequirements,
 };
 use solar::{
-    ast::{ElementaryType, LitKind, StrKind, UnOpKind},
+    ast::{ElementaryType, LitKind, StmtKind as AstStmtKind, StrKind, UnOpKind, yul},
+    interface::Session,
     sema::{
         hir::{Event, Expr, ExprKind, StmtKind},
         ty::{Gcx, Ty, TyKind},
@@ -42,6 +43,37 @@ impl InspectResult {
     const fn empty(control_flow: ControlFlow<()>) -> Self {
         Self { control_flow, formatted_output: None, last_result: None }
     }
+}
+
+fn yul_inspector_line(input: &str) -> Option<String> {
+    let sess = Session::builder().with_buffer_emitter(Default::default()).build();
+    sess.enter_sequential(|| {
+        let arena = solar::ast::Arena::new();
+        let mut parser = solar::parse::Parser::from_source_code(
+            &sess,
+            &arena,
+            "ChiselInput.sol".to_string().into(),
+            input,
+        )
+        .ok()?;
+        let stmt = parser.parse_stmt().map_err(|err| err.emit()).ok()?;
+        let AstStmtKind::Assembly(assembly) = &stmt.kind else { return None };
+        let last = assembly.block.stmts.last()?;
+        let yul::StmtKind::Expr(expr) = &last.kind else { return None };
+
+        let stmt_range = sess.source_map().span_to_source(stmt.span).ok()?.data;
+        if !input.get(stmt_range.end..)?.trim().is_empty() {
+            return None;
+        }
+        let expr_range = sess.source_map().span_to_source(expr.span).ok()?.data;
+        let expression = input.get(expr_range.clone())?;
+
+        let mut assembly = input.to_string();
+        assembly.replace_range(expr_range, &format!("__chisel_yul_result := {expression}"));
+        Some(format!(
+            "uint256 __chisel_yul_result; {assembly} bytes memory inspectoor = abi.encode(__chisel_yul_result);"
+        ))
+    })
 }
 
 /// Executor implementation for [SessionSource]
@@ -81,7 +113,19 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
             Ok((source, _)) => source,
             Err(err) => {
                 debug!(%err, "failed to build new source for inspection");
-                return Ok(InspectResult::empty(ControlFlow::Continue(())));
+                let Some(line) = yul_inspector_line(input) else {
+                    return Ok(InspectResult::empty(ControlFlow::Continue(())));
+                };
+                if self
+                    .clone_with_new_line(input.to_string())
+                    .is_ok_and(|(source, _)| source.build().is_ok())
+                {
+                    return Ok(InspectResult::empty(ControlFlow::Continue(())));
+                }
+                let Ok((source, _)) = self.clone_with_new_line(line) else {
+                    return Ok(InspectResult::empty(ControlFlow::Continue(())));
+                };
+                source
             }
         };
 

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -303,8 +303,18 @@ repl_test!(eval_subcommand, "eval type(uint8).max", |repl| {
 
 // Issue #4963: inspect the value of the final inline assembly expression.
 repl_test!(inline_assembly_expression, |repl| {
-    repl.sendln("assembly { let value := not(0) add(value, 0) }");
-    repl.expect("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    repl.sendln("uint256 value = 1");
+    repl.sendln("assembly { value := 2 add(value, 0) } // trailing comment");
+    repl.expect("Decimal: 2");
+    repl.sendln("value");
+    repl.expect("Decimal: 2");
+
+    repl.sendln("assembly { let __chisel_yul_result := 3 add(__chisel_yul_result, 0) }");
+    repl.expect("Decimal: 3");
+
+    repl.sendln("uint256 __chisel_yul_result_1 = 0");
+    repl.sendln("assembly { add(3, 4) }");
+    repl.expect("Decimal: 7");
 });
 
 repl_test!(

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -301,6 +301,12 @@ repl_test!(eval_subcommand, "eval type(uint8).max", |repl| {
     repl.expect("Decimal: 255");
 });
 
+// Issue #4963: inspect the value of the final inline assembly expression.
+repl_test!(inline_assembly_expression, |repl| {
+    repl.sendln("assembly { let value := not(0) add(value, 0) }");
+    repl.expect("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+});
+
 repl_test!(
     eval_tempo_network_uses_tempo_executor,
     "--network tempo eval address(0xfeEC000000000000000000000000000000000000).code.length",


### PR DESCRIPTION
## Motivation

Chisel cannot currently inspect a value-producing inline assembly block such as `assembly { not(0) }` because Solidity rejects it as a top-level expression statement.

## Solution

- Parse inline assembly inputs with Solar and identify the final Yul expression.
- Assign that expression to a temporary `uint256` and reuse Chisel’s existing ABI inspection path.
- Preserve existing behavior for valid side-effect-only assembly blocks.

## Testing

- `cargo test -p chisel --test it` (40 passed)
- `cargo test -p chisel --lib` (20 passed)
- `cargo +nightly clippy -p chisel --lib --no-deps -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- Live-tested expression-only, multi-statement, memory-safe, and side-effect-only assembly inputs.

Closes #4963