### PR TITLE
fix(deps): pin Alloy decoder patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,8 +197,7 @@ dependencies = [
 [[package]]
 name = "alloy-dyn-abi"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -377,8 +376,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-abi"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cee30dd4c2f4b23f434fdf675e7bf9681b86768141277266c6f548ef25cba0a"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -484,8 +482,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -926,8 +923,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -940,8 +936,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro-expander"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -959,8 +954,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro-input"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -977,8 +971,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-type-parser"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "serde",
  "winnow 1.0.4",
@@ -987,8 +980,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-types"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -1212,7 +1204,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1236,7 +1228,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3249,7 +3241,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.19",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3408,7 +3400,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4633,7 +4625,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4940,7 +4932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5794,7 +5786,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "path-slash",
  "rand 0.10.2",
  "rayon",
@@ -6548,8 +6540,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -7003,7 +6995,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7363,7 +7355,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8188,7 +8180,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9615,7 +9607,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11000,7 +10992,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11059,7 +11051,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11827,7 +11819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12381,8 +12373,7 @@ dependencies = [
 [[package]]
 name = "syn-solidity"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -12467,7 +12458,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12691,7 +12682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13860,7 +13851,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14008,7 +13999,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -573,15 +573,15 @@ foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", 
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "eabd2e218a7606505430d84bfeacd145e2c1eff3" }
 
 ## alloy-core
-# alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
-# alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }
-# alloy-primitives = { path = "../../alloy-rs/core/crates/primitives" }
-# alloy-sol-macro = { path = "../../alloy-rs/core/crates/sol-macro" }
-# alloy-sol-macro-expander = { path = "../../alloy-rs/core/crates/sol-macro-expander" }
-# alloy-sol-macro-input = { path = "../../alloy-rs/core/crates/sol-macro-input" }
-# alloy-sol-type-parser = { path = "../../alloy-rs/core/crates/sol-type-parser" }
-# alloy-sol-types = { path = "../../alloy-rs/core/crates/sol-types" }
-# syn-solidity = { path = "../../alloy-rs/core/crates/syn-solidity" }
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-macro-expander = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-macro-input = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-type-parser = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
 
 ## alloy
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "395521c" }


### PR DESCRIPTION
Pins all Alloy Core workspace patches to the revision used by Tempo. Cargo only honors patches from the workspace root, so locally patched Tempo crates otherwise resolve the crates.io Alloy release and fail to find the bounded ABI decoder APIs.

This dependency-only compatibility change does not need a changelog entry; please apply `L-ignore`.

AI assistance was used to diagnose the Cargo patch resolution and prepare this change.

Prompted by: @klkvr
