### PR TITLE
refactor(evm): make executor networks explicit

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -316,7 +316,6 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                     .logs(self.config.foundry_config.live_logs)
                     .chisel_state(final_pc)
                     .trace_requirements(TraceRequirements::none().with_calls(true))
-                    .networks(self.config.evm_opts.networks)
                     .cheatcodes(
                         CheatsConfig::new(
                             &self.config.foundry_config,
@@ -330,7 +329,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
             })
             .gas_limit(self.config.evm_opts.gas_limit())
             .legacy_assertions(self.config.foundry_config.legacy_assertions)
-            .build(evm_env, tx_env, backend);
+            .build(evm_env, tx_env, backend, self.config.evm_opts.networks);
 
         Ok(ChiselRunner::new(executor, U256::MAX, Address::ZERO, self.config.calldata.clone()))
     }

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -20,11 +20,13 @@ use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, TxKind, U256};
 use eyre::WrapErr;
 use foundry_fork_db::DatabaseError;
+#[cfg(feature = "monad")]
+use revm::context_interface::result::HaltReason;
 use revm::{
     Database, DatabaseCommit,
     bytecode::Bytecode,
     context::{ContextTr, Transaction},
-    context_interface::result::{HaltReason, ResultAndState},
+    context_interface::result::ResultAndState,
     database::DatabaseRef,
     primitives::AddressMap,
     state::{Account, AccountInfo, EvmState},

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -3,6 +3,7 @@ use foundry_evm_core::{
     backend::Backend,
     evm::{BlockEnvFor, EvmEnvFor, FoundryEvmNetwork, SpecFor, TxEnvFor},
 };
+use foundry_evm_networks::NetworkConfigs;
 use revm::context::{Block, Transaction};
 
 /// The builder that allows to configure an evm [`Executor`] which a stack of optional
@@ -83,8 +84,10 @@ impl<FEN: FoundryEvmNetwork> ExecutorBuilder<FEN> {
         mut evm_env: EvmEnvFor<FEN>,
         tx_env: TxEnvFor<FEN>,
         db: Backend<FEN>,
+        networks: NetworkConfigs,
     ) -> Executor<FEN> {
         let Self { mut stack, gas_limit, spec, legacy_assertions, .. } = self;
+        stack.networks = networks;
         if stack.block.is_none() {
             stack.block = Some(evm_env.block_env.clone());
         }
@@ -95,6 +98,6 @@ impl<FEN: FoundryEvmNetwork> ExecutorBuilder<FEN> {
         if let Some(spec) = spec {
             evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec);
         }
-        Executor::new(db, evm_env, tx_env, stack.build(), gas_limit, legacy_assertions)
+        Executor::new(db, evm_env, tx_env, stack.build(), networks, gas_limit, legacy_assertions)
     }
 }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1978,6 +1978,7 @@ mod tests {
             EvmEnvFor::<EthEvmNetwork>::default(),
             TxEnvFor::<EthEvmNetwork>::default(),
             Backend::spawn(None).unwrap(),
+            Default::default(),
         );
         executor.inspector_mut().collect_edge_coverage_with_config(&corpus_config(corpus_root));
         // CALLDATALOAD(4); PUSH1 8; JUMPI; STOP; JUMPDEST; STOP.

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -2373,6 +2373,7 @@ mod tests {
                 EvmEnvFor::<EthEvmNetwork>::default(),
                 TxEnvFor::<EthEvmNetwork>::default(),
                 backend,
+                Default::default(),
             );
         let target = Address::repeat_byte(0x11);
         let mut code = vec![0x6e]; // PUSH15.
@@ -2771,6 +2772,7 @@ mod tests {
             EvmEnvFor::<EthEvmNetwork>::default(),
             TxEnvFor::<EthEvmNetwork>::default(),
             backend,
+            Default::default(),
         );
         // Return ABI-encoded `true` for the invariant predicate.
         executor

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -510,6 +510,7 @@ mod tests {
                 EvmEnvFor::<EthEvmNetwork>::default(),
                 TxEnvFor::<EthEvmNetwork>::default(),
                 backend,
+                Default::default(),
             );
         let invariant_address = Address::repeat_byte(0x11);
         executor

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -42,6 +42,7 @@ use foundry_evm_core::{
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::ObservedCall;
+use foundry_evm_networks::NetworkConfigs;
 use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     bytecode::Bytecode,
@@ -164,12 +165,14 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         mut backend: Backend<FEN>,
         evm_env: EvmEnvFor<FEN>,
         tx_env: TxEnvFor<FEN>,
-        inspector: InspectorStack<FEN>,
+        mut inspector: InspectorStack<FEN>,
+        networks: NetworkConfigs,
         gas_limit: u64,
         legacy_assertions: bool,
     ) -> Self {
-        backend.set_networks(inspector.networks);
-        let extra_cheatcode_addresses = inspector.networks.extra_cheatcode_addresses();
+        inspector.networks(networks);
+        backend.set_networks(networks);
+        let extra_cheatcode_addresses = networks.extra_cheatcode_addresses();
         backend.extend_persistent_accounts(extra_cheatcode_addresses.iter().copied());
 
         // Need to create a non-empty contract on the cheatcodes address so `extcodesize` checks
@@ -1804,7 +1807,6 @@ mod tests {
     #[cfg(feature = "monad")]
     use foundry_evm_core::{constants::MONAD_CHEATCODE_ADDRESS, evm::MonadEvmNetwork};
     #[cfg(feature = "monad")]
-    use foundry_evm_networks::NetworkConfigs;
     use foundry_evm_traces::InternalTraceMode;
     use revm::context::TxEnv;
     use std::{sync::mpsc, thread};
@@ -1844,22 +1846,25 @@ mod tests {
 
     #[cfg(feature = "monad")]
     #[test]
-    fn extra_cheatcode_accounts_follow_the_active_network() {
-        let default_network = ExecutorBuilder::<MonadEvmNetwork>::default().build(
-            EvmEnvFor::<MonadEvmNetwork>::default(),
-            TxEnvFor::<MonadEvmNetwork>::default(),
+    fn executor_networks_follow_explicit_configuration() {
+        let ethereum = ExecutorBuilder::<EthEvmNetwork>::default().build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
             Backend::spawn(None).unwrap(),
+            NetworkConfigs::default(),
         );
-        assert!(!default_network.backend().networks().is_monad());
-        assert!(!default_network.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
+        assert!(!ethereum.backend().networks().is_monad());
+        assert!(!ethereum.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
 
         let monad = ExecutorBuilder::<MonadEvmNetwork>::default()
-            .inspectors(|stack| stack.networks(NetworkConfigs::with_monad()))
+            .inspectors(|stack| stack.networks(NetworkConfigs::default()))
             .build(
                 EvmEnvFor::<MonadEvmNetwork>::default(),
                 TxEnvFor::<MonadEvmNetwork>::default(),
                 Backend::spawn(None).unwrap(),
+                NetworkConfigs::with_monad(),
             );
+        assert!(monad.inspector().networks.is_monad());
         assert!(monad.backend().networks().is_monad());
         assert!(monad.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
     }
@@ -1956,6 +1961,7 @@ mod tests {
             EvmEnvFor::<EthEvmNetwork>::default(),
             TxEnvFor::<EthEvmNetwork>::default(),
             backend,
+            NetworkConfigs::default(),
         );
 
         executor.evm_env_mut().cfg_env.set_spec_and_mainnet_gas_params(SpecId::HOMESTEAD);
@@ -2007,7 +2013,7 @@ mod tests {
             .inspectors(|stack| stack.cheatcodes(cheats_config))
             .spec_id(SpecId::AMSTERDAM)
             .gas_limit(1_000_000)
-            .build(EvmEnv::default(), TxEnv::default(), backend);
+            .build(EvmEnv::default(), TxEnv::default(), backend, NetworkConfigs::default());
 
         let target = Address::repeat_byte(0x11);
         // PUSH0; PUSH0; PUSH0; CREATE; POP; STOP.
@@ -2039,7 +2045,7 @@ mod tests {
             .inspectors(|stack| stack.cheatcodes(cheats_config))
             .spec_id(SpecId::AMSTERDAM)
             .gas_limit(1_000_000)
-            .build(EvmEnv::default(), TxEnv::default(), backend);
+            .build(EvmEnv::default(), TxEnv::default(), backend, NetworkConfigs::default());
 
         let target = Address::repeat_byte(0x11);
         let mocked = Address::repeat_byte(0x22);
@@ -2085,6 +2091,7 @@ mod tests {
             EvmEnvFor::<EthEvmNetwork>::default(),
             TxEnvFor::<EthEvmNetwork>::default(),
             backend,
+            NetworkConfigs::default(),
         );
         executor.evm_env_mut().cfg_env.disable_nonce_check = true;
         let target = Address::repeat_byte(0x11);
@@ -2128,6 +2135,7 @@ mod tests {
             EvmEnvFor::<EthEvmNetwork>::default(),
             TxEnvFor::<EthEvmNetwork>::default(),
             backend,
+            NetworkConfigs::default(),
         );
         let early_exit = EarlyExit::new(false);
         executor.inspector_mut().set_early_exit(early_exit.clone());
@@ -2167,6 +2175,7 @@ mod tests {
             EvmEnvFor::<EthEvmNetwork>::default(),
             TxEnvFor::<EthEvmNetwork>::default(),
             backend,
+            NetworkConfigs::default(),
         );
         let early_exit = EarlyExit::new(false);
         executor.inspector_mut().set_early_exit(early_exit.clone());
@@ -2188,6 +2197,7 @@ mod tests {
             EvmEnvFor::<EthEvmNetwork>::default(),
             TxEnvFor::<EthEvmNetwork>::default(),
             backend,
+            NetworkConfigs::default(),
         );
         let cancellation = EvmExecutionCancellation::campaign(
             EarlyExit::new(false),
@@ -2215,6 +2225,7 @@ mod tests {
             EvmEnvFor::<EthEvmNetwork>::default(),
             TxEnvFor::<EthEvmNetwork>::default(),
             backend,
+            NetworkConfigs::default(),
         );
         let before = executor.backend().basic_ref(SYSTEM_ADDRESS).unwrap();
 
@@ -2250,7 +2261,7 @@ mod tests {
         let mut executor = ExecutorBuilder::default()
             .inspectors(|stack| stack.cheatcodes(cheats_config))
             .spec_id(SpecId::CANCUN)
-            .build(EvmEnv::default(), TxEnv::default(), backend);
+            .build(EvmEnv::default(), TxEnv::default(), backend, NetworkConfigs::default());
 
         let original: Vec<B256> = vec![B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
         executor.tx_env_mut().set_blob_hashes(original.clone());

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1806,7 +1806,6 @@ mod tests {
     use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
     #[cfg(feature = "monad")]
     use foundry_evm_core::{constants::MONAD_CHEATCODE_ADDRESS, evm::MonadEvmNetwork};
-    #[cfg(feature = "monad")]
     use foundry_evm_traces::InternalTraceMode;
     use revm::context::TxEnv;
     use std::{sync::mpsc, thread};

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -38,13 +38,10 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         // is enabled, tracing will be enabled only for the targeted transaction
         let mut executor = ExecutorBuilder::default()
             .inspectors(|stack| {
-                stack
-                    .trace_requirements(trace_requirements)
-                    .networks(networks)
-                    .create2_deployer(create2_deployer)
+                stack.trace_requirements(trace_requirements).create2_deployer(create2_deployer)
             })
             .spec_id_opt(version.map(evm_spec_id::<SpecFor<FEN>>))
-            .build(env.0, env.1, db);
+            .build(env.0, env.1, db, networks);
 
         // Apply the state overrides.
         if let Some(state_overrides) = state_overrides {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -211,7 +211,10 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
         self
     }
 
-    /// Set networks with enabled features.
+    /// Sets networks when building an inspector stack directly.
+    ///
+    /// [`ExecutorBuilder::build`](crate::executors::ExecutorBuilder::build) overrides this with its
+    /// explicit network configuration so the executor, backend, and inspector remain in sync.
     #[inline]
     pub const fn networks(mut self, networks: NetworkConfigs) -> Self {
         self.networks = networks;

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -702,14 +702,18 @@ impl NetworkConfigs {
 
     /// Applies an authoritative execution profile while preserving orthogonal settings.
     pub fn with_execution_profile(self, profile: Self) -> Self {
-        let mut resolved = profile.canonical_execution_profile();
+        let mut resolved = if profile.is_celo() {
+            Self::with_celo()
+        } else {
+            profile.resolved_network().map(Into::into).unwrap_or_default()
+        };
         resolved.bypass_prevrandao = self.bypass_prevrandao;
         resolved
     }
 
     /// Applies an endpoint-reported execution profile while preserving orthogonal settings.
     pub fn with_rpc_profile(self, profile: Self) -> Self {
-        self.with_execution_profile(profile)
+        self.with_execution_profile(profile.canonical_execution_profile())
     }
 
     /// Parses the execution profile reported by `anvil_nodeInfo`.
@@ -1282,13 +1286,33 @@ mod tests {
     fn authoritative_execution_profile_preserves_orthogonal_settings() {
         let inline = NetworkConfigs { bypass_prevrandao: true, ..NetworkConfigs::with_tempo() };
 
-        let ethereum = inline.with_execution_profile(NetworkConfigs::with_ethereum());
-        assert!(ethereum.has_same_execution_profile(&NetworkConfigs::with_ethereum()));
-        assert!(ethereum.bypass_prevrandao(NamedChain::Mainnet as u64));
+        #[cfg_attr(not(any(feature = "optimism", feature = "monad")), allow(unused_mut))]
+        let mut profiles = vec![
+            NetworkConfigs::with_ethereum(),
+            NetworkConfigs::with_tempo(),
+            NetworkConfigs::with_celo(),
+        ];
+        #[cfg(feature = "optimism")]
+        profiles.push(NetworkVariant::Optimism.into());
+        #[cfg(feature = "monad")]
+        profiles.push(NetworkConfigs::with_monad());
 
-        let celo = inline.with_execution_profile(NetworkConfigs::with_celo());
-        assert!(celo.has_same_execution_profile(&NetworkConfigs::with_celo()));
-        assert!(celo.bypass_prevrandao(NamedChain::Mainnet as u64));
+        for profile in profiles {
+            let resolved = inline.with_execution_profile(profile);
+            assert!(resolved.has_same_execution_profile(&profile));
+            assert!(resolved.has_network_selection());
+            assert!(resolved.bypass_prevrandao(NamedChain::Mainnet as u64));
+        }
+
+        let ethereum = inline.with_execution_profile(NetworkConfigs::with_ethereum());
+        assert_eq!(
+            ethereum.try_with_chain_id(NamedChain::Tempo as u64).unwrap(),
+            ethereum,
+            "an authoritative Ethereum profile must prevent later endpoint inference",
+        );
+
+        let rpc_ethereum = inline.with_rpc_profile(NetworkConfigs::with_ethereum());
+        assert!(!rpc_ethereum.has_network_selection());
     }
 
     #[test]

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -700,11 +700,16 @@ impl NetworkConfigs {
         }
     }
 
-    /// Applies an endpoint-reported execution profile while preserving orthogonal settings.
-    pub fn with_rpc_profile(self, profile: Self) -> Self {
+    /// Applies an authoritative execution profile while preserving orthogonal settings.
+    pub fn with_execution_profile(self, profile: Self) -> Self {
         let mut resolved = profile.canonical_execution_profile();
         resolved.bypass_prevrandao = self.bypass_prevrandao;
         resolved
+    }
+
+    /// Applies an endpoint-reported execution profile while preserving orthogonal settings.
+    pub fn with_rpc_profile(self, profile: Self) -> Self {
+        self.with_execution_profile(profile)
     }
 
     /// Parses the execution profile reported by `anvil_nodeInfo`.
@@ -1271,6 +1276,19 @@ mod tests {
         );
         assert_eq!(NetworkConfigs::with_celo().execution_family_name(), "ethereum");
         assert_eq!(NetworkConfigs::with_celo().execution_profile_name(), "celo");
+    }
+
+    #[test]
+    fn authoritative_execution_profile_preserves_orthogonal_settings() {
+        let inline = NetworkConfigs { bypass_prevrandao: true, ..NetworkConfigs::with_tempo() };
+
+        let ethereum = inline.with_execution_profile(NetworkConfigs::with_ethereum());
+        assert!(ethereum.has_same_execution_profile(&NetworkConfigs::with_ethereum()));
+        assert!(ethereum.bypass_prevrandao(NamedChain::Mainnet as u64));
+
+        let celo = inline.with_execution_profile(NetworkConfigs::with_celo());
+        assert!(celo.has_same_execution_profile(&NetworkConfigs::with_celo()));
+        assert!(celo.bypass_prevrandao(NamedChain::Mainnet as u64));
     }
 
     #[test]

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -580,6 +580,12 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
     pub fn configure_executor(&self, executor: &mut Executor<FEN>) {
         // TODO: See above
 
+        debug_assert!(
+            executor.backend().networks().has_same_execution_profile(&self.evm_opts.networks)
+        );
+        debug_assert!(
+            executor.inspector().networks.has_same_execution_profile(&self.evm_opts.networks)
+        );
         let inspector = executor.inspector_mut();
         // inspector.set_env(&self.env);
         if let Some(cheatcodes) = inspector.cheatcodes.as_mut() {
@@ -590,7 +596,6 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
         inspector.tracing_requirements(self.trace_requirements());
         inspector.collect_line_coverage(self.line_coverage);
         inspector.enable_isolation(self.isolation);
-        inspector.networks(self.evm_opts.networks);
         // inspector.set_create2_deployer(self.evm_opts.create2_deployer);
 
         // executor.env_mut().clone_from(&self.env);
@@ -624,14 +629,13 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
                     .trace_requirements(self.trace_requirements())
                     .line_coverage(self.line_coverage)
                     .enable_isolation(self.isolation)
-                    .networks(self.evm_opts.networks)
                     .create2_deployer(self.evm_opts.create2_deployer)
                     .set_analysis(analysis)
             })
             .spec_id(self.spec_id)
             .gas_limit(self.evm_opts.gas_limit())
             .legacy_assertions(self.config.legacy_assertions)
-            .build(self.evm_env.clone(), self.tx_env.clone(), db)
+            .build(self.evm_env.clone(), self.tx_env.clone(), db, self.evm_opts.networks)
     }
 
     fn trace_requirements(&self) -> TraceRequirements {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -932,7 +932,9 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
     /// Returns the configuration for a contract or function.
     fn inline_config(&self, func: Option<&Function>) -> Result<Config> {
-        inline_config_for(&self.config, &self.mcr.inline_config, self.name, func)
+        let mut config = inline_config_for(&self.config, &self.mcr.inline_config, self.name, func)?;
+        config.networks = config.networks.with_execution_profile(self.tcfg.evm_opts.networks);
+        Ok(config)
     }
 
     /// Collect fixtures from test contract.

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -524,8 +524,8 @@ forgetest!(per_test_network_routing, |prj, cmd| {
             }
         }
 
+        /// forge-config: default.networks.network = "tempo"
         contract TempoNetwork {
-            /// forge-config: default.networks.network = "tempo"
             function test_fee_manager_callable_on_tempo() public view {
                 // Sentinel bytecode (0xef) is injected at every Tempo precompile address.
                 require(
@@ -545,9 +545,10 @@ forgetest!(per_test_network_routing, |prj, cmd| {
             }
         }
 
-        // Mixed contract: one function annotated with Tempo, one unannotated (runs on Ethereum).
+        // Mixed contract: the contract defaults to Tempo, while one function overrides Ethereum.
+        /// forge-config: default.networks.network = "tempo"
         contract MixedNetwork {
-            // No annotation -> runs on Ethereum; precompile must be absent.
+            /// forge-config: default.networks.network = "ethereum"
             function test_fee_manager_absent_on_ethereum() public view {
                 require(
                     TIP_FEE_MANAGER.code.length == 0,
@@ -555,7 +556,6 @@ forgetest!(per_test_network_routing, |prj, cmd| {
                 );
             }
 
-            /// forge-config: default.networks.network = "tempo"
             function test_fee_manager_callable_on_tempo() public view {
                 require(
                     TIP_FEE_MANAGER.code.length > 0,

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -524,8 +524,8 @@ forgetest!(per_test_network_routing, |prj, cmd| {
             }
         }
 
-        /// forge-config: default.networks.network = "tempo"
         contract TempoNetwork {
+            /// forge-config: default.networks.network = "tempo"
             function test_fee_manager_callable_on_tempo() public view {
                 // Sentinel bytecode (0xef) is injected at every Tempo precompile address.
                 require(
@@ -545,10 +545,9 @@ forgetest!(per_test_network_routing, |prj, cmd| {
             }
         }
 
-        // Mixed contract: the contract defaults to Tempo, while one function overrides Ethereum.
-        /// forge-config: default.networks.network = "tempo"
+        // Mixed contract: one function annotated with Tempo, one unannotated (runs on Ethereum).
         contract MixedNetwork {
-            /// forge-config: default.networks.network = "ethereum"
+            // No annotation -> runs on Ethereum; precompile must be absent.
             function test_fee_manager_absent_on_ethereum() public view {
                 require(
                     TIP_FEE_MANAGER.code.length == 0,
@@ -556,6 +555,7 @@ forgetest!(per_test_network_routing, |prj, cmd| {
                 );
             }
 
+            /// forge-config: default.networks.network = "tempo"
             function test_fee_manager_callable_on_tempo() public view {
                 require(
                     TIP_FEE_MANAGER.code.length > 0,
@@ -596,6 +596,52 @@ Ran 1 test for test/inline.sol:[..]Network
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
 Ran 3 test suites [ELAPSED]: 4 tests passed, 0 failed, 0 skipped (4 total tests)
+
+"#]]);
+});
+
+// Contract-level network configuration must not override the execution profile selected for each
+// multi-network pass. Function-level configuration can still select a different pass.
+forgetest!(contract_network_preserves_pass_profile, |prj, cmd| {
+    prj.add_test(
+        "inline.sol",
+        r#"
+        address constant TIP_FEE_MANAGER = 0xfeEC000000000000000000000000000000000000;
+
+        /// forge-config: default.networks.network = "tempo"
+        contract ContractNetwork {
+            /// forge-config: default.networks.network = "ethereum"
+            function test_fee_manager_absent_on_ethereum() public view {
+                require(
+                    TIP_FEE_MANAGER.code.length == 0,
+                    "TipFeeManager should not exist on Ethereum"
+                );
+            }
+
+            function test_fee_manager_callable_on_tempo() public view {
+                require(
+                    TIP_FEE_MANAGER.code.length > 0,
+                    "TipFeeManager must be deployed on Tempo"
+                );
+            }
+        }
+        "#,
+    );
+
+    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/inline.sol:ContractNetwork
+[PASS] test_fee_manager_absent_on_ethereum() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test for test/inline.sol:ContractNetwork
+[PASS] test_fee_manager_callable_on_tempo() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 
 "#]]);
 });

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -1058,7 +1058,6 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
                 stack
                     .logs(self.config.live_logs)
                     .trace_requirements(script_trace_requirements(&self.config, debug))
-                    .networks(self.evm_opts.networks)
                     .create2_deployer(self.evm_opts.create2_deployer)
             })
             .gas_limit(self.evm_opts.gas_limit())
@@ -1088,9 +1087,11 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         // (e.g. script deployment, setUp) use the correct fee token for Tempo networks.
         tx_env.set_fee_token(self.tempo.fee_token);
 
-        let mut runner =
-            ScriptRunner::new(builder.build(evm_env, tx_env, db), self.evm_opts.clone())
-                .with_debug_bytecodes(debug);
+        let mut runner = ScriptRunner::new(
+            builder.build(evm_env, tx_env, db, self.evm_opts.networks),
+            self.evm_opts.clone(),
+        )
+        .with_debug_bytecodes(debug);
 
         if self.sender_nonce_override.is_some() {
             runner.executor.set_nonce(self.evm_opts.sender, self.sender_nonce)?;


### PR DESCRIPTION
Executor construction previously sourced network configuration indirectly from the inspector stack, allowing the inspector and backend configuration to diverge.

This makes the selected network an explicit executor construction input and propagates it consistently to the inspector and backend. Inline test configuration retains the active pass’s execution profile while preserving orthogonal network settings.
