### PR TITLE
chore(anvil): fix nightly clippy

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![recursion_limit = "256"]
 
 #[cfg(feature = "optimism")]
 use op_alloy_rpc_types as _;


### PR DESCRIPTION
Raises Anvil's recursion limit to satisfy the latest nightly compiler's recursion-depth lint.