### PR TITLE
fix(doc): reject invalid backtick fences

### DIFF
--- a/.changelog/reject-invalid-mdx-backtick-fences.md
+++ b/.changelog/reject-invalid-mdx-backtick-fences.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-doc: patch
+---
+
+Reject invalid Markdown backtick fences when escaping homepage content for generated MDX documentation.

--- a/crates/doc/src/vocs.rs
+++ b/crates/doc/src/vocs.rs
@@ -347,7 +347,10 @@ fn escape_mdx_outside_code_fences(text: &str) -> String {
                     return None;
                 }
                 let len = trimmed.chars().take_while(|&ch| ch == marker).count();
-                (len >= 3).then_some(Fence { marker, len })
+                if len < 3 || marker == '`' && trimmed[len..].contains('`') {
+                    return None;
+                }
+                Some(Fence { marker, len })
             });
             if let Some(opening) = opening {
                 fence = Some(opening);
@@ -656,6 +659,14 @@ End {brace}.
         let out = escape_mdx_outside_code_fences(input);
 
         assert_eq!(out, input.replace("Outside {text}", r"Outside \{text}"));
+    }
+
+    #[test]
+    fn escape_mdx_rejects_backticks_in_fence_info() {
+        let input = "```bad`\n```still-bad`\n{process.exit(42)}\n";
+        let out = escape_mdx_outside_code_fences(input);
+
+        assert_eq!(out, input.replace("{process.exit(42)}", r"\{process.exit(42)}"));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #16279. The homepage MDX fence scanner still accepted backtick fence openers whose info strings contained backticks, even though CommonMark rejects them. This parser mismatch could leave braces in ordinary Markdown text unescaped and expose them as MDX expressions.

Reject these invalid openers so the scanner remains aligned with the Markdown parser, with regression coverage for the reported case.

Prepared with assistance from OpenAI Codex.
