### PR TITLE
test(forge): cover Tempo trace labels

### DIFF
--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -645,3 +645,46 @@ Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 
 "#]]);
 });
+
+// TIP20 calls made in an inline Tempo pass should use the token name loaded from Tempo state in
+// rendered traces.
+forgetest!(tempo_pass_traces_tip20_name, |prj, cmd| {
+    prj.add_test(
+        "inline.sol",
+        r#"
+        interface ITIP20 {
+            function balanceOf(address account) external view returns (uint256);
+        }
+
+        contract TempoTraceLabels {
+            address constant ALPHA_USD = 0x20C0000000000000000000000000000000000001;
+
+            /// forge-config: default.networks.network = "tempo"
+            function test_tip20_trace_uses_name() public view {
+                ITIP20(ALPHA_USD).balanceOf(address(this));
+            }
+        }
+        "#,
+    );
+
+    cmd.args(["test", "--mt", "test_tip20_trace_uses_name", "-vvvv"]).assert_success().stdout_eq(
+        str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/inline.sol:TempoTraceLabels
+[PASS] test_tip20_trace_uses_name() ([GAS])
+Traces:
+  [..] TempoTraceLabels::test_tip20_trace_uses_name()
+    ├─ [..] AlphaUSD::balanceOf([..]) [staticcall]
+    │   └─ ← [Return] [..]
+    └─ ← [Stop]
+
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]],
+    );
+});


### PR DESCRIPTION
Adds an end-to-end Forge CLI regression test for inline Tempo network passes. The test calls the dynamically initialized AlphaUSD TIP-20 token under `-vvvv` and snapshots the rendered `AlphaUSD::balanceOf` trace, covering network-pass selection through Tempo state-backed label collection and CLI rendering.

This is a test-only change, so the PR should receive the `L-ignore` label instead of adding a changelog entry.

This PR was written with Codex, including code generation and validation.
