### PR TITLE
perf(symbolic): reuse solver normalization across queries

### DIFF
--- a/.changelog/symbolic-normalization-cache.md
+++ b/.changelog/symbolic-normalization-cache.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Sped up symbolic tests by reusing context-free solver normalization across queries.

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -20,10 +20,14 @@ pub(crate) use hard_arith_fallback::{
 #[cfg(test)]
 pub(crate) use monotonic_product::product_monotonic_unsat;
 use monotonic_product::{product_monotonic_unsat_normalized, remove_implied_monotonic_constraints};
-pub(crate) use opt::normalize_constraints_for_solver;
-use opt::{constraints_are_directly_unsat, sorted_bool_exprs_are_subset, write_smt_assertions};
+use opt::{
+    constraints_are_directly_unsat, normalize_constraints_for_solver_cached,
+    sorted_bool_exprs_are_subset, write_smt_assertions,
+};
 #[cfg(test)]
-pub(crate) use opt::{normalize_bool_for_solver, normalize_expr_for_solver};
+pub(crate) use opt::{
+    normalize_bool_for_solver, normalize_constraints_for_solver, normalize_expr_for_solver,
+};
 
 const Z3_QUERY_END: &str = "foundry-query-complete";
 
@@ -230,6 +234,7 @@ pub(crate) struct SmtLibSubprocessSolver {
     captured_diagnostics: Option<String>,
     heuristic_witnesses: usize,
     replayable_storage: SymbolicVars,
+    normalization_cache: HashMap<SymBoolExpr, SymBoolExpr>,
     sat_cache: HashMap<Vec<SymBoolExpr>, bool>,
     model_cache: HashMap<Vec<SymBoolExpr>, SymbolicModel>,
     sat_queries: usize,
@@ -264,6 +269,7 @@ impl SmtLibSubprocessSolver {
             captured_diagnostics: None,
             heuristic_witnesses: 0,
             replayable_storage: SymbolicVars::default(),
+            normalization_cache: HashMap::default(),
             sat_cache: HashMap::default(),
             model_cache: HashMap::default(),
             sat_queries: 0,
@@ -335,6 +341,7 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
     }
 
     fn clear_context_caches(&mut self) {
+        self.normalization_cache.clear();
         self.sat_cache.clear();
         self.model_cache.clear();
     }
@@ -422,7 +429,8 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         constraints: &[SymBoolExpr],
     ) -> Result<SymbolicModel, SymbolicError> {
         self.model_queries += 1;
-        let smt_constraints = normalize_constraints_for_solver(cx, constraints);
+        let smt_constraints =
+            normalize_constraints_for_solver_cached(cx, constraints, &mut self.normalization_cache);
         let cache_key = smt_constraints.clone();
 
         if self.sat_cache.get(&cache_key) == Some(&false) {
@@ -549,7 +557,8 @@ impl SmtLibSubprocessSolver {
         defer_hard_arith_without_witness: bool,
     ) -> Result<bool, SymbolicError> {
         self.sat_queries += 1;
-        let smt_constraints = normalize_sat_constraints(cx, constraints);
+        let smt_constraints =
+            normalize_sat_constraints(cx, constraints, &mut self.normalization_cache);
         let cache_key = smt_constraints.clone();
         if let Some(result) = self.sat_cache.get(&cache_key) {
             self.sat_cache_hits += 1;
@@ -565,14 +574,16 @@ impl SmtLibSubprocessSolver {
         if defer_hard_arith_without_witness
             && let Some((condition, base)) = constraints.split_last()
             && {
-                let normalized_base = normalize_sat_constraints(cx, base);
+                let normalized_base =
+                    normalize_sat_constraints(cx, base, &mut self.normalization_cache);
                 self.sat_cache.get(&normalized_base) == Some(&true)
             }
             && {
                 let mut complement = Vec::with_capacity(constraints.len());
                 complement.extend(base.iter().cloned());
                 complement.push(condition.clone().not(cx));
-                let normalized_complement = normalize_sat_constraints(cx, &complement);
+                let normalized_complement =
+                    normalize_sat_constraints(cx, &complement, &mut self.normalization_cache);
                 self.has_cached_unsat_subset(&normalized_complement)
             }
         {
@@ -844,8 +855,16 @@ impl SmtLibSubprocessSolver {
 }
 
 /// Normalizes satisfiability constraints and removes soundly implied nonlinear comparisons.
-fn normalize_sat_constraints(cx: &mut SymCx, constraints: &[SymBoolExpr]) -> Vec<SymBoolExpr> {
-    remove_implied_monotonic_constraints(normalize_constraints_for_solver(cx, constraints))
+fn normalize_sat_constraints(
+    cx: &mut SymCx,
+    constraints: &[SymBoolExpr],
+    normalization_cache: &mut HashMap<SymBoolExpr, SymBoolExpr>,
+) -> Vec<SymBoolExpr> {
+    remove_implied_monotonic_constraints(normalize_constraints_for_solver_cached(
+        cx,
+        constraints,
+        normalization_cache,
+    ))
 }
 
 /// Returns a hard-arithmetic fallback model only after validating it against original constraints.

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -1,12 +1,42 @@
 use super::*;
 
 /// Normalizes path constraints into an equivalent, solver-friendlier form.
+#[cfg(test)]
 pub(crate) fn normalize_constraints_for_solver(
     cx: &mut SymCx,
     constraints: &[SymBoolExpr],
 ) -> Vec<SymBoolExpr> {
+    normalize_constraints_for_solver_with(cx, constraints, |cx, constraint| {
+        normalize_bool_for_solver(cx, constraint.clone())
+    })
+}
+
+/// Reuses context-free normalization results while retaining per-query contextual rewrites.
+pub(super) fn normalize_constraints_for_solver_cached(
+    cx: &mut SymCx,
+    constraints: &[SymBoolExpr],
+    normalization_cache: &mut HashMap<SymBoolExpr, SymBoolExpr>,
+) -> Vec<SymBoolExpr> {
+    normalize_constraints_for_solver_with(cx, constraints, |cx, constraint| {
+        if let Some(normalized) = normalization_cache.get(constraint) {
+            return normalized.clone();
+        }
+        let normalized = normalize_bool_for_solver(cx, constraint.clone());
+        // These are strong hash-consed handles, so bound their lifetime like the SAT cache.
+        if normalization_cache.len() < SYMBOLIC_SOLVER_SAT_CACHE_MAX_ENTRIES {
+            normalization_cache.insert(constraint.clone(), normalized.clone());
+        }
+        normalized
+    })
+}
+
+fn normalize_constraints_for_solver_with(
+    cx: &mut SymCx,
+    constraints: &[SymBoolExpr],
+    mut normalize: impl FnMut(&mut SymCx, &SymBoolExpr) -> SymBoolExpr,
+) -> Vec<SymBoolExpr> {
     let normalized = normalize_constraint_batch(
-        constraints.iter().cloned().map(|constraint| normalize_bool_for_solver(cx, constraint)),
+        constraints.iter().map(|constraint| normalize(cx, constraint)),
         constraints.len(),
     );
     if matches!(normalized.as_slice(), [expr] if expr.as_const() == Some(false)) {
@@ -1850,6 +1880,35 @@ impl ConstraintContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cached_normalization_keeps_contextual_rewrites_per_query() {
+        let mut cx = SymCx::new();
+        let value = SymExpr::var(&mut cx, "value");
+        let mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
+        let masked = SymExpr::binop(&mut cx, SymBinOp::And, value.clone(), mask);
+        let identity = SymBoolExpr::eq(&mut cx, masked, value.clone());
+        let upper = SymExpr::constant(&mut cx, U256::from(1) << 160);
+        let bounded = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, value, upper);
+        let mut cache = HashMap::default();
+
+        let normalized = normalize_constraints_for_solver_cached(
+            &mut cx,
+            &[identity.clone(), bounded.clone()],
+            &mut cache,
+        );
+        assert_eq!(normalized, vec![bounded]);
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&identity), Some(&identity));
+
+        let normalized = normalize_constraints_for_solver_cached(
+            &mut cx,
+            std::slice::from_ref(&identity),
+            &mut cache,
+        );
+        assert_eq!(normalized, vec![identity]);
+        assert_eq!(cache.len(), 2);
+    }
 
     #[test]
     fn direct_contradiction_uses_members_of_derived_positive_conjunction() {


### PR DESCRIPTION
## Summary

- reuse context-free normalization of hash-consed path constraints across solver queries
- continue running context-dependent rewrites for every query and clear the cache with each new symbolic context
- bound retained normalization results with the existing 4,096-entry solver cache limit

## Benchmarks

Measured profiling builds with Hyperfine against current master:

| Workload | Master | This PR | Improvement |
| --- | ---: | ---: | ---: |
| 2,048-branch `checkDispatch` | 3.730s ± 0.016s | 2.372s ± 0.008s | 36.4% / 1.57x |
| Solady broad `check*`, 1 thread | 745.9ms ± 4.8ms | 570.7ms ± 5.6ms | 23.5% / 1.31x |
| Echidna FullMath | 312.5ms ± 1.7ms | 242.7ms ± 2.0ms | 22.3% / 1.29x |

On Echidna FullMath, Samply showed constraint-normalization CPU falling by 89.3% and total symbolic-executor CPU falling by 20.7%. Grandizzy remained neutral. Timing-stripped JSON output matched master across all benchmark suites.
