### PR TITLE
perf(symbolic): trim model evaluation cache

### DIFF
--- a/.changelog/symbolic-selective-model-cache.md
+++ b/.changelog/symbolic-selective-model-cache.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Sped up symbolic tests with large constraint sets by avoiding one-use model-evaluation cache entries.

--- a/crates/evm/symbolic/src/runtime/expr/mod.rs
+++ b/crates/evm/symbolic/src/runtime/expr/mod.rs
@@ -93,7 +93,10 @@ impl<'a, M: SymbolicModelLookup + ?Sized> ModelEvaluator<'a, M> {
         if let SymBoolExprKind::Const(value) = kind {
             return Ok(*value);
         }
-        if let Some(value) = self.bools.get(expr) {
+        // `Not` and `Cmp` cheaply recombine child results, so memoizing them adds one-use entries
+        // for ordinary path constraints. Conjunctions can share additional Boolean work.
+        let cache_result = matches!(kind, SymBoolExprKind::And(_));
+        if cache_result && let Some(value) = self.bools.get(expr) {
             return Ok(*value);
         }
 
@@ -114,7 +117,9 @@ impl<'a, M: SymbolicModelLookup + ?Sized> ModelEvaluator<'a, M> {
                 op.eval(self.eval_word(left)?, self.eval_word(right)?)
             }
         };
-        self.bools.insert(expr.clone(), value);
+        if cache_result {
+            self.bools.insert(expr.clone(), value);
+        }
         Ok(value)
     }
 }
@@ -125,4 +130,25 @@ pub(crate) fn eval_model_constraints<M: SymbolicModelLookup + ?Sized>(
 ) -> bool {
     let mut evaluator = ModelEvaluator::new(model);
     constraints.iter().all(|constraint| evaluator.eval_bool(constraint).unwrap_or(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_evaluator_only_caches_conjunctions() {
+        let mut cx = SymCx::new();
+        let value = SymExpr::var(&mut cx, "value");
+        let one = SymExpr::constant(&mut cx, U256::from(1));
+        let condition = SymBoolExpr::eq(&mut cx, value, one).not(&mut cx);
+        let model = SymbolicModel::default();
+        let mut evaluator = ModelEvaluator::new(&model);
+
+        assert!(evaluator.eval_bool(&condition).unwrap());
+        assert!(evaluator.bools.is_empty());
+        let conjunction = SymBoolExpr::and(&mut cx, vec![condition.clone(), condition]);
+        assert!(evaluator.eval_bool(&conjunction).unwrap());
+        assert_eq!(evaluator.bools.len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary

Symbolic model evaluation currently caches every non-constant Boolean expression, even though comparison and negation nodes on ordinary path constraints are generally evaluated once and cheaply recombine their children. This keeps memoization for reusable conjunctions and word expressions while avoiding the allocation, hashing, and retention cost of those one-use Boolean entries.

The focused regression test locks in that comparison and negation results do not populate the Boolean cache while conjunctions still do. This PR was written with Codex assistance for profiling, implementation, benchmarking, and validation.

## Benchmarks

Measured against master at `0ff0cb1b7` with a 2,048-branch symbolic test. Cold samples ran `forge clean` before each iteration; both builds explored the same 2,049 paths, made 4,098 solver queries, and produced identical normalized JSON results.

### Results

| Mode / order | Master | This PR | Improvement |
| --- | ---: | ---: | ---: |
| Warm, master first | 4.680s ± 0.180s | 3.661s ± 0.032s | 1.28x |
| Warm, PR first | 4.689s ± 0.041s | 3.720s ± 0.057s | 1.26x |
| Cold, master first | 6.297s ± 0.557s | 4.400s ± 0.051s | 1.43x |
| Cold, PR first | 5.408s ± 0.073s | 4.377s ± 0.036s | 1.24x |

An ordinary 13-test Solady symbolic set remained neutral at 222.4ms on master and 220.6ms on this PR.
