### PR TITLE
perf(symbolic): speed up direct contradiction checks

### DIFF
--- a/.changelog/symbolic-direct-contradiction-lookup.md
+++ b/.changelog/symbolic-direct-contradiction-lookup.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Sped up symbolic tests with large path-constraint sets by avoiding repeated linear contradiction scans.

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -51,14 +51,16 @@ fn normalize_constraint_batch(
 fn sort_dedup_bool_exprs(exprs: &mut Vec<SymBoolExpr>) {
     // Hash-consing already caches deterministic structural hashes. Only render full structural
     // keys for the exceedingly rare case where two distinct expressions collide.
-    exprs.sort_unstable_by(|left, right| {
-        if left == right {
-            return std::cmp::Ordering::Equal;
-        }
-        left.stable_hash_cmp(right)
-            .then_with(|| bool_structural_key(left).cmp(&bool_structural_key(right)))
-    });
+    exprs.sort_unstable_by(bool_expr_cmp);
     exprs.dedup();
+}
+
+fn bool_expr_cmp(left: &SymBoolExpr, right: &SymBoolExpr) -> std::cmp::Ordering {
+    if left == right {
+        return std::cmp::Ordering::Equal;
+    }
+    left.stable_hash_cmp(right)
+        .then_with(|| bool_structural_key(left).cmp(&bool_structural_key(right)))
 }
 
 fn bool_structural_key(expr: &SymBoolExpr) -> String {
@@ -186,7 +188,7 @@ const fn expr_ternop_key(op: SymTernOp) -> u8 {
     }
 }
 
-/// Returns whether normalized conjunctive constraints contain a direct contradiction.
+/// Returns whether canonically ordered normalized constraints contain a direct contradiction.
 pub(super) fn constraints_are_directly_unsat(cx: &mut SymCx, constraints: &[SymBoolExpr]) -> bool {
     let mut derived = Vec::new();
     for constraint in constraints {
@@ -198,8 +200,10 @@ pub(super) fn constraints_are_directly_unsat(cx: &mut SymCx, constraints: &[SymB
         }
         derived.push(fact);
     }
-    let contains =
-        |expected: &SymBoolExpr| constraints.contains(expected) || derived.contains(expected);
+    let contains = |expected: &SymBoolExpr| {
+        constraints.binary_search_by(|candidate| bool_expr_cmp(candidate, expected)).is_ok()
+            || derived.contains(expected)
+    };
     constraints.iter().chain(&derived).any(|constraint| match constraint.kind() {
         SymBoolExprKind::Const(false) => true,
         SymBoolExprKind::Not(inner)
@@ -1860,7 +1864,8 @@ mod tests {
         let either_word = SymExpr::binop(&mut cx, SymBinOp::Or, x_word, y_word);
         let neither_is_zero = SymBoolExpr::eq(&mut cx, either_word, zero);
 
-        assert!(constraints_are_directly_unsat(&mut cx, &[neither_is_zero, x_is_zero]));
+        let constraints = normalize_constraints_for_solver(&mut cx, &[neither_is_zero, x_is_zero]);
+        assert!(constraints_are_directly_unsat(&mut cx, &constraints));
     }
 
     #[test]
@@ -1876,7 +1881,8 @@ mod tests {
         let both_word = SymExpr::binop(&mut cx, SymBinOp::And, x_word, y_word);
         let not_both = SymBoolExpr::eq(&mut cx, both_word, zero);
 
-        assert!(!constraints_are_directly_unsat(&mut cx, &[not_both, x_is_zero]));
+        let constraints = normalize_constraints_for_solver(&mut cx, &[not_both, x_is_zero]);
+        assert!(!constraints_are_directly_unsat(&mut cx, &constraints));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reuse the canonical constraint ordering to binary-search for direct contradictions instead of repeatedly scanning the full list.
- Preserve the existing structural-hash collision fallback and normalize the direct-check unit-test inputs through the production path.

This changes the direct contradiction check from quadratic to `O(n log n)` without adding allocations or a new cache.

This PR was written with Codex assistance for profiling, implementation, benchmarking, and validation.

## Benchmarks

Measured against `6c13ac72a` with release builds on a symbolic test containing 2,048 sequential branches. Each sample removed `out` and `cache` with `forge clean` before running:

```console
forge test --symbolic --offline --match-test checkDispatch \
  --symbolic-max-paths 4096 --symbolic-max-depth 20000 -q
```

### Results

| Measurement order | Master | This PR | Improvement |
| --- | ---: | ---: | ---: |
| Master first | 7.197s ± 0.540s | 5.505s ± 0.129s | 1.31x faster |
| This PR first | 7.422s ± 1.063s | 5.440s ± 0.093s | 1.36x faster |

Both builds explored 2,049 paths and issued 4,098 solver queries with identical normalized JSON output after removing timing fields.
