### PR TITLE
refactor: qualify Monad-only imports

### DIFF
--- a/.changelog/cleanup-monad-feature-imports.md
+++ b/.changelog/cleanup-monad-feature-imports.md
@@ -1,0 +1,17 @@
+---
+anvil: patch
+cast: patch
+chisel: patch
+forge: patch
+forge-script: patch
+forge-verify: patch
+foundry-cheatcodes: patch
+foundry-config: patch
+foundry-evm: patch
+foundry-evm-core: patch
+foundry-evm-hardforks: patch
+foundry-evm-networks: patch
+foundry-evm-traces: patch
+---
+
+Cleaned up Monad feature-gated imports without changing runtime behavior.

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -929,8 +929,6 @@ fn duration_from_secs_f64(s: &str) -> Result<Duration, String> {
 mod tests {
     use super::*;
     use foundry_evm::hardfork::EthereumHardfork;
-    #[cfg(feature = "monad")]
-    use foundry_evm::hardfork::MonadHardfork;
     #[cfg(feature = "optimism")]
     use foundry_evm::hardfork::OpHardfork;
     use std::{env, net::Ipv4Addr};
@@ -1204,7 +1202,7 @@ mod tests {
         let args: NodeArgs =
             NodeArgs::parse_from(["anvil", "--network", "monad", "--hardfork", "MonadNine"]);
         let config = args.into_node_config().unwrap();
-        assert_eq!(config.hardfork, Some(MonadHardfork::MonadNine.into()));
+        assert_eq!(config.hardfork, Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()));
         assert!(config.networks.is_monad());
     }
 
@@ -1214,7 +1212,7 @@ mod tests {
         let args: NodeArgs = NodeArgs::parse_from(["anvil", "--network", "monad"]);
         let config = args.into_node_config().unwrap();
         assert_eq!(config.hardfork, None);
-        assert_eq!(config.get_hardfork(), MonadHardfork::default().into());
+        assert_eq!(config.get_hardfork(), foundry_evm::hardfork::MonadHardfork::default().into());
         assert!(config.networks.is_monad());
     }
 

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -42,8 +42,6 @@ use foundry_common::{
     provider::{ProviderBuilder, RetryProvider, is_rpc_method_not_found, redact_url},
 };
 use foundry_config::Config;
-#[cfg(feature = "monad")]
-use foundry_evm::hardfork::MonadHardfork;
 use foundry_evm::{
     backend::{BlockchainDb, BlockchainDbMeta, SharedBackend},
     constants::DEFAULT_CREATE2_DEPLOYER,
@@ -1417,7 +1415,9 @@ impl NodeConfig {
         #[cfg(feature = "monad")]
         {
             decoder_builder = decoder_builder.with_monad_hardfork(
-                self.networks.is_monad().then(|| MonadHardfork::from(active_hardfork)),
+                self.networks
+                    .is_monad()
+                    .then(|| foundry_evm::hardfork::MonadHardfork::from(active_hardfork)),
             );
         }
         if self.print_traces {
@@ -2678,7 +2678,10 @@ mod tests {
         config.fork_source_chain_id = Some(143);
 
         assert_eq!(config.get_chain_id(), 1);
-        assert_eq!(config.get_hardfork(), FoundryHardfork::Monad(MonadHardfork::MonadEight));
+        assert_eq!(
+            config.get_hardfork(),
+            FoundryHardfork::Monad(foundry_evm::hardfork::MonadHardfork::MonadEight)
+        );
     }
 
     #[test]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -5,8 +5,6 @@ use super::{
     },
     preserve_simulation_request_fields,
 };
-#[cfg(feature = "monad")]
-use crate::eth::backend::executor::build_tx_env_for_pending;
 use crate::{
     ClientFork, LoggingManager, Miner, MiningMode, StorageInfo,
     eth::{
@@ -100,8 +98,6 @@ use foundry_common::{
     tempo::{PaymentLaneClassification, PaymentLaneReason, classify_payment_lane},
     version::{COMMIT_SHA, SEMVER_VERSION},
 };
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::protocol_system_call;
 use foundry_evm::decode::RevertDecoder;
 use foundry_primitives::{
     FoundryNetwork, FoundryReceiptEnvelope, FoundryTransactionRequest, FoundryTxEnvelope,
@@ -111,11 +107,7 @@ use futures::{
     StreamExt, TryFutureExt,
     channel::{mpsc::Receiver, oneshot},
 };
-#[cfg(feature = "monad")]
-use monad_revm::staking::constants::SYSTEM_ADDRESS as MONAD_SYSTEM_ADDRESS;
 use parking_lot::RwLock;
-#[cfg(feature = "monad")]
-use revm::context::TxEnv;
 use revm::{
     context::BlockEnv,
     context_interface::{
@@ -4143,10 +4135,15 @@ impl EthApi<FoundryNetwork> {
 
         let pending = PendingTransaction::with_sender(
             MaybeImpersonatedTransaction::new(transaction),
-            MONAD_SYSTEM_ADDRESS,
+            monad_revm::staking::constants::SYSTEM_ADDRESS,
         );
-        let tx_env: TxEnv = build_tx_env_for_pending(&pending, self.backend.cheats());
-        protocol_system_call(&tx_env).is_ok_and(|call| call.is_some()).then_some(pending)
+        let tx_env: revm::context::TxEnv = crate::eth::backend::executor::build_tx_env_for_pending(
+            &pending,
+            self.backend.cheats(),
+        );
+        foundry_evm::core::evm::protocol_system_call(&tx_env)
+            .is_ok_and(|call| call.is_some())
+            .then_some(pending)
     }
 
     /// Reorg the chain to a specific depth and mine new blocks back to the canonical height.
@@ -4254,7 +4251,7 @@ impl EthApi<FoundryNetwork> {
                         let protocol_pending = {
                             #[cfg(feature = "monad")]
                             {
-                                if from == MONAD_SYSTEM_ADDRESS {
+                                if from == monad_revm::staking::constants::SYSTEM_ADDRESS {
                                     self.monad_protocol_reorg_transaction(
                                         typed_tx.clone().into_impersonated(),
                                     )

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -1,7 +1,5 @@
 //! Helper types for working with [revm]
 
-#[cfg(feature = "monad")]
-use std::collections::BTreeSet;
 use std::{
     collections::BTreeMap,
     fmt::{self, Debug},
@@ -29,8 +27,6 @@ use foundry_evm::backend::{
     BlockchainDb, DatabaseError, DatabaseResult, EmptyDBWrapper, MemDb, RevertStateSnapshotAction,
     StateSnapshot,
 };
-#[cfg(feature = "monad")]
-use foundry_evm::hardfork::MonadHardfork;
 use foundry_primitives::{FoundryHeader, FoundryReceiptEnvelope, FoundryTxEnvelope};
 use revm::{
     Database, DatabaseCommit,
@@ -59,7 +55,7 @@ pub struct MonadBlockReplayProfile {
     /// Chain ID active when the block was executed.
     pub execution_chain_id: u64,
     /// Monad hardfork active when the block was executed.
-    pub hardfork: MonadHardfork,
+    pub hardfork: foundry_evm::hardfork::MonadHardfork,
 }
 
 /// Inserts a block hash, discards entries outside the EVM-visible cache, and returns its head.
@@ -726,7 +722,7 @@ pub struct SerializableState {
     /// used, so it is preserved even while the corresponding transaction bodies are retained.
     #[cfg(feature = "monad")]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub monad_block_participants: BTreeMap<B256, BTreeSet<Address>>,
+    pub monad_block_participants: BTreeMap<B256, std::collections::BTreeSet<Address>>,
     /// Execution profile used for each locally stored Monad block.
     #[cfg(feature = "monad")]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1,10 +1,6 @@
 //! In-memory blockchain backend.
 use self::{in_memory_db::StateRootDb, state::trie_storage};
 
-#[cfg(feature = "monad")]
-use crate::eth::backend::db::MonadBlockReplayProfile;
-#[cfg(feature = "monad")]
-use crate::eth::backend::replay::execute_historical_replay_with;
 use crate::{
     ForkChoice, NodeConfig, PrecompileFactory,
     config::{ForkTransactionReplay, PruneStateHistoryConfig},
@@ -65,8 +61,6 @@ use alloy_eips::{
     eip7840::BlobParams,
     eip7910::SystemContract,
 };
-#[cfg(feature = "monad")]
-use alloy_evm::block::BlockExecutionError;
 use alloy_evm::{
     Database, EthEvmFactory, Evm, EvmEnv, EvmFactory, FromTxWithEncoded,
     block::{BlockExecutionResult, BlockExecutor, StateDB},
@@ -74,8 +68,6 @@ use alloy_evm::{
     overrides::{OverrideBlockHashes, apply_state_overrides},
     precompiles::{DynPrecompile, MovePrecompileError, Precompile, PrecompilesMap},
 };
-#[cfg(feature = "monad")]
-use alloy_monad_evm::{MonadContext, MonadEvmFactory};
 use alloy_network::{
     AnyHeader, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction, AnyTxEnvelope, AnyTxType, Network,
     NetworkTransactionBuilder, ReceiptResponse, UnknownTxEnvelope, UnknownTypedTransaction,
@@ -127,15 +119,8 @@ use anvil_rpc::error::{ErrorCode, RpcError};
 use chrono::Datelike;
 use eyre::{Context, Result};
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::{
-    FoundryEvmFactory, monad_block_participants as collect_monad_block_participants,
-    protocol_system_call,
-};
 #[cfg(feature = "optimism")]
 use foundry_evm::hardfork::OpHardfork;
-#[cfg(feature = "monad")]
-use foundry_evm::utils::get_blob_params;
 use foundry_evm::{
     backend::{BlockchainDb, DatabaseError, DatabaseResult, RevertStateSnapshotAction},
     constants::{DEFAULT_CREATE2_DEPLOYER, DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE},
@@ -164,15 +149,11 @@ use foundry_primitives::{
     FoundryTxEnvelope, FoundryTxReceipt, TempoTransactionRequest,
 };
 use futures::channel::mpsc::{UnboundedSender, unbounded};
-#[cfg(feature = "monad")]
-use monad_revm::{MonadCfgEnv, MonadChainContext, MonadHardfork, instructions::monad_gas_params};
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, POST_EXEC_TX_TYPE_ID};
 #[cfg(feature = "optimism")]
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
-#[cfg(feature = "monad")]
-use revm::context_interface::result::InvalidTransaction;
 use revm::{
     Database as RevmDatabase, DatabaseCommit, Inspector,
     context::{Block as RevmBlock, BlockEnv, Cfg, CfgEnv, ContextSetters, ContextTr, TxEnv},
@@ -449,7 +430,7 @@ impl<D> Drop for StagedForkDbUser<D> {
 }
 
 #[cfg(feature = "monad")]
-pub(crate) type MonadReplayContext = MonadChainContext;
+pub(crate) type MonadReplayContext = monad_revm::MonadChainContext;
 // Opaque stand-in that keeps feature-independent replay context plumbing type-stable.
 #[cfg(not(feature = "monad"))]
 #[derive(Clone)]
@@ -716,7 +697,7 @@ pub trait BackendInspector<DB: Database>:
     Inspector<EthEvmContext<DB>>
     + Inspector<OpEvmContext<DB>>
     + Inspector<TempoContext<DB>>
-    + Inspector<MonadContext<DB>>
+    + Inspector<alloy_monad_evm::MonadContext<DB>>
 {
 }
 #[cfg(all(feature = "optimism", feature = "monad"))]
@@ -724,7 +705,7 @@ impl<DB: Database, T> BackendInspector<DB> for T where
     T: Inspector<EthEvmContext<DB>>
         + Inspector<OpEvmContext<DB>>
         + Inspector<TempoContext<DB>>
-        + Inspector<MonadContext<DB>>
+        + Inspector<alloy_monad_evm::MonadContext<DB>>
 {
 }
 #[cfg(all(feature = "optimism", not(feature = "monad")))]
@@ -739,12 +720,16 @@ impl<DB: Database, T> BackendInspector<DB> for T where
 }
 #[cfg(all(not(feature = "optimism"), feature = "monad"))]
 pub trait BackendInspector<DB: Database>:
-    Inspector<EthEvmContext<DB>> + Inspector<TempoContext<DB>> + Inspector<MonadContext<DB>>
+    Inspector<EthEvmContext<DB>>
+    + Inspector<TempoContext<DB>>
+    + Inspector<alloy_monad_evm::MonadContext<DB>>
 {
 }
 #[cfg(all(not(feature = "optimism"), feature = "monad"))]
 impl<DB: Database, T> BackendInspector<DB> for T where
-    T: Inspector<EthEvmContext<DB>> + Inspector<TempoContext<DB>> + Inspector<MonadContext<DB>>
+    T: Inspector<EthEvmContext<DB>>
+        + Inspector<TempoContext<DB>>
+        + Inspector<alloy_monad_evm::MonadContext<DB>>
 {
 }
 #[cfg(all(not(feature = "optimism"), not(feature = "monad")))]
@@ -1346,8 +1331,8 @@ impl<N: Network> Backend<N> {
 
     /// Returns the active Monad hardfork.
     #[cfg(feature = "monad")]
-    pub fn monad_hardfork(&self) -> MonadHardfork {
-        MonadHardfork::from(self.hardfork())
+    pub fn monad_hardfork(&self) -> monad_revm::MonadHardfork {
+        monad_revm::MonadHardfork::from(self.hardfork())
     }
 
     /// Returns whether a Tempo hardfork is active on this backend.
@@ -1532,15 +1517,16 @@ impl<N: Network> Backend<N> {
     }
 
     #[cfg(feature = "monad")]
-    fn monad_cfg_env(&self, evm_env: &EvmEnv) -> Option<MonadCfgEnv> {
+    fn monad_cfg_env(&self, evm_env: &EvmEnv) -> Option<monad_revm::MonadCfgEnv> {
         if !self.is_monad() {
             return None;
         }
 
-        let hardfork = MonadHardfork::from(self.hardfork());
-        Some(MonadCfgEnv::from(
-            evm_env.cfg_env.clone().with_spec_and_gas_params(hardfork, monad_gas_params(hardfork)),
-        ))
+        let hardfork = monad_revm::MonadHardfork::from(self.hardfork());
+        Some(monad_revm::MonadCfgEnv::from(evm_env.cfg_env.clone().with_spec_and_gas_params(
+            hardfork,
+            monad_revm::instructions::monad_gas_params(hardfork),
+        )))
     }
 
     fn tx_gas_limit_cap(&self, evm_env: &EvmEnv) -> u64 {
@@ -1656,7 +1642,7 @@ impl<N: Network> Backend<N> {
         #[cfg(feature = "monad")]
         let hardfork = if self.is_monad() {
             let block_hash = block.header.hash_slow();
-            let fallback = MonadBlockReplayProfile {
+            let fallback = crate::eth::backend::db::MonadBlockReplayProfile {
                 execution_chain_id: evm_env.cfg_env.chain_id,
                 hardfork: self.monad_hardfork(),
             };
@@ -2530,7 +2516,7 @@ impl<N: Network> Backend<N> {
                 monad::PreparedExecution {
                     context,
                     kind: execution.kind,
-                    hardfork: MonadHardfork::from(execution.hardfork),
+                    hardfork: monad_revm::MonadHardfork::from(execution.hardfork),
                 },
             )?
         } else {
@@ -3149,7 +3135,7 @@ impl<N: Network> Backend<N> {
                     monad::PreparedExecution {
                         context,
                         kind: EnvelopeExecutionKind::Transaction,
-                        hardfork: MonadHardfork::from(hardfork),
+                        hardfork: monad_revm::MonadHardfork::from(hardfork),
                     },
                 )
             }
@@ -5047,7 +5033,7 @@ where
         let hardfork = if self.is_monad() {
             explicit_monad_hardfork
                 .or_else(|| {
-                    MonadHardfork::from_chain_and_timestamp(source_chain_id, timestamp)
+                    monad_revm::MonadHardfork::from_chain_and_timestamp(source_chain_id, timestamp)
                         .map(FoundryHardfork::Monad)
                 })
                 .unwrap_or_else(|| self.hardfork())
@@ -5080,7 +5066,9 @@ where
 
         #[cfg(feature = "monad")]
         let monad_participants = self.is_monad().then(|| {
-            collect_monad_block_participants(&self.monad_historical_replay_tx_envs(&transactions))
+            foundry_evm::core::evm::monad_block_participants(
+                &self.monad_historical_replay_tx_envs(&transactions),
+            )
         });
 
         let (block_info, state_changes, block_hash) = {
@@ -5146,9 +5134,9 @@ where
                 storage.monad_block_participants.insert(block_hash, participants);
                 storage.monad_block_replay_profiles.insert(
                     block_hash,
-                    MonadBlockReplayProfile {
+                    crate::eth::backend::db::MonadBlockReplayProfile {
                         execution_chain_id,
-                        hardfork: MonadHardfork::from(hardfork),
+                        hardfork: monad_revm::MonadHardfork::from(hardfork),
                     },
                 );
             }
@@ -5171,7 +5159,8 @@ where
             let spec_id = SpecId::from(hardfork);
             evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec_id);
             self.fees.set_execution_rules(spec_id, self.networks.base_fee_params(timestamp), None);
-            self.fees.set_blob_params(get_blob_params(source_chain_id, timestamp));
+            self.fees
+                .set_blob_params(foundry_evm::utils::get_blob_params(source_chain_id, timestamp));
 
             // An inferred hardfork follows the replayed source block. Keep an explicit override
             // fixed, even when the source schedule differs.
@@ -5286,26 +5275,30 @@ where
 
         #[cfg(feature = "monad")]
         if self.is_monad() {
-            let hardfork = MonadHardfork::from(hardfork);
+            let hardfork = monad_revm::MonadHardfork::from(hardfork);
             let monad_env = Self::build_monad_evm_env(evm_env, hardfork);
-            let mut evm =
-                MonadEvmFactory::default().create_evm_with_inspector(db, monad_env, inspector);
+            let mut evm = alloy_monad_evm::MonadEvmFactory::default()
+                .create_evm_with_inspector(db, monad_env, inspector);
             let transaction_context = monad_context
                 .ok_or_else(|| eyre::eyre!("Monad replay ancestor context is unavailable"))?;
             evm.ctx_mut().chain = transaction_context;
             return run!(evm, |executor| {
-                execute_historical_replay_with(
+                crate::eth::backend::replay::execute_historical_replay_with(
                     executor,
                     transactions,
                     inspector_tx_config,
                     |evm, tx_env, _transaction_hash| {
                         monad::prepare_transaction(evm, &tx_env);
-                        let result = match MonadEvmFactory::default()
-                            .try_transact_system_replay(evm, &tx_env)
-                            .map_err(BlockExecutionError::msg)
-                        {
+                        let result = match foundry_evm::core::evm::FoundryEvmFactory::try_transact_system_replay(
+                            &alloy_monad_evm::MonadEvmFactory::default(),
+                            evm,
+                            &tx_env,
+                        )
+                        .map_err(alloy_evm::block::BlockExecutionError::msg) {
                             Ok(Some(result)) => Ok(result),
-                            Ok(None) => evm.transact(tx_env).map_err(BlockExecutionError::msg),
+                            Ok(None) => evm
+                                .transact(tx_env)
+                                .map_err(alloy_evm::block::BlockExecutionError::msg),
                             Err(err) => Err(err),
                         };
                         if result.is_err() {
@@ -5513,7 +5506,7 @@ where
                         )
                     })
                     .collect::<Vec<_>>();
-                collect_monad_block_participants(&tx_envs)
+                foundry_evm::core::evm::monad_block_participants(&tx_envs)
             });
 
             if let Some(parent_state) = parent_state {
@@ -5545,7 +5538,7 @@ where
                 storage.monad_block_participants.insert(block_hash, participants);
                 storage.monad_block_replay_profiles.insert(
                     block_hash,
-                    MonadBlockReplayProfile {
+                    crate::eth::backend::db::MonadBlockReplayProfile {
                         execution_chain_id: evm_env.cfg_env.chain_id,
                         hardfork: hardfork.into(),
                     },
@@ -8701,7 +8694,7 @@ where
         if self.is_monad() && pool_tx.is_replay {
             let tx_env: TxEnv =
                 build_tx_env_for_pending(&pool_tx.pending_transaction, self.cheats());
-            match protocol_system_call(&tx_env) {
+            match foundry_evm::core::evm::protocol_system_call(&tx_env) {
                 Ok(Some(system_call)) => {
                     if system_call
                         .chain_id
@@ -8722,9 +8715,11 @@ where
                 }
                 Ok(None) => {}
                 Err(err) => {
-                    return Err(InvalidTransactionError::Revm(InvalidTransaction::Str(
-                        err.to_string().into(),
-                    )));
+                    return Err(InvalidTransactionError::Revm(
+                        revm::context_interface::result::InvalidTransaction::Str(
+                            err.to_string().into(),
+                        ),
+                    ));
                 }
             }
         }
@@ -9398,25 +9393,11 @@ pub use foundry_evm::core::evm::IntoInstructionResult;
 mod tests {
     use super::{ForkCacheNamespace, ForkCacheSource, StagedForkCacheLease, StagedForkDbUser};
     use crate::{NodeConfig, spawn};
-    #[cfg(feature = "monad")]
-    use alloy_consensus::{BlockHeader, constants::EMPTY_ROOT_HASH};
-    #[cfg(feature = "monad")]
-    use alloy_network::TransactionBuilder;
-    #[cfg(feature = "monad")]
-    use alloy_primitives::Address;
     use alloy_primitives::{B256, U256};
-    #[cfg(feature = "monad")]
-    use alloy_provider::Provider;
-    #[cfg(feature = "monad")]
-    use alloy_rpc_types::TransactionRequest;
     use foundry_evm::{
         backend::{BlockchainDb, BlockchainDbMeta},
         hardfork::{EthereumHardfork, FoundryHardfork},
     };
-    #[cfg(feature = "monad")]
-    use foundry_evm::{hardfork::MonadHardfork, traces::CallTraceDecoderBuilder};
-    #[cfg(feature = "monad")]
-    use monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS;
     use std::sync::Arc;
     use tempfile::tempdir;
 
@@ -9704,8 +9685,13 @@ mod tests {
     #[cfg(feature = "monad")]
     #[tokio::test]
     async fn monad_load_state_rebuilds_participant_cache() {
-        let config =
-            || NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into()));
+        use alloy_network::TransactionBuilder as _;
+        use alloy_provider::Provider as _;
+
+        let config = || {
+            NodeConfig::test_monad()
+                .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()))
+        };
         let (api, handle) = spawn(config()).await;
         let provider = handle.http_provider();
         let accounts = provider.get_accounts().await.unwrap();
@@ -9713,7 +9699,7 @@ mod tests {
 
         let receipt = provider
             .send_transaction(
-                TransactionRequest::default()
+                alloy_rpc_types::TransactionRequest::default()
                     .with_from(sender)
                     .with_to(accounts[1])
                     .with_value(U256::from(1))
@@ -9738,9 +9724,13 @@ mod tests {
     #[cfg(feature = "monad")]
     #[tokio::test]
     async fn monad_load_state_restores_pruned_participant_cache() {
+        use alloy_consensus::BlockHeader as _;
+        use alloy_network::TransactionBuilder as _;
+        use alloy_provider::Provider as _;
+
         let config = || {
             NodeConfig::test_monad()
-                .with_hardfork(Some(MonadHardfork::MonadNine.into()))
+                .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()))
                 .with_transaction_block_keeper(Some(1usize))
         };
         let (api, handle) = spawn(config()).await;
@@ -9750,7 +9740,7 @@ mod tests {
 
         let first_receipt = provider
             .send_transaction(
-                TransactionRequest::default()
+                alloy_rpc_types::TransactionRequest::default()
                     .with_from(sender)
                     .with_to(accounts[1])
                     .with_value(U256::from(1))
@@ -9763,7 +9753,7 @@ mod tests {
             .unwrap();
         let second_receipt = provider
             .send_transaction(
-                TransactionRequest::default()
+                alloy_rpc_types::TransactionRequest::default()
                     .with_from(sender)
                     .with_to(accounts[1])
                     .with_value(U256::from(1))
@@ -9781,7 +9771,10 @@ mod tests {
             let storage = api.backend.blockchain.storage.read();
             let first_block = storage.blocks.get(&first_block_hash).unwrap();
             assert!(first_block.body.transactions.is_empty());
-            assert_ne!(first_block.header.transactions_root(), EMPTY_ROOT_HASH);
+            assert_ne!(
+                first_block.header.transactions_root(),
+                alloy_consensus::constants::EMPTY_ROOT_HASH
+            );
             assert!(storage.monad_block_participants[&first_block_hash].contains(&sender));
             assert!(!storage.blocks[&second_block_hash].body.transactions.is_empty());
         }
@@ -9807,21 +9800,25 @@ mod tests {
     #[cfg(feature = "monad")]
     #[tokio::test]
     async fn monad_load_state_rejection_is_atomic() {
+        use alloy_consensus::BlockHeader as _;
+        use alloy_network::TransactionBuilder as _;
+        use alloy_provider::Provider as _;
+
         let config = || {
             NodeConfig::test_monad()
-                .with_hardfork(Some(MonadHardfork::MonadNine.into()))
+                .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()))
                 .with_transaction_block_keeper(Some(1usize))
         };
         let (source_api, source_handle) = spawn(config()).await;
         let source_provider = source_handle.http_provider();
         let accounts = source_provider.get_accounts().await.unwrap();
-        let sentinel = Address::repeat_byte(0x77);
+        let sentinel = alloy_primitives::Address::repeat_byte(0x77);
 
         source_api.anvil_set_balance(sentinel, U256::from(123)).await.unwrap();
         for nonce in 0..2 {
             source_provider
                 .send_transaction(
-                    TransactionRequest::default()
+                    alloy_rpc_types::TransactionRequest::default()
                         .with_from(accounts[0])
                         .with_to(accounts[1])
                         .with_nonce(nonce)
@@ -9840,7 +9837,9 @@ mod tests {
             .blocks
             .iter()
             .find(|block| {
-                block.transactions.is_empty() && block.header.transactions_root() != EMPTY_ROOT_HASH
+                block.transactions.is_empty()
+                    && block.header.transactions_root()
+                        != alloy_consensus::constants::EMPTY_ROOT_HASH
             })
             .unwrap()
             .header
@@ -9869,30 +9868,44 @@ mod tests {
     #[cfg(feature = "monad")]
     #[tokio::test]
     async fn monad_trace_decoder_follows_resolved_hardfork() {
-        let (monad_eight, _) =
-            spawn(NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadEight.into())))
-                .await;
-        let stale_monad_nine = CallTraceDecoderBuilder::new()
-            .with_monad_hardfork(Some(MonadHardfork::MonadNine))
+        let (monad_eight, _) = spawn(
+            NodeConfig::test_monad()
+                .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadEight.into())),
+        )
+        .await;
+        let stale_monad_nine = foundry_evm::traces::CallTraceDecoderBuilder::new()
+            .with_monad_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine))
             .build();
         *monad_eight.backend.call_trace_decoder.write() = Arc::new(stale_monad_nine);
 
         let decoder = monad_eight.backend.call_trace_decoder();
-        assert_eq!(decoder.monad_hardfork(), Some(MonadHardfork::MonadEight));
-        assert!(!decoder.labels.contains_key(&RESERVE_BALANCE_ADDRESS));
+        assert_eq!(
+            decoder.monad_hardfork(),
+            Some(foundry_evm::hardfork::MonadHardfork::MonadEight)
+        );
+        assert!(
+            !decoder
+                .labels
+                .contains_key(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
+        );
 
-        let (monad_nine, _) =
-            spawn(NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into())))
-                .await;
-        let stale_monad_eight = CallTraceDecoderBuilder::new()
-            .with_monad_hardfork(Some(MonadHardfork::MonadEight))
+        let (monad_nine, _) = spawn(
+            NodeConfig::test_monad()
+                .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into())),
+        )
+        .await;
+        let stale_monad_eight = foundry_evm::traces::CallTraceDecoderBuilder::new()
+            .with_monad_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadEight))
             .build();
         *monad_nine.backend.call_trace_decoder.write() = Arc::new(stale_monad_eight);
 
         let decoder = monad_nine.backend.call_trace_decoder();
-        assert_eq!(decoder.monad_hardfork(), Some(MonadHardfork::MonadNine));
+        assert_eq!(decoder.monad_hardfork(), Some(foundry_evm::hardfork::MonadHardfork::MonadNine));
         assert_eq!(
-            decoder.labels.get(&RESERVE_BALANCE_ADDRESS).map(String::as_str),
+            decoder
+                .labels
+                .get(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
+                .map(String::as_str),
             Some("ReserveBalance")
         );
     }

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -1,6 +1,4 @@
 //! In-memory blockchain storage
-#[cfg(feature = "monad")]
-use crate::eth::backend::db::MonadBlockReplayProfile;
 use crate::eth::{
     backend::{
         db::{
@@ -30,8 +28,6 @@ use anvil_core::eth::{
     block::{Block, create_block},
     transaction::{MaybeImpersonatedTransaction, TransactionInfo},
 };
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::MonadBlockParticipants;
 use foundry_evm::{
     backend::MemDb,
     traces::{CallKind, ParityTraceBuilder, TracingInspectorConfig},
@@ -321,10 +317,10 @@ pub struct BlockchainStorage<N: Network> {
     pub total_difficulty: U256,
     /// Monad senders and authorities retained even when old transaction bodies are pruned.
     #[cfg(feature = "monad")]
-    pub monad_block_participants: B256HashMap<MonadBlockParticipants>,
+    pub monad_block_participants: B256HashMap<foundry_evm::core::evm::MonadBlockParticipants>,
     /// Execution profile used when each locally stored Monad block was created.
     #[cfg(feature = "monad")]
-    pub monad_block_replay_profiles: B256HashMap<MonadBlockReplayProfile>,
+    pub monad_block_replay_profiles: B256HashMap<crate::eth::backend::db::MonadBlockReplayProfile>,
 }
 
 impl<N: Network> BlockchainStorage<N> {

--- a/crates/anvil/src/eth/backend/replay.rs
+++ b/crates/anvil/src/eth/backend/replay.rs
@@ -19,8 +19,6 @@ use anvil_core::eth::transaction::{MaybeImpersonatedTransaction, TransactionInfo
 use eyre::{Context, Result};
 use foundry_evm::core::evm::IntoInstructionResult;
 use foundry_primitives::{FoundryReceiptEnvelope, FoundryTxEnvelope};
-#[cfg(feature = "monad")]
-use monad_revm::staking::constants::SYSTEM_ADDRESS as MONAD_SYSTEM_ADDRESS;
 use revm::{
     Database,
     context_interface::result::{ExecutionResult, Output},
@@ -108,7 +106,7 @@ pub(crate) fn prepare_fork_transaction_replay(
             );
             #[cfg(feature = "monad")]
             let sender = if trust_monad_protocol_sender
-                && source_transaction.from() == MONAD_SYSTEM_ADDRESS
+                && source_transaction.from() == monad_revm::staking::constants::SYSTEM_ADDRESS
             {
                 source_transaction.from()
             } else {

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -30,8 +30,6 @@ use anvil_core::{
 };
 use foundry_common::version::{COMMIT_SHA, SEMVER_VERSION};
 use foundry_evm::hardfork::EthereumHardfork;
-#[cfg(feature = "monad")]
-use foundry_evm::hardfork::MonadHardfork;
 use foundry_evm_networks::NetworkConfigs;
 use foundry_primitives::FoundryTxEnvelope;
 use futures::{FutureExt, StreamExt};
@@ -1915,7 +1913,8 @@ async fn can_get_node_info_tempo_t1() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "monad")]
 async fn can_get_node_info_monad() {
-    let config = NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadEight.into()));
+    let config = NodeConfig::test_monad()
+        .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadEight.into()));
     let (api, handle) = spawn(config).await;
 
     let node_info = api.anvil_node_info().await.unwrap();

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -47,8 +47,6 @@ use foundry_config::{
         value::{Dict, Map},
     },
 };
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::MonadEvmNetwork;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -263,7 +261,11 @@ impl CallArgs {
         #[cfg(feature = "monad")]
         if evm_opts.networks.is_monad() {
             return self
-                .run_with_network_and_opts::<MonadEvmNetwork>(config, evm_opts, auth_preflight)
+                .run_with_network_and_opts::<foundry_evm::core::evm::MonadEvmNetwork>(
+                    config,
+                    evm_opts,
+                    auth_preflight,
+                )
                 .await;
         }
 

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -42,8 +42,6 @@ use foundry_config::{
         value::{Dict, Map},
     },
 };
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::MonadEvmNetwork;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -171,7 +169,9 @@ impl RunArgs {
 
         #[cfg(feature = "monad")]
         if evm_opts.networks.is_monad() {
-            return self.run_with_evm::<MonadEvmNetwork>(config, evm_opts).await;
+            return self
+                .run_with_evm::<foundry_evm::core::evm::MonadEvmNetwork>(config, evm_opts)
+                .await;
         }
 
         #[cfg(feature = "optimism")]

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -7,10 +7,6 @@ use foundry_common::{ContractsByArtifactBuilder, compile::ProjectCompiler};
 use foundry_compilers::artifacts::output_selection::ContractOutputSelection;
 use foundry_config::{Config, FoundryHardfork, TracingConfig};
 use foundry_debugger::Debugger;
-#[cfg(all(test, feature = "monad"))]
-use foundry_evm::hardforks::EthereumHardfork;
-#[cfg(feature = "monad")]
-use foundry_evm::hardforks::MonadHardfork;
 use foundry_evm::{
     hardforks::{ExecutionSpec, TempoHardfork},
     opts::ForkEndpointIdentity,
@@ -92,7 +88,8 @@ pub(crate) async fn handle_traces(
     #[cfg(feature = "monad")]
     let is_monad = execution_network.is_monad();
     #[cfg(feature = "monad")]
-    let monad_hardfork = resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork);
+    let monad_hardfork =
+        resolved_hardfork.and_then(foundry_evm::hardforks::MonadHardfork::from_foundry_hardfork);
     let mut builder = CallTraceDecoderBuilder::new()
         .with_tracing_config(tracing)
         .with_signature_identifier(SignaturesIdentifier::from_config(config)?)
@@ -103,9 +100,9 @@ pub(crate) async fn handle_traces(
         );
     #[cfg(feature = "monad")]
     {
-        builder = builder.with_monad_hardfork(
-            monad_hardfork.or_else(|| is_monad.then(|| config.evm_spec_id::<MonadHardfork>())),
-        );
+        builder = builder.with_monad_hardfork(monad_hardfork.or_else(|| {
+            is_monad.then(|| config.evm_spec_id::<foundry_evm::hardforks::MonadHardfork>())
+        }));
     }
     let mut identifier = TraceIdentifiers::new().with_external(config, Some(chain))?;
     if let Some(contracts) = &known_contracts {
@@ -187,9 +184,9 @@ mod tests {
     #[test]
     #[cfg(feature = "monad")]
     fn remote_trace_hardfork_ignores_cross_network_override() {
-        let ethereum = FoundryHardfork::Ethereum(EthereumHardfork::Cancun);
-        let monad_eight = FoundryHardfork::Monad(MonadHardfork::MonadEight);
-        let monad_nine = FoundryHardfork::Monad(MonadHardfork::MonadNine);
+        let ethereum = FoundryHardfork::Ethereum(foundry_evm::hardforks::EthereumHardfork::Cancun);
+        let monad_eight = FoundryHardfork::Monad(foundry_evm::hardforks::MonadHardfork::MonadEight);
+        let monad_nine = FoundryHardfork::Monad(foundry_evm::hardforks::MonadHardfork::MonadNine);
 
         assert_eq!(
             select_remote_trace_hardfork(Some(ethereum), Some(monad_nine), NetworkVariant::Monad),

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -15,10 +15,6 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolValue;
 use anvil::NodeConfig;
 use foundry_evm::core::tempo::PATH_USD_ADDRESS;
-#[cfg(feature = "monad")]
-use foundry_evm::hardfork::MonadHardfork;
-#[cfg(feature = "monad")]
-use foundry_test_utils::rpc::spawn_canonical_monad_system_rpc;
 use foundry_test_utils::{
     rpc::{
         next_etherscan_api_key, next_http_archive_rpc_url, next_http_rpc_endpoint,
@@ -7605,7 +7601,8 @@ Transaction successfully executed.
 
 #[cfg(feature = "monad")]
 casttest!(monad_call_trace_uses_monad_evm_network, async |_prj, cmd| {
-    let config = NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into()));
+    let config = NodeConfig::test_monad()
+        .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()));
     let (_api, handle) = anvil::spawn(config).await;
     let endpoint = handle.http_endpoint();
     let reserve_balance_address = MONAD_RESERVE_BALANCE_ADDRESS.to_string();
@@ -7632,7 +7629,7 @@ casttest!(monad_call_trace_uses_monad_evm_network, async |_prj, cmd| {
 #[cfg(feature = "monad")]
 casttest!(monad_call_trace_resolves_effective_hardfork, async |_prj, cmd| {
     let config = NodeConfig::test_monad()
-        .with_hardfork(Some(MonadHardfork::MonadEight.into()))
+        .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadEight.into()))
         .with_chain_id(Some(MONAD_TESTNET_CHAIN_ID))
         .with_genesis_timestamp(Some(MONAD_NINE_TESTNET_ACTIVATION_TIMESTAMP - 1));
     let (_api, monad_eight_handle) = anvil::spawn(config).await;
@@ -7710,7 +7707,7 @@ casttest!(monad_call_trace_resolves_effective_hardfork, async |_prj, cmd| {
     );
 
     let config = NodeConfig::test_monad()
-        .with_hardfork(Some(MonadHardfork::MonadNine.into()))
+        .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()))
         .with_chain_id(Some(MONAD_TESTNET_CHAIN_ID))
         .with_genesis_timestamp(Some(MONAD_NINE_TESTNET_ACTIVATION_TIMESTAMP));
     let (_origin_api, monad_nine_origin) = anvil::spawn(config).await;
@@ -7776,7 +7773,8 @@ casttest!(monad_call_trace_resolves_effective_hardfork, async |_prj, cmd| {
 
 #[cfg(feature = "monad")]
 casttest!(monad_call_trace_uses_parent_sender_context, async |_prj, cmd| {
-    let config = NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into()));
+    let config = NodeConfig::test_monad()
+        .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()));
     let (api, handle) = anvil::spawn(config).await;
     let provider = handle.http_provider();
     let sender = provider.get_accounts().await.unwrap()[0];
@@ -7830,7 +7828,8 @@ casttest!(monad_call_trace_uses_parent_sender_context, async |_prj, cmd| {
 
 #[cfg(feature = "monad")]
 casttest!(monad_run_replays_reserve_balance_precompile_tx, async |_prj, cmd| {
-    let config = NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into()));
+    let config = NodeConfig::test_monad()
+        .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()));
     let (_api, handle) = anvil::spawn(config).await;
     let provider = handle.http_provider();
     let from = provider.get_accounts().await.unwrap()[0];
@@ -7858,7 +7857,7 @@ casttest!(monad_run_replays_reserve_balance_precompile_tx, async |_prj, cmd| {
 #[cfg(feature = "monad")]
 casttest!(monad_run_preserves_endpoint_hardfork, async |_prj, cmd| {
     let origin_config = NodeConfig::test_monad()
-        .with_hardfork(Some(MonadHardfork::MonadNine.into()))
+        .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()))
         .with_chain_id(Some(MONAD_TESTNET_CHAIN_ID))
         .with_genesis_timestamp(Some(MONAD_NINE_TESTNET_ACTIVATION_TIMESTAMP - 2));
     let (_origin_api, origin_handle) = anvil::spawn(origin_config).await;
@@ -7948,7 +7947,8 @@ casttest!(monad_run_preserves_endpoint_hardfork, async |_prj, cmd| {
 
 #[cfg(feature = "monad")]
 casttest!(monad_run_traces_protocol_system_call, async |_prj, cmd| {
-    let config = NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into()));
+    let config = NodeConfig::test_monad()
+        .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()));
     let (api, handle) = anvil::spawn(config).await;
     let provider = handle.http_provider();
     api.anvil_impersonate_account(MONAD_SYSTEM_ADDRESS).await.unwrap();
@@ -7988,7 +7988,8 @@ casttest!(monad_run_traces_protocol_system_call, async |_prj, cmd| {
         original.stdout_lossy()
     );
 
-    let canonical_endpoint = spawn_canonical_monad_system_rpc(endpoint.clone(), tx_hash).await;
+    let canonical_endpoint =
+        foundry_test_utils::rpc::spawn_canonical_monad_system_rpc(endpoint.clone(), tx_hash).await;
     let output = cmd
         .cast_fuse()
         .args(["run", &tx_hash_string, "--rpc-url", &canonical_endpoint, "--quick"])
@@ -8034,7 +8035,8 @@ Replaying system transactions is currently not supported.
 
 #[cfg(feature = "monad")]
 casttest!(monad_run_replays_current_sender_context, async |_prj, cmd| {
-    let config = NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into()));
+    let config = NodeConfig::test_monad()
+        .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()));
     let (api, handle) = anvil::spawn(config).await;
     let provider = handle.http_provider();
     let sender = provider.get_accounts().await.unwrap()[0];

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -23,8 +23,6 @@ use foundry_common::{
     },
     tempo::{TIP20_MAX_LOGO_URI_BYTES, Tip20LogoUriValidationError, validate_tip20_logo_uri},
 };
-#[cfg(feature = "monad")]
-use foundry_evm_core::FoundryJournal;
 use foundry_evm_core::{
     FoundryBlock, FoundryTransaction,
     backend::{DatabaseError, DatabaseExt, RevertStateSnapshotAction},
@@ -1608,6 +1606,8 @@ fn inner_snapshot_state<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCtxt<'_, '_, FEN
     ccx.state.fork_block_number_override_snapshots.insert(id, ccx.state.fork_block_number_override);
     #[cfg(feature = "monad")]
     {
+        use foundry_evm_core::FoundryJournal as _;
+
         ccx.state
             .context_snapshots
             .insert(id, (ccx.ecx.chain().clone(), ccx.ecx.journal().capture_reserve_balance()));
@@ -1672,9 +1672,13 @@ fn inner_revert_to_state<FEN: FoundryEvmNetwork>(
     ) {
         ccx.ecx.set_journal_inner(restored);
         #[cfg(feature = "monad")]
-        if let Some((context, state)) = ccx.state.context_snapshots.get(&snapshot_id) {
-            *ccx.ecx.chain_mut() = context.clone();
-            ccx.ecx.journal_mut().restore_reserve_balance(state.clone());
+        {
+            use foundry_evm_core::FoundryJournal as _;
+
+            if let Some((context, state)) = ccx.state.context_snapshots.get(&snapshot_id) {
+                *ccx.ecx.chain_mut() = context.clone();
+                ccx.ecx.journal_mut().restore_reserve_balance(state.clone());
+            }
         }
         refresh_chain_journal(ccx.ecx);
         ccx.ecx.set_evm(evm_env);
@@ -1712,9 +1716,13 @@ fn inner_revert_to_state_and_delete<FEN: FoundryEvmNetwork>(
     ) {
         ccx.ecx.set_journal_inner(restored);
         #[cfg(feature = "monad")]
-        if let Some((context, state)) = ccx.state.context_snapshots.remove(&snapshot_id) {
-            *ccx.ecx.chain_mut() = context;
-            ccx.ecx.journal_mut().restore_reserve_balance(state);
+        {
+            use foundry_evm_core::FoundryJournal as _;
+
+            if let Some((context, state)) = ccx.state.context_snapshots.remove(&snapshot_id) {
+                *ccx.ecx.chain_mut() = context;
+                ccx.ecx.journal_mut().restore_reserve_balance(state);
+            }
         }
         refresh_chain_journal(ccx.ecx);
         ccx.ecx.set_evm(evm_env);

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -16,8 +16,6 @@ use foundry_evm_core::{
     evm::{BlockEnvFor, EvmFactoryFor, FoundryContextFor, FoundryEvmNetwork, SpecFor, TxEnvFor},
     fork::CreateFork,
 };
-#[cfg(feature = "monad")]
-use foundry_evm_core::{backend::ContextUpdate, evm::ChainFor, refresh_chain_journal};
 use revm::context::ContextTr;
 
 impl Cheatcode for activeForkCall {
@@ -427,16 +425,16 @@ fn create_fork_request<FEN: FoundryEvmNetwork>(
 #[cfg(feature = "monad")]
 fn apply_context_update<FEN: FoundryEvmNetwork>(
     ecx: &mut FoundryContextFor<'_, FEN>,
-    context_update: ContextUpdate<ChainFor<FEN>>,
+    context_update: foundry_evm_core::backend::ContextUpdate<foundry_evm_core::evm::ChainFor<FEN>>,
 ) {
     match context_update {
-        ContextUpdate::Unchanged => {}
-        ContextUpdate::Replace(chain_context) => {
+        foundry_evm_core::backend::ContextUpdate::Unchanged => {}
+        foundry_evm_core::backend::ContextUpdate::Replace(chain_context) => {
             *ecx.chain_mut() = chain_context;
-            refresh_chain_journal(ecx);
+            foundry_evm_core::refresh_chain_journal(ecx);
         }
-        ContextUpdate::Rebase => {
-            refresh_chain_journal(ecx);
+        foundry_evm_core::backend::ContextUpdate::Rebase => {
+            foundry_evm_core::refresh_chain_journal(ecx);
         }
     }
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1,7 +1,5 @@
 //! Cheatcode EVM inspector.
 
-#[cfg(feature = "monad")]
-use crate::monad::{apply_monad_cheatcode as apply_monad_cheatcode_call, is_monad_cheatcode_call};
 use crate::{
     Cheatcode, CheatsConfig, CheatsCtxt, Error, Result,
     Vm::{self, AccountAccess},
@@ -51,15 +49,11 @@ use foundry_evm_core::{
     },
     refresh_chain_journal,
 };
-#[cfg(feature = "monad")]
-use foundry_evm_core::{FoundryJournal, evm::refresh_nested_chain_journal};
 use foundry_evm_traces::{
     TracingInspector, TracingInspectorConfig, identifier::SignaturesIdentifier,
 };
 use foundry_wallets::wallet_multi::MultiWallet;
 use itertools::Itertools;
-#[cfg(feature = "monad")]
-use monad_revm::reserve_balance::tracker::ReserveBalanceTracker;
 use proptest::test_runner::{RngAlgorithm, TestRng, TestRunner};
 use rand::Rng;
 use revm::{
@@ -192,7 +186,7 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
         let factory = FEN::EvmFactory::default();
         let chain_context = ecx.chain().clone();
         #[cfg(feature = "monad")]
-        let state = ecx.journal().capture_reserve_balance();
+        let state = foundry_evm_core::FoundryJournal::capture_reserve_balance(ecx.journal());
         let mut nested_chain_context = None;
         #[cfg(feature = "monad")]
         let mut reserve_balance = None;
@@ -201,14 +195,16 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
             *evm.journal_inner_mut() = journaled_state;
             #[cfg(feature = "monad")]
             {
-                evm.journal_mut().restore_reserve_balance(state);
-                refresh_nested_chain_journal(&mut *evm);
+                foundry_evm_core::FoundryJournal::restore_reserve_balance(evm.journal_mut(), state);
+                foundry_evm_core::evm::refresh_nested_chain_journal(&mut *evm);
             }
             f(&mut *evm)?;
             nested_chain_context = Some(evm.chain_mut().clone());
             #[cfg(feature = "monad")]
             {
-                reserve_balance = Some(evm.journal_mut().capture_reserve_balance());
+                reserve_balance = Some(foundry_evm_core::FoundryJournal::capture_reserve_balance(
+                    evm.journal_mut(),
+                ));
             }
             let sub_inner = evm.journal_inner_mut().clone();
             let sub_evm_env = evm.to_evm_env();
@@ -216,8 +212,10 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
         })?;
         *ecx.chain_mut() = nested_chain_context.expect("nested EVM chain context was captured");
         #[cfg(feature = "monad")]
-        ecx.journal_mut()
-            .restore_reserve_balance(reserve_balance.expect("nested EVM state was captured"));
+        foundry_evm_core::FoundryJournal::restore_reserve_balance(
+            ecx.journal_mut(),
+            reserve_balance.expect("nested EVM state was captured"),
+        );
         refresh_chain_journal(ecx);
         Ok(())
     }
@@ -908,7 +906,8 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// Transaction-position context and Monad's reserve-balance-tracker state captured atomically
     /// alongside state snapshots.
     #[cfg(feature = "monad")]
-    pub context_snapshots: HashMap<U256, (ChainFor<FEN>, ReserveBalanceTracker)>,
+    pub context_snapshots:
+        HashMap<U256, (ChainFor<FEN>, monad_revm::reserve_balance::tracker::ReserveBalanceTracker)>,
 
     /// Whether we are currently executing inside an isolation context, i.e.
     /// the synthetic inner transaction wrapped by
@@ -1318,7 +1317,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         // but only if the backend is in forking mode
         ecx.db_mut().ensure_cheatcode_access_forking_mode(&caller)?;
 
-        apply_monad_cheatcode_call(
+        crate::monad::apply_monad_cheatcode(
             &mut CheatsCtxt { state: self, ecx, gas_limit: call.gas_limit, caller },
             &input,
         )
@@ -1456,7 +1455,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         }
 
         #[cfg(feature = "monad")]
-        if is_monad_cheatcode_call(
+        if crate::monad::is_monad_cheatcode_call(
             self.config.evm_opts.networks.extra_cheatcode_addresses(),
             call.target_address,
         ) {
@@ -2366,7 +2365,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             || call.target_address == HARDHAT_CONSOLE_ADDRESS;
         #[cfg(feature = "monad")]
         let cheatcode_call = cheatcode_call
-            || is_monad_cheatcode_call(
+            || crate::monad::is_monad_cheatcode_call(
                 self.config.evm_opts.networks.extra_cheatcode_addresses(),
                 call.target_address,
             );

--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -7,8 +7,6 @@ use eyre::{Context, Result};
 use foundry_cli::utils::{self, LoadConfig};
 use foundry_common::fs;
 use foundry_config::Config;
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::MonadEvmNetwork;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -74,7 +72,7 @@ pub async fn run_command(args: Chisel) -> Result<()> {
 
     #[cfg(feature = "monad")]
     if evm_opts.networks.is_monad() {
-        return Box::pin(run_command_with_network::<MonadEvmNetwork>(
+        return Box::pin(run_command_with_network::<foundry_evm::core::evm::MonadEvmNetwork>(
             args,
             config,
             evm_opts,

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -13,8 +13,6 @@ use eyre::{Context, Result};
 use forge_fmt::FormatterConfig;
 use foundry_cli::utils::fetch_abi_from_etherscan;
 use foundry_config::{Chain, Config, RpcEndpointUrl};
-#[cfg(feature = "monad")]
-use foundry_evm::hardforks::MonadHardfork;
 use foundry_evm::{
     core::evm::FoundryEvmNetwork,
     decode::decode_console_logs,
@@ -191,7 +189,8 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         #[cfg(feature = "monad")]
         {
             builder = builder.with_monad_hardfork(
-                resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork),
+                resolved_hardfork
+                    .and_then(foundry_evm::hardforks::MonadHardfork::from_foundry_hardfork),
             );
         }
         let mut decoder = builder.build();
@@ -698,16 +697,7 @@ fn preprocess<'a>(input: &'a str, last_result: Option<&str>) -> Result<(bool, Co
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "monad")]
-    use foundry_config::SolcReq;
-    #[cfg(feature = "monad")]
-    use foundry_evm::core::evm::MonadEvmNetwork;
-    use foundry_evm::{
-        core::evm::EthEvmNetwork,
-        opts::{Env, EvmOpts},
-    };
-    #[cfg(feature = "monad")]
-    use semver::Version;
+    use foundry_evm::{core::evm::EthEvmNetwork, opts::EvmOpts};
 
     fn config_with_network(network: Option<&str>) -> Config {
         let mut config = Config::default();
@@ -772,12 +762,12 @@ mod tests {
         let evm_opts = EvmOpts {
             fork_url: Some("http://localhost:8545".to_string()),
             networks,
-            env: Env { chain_id: Some(143), ..Default::default() },
+            env: foundry_evm::opts::Env { chain_id: Some(143), ..Default::default() },
             ..Default::default()
         };
-        let config = SessionSourceConfig::<MonadEvmNetwork> {
+        let config = SessionSourceConfig::<foundry_evm::core::evm::MonadEvmNetwork> {
             foundry_config: Config {
-                solc: Some(SolcReq::Version(Version::new(0, 8, 29))),
+                solc: Some(foundry_config::SolcReq::Version(semver::Version::new(0, 8, 29))),
                 networks,
                 chain: Some(Chain::from(143u64)),
                 ..Default::default()

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3279,8 +3279,6 @@ mod tests {
         ModelCheckerEngine, YulDetails,
         vyper::{VyperOptimizationLevel, VyperOptimizationMode, VyperVenomSettings},
     };
-    #[cfg(feature = "monad")]
-    use foundry_evm_hardforks::MonadHardfork;
     use foundry_evm_hardforks::{TempoHardfork, latest_active_tempo_hardfork};
     use similar_asserts::assert_eq;
     use soldeer_core::remappings::RemappingsLocation;
@@ -5779,8 +5777,14 @@ mod tests {
             )?;
 
             let config = Config::load().unwrap();
-            assert_eq!(config.hardfork, Some(FoundryHardfork::Monad(MonadHardfork::MonadNine)));
-            assert_eq!(config.evm_spec_id::<MonadHardfork>(), MonadHardfork::MonadNine);
+            assert_eq!(
+                config.hardfork,
+                Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine))
+            );
+            assert_eq!(
+                config.evm_spec_id::<foundry_evm_hardforks::MonadHardfork>(),
+                foundry_evm_hardforks::MonadHardfork::MonadNine
+            );
             assert_eq!(
                 config.hardfork.as_ref().and_then(FoundryHardfork::namespace),
                 Some("monad")

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -1,8 +1,6 @@
 //! A wrapper around `Backend` that is clone-on-write used for fuzzing.
 
 use super::BackendError;
-#[cfg(feature = "monad")]
-use crate::evm::protocol_system_call;
 use crate::{
     FoundryInspectorExt,
     backend::{
@@ -20,8 +18,6 @@ use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, TxKind, U256};
 use eyre::WrapErr;
 use foundry_fork_db::DatabaseError;
-#[cfg(feature = "monad")]
-use revm::context_interface::result::HaltReason;
 use revm::{
     Database, DatabaseCommit,
     bytecode::Bytecode,
@@ -135,8 +131,10 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         tx_env: &mut TxEnvFor<FEN>,
         chain_context: ChainFor<FEN>,
         inspector: I,
-    ) -> eyre::Result<Option<ResultAndState<HaltReason>>> {
-        if !self.backend.networks().is_monad() || protocol_system_call(tx_env)?.is_none() {
+    ) -> eyre::Result<Option<ResultAndState<revm::context_interface::result::HaltReason>>> {
+        if !self.backend.networks().is_monad()
+            || crate::evm::protocol_system_call(tx_env)?.is_none()
+        {
             return Ok(None);
         }
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -3041,10 +3041,6 @@ fn fork_block_number(fork: &ForkId) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::{Fork, apply_state_changeset};
-    #[cfg(feature = "monad")]
-    use crate::evm::MonadEvmNetwork;
-    #[cfg(feature = "monad")]
-    use crate::fork::CreateFork;
     use crate::{
         backend::{Backend, ForkPosition},
         evm::EthEvmNetwork,
@@ -3282,8 +3278,13 @@ mod tests {
             opts
         }
 
-        fn target_fork(opts: EvmOpts, url: String) -> CreateFork {
-            CreateFork { url, enable_caching: false, evm_opts: opts, expected_context: None }
+        fn target_fork(opts: EvmOpts, url: String) -> crate::fork::CreateFork {
+            crate::fork::CreateFork {
+                url,
+                enable_caching: false,
+                evm_opts: opts,
+                expected_context: None,
+            }
         }
 
         let (ethereum_base_api, ethereum_base) = spawn(NodeConfig::test()).await;
@@ -3309,7 +3310,7 @@ mod tests {
 
         let inferred_monad = pinned_opts(monad_base.http_endpoint(), None).await;
         assert!(inferred_monad.fork_network_is_inferred);
-        let error = Backend::<MonadEvmNetwork>::spawn(Some(target_fork(
+        let error = Backend::<crate::evm::MonadEvmNetwork>::spawn(Some(target_fork(
             inferred_monad,
             ethereum_target.http_endpoint(),
         )))
@@ -3333,7 +3334,7 @@ mod tests {
         let explicit_monad =
             pinned_opts(monad_base.http_endpoint(), Some(NetworkConfigs::with_monad())).await;
         assert!(!explicit_monad.fork_network_is_inferred);
-        let _backend = Backend::<MonadEvmNetwork>::spawn(Some(target_fork(
+        let _backend = Backend::<crate::evm::MonadEvmNetwork>::spawn(Some(target_fork(
             explicit_monad,
             ethereum_target.http_endpoint(),
         )))

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,17 +1,10 @@
 use std::fmt::Debug;
-#[cfg(feature = "monad")]
-use std::ops::{Deref, DerefMut};
 
 use alloy_consensus::Typed2718;
 pub use alloy_evm::EvmEnv;
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
 use alloy_primitives::{Address, B256, Bytes, U256};
-#[cfg(feature = "monad")]
-use monad_revm::{
-    MonadCfgEnv, MonadChainContext, MonadJournal, MonadJournalTr,
-    reserve_balance::tracker::ReserveBalanceTracker,
-};
 #[cfg(feature = "optimism")]
 use op_revm::transaction::deposit::DEPOSIT_TRANSACTION_TYPE;
 use revm::{
@@ -446,13 +439,19 @@ impl<Tx> FoundryChain<Tx> for () {}
 pub trait FoundryJournal: JournalExt {
     /// Captures Monad's reserve-balance tracker for the active transaction.
     #[cfg(feature = "monad")]
-    fn capture_reserve_balance(&self) -> ReserveBalanceTracker {
-        ReserveBalanceTracker::default()
+    fn capture_reserve_balance(
+        &self,
+    ) -> monad_revm::reserve_balance::tracker::ReserveBalanceTracker {
+        monad_revm::reserve_balance::tracker::ReserveBalanceTracker::default()
     }
 
     /// Restores Monad's reserve-balance tracker for the active transaction.
     #[cfg(feature = "monad")]
-    fn restore_reserve_balance(&mut self, _tracker: ReserveBalanceTracker) {}
+    fn restore_reserve_balance(
+        &mut self,
+        _tracker: monad_revm::reserve_balance::tracker::ReserveBalanceTracker,
+    ) {
+    }
 
     /// Whether transaction boundaries currently preserve the reserve-balance tracker, e.g. for
     /// an isolated call that models an inner call of the enclosing transaction rather than a
@@ -470,21 +469,26 @@ pub trait FoundryJournal: JournalExt {
 impl<DB: Database> FoundryJournal for Journal<DB> {}
 
 #[cfg(feature = "monad")]
-impl<DB: Database> FoundryJournal for MonadJournal<DB> {
-    fn capture_reserve_balance(&self) -> ReserveBalanceTracker {
-        self.reserve_balance().clone()
+impl<DB: Database> FoundryJournal for monad_revm::MonadJournal<DB> {
+    fn capture_reserve_balance(
+        &self,
+    ) -> monad_revm::reserve_balance::tracker::ReserveBalanceTracker {
+        monad_revm::MonadJournalTr::reserve_balance(self).clone()
     }
 
-    fn restore_reserve_balance(&mut self, tracker: ReserveBalanceTracker) {
-        *self.reserve_balance_mut() = tracker;
+    fn restore_reserve_balance(
+        &mut self,
+        tracker: monad_revm::reserve_balance::tracker::ReserveBalanceTracker,
+    ) {
+        *monad_revm::MonadJournalTr::reserve_balance_mut(self) = tracker;
     }
 
     fn preserves_reserve_balance(&self) -> bool {
-        self.preserves_reserve_balance_tracker()
+        monad_revm::MonadJournalTr::preserves_reserve_balance_tracker(self)
     }
 
     fn set_preserve_reserve_balance(&mut self, preserve: bool) {
-        self.set_preserve_reserve_balance_tracker(preserve);
+        monad_revm::MonadJournalTr::set_preserve_reserve_balance_tracker(self, preserve);
     }
 }
 
@@ -615,7 +619,14 @@ impl<
 
 #[cfg(feature = "monad")]
 impl<DB: Database> FoundryContextExt
-    for Context<BlockEnv, TxEnv, MonadCfgEnv, DB, MonadJournal<DB>, MonadChainContext>
+    for Context<
+        BlockEnv,
+        TxEnv,
+        monad_revm::MonadCfgEnv,
+        DB,
+        monad_revm::MonadJournal<DB>,
+        monad_revm::MonadChainContext,
+    >
 {
     type Spec = <Self::Cfg as Cfg>::Spec;
     fn block_mut(&mut self) -> &mut Self::Block {
@@ -641,16 +652,16 @@ impl<DB: Database> FoundryContextExt
     fn set_spec_and_gas_params(&mut self, spec: Self::Spec) {
         let mut cfg = self.cfg.clone().into_inner();
         cfg.spec = spec;
-        self.cfg = MonadCfgEnv::from(cfg);
+        self.cfg = monad_revm::MonadCfgEnv::from(cfg);
     }
 
     fn db_journal_inner_mut(&mut self) -> (&mut Self::Db, &mut JournaledState) {
-        let journal: &mut Journal<DB> = self.journaled_state.deref_mut();
+        let journal: &mut Journal<DB> = std::ops::DerefMut::deref_mut(&mut self.journaled_state);
         (&mut journal.database, &mut journal.inner)
     }
 
     fn journal_inner(&self) -> &JournaledState {
-        let journal: &Journal<DB> = self.journaled_state.deref();
+        let journal: &Journal<DB> = std::ops::Deref::deref(&self.journaled_state);
         &journal.inner
     }
 }
@@ -932,15 +943,11 @@ mod tests {
     use super::*;
     use alloy_consensus::{Signed, TxEip1559, transaction::Recovered};
     use alloy_evm::{EthEvmFactory, EvmFactory};
-    #[cfg(feature = "monad")]
-    use alloy_monad_evm::MonadEvmFactory;
     use alloy_network::{AnyTxType, UnknownTxEnvelope, UnknownTypedTransaction};
     use alloy_primitives::Signature;
     use alloy_rpc_types::{Transaction as RpcTransaction, TransactionInfo};
     use alloy_serde::WithOtherFields;
     use foundry_evm_hardforks::TempoHardfork;
-    #[cfg(feature = "monad")]
-    use monad_revm::{MonadHardfork, cfg::MONAD_MEMORY_LIMIT};
     use revm::database::EmptyDB;
     use tempo_alloy::primitives::{
         AASigned, TempoSignature, TempoTransaction, TempoTxEnvelope,
@@ -974,9 +981,12 @@ mod tests {
     #[test]
     #[cfg(feature = "monad")]
     fn monad_evm_foundry_context_ext_implementation() {
-        let mut evm = MonadEvmFactory::default().create_evm(
+        let mut evm = alloy_monad_evm::MonadEvmFactory::default().create_evm(
             EmptyDB::default(),
-            EvmEnv::new(CfgEnv::new_with_spec(MonadHardfork::MonadNine), BlockEnv::default()),
+            EvmEnv::new(
+                CfgEnv::new_with_spec(monad_revm::MonadHardfork::MonadNine),
+                BlockEnv::default(),
+            ),
         );
 
         // Test EVM Context Block mutation
@@ -988,8 +998,8 @@ mod tests {
         assert_eq!(evm.ctx().tx().nonce(), 99);
 
         // Test EVM Context Cfg mutation
-        evm.ctx_mut().cfg_mut().spec = MonadHardfork::MonadEight;
-        assert_eq!(evm.ctx().cfg().spec, MonadHardfork::MonadEight);
+        evm.ctx_mut().cfg_mut().spec = monad_revm::MonadHardfork::MonadEight;
+        assert_eq!(evm.ctx().cfg().spec, monad_revm::MonadHardfork::MonadEight);
 
         // Round-trip test to ensure no issues with cloning and setting tx_env and evm_env
         let tx_env = evm.ctx().tx_clone();
@@ -1003,18 +1013,18 @@ mod tests {
     fn monad_memory_limit_follows_hardfork_transitions() {
         const FOUNDRY_MEMORY_LIMIT: u64 = 128 * 1024 * 1024;
 
-        let mut cfg = CfgEnv::new_with_spec(MonadHardfork::MonadEight);
+        let mut cfg = CfgEnv::new_with_spec(monad_revm::MonadHardfork::MonadEight);
         cfg.memory_limit = FOUNDRY_MEMORY_LIMIT;
-        let mut evm = MonadEvmFactory::default()
+        let mut evm = alloy_monad_evm::MonadEvmFactory::default()
             .create_evm(EmptyDB::default(), EvmEnv::new(cfg, BlockEnv::default()));
 
         assert_eq!(evm.ctx().cfg().memory_limit(), FOUNDRY_MEMORY_LIMIT);
 
-        evm.ctx_mut().set_spec_and_gas_params(MonadHardfork::MonadNine);
+        evm.ctx_mut().set_spec_and_gas_params(monad_revm::MonadHardfork::MonadNine);
         assert_eq!(evm.ctx().cfg().inner().memory_limit, FOUNDRY_MEMORY_LIMIT);
-        assert_eq!(evm.ctx().cfg().memory_limit(), MONAD_MEMORY_LIMIT);
+        assert_eq!(evm.ctx().cfg().memory_limit(), monad_revm::cfg::MONAD_MEMORY_LIMIT);
 
-        evm.ctx_mut().set_spec_and_gas_params(MonadHardfork::MonadEight);
+        evm.ctx_mut().set_spec_and_gas_params(monad_revm::MonadHardfork::MonadEight);
         assert_eq!(evm.ctx().cfg().memory_limit(), FOUNDRY_MEMORY_LIMIT);
     }
 

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -9,16 +9,12 @@ use alloy_consensus::{SignableTransaction, Signed, transaction::SignerRecoverabl
 use alloy_evm::{
     EthEvmFactory, Evm, EvmEnv, EvmFactory, FromRecoveredTx, precompiles::PrecompilesMap,
 };
-#[cfg(feature = "monad")]
-use alloy_monad_evm::MonadEvmFactory;
 use alloy_network::{Ethereum, Network};
 use alloy_primitives::{Address, Signature, U256};
 use alloy_rlp::Decodable;
 use foundry_common::{FoundryReceiptResponse, FoundryTransactionBuilder, fmt::UIfmt};
 use foundry_config::ExecutionSpec;
 use foundry_fork_db::{DatabaseError, ForkBlockEnv};
-#[cfg(feature = "monad")]
-use revm::inspector::Inspector;
 use revm::{
     Database,
     context::{
@@ -92,7 +88,7 @@ pub struct MonadEvmNetwork;
 #[cfg(feature = "monad")]
 impl FoundryEvmNetwork for MonadEvmNetwork {
     type Network = Ethereum;
-    type EvmFactory = MonadEvmFactory;
+    type EvmFactory = alloy_monad_evm::MonadEvmFactory;
 }
 
 /// Convenience type aliases for accessing associated types through [`FoundryEvmNetwork`].
@@ -184,7 +180,7 @@ pub trait FoundryEvmFactory:
     ) -> eyre::Result<Option<ResultAndState<Self::HaltReason>>>
     where
         DB: alloy_evm::Database,
-        I: Inspector<Self::Context<DB>>,
+        I: revm::inspector::Inspector<Self::Context<DB>>,
     {
         Ok(None)
     }

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -21,8 +21,6 @@ use foundry_common::{
     provider::{ProviderBuilder, is_rpc_method_not_found},
 };
 use foundry_config::{Chain, Config, ExecutionSpec, FoundryHardfork, GasLimit};
-#[cfg(feature = "monad")]
-use foundry_evm_hardforks::MonadHardfork;
 use foundry_evm_hardforks::TempoHardfork;
 use foundry_evm_networks::{NetworkConfigs, NetworkVariant};
 use revm::{context::CfgEnv, primitives::hardfork::SpecId};
@@ -1455,9 +1453,9 @@ where
         Some(FoundryHardfork::Tempo(config.evm_spec_id::<TempoHardfork>()))
     } else {
         #[cfg(feature = "monad")]
-        let hardfork = networks
-            .is_monad()
-            .then(|| FoundryHardfork::Monad(config.evm_spec_id::<MonadHardfork>()));
+        let hardfork = networks.is_monad().then(|| {
+            FoundryHardfork::Monad(config.evm_spec_id::<foundry_evm_hardforks::MonadHardfork>())
+        });
         #[cfg(not(feature = "monad"))]
         let hardfork = None;
         hardfork
@@ -1541,8 +1539,6 @@ mod tests {
     use alloy_network::TransactionBuilder;
     use alloy_primitives::bytes;
     use alloy_rpc_types::TransactionRequest;
-    #[cfg(feature = "monad")]
-    use alloy_rpc_types::anvil::Forking;
     use alloy_serde::WithOtherFields;
     use foundry_test_utils::rpc::{
         spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
@@ -1864,10 +1860,10 @@ mod tests {
     }
 
     #[cfg(feature = "monad")]
-    fn monad_env(timestamp: u64) -> EvmEnv<MonadHardfork, BlockEnv> {
+    fn monad_env(timestamp: u64) -> EvmEnv<foundry_evm_hardforks::MonadHardfork, BlockEnv> {
         let mut block = BlockEnv::default();
         block.set_timestamp(U256::from(timestamp));
-        let mut cfg = CfgEnv::new_with_spec(MonadHardfork::default());
+        let mut cfg = CfgEnv::new_with_spec(foundry_evm_hardforks::MonadHardfork::default());
         cfg.chain_id = NamedChain::Monad as u64;
         EvmEnv::new(cfg, block)
     }
@@ -1877,7 +1873,8 @@ mod tests {
     fn resolve_execution_spec_uses_monad_activation_timestamp() {
         let config = Config::default();
         let networks = NetworkConfigs::with_monad();
-        let activation = MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+        let activation =
+            foundry_evm_hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
 
         let mut before = monad_env(activation - 1);
         assert_eq!(
@@ -1889,9 +1886,9 @@ mod tests {
                 None,
                 None,
             ),
-            Some(FoundryHardfork::Monad(MonadHardfork::MonadEight))
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight))
         );
-        assert_eq!(before.cfg_env.spec, MonadHardfork::MonadEight);
+        assert_eq!(before.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadEight);
 
         let mut after = monad_env(activation);
         assert_eq!(
@@ -1903,18 +1900,20 @@ mod tests {
                 None,
                 None,
             ),
-            Some(FoundryHardfork::Monad(MonadHardfork::MonadNine))
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine))
         );
-        assert_eq!(after.cfg_env.spec, MonadHardfork::MonadNine);
+        assert_eq!(after.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadNine);
     }
 
     #[test]
     #[cfg(feature = "monad")]
     fn resolve_execution_spec_prefers_exact_endpoint_hardfork() {
         let config = Config::default();
-        let activation = MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+        let activation =
+            foundry_evm_hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
         let mut env = monad_env(activation);
-        let endpoint_hardfork = FoundryHardfork::Monad(MonadHardfork::MonadEight);
+        let endpoint_hardfork =
+            FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight);
 
         assert_eq!(
             resolve_execution_spec(
@@ -1927,7 +1926,7 @@ mod tests {
             ),
             Some(endpoint_hardfork)
         );
-        assert_eq!(env.cfg_env.spec, MonadHardfork::MonadEight);
+        assert_eq!(env.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadEight);
     }
 
     #[test]
@@ -1935,7 +1934,8 @@ mod tests {
     fn resolve_execution_spec_ignores_schedule_for_local_env() {
         let config = Config::default();
         let networks = NetworkConfigs::with_monad();
-        let activation = MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+        let activation =
+            foundry_evm_hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
         let mut env = monad_env(activation - 1);
 
         assert_eq!(
@@ -1947,9 +1947,9 @@ mod tests {
                 None,
                 None,
             ),
-            Some(FoundryHardfork::Monad(MonadHardfork::MonadNine))
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine))
         );
-        assert_eq!(env.cfg_env.spec, MonadHardfork::MonadNine);
+        assert_eq!(env.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadNine);
     }
 
     #[test]
@@ -2042,9 +2042,10 @@ mod tests {
     #[cfg(feature = "monad")]
     fn resolve_execution_spec_honors_explicit_precedence() {
         let networks = NetworkConfigs::with_monad();
-        let activation = MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+        let activation =
+            foundry_evm_hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
         let mut configured = Config {
-            hardfork: Some(FoundryHardfork::Monad(MonadHardfork::MonadNine)),
+            hardfork: Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine)),
             ..Default::default()
         };
         let mut env = monad_env(activation - 1);
@@ -2060,7 +2061,7 @@ mod tests {
             ),
             configured.hardfork
         );
-        assert_eq!(env.cfg_env.spec, MonadHardfork::MonadNine);
+        assert_eq!(env.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadNine);
 
         configured.hardfork = None;
         assert_eq!(
@@ -2069,18 +2070,19 @@ mod tests {
                 networks,
                 &mut env,
                 ExecutionSpecContext::fork(NamedChain::Monad as u64, None),
-                Some(MonadHardfork::MonadEight),
-                Some(FoundryHardfork::Monad(MonadHardfork::MonadEight)),
+                Some(foundry_evm_hardforks::MonadHardfork::MonadEight),
+                Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight)),
             ),
-            Some(FoundryHardfork::Monad(MonadHardfork::MonadEight))
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight))
         );
-        assert_eq!(env.cfg_env.spec, MonadHardfork::MonadEight);
+        assert_eq!(env.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadEight);
     }
 
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "monad")]
     async fn fork_context_preserves_source_chain_with_execution_override() {
-        let activation = MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+        let activation =
+            foundry_evm_hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
         let (_api, handle) = anvil::spawn(
             anvil::NodeConfig::test()
                 .with_networks(NetworkConfigs::with_ethereum())
@@ -2096,8 +2098,10 @@ mod tests {
         evm_opts.env.chain_id = Some(NamedChain::Mainnet as u64);
         evm_opts.networks = NetworkConfigs::with_monad();
 
-        let (mut evm_env, tx_env, fork_context) =
-            evm_opts.env_with_fork_context::<MonadHardfork, BlockEnv, TxEnv>().await.unwrap();
+        let (mut evm_env, tx_env, fork_context) = evm_opts
+            .env_with_fork_context::<foundry_evm_hardforks::MonadHardfork, BlockEnv, TxEnv>()
+            .await
+            .unwrap();
         let fork_context = fork_context.unwrap();
 
         assert_eq!(fork_context.source_chain_id, NamedChain::Monad as u64);
@@ -2114,7 +2118,7 @@ mod tests {
                 None,
                 None,
             ),
-            Some(FoundryHardfork::Monad(MonadHardfork::MonadEight))
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight))
         );
     }
 
@@ -2484,22 +2488,28 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "monad")]
     async fn fork_context_carries_exact_monad_anvil_hardfork() {
-        let activation = MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+        let activation =
+            foundry_evm_hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
         let (_api, handle) = anvil::spawn(
             anvil::NodeConfig::test_monad()
                 .with_chain_id(Some(NamedChain::Monad as u64))
                 .with_genesis_timestamp(Some(activation))
-                .with_hardfork(Some(MonadHardfork::MonadEight.into())),
+                .with_hardfork(Some(foundry_evm_hardforks::MonadHardfork::MonadEight.into())),
         )
         .await;
         let mut evm_opts = EvmOpts { fork_url: Some(handle.http_endpoint()), ..Default::default() };
 
         evm_opts.infer_network_from_fork().await.unwrap();
-        let (mut evm_env, _, context) =
-            evm_opts.env_with_fork_context::<MonadHardfork, BlockEnv, TxEnv>().await.unwrap();
+        let (mut evm_env, _, context) = evm_opts
+            .env_with_fork_context::<foundry_evm_hardforks::MonadHardfork, BlockEnv, TxEnv>()
+            .await
+            .unwrap();
         let context = context.unwrap();
 
-        assert_eq!(context.hardfork, Some(FoundryHardfork::Monad(MonadHardfork::MonadEight)));
+        assert_eq!(
+            context.hardfork,
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight))
+        );
         assert_eq!(
             resolve_execution_spec(
                 &Config::default(),
@@ -2511,7 +2521,7 @@ mod tests {
             ),
             context.hardfork
         );
-        assert_eq!(evm_env.cfg_env.spec, MonadHardfork::MonadEight);
+        assert_eq!(evm_env.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadEight);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2520,13 +2530,13 @@ mod tests {
         let (_api, monad_eight) = anvil::spawn(
             anvil::NodeConfig::test_monad()
                 .with_chain_id(Some(NamedChain::MonadTestnet as u64))
-                .with_hardfork(Some(MonadHardfork::MonadEight.into())),
+                .with_hardfork(Some(foundry_evm_hardforks::MonadHardfork::MonadEight.into())),
         )
         .await;
         let (_api, monad_nine) = anvil::spawn(
             anvil::NodeConfig::test_monad()
                 .with_chain_id(Some(NamedChain::Monad as u64))
-                .with_hardfork(Some(MonadHardfork::MonadNine.into())),
+                .with_hardfork(Some(foundry_evm_hardforks::MonadHardfork::MonadNine.into())),
         )
         .await;
         let (fork_api, fork_handle) = anvil::spawn(
@@ -2543,25 +2553,35 @@ mod tests {
         evm_opts.infer_network_from_fork().await.unwrap();
         let cached = evm_opts.fork_endpoint.as_ref().unwrap();
         assert_eq!(cached.source_chain_id, NamedChain::MonadTestnet as u64);
-        assert_eq!(cached.hardfork, Some(FoundryHardfork::Monad(MonadHardfork::MonadEight)));
+        assert_eq!(
+            cached.hardfork,
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight))
+        );
 
-        let (_, _, first) =
-            evm_opts.env_with_fork_context::<MonadHardfork, BlockEnv, TxEnv>().await.unwrap();
+        let (_, _, first) = evm_opts
+            .env_with_fork_context::<foundry_evm_hardforks::MonadHardfork, BlockEnv, TxEnv>()
+            .await
+            .unwrap();
         assert_eq!(first.unwrap().source_chain_id, NamedChain::MonadTestnet as u64);
 
         fork_api
-            .anvil_reset(Some(Forking {
+            .anvil_reset(Some(alloy_rpc_types::anvil::Forking {
                 json_rpc_url: Some(monad_nine.http_endpoint()),
                 block_number: Some(0),
             }))
             .await
             .unwrap();
 
-        let (_, _, second) =
-            evm_opts.env_with_fork_context::<MonadHardfork, BlockEnv, TxEnv>().await.unwrap();
+        let (_, _, second) = evm_opts
+            .env_with_fork_context::<foundry_evm_hardforks::MonadHardfork, BlockEnv, TxEnv>()
+            .await
+            .unwrap();
         let second = second.unwrap();
         assert_eq!(second.source_chain_id, NamedChain::Monad as u64);
-        assert_eq!(second.hardfork, Some(FoundryHardfork::Monad(MonadHardfork::MonadNine)));
+        assert_eq!(
+            second.hardfork,
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2632,7 +2652,7 @@ mod tests {
         assert_eq!(
             endpoint_hardfork(NetworkVariant::Monad, "MonadNine", EndpointHardforkPolicy::Required)
                 .unwrap(),
-            Some(FoundryHardfork::Monad(MonadHardfork::MonadNine))
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine))
         );
     }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1803,8 +1803,6 @@ mod tests {
     };
     use foundry_config::Config;
     use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
-    #[cfg(feature = "monad")]
-    use foundry_evm_core::{constants::MONAD_CHEATCODE_ADDRESS, evm::MonadEvmNetwork};
     use foundry_evm_traces::InternalTraceMode;
     use revm::context::TxEnv;
     use std::{sync::mpsc, thread};
@@ -1833,11 +1831,16 @@ mod tests {
     fn network_cheatcode_revert_handling_is_monad_specific() {
         let target = Address::from([0x11; 20]);
 
-        assert!(should_ignore_revert(false, target, Some(MONAD_CHEATCODE_ADDRESS), &[]));
+        assert!(should_ignore_revert(
+            false,
+            target,
+            Some(foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS),
+            &[]
+        ));
         assert!(!should_ignore_revert(
             false,
             target,
-            Some(MONAD_CHEATCODE_ADDRESS),
+            Some(foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS),
             NetworkConfigs::with_monad().extra_cheatcode_addresses(),
         ));
     }
@@ -1852,19 +1855,25 @@ mod tests {
             NetworkConfigs::default(),
         );
         assert!(!ethereum.backend().networks().is_monad());
-        assert!(!ethereum.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
+        assert!(
+            !ethereum
+                .backend()
+                .is_persistent(&foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS)
+        );
 
-        let monad = ExecutorBuilder::<MonadEvmNetwork>::default()
+        let monad = ExecutorBuilder::<foundry_evm_core::evm::MonadEvmNetwork>::default()
             .inspectors(|stack| stack.networks(NetworkConfigs::default()))
             .build(
-                EvmEnvFor::<MonadEvmNetwork>::default(),
-                TxEnvFor::<MonadEvmNetwork>::default(),
+                EvmEnvFor::<foundry_evm_core::evm::MonadEvmNetwork>::default(),
+                TxEnvFor::<foundry_evm_core::evm::MonadEvmNetwork>::default(),
                 Backend::spawn(None).unwrap(),
                 NetworkConfigs::with_monad(),
             );
         assert!(monad.inspector().networks.is_monad());
         assert!(monad.backend().networks().is_monad());
-        assert!(monad.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
+        assert!(
+            monad.backend().is_persistent(&foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS)
+        );
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -10,8 +10,6 @@ use foundry_evm_core::{
     fork::CreateFork,
     opts::{EvmOpts, ExecutionSpecContext, resolve_execution_spec},
 };
-#[cfg(feature = "monad")]
-use foundry_evm_hardforks::MonadHardfork;
 use foundry_evm_hardforks::{ExecutionSpec, FoundryHardfork, TempoHardfork};
 use foundry_evm_networks::NetworkConfigs;
 use foundry_evm_traces::TraceRequirements;
@@ -126,7 +124,8 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
     ) {
         let tempo_hardfork = resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork);
         #[cfg(feature = "monad")]
-        let monad_hardfork = resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork);
+        let monad_hardfork =
+            resolved_hardfork.and_then(foundry_evm_hardforks::MonadHardfork::from_foundry_hardfork);
         #[cfg(not(feature = "monad"))]
         let monad_hardfork = None;
 
@@ -174,7 +173,9 @@ fn network_hardfork_from_evm_version(
     }
     #[cfg(feature = "monad")]
     if networks.is_monad() {
-        return Some(FoundryHardfork::Monad(evm_spec_id::<MonadHardfork>(evm_version)));
+        return Some(FoundryHardfork::Monad(evm_spec_id::<foundry_evm_hardforks::MonadHardfork>(
+            evm_version,
+        )));
     }
     None
 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -24,8 +24,6 @@ use foundry_evm_core::{
     precompiles::P256_VERIFY,
     refresh_chain_journal,
 };
-#[cfg(feature = "monad")]
-use foundry_evm_core::{FoundryJournal, evm::refresh_nested_chain_journal};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_networks::{NetworkConfigs, arbitrum};
 use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
@@ -477,7 +475,7 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
         let factory = FEN::EvmFactory::default();
         let chain_context = ecx.chain().clone();
         #[cfg(feature = "monad")]
-        let state = ecx.journal().capture_reserve_balance();
+        let state = foundry_evm_core::FoundryJournal::capture_reserve_balance(ecx.journal());
         let mut nested_chain_context = None;
         #[cfg(feature = "monad")]
         let mut reserve_balance = None;
@@ -487,14 +485,16 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
             *evm.journal_inner_mut() = journaled_state;
             #[cfg(feature = "monad")]
             {
-                evm.journal_mut().restore_reserve_balance(state);
-                refresh_nested_chain_journal(&mut *evm);
+                foundry_evm_core::FoundryJournal::restore_reserve_balance(evm.journal_mut(), state);
+                foundry_evm_core::evm::refresh_nested_chain_journal(&mut *evm);
             }
             f(&mut *evm)?;
             nested_chain_context = Some(evm.chain_mut().clone());
             #[cfg(feature = "monad")]
             {
-                reserve_balance = Some(evm.journal_mut().capture_reserve_balance());
+                reserve_balance = Some(foundry_evm_core::FoundryJournal::capture_reserve_balance(
+                    evm.journal_mut(),
+                ));
             }
             let sub_inner = evm.journal_inner_mut().clone();
             let sub_evm_env = evm.to_evm_env();
@@ -502,8 +502,10 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
         })?;
         *ecx.chain_mut() = nested_chain_context.expect("nested EVM chain context was captured");
         #[cfg(feature = "monad")]
-        ecx.journal_mut()
-            .restore_reserve_balance(reserve_balance.expect("nested EVM state was captured"));
+        foundry_evm_core::FoundryJournal::restore_reserve_balance(
+            ecx.journal_mut(),
+            reserve_balance.expect("nested EVM state was captured"),
+        );
         refresh_chain_journal(ecx);
         Ok(())
     }
@@ -1044,7 +1046,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         };
 
         #[cfg(feature = "monad")]
-        let state = ecx.journal().capture_reserve_balance();
+        let state = foundry_evm_core::FoundryJournal::capture_reserve_balance(ecx.journal());
         #[cfg(feature = "monad")]
         let mut reserve_balance = None;
         let mut nested_chain_context = None;
@@ -1056,9 +1058,15 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
                 evm.journal_inner_mut().state = isolated_state;
                 #[cfg(feature = "monad")]
                 {
-                    evm.journal_mut().restore_reserve_balance(state);
-                    refresh_nested_chain_journal(&mut *evm);
-                    evm.journal_mut().set_preserve_reserve_balance(true);
+                    foundry_evm_core::FoundryJournal::restore_reserve_balance(
+                        evm.journal_mut(),
+                        state,
+                    );
+                    foundry_evm_core::evm::refresh_nested_chain_journal(&mut *evm);
+                    foundry_evm_core::FoundryJournal::set_preserve_reserve_balance(
+                        evm.journal_mut(),
+                        true,
+                    );
                 }
                 // Set depth to 1 to make sure traces are collected correctly.
                 evm.journal_inner_mut().depth = 1;
@@ -1066,7 +1074,10 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
                 nested_chain_context = Some(evm.chain_mut().clone());
                 #[cfg(feature = "monad")]
                 {
-                    reserve_balance = Some(evm.journal_mut().capture_reserve_balance());
+                    reserve_balance =
+                        Some(foundry_evm_core::FoundryJournal::capture_reserve_balance(
+                            evm.journal_mut(),
+                        ));
                 }
                 (res, evm.to_evm_env())
             };
@@ -1096,7 +1107,8 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
 
         let Ok(res) = res else {
             #[cfg(feature = "monad")]
-            ecx.journal_mut().restore_reserve_balance(
+            foundry_evm_core::FoundryJournal::restore_reserve_balance(
+                ecx.journal_mut(),
                 reserve_balance.expect("isolated transaction state was captured"),
             );
             refresh_chain_journal(ecx);
@@ -1133,7 +1145,8 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
             }
         }
         #[cfg(feature = "monad")]
-        ecx.journal_mut().restore_reserve_balance(
+        foundry_evm_core::FoundryJournal::restore_reserve_balance(
+            ecx.journal_mut(),
             reserve_balance.expect("isolated transaction state was captured"),
         );
         refresh_chain_journal(ecx);

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -529,8 +529,6 @@ pub fn ethereum_hardfork_from_block_tag(block: impl Into<BlockNumberOrTag>) -> E
 mod tests {
     use super::*;
     use alloy_hardforks::ethereum::mainnet::*;
-    #[cfg(feature = "monad")]
-    use monad_revm::{MONAD_MAINNET_CHAIN_ID, MONAD_TESTNET_CHAIN_ID};
     use tempo_hardfork::constants::{mainnet::*, moderato::*};
 
     #[test]
@@ -673,19 +671,31 @@ mod tests {
     #[cfg(feature = "monad")]
     fn test_monad_hardfork_from_chain_and_timestamp() {
         assert_eq!(
-            FoundryHardfork::from_chain_and_timestamp(MONAD_MAINNET_CHAIN_ID, 1_763_648_999),
+            FoundryHardfork::from_chain_and_timestamp(
+                monad_revm::MONAD_MAINNET_CHAIN_ID,
+                1_763_648_999,
+            ),
             Some(FoundryHardfork::Monad(MonadHardfork::MonadEight))
         );
         assert_eq!(
-            FoundryHardfork::from_chain_and_timestamp(MONAD_MAINNET_CHAIN_ID, 1_773_930_600),
+            FoundryHardfork::from_chain_and_timestamp(
+                monad_revm::MONAD_MAINNET_CHAIN_ID,
+                1_773_930_600,
+            ),
             Some(FoundryHardfork::Monad(MonadHardfork::MonadNine))
         );
         assert_eq!(
-            FoundryHardfork::from_chain_and_timestamp(MONAD_TESTNET_CHAIN_ID, 1_773_152_999),
+            FoundryHardfork::from_chain_and_timestamp(
+                monad_revm::MONAD_TESTNET_CHAIN_ID,
+                1_773_152_999,
+            ),
             Some(FoundryHardfork::Monad(MonadHardfork::MonadEight))
         );
         assert_eq!(
-            FoundryHardfork::from_chain_and_timestamp(MONAD_TESTNET_CHAIN_ID, 1_773_153_000),
+            FoundryHardfork::from_chain_and_timestamp(
+                monad_revm::MONAD_TESTNET_CHAIN_ID,
+                1_773_153_000,
+            ),
             Some(FoundryHardfork::Monad(MonadHardfork::MonadNine))
         );
     }

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -14,7 +14,7 @@ use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use alloy_primitives::{Address, ChainId, address, map::AddressHashMap};
 use clap::Parser;
 #[cfg(feature = "monad")]
-use foundry_evm_hardforks::MonadHardfork;
+type MonadHardfork = foundry_evm_hardforks::MonadHardfork;
 #[cfg(feature = "optimism")]
 use foundry_evm_hardforks::OpHardfork;
 use foundry_evm_hardforks::{
@@ -22,11 +22,6 @@ use foundry_evm_hardforks::{
 };
 #[cfg(not(feature = "monad"))]
 type MonadHardfork = ();
-#[cfg(feature = "monad")]
-use monad_revm::{
-    MONAD_MAX_CODE_SIZE, MONAD_MAX_INITCODE_SIZE, reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
-    staking::STAKING_ADDRESS,
-};
 use revm::precompile::{
     Precompile as RevmPrecompile,
     secp256r1::{P256VERIFY, P256VERIFY_OSAKA},
@@ -71,12 +66,16 @@ const TEMPO_PRECOMPILES: &[(&str, Address)] = &[
 ];
 
 #[cfg(feature = "monad")]
-const MONAD_PRECOMPILE_LABELS: &[(&str, Address)] =
-    &[("Staking", STAKING_ADDRESS), ("ReserveBalance", RESERVE_BALANCE_ADDRESS)];
+const MONAD_PRECOMPILE_LABELS: &[(&str, Address)] = &[
+    ("Staking", monad_revm::staking::STAKING_ADDRESS),
+    ("ReserveBalance", monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS),
+];
 
 #[cfg(feature = "monad")]
-const MONAD_PRECOMPILES: &[(&str, Address)] =
-    &[("MonadStaking", STAKING_ADDRESS), ("MonadReserveBalance", RESERVE_BALANCE_ADDRESS)];
+const MONAD_PRECOMPILES: &[(&str, Address)] = &[
+    ("MonadStaking", monad_revm::staking::STAKING_ADDRESS),
+    ("MonadReserveBalance", monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS),
+];
 
 /// BSC secp256r1 precompile address introduced by the Haber hardfork.
 const BSC_P256_ADDRESS: Address = address!("0000000000000000000000000000000000000100");
@@ -152,8 +151,9 @@ pub fn active_tempo_precompile_addresses(hardfork: TempoHardfork) -> impl Iterat
 /// Returns whether a well-known Monad precompile address is active at `hardfork`.
 #[cfg(feature = "monad")]
 pub fn is_monad_precompile_active_at(address: Address, hardfork: MonadHardfork) -> bool {
-    address == STAKING_ADDRESS
-        || (address == RESERVE_BALANCE_ADDRESS && MonadHardfork::MonadNine.is_enabled_in(hardfork))
+    address == monad_revm::staking::STAKING_ADDRESS
+        || (address == monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS
+            && MonadHardfork::MonadNine.is_enabled_in(hardfork))
 }
 
 #[derive(
@@ -612,8 +612,8 @@ impl NetworkConfigs {
     #[cfg(feature = "monad")]
     pub fn contract_size_limits(&self) -> Option<NetworkContractSizeLimits> {
         self.is_monad().then_some(NetworkContractSizeLimits {
-            runtime: MONAD_MAX_CODE_SIZE,
-            initcode: MONAD_MAX_INITCODE_SIZE,
+            runtime: monad_revm::MONAD_MAX_CODE_SIZE,
+            initcode: monad_revm::MONAD_MAX_INITCODE_SIZE,
         })
     }
 
@@ -1497,7 +1497,7 @@ mod tests {
 
         assert_eq!(
             cfg.precompiles(None, Some(MonadHardfork::MonadEight)).get("MonadStaking"),
-            Some(&STAKING_ADDRESS)
+            Some(&monad_revm::staking::STAKING_ADDRESS)
         );
         assert!(
             !cfg.precompiles(None, Some(MonadHardfork::MonadEight))
@@ -1505,17 +1505,20 @@ mod tests {
         );
         assert_eq!(
             cfg.precompiles(None, Some(MonadHardfork::MonadNine)).get("MonadReserveBalance"),
-            Some(&RESERVE_BALANCE_ADDRESS)
+            Some(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
         );
         assert_eq!(
             cfg.precompiles_label(None, Some(MonadHardfork::MonadNine))
-                .get(&RESERVE_BALANCE_ADDRESS),
+                .get(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS),
             Some(&"ReserveBalance".to_string())
         );
-        assert!(cfg.precompiles_label(None, None).contains_key(&RESERVE_BALANCE_ADDRESS));
+        assert!(
+            cfg.precompiles_label(None, None)
+                .contains_key(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
+        );
         assert!(
             !cfg.precompiles_label(None, Some(MonadHardfork::MonadEight))
-                .contains_key(&RESERVE_BALANCE_ADDRESS)
+                .contains_key(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
         );
     }
 
@@ -1563,8 +1566,8 @@ mod tests {
     #[cfg(feature = "monad")]
     fn contract_size_limits_monad() {
         let limits = NetworkConfigs::with_monad().contract_size_limits().unwrap();
-        assert_eq!(limits.runtime, MONAD_MAX_CODE_SIZE);
-        assert_eq!(limits.initcode, MONAD_MAX_INITCODE_SIZE);
+        assert_eq!(limits.runtime, monad_revm::MONAD_MAX_CODE_SIZE);
+        assert_eq!(limits.initcode, monad_revm::MONAD_MAX_INITCODE_SIZE);
         assert!(NetworkConfigs::default().contract_size_limits().is_none());
     }
 

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -15,8 +15,6 @@ use foundry_common::{
     get_contract_name, selectors::SelectorKind,
 };
 use foundry_config::TracingConfig;
-#[cfg(feature = "monad")]
-use foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS;
 use foundry_evm_core::{
     abi::{Vm, console},
     constants::{CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS},
@@ -28,14 +26,10 @@ use foundry_evm_core::{
     },
 };
 #[cfg(feature = "monad")]
-use foundry_evm_hardforks::MonadHardfork;
+type MonadHardfork = foundry_evm_hardforks::MonadHardfork;
 use foundry_evm_hardforks::TempoHardfork;
-#[cfg(feature = "monad")]
-use foundry_evm_networks::is_monad_precompile_active_at;
 use foundry_evm_networks::{NetworkConfigs, NetworkVariant, celo::transfer::CELO_TRANSFER_LABEL};
 use itertools::Itertools;
-#[cfg(feature = "monad")]
-use monad_revm::{reserve_balance::abi::RESERVE_BALANCE_ADDRESS, staking::STAKING_ADDRESS};
 use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
 use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
 
@@ -56,9 +50,6 @@ use tempo_precompiles::{
 #[cfg(feature = "monad")]
 mod monad;
 pub(crate) mod precompiles;
-
-#[cfg(feature = "monad")]
-use monad::{IMonadStaking, IMonadStakingSyscalls, IReserveBalance};
 
 #[cfg(not(feature = "monad"))]
 type MonadHardfork = ();
@@ -657,15 +648,31 @@ impl CallTraceDecoder {
         }
         let Some(hardfork) = self.monad_hardfork else { return };
 
-        self.labels.entry(MONAD_CHEATCODE_ADDRESS).or_insert_with(|| "MonadVM".to_string());
-        self.register_address_abi(STAKING_ADDRESS, &IMonadStaking::abi::contract());
-        self.register_address_abi(STAKING_ADDRESS, &IMonadStakingSyscalls::abi::contract());
-        self.labels.entry(STAKING_ADDRESS).or_insert_with(|| "Staking".to_string());
+        self.labels
+            .entry(foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS)
+            .or_insert_with(|| "MonadVM".to_string());
+        self.register_address_abi(
+            monad_revm::staking::STAKING_ADDRESS,
+            &monad::IMonadStaking::abi::contract(),
+        );
+        self.register_address_abi(
+            monad_revm::staking::STAKING_ADDRESS,
+            &monad::IMonadStakingSyscalls::abi::contract(),
+        );
+        self.labels
+            .entry(monad_revm::staking::STAKING_ADDRESS)
+            .or_insert_with(|| "Staking".to_string());
 
-        if is_monad_precompile_active_at(RESERVE_BALANCE_ADDRESS, hardfork) {
-            self.register_address_abi(RESERVE_BALANCE_ADDRESS, &IReserveBalance::abi::contract());
+        if foundry_evm_networks::is_monad_precompile_active_at(
+            monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+            hardfork,
+        ) {
+            self.register_address_abi(
+                monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+                &monad::IReserveBalance::abi::contract(),
+            );
             self.labels
-                .entry(RESERVE_BALANCE_ADDRESS)
+                .entry(monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
                 .or_insert_with(|| "ReserveBalance".to_string());
         }
     }
@@ -1609,15 +1616,8 @@ fn constructor_signature(constructor: &Constructor) -> String {
 mod tests {
     use super::*;
     use alloy_primitives::{address, aliases::U96, hex};
-    #[cfg(feature = "monad")]
-    use alloy_sol_types::TopicList;
     use alloy_sol_types::{SolCall, SolError, SolEvent};
     use foundry_evm_core::precompiles::P256_VERIFY;
-    #[cfg(feature = "monad")]
-    use monad_revm::{
-        reserve_balance::interface::IReserveBalance::dippedIntoReserveCall,
-        staking::interface::IMonadStaking::{getEpochCall, getEpochReturn},
-    };
     use std::borrow::Cow;
 
     #[cfg(feature = "monad")]
@@ -1648,7 +1648,7 @@ mod tests {
     #[cfg(feature = "monad")]
     fn typed_event_abi_item<E: SolEvent>() -> (String, usize, String) {
         let signature_topics = usize::from(!E::ANONYMOUS);
-        let indexed_inputs = <E::TopicList as TopicList>::COUNT - signature_topics;
+        let indexed_inputs = <E::TopicList as alloy_sol_types::TopicList>::COUNT - signature_topics;
         (E::SIGNATURE_HASH.to_string(), indexed_inputs, E::SIGNATURE.to_string())
     }
 
@@ -1669,9 +1669,9 @@ mod tests {
             staking::interface::IMonadStaking as RevmMonadStaking,
         };
 
-        let local_staking_functions = IMonadStaking::abi::functions()
+        let local_staking_functions = monad::IMonadStaking::abi::functions()
             .into_values()
-            .chain(IMonadStakingSyscalls::abi::functions().into_values())
+            .chain(monad::IMonadStakingSyscalls::abi::functions().into_values())
             .flatten();
         let mut revm_staking_functions = vec![
             typed_call_abi_item::<RevmMonadStaking::addValidatorCall>(),
@@ -1716,19 +1716,19 @@ mod tests {
         ];
         revm_staking_events.sort();
         assert_eq!(
-            event_abi_items(IMonadStaking::abi::events().into_values().flatten()),
+            event_abi_items(monad::IMonadStaking::abi::events().into_values().flatten()),
             revm_staking_events,
             "Monad staking event selectors drifted from monad_revm",
         );
 
         assert_eq!(
-            function_abi_items(IReserveBalance::abi::functions().into_values().flatten()),
+            function_abi_items(monad::IReserveBalance::abi::functions().into_values().flatten()),
             vec![typed_call_abi_item::<RevmReserveBalance::dippedIntoReserveCall>()],
             "Monad reserve-balance function selectors drifted from monad_revm",
         );
 
         assert_eq!(
-            event_abi_items(IReserveBalance::abi::events().into_values().flatten()),
+            event_abi_items(monad::IReserveBalance::abi::events().into_values().flatten()),
             Vec::<(String, usize, String)>::new(),
             "Monad reserve-balance event selectors drifted from monad_revm",
         );
@@ -2742,13 +2742,18 @@ mod tests {
     #[cfg(feature = "monad")]
     async fn test_decodes_monad_staking_precompile_call() {
         let trace = CallTrace {
-            address: STAKING_ADDRESS,
-            data: getEpochCall::SELECTOR.to_vec().into(),
-            output: getEpochCall::abi_encode_returns(&getEpochReturn {
-                epoch: 42,
-                inEpochDelayPeriod: true,
-            })
-            .into(),
+            address: monad_revm::staking::STAKING_ADDRESS,
+            data: monad_revm::staking::interface::IMonadStaking::getEpochCall::SELECTOR
+                .to_vec()
+                .into(),
+            output:
+                monad_revm::staking::interface::IMonadStaking::getEpochCall::abi_encode_returns(
+                    &monad_revm::staking::interface::IMonadStaking::getEpochReturn {
+                        epoch: 42,
+                        inEpochDelayPeriod: true,
+                    },
+                )
+                .into(),
             success: true,
             ..Default::default()
         };
@@ -2767,8 +2772,8 @@ mod tests {
     async fn test_decodes_monad_staking_syscall() {
         let block_author = Address::from([0x42; 20]);
         let trace = CallTrace {
-            address: STAKING_ADDRESS,
-            data: IMonadStakingSyscalls::syscallRewardCall { blockAuthor: block_author }
+            address: monad_revm::staking::STAKING_ADDRESS,
+            data: monad::IMonadStakingSyscalls::syscallRewardCall { blockAuthor: block_author }
                 .abi_encode()
                 .into(),
             success: true,
@@ -2789,8 +2794,10 @@ mod tests {
     #[cfg(feature = "monad")]
     async fn test_decodes_monad_reserve_balance_precompile_call() {
         let trace = CallTrace {
-            address: RESERVE_BALANCE_ADDRESS,
-            data: dippedIntoReserveCall::SELECTOR.to_vec().into(),
+            address: monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+            data: monad_revm::reserve_balance::interface::IReserveBalance::dippedIntoReserveCall::SELECTOR
+                .to_vec()
+                .into(),
             output: true.abi_encode().into(),
             success: true,
             ..Default::default()
@@ -2819,7 +2826,8 @@ mod tests {
         );
 
         let decoder = monad_decoder(MonadHardfork::MonadEight);
-        let decoded = decoder.decode_event_with_address(STAKING_ADDRESS, &log).await;
+        let decoded =
+            decoder.decode_event_with_address(monad_revm::staking::STAKING_ADDRESS, &log).await;
 
         assert_eq!(decoded.name.as_deref(), Some("Delegate"));
         let params = decoded.params.expect("params");
@@ -2828,7 +2836,12 @@ mod tests {
         assert_eq!(params[2], ("amount".to_string(), "1000".to_string()));
         assert_eq!(params[3], ("activationEpoch".to_string(), "9".to_string()));
 
-        let collision = decoder.decode_event_with_address(RESERVE_BALANCE_ADDRESS, &log).await;
+        let collision = decoder
+            .decode_event_with_address(
+                monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+                &log,
+            )
+            .await;
         assert_eq!(collision.name, None);
     }
 
@@ -2836,18 +2849,27 @@ mod tests {
     #[cfg(feature = "monad")]
     async fn test_monad_metadata_is_not_registered_for_ethereum() {
         let decoder = CallTraceDecoderBuilder::new().with_chain_id(Some(1)).build();
-        for address in [MONAD_CHEATCODE_ADDRESS, STAKING_ADDRESS, RESERVE_BALANCE_ADDRESS] {
+        for address in [
+            foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS,
+            monad_revm::staking::STAKING_ADDRESS,
+            monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+        ] {
             assert!(!decoder.labels.contains_key(&address));
         }
 
         let staking_trace = CallTrace {
-            address: STAKING_ADDRESS,
-            data: getEpochCall::SELECTOR.to_vec().into(),
-            output: getEpochCall::abi_encode_returns(&getEpochReturn {
-                epoch: 42,
-                inEpochDelayPeriod: true,
-            })
-            .into(),
+            address: monad_revm::staking::STAKING_ADDRESS,
+            data: monad_revm::staking::interface::IMonadStaking::getEpochCall::SELECTOR
+                .to_vec()
+                .into(),
+            output:
+                monad_revm::staking::interface::IMonadStaking::getEpochCall::abi_encode_returns(
+                    &monad_revm::staking::interface::IMonadStaking::getEpochReturn {
+                        epoch: 42,
+                        inEpochDelayPeriod: true,
+                    },
+                )
+                .into(),
             success: true,
             ..Default::default()
         };
@@ -2858,8 +2880,10 @@ mod tests {
         );
 
         let reserve_trace = CallTrace {
-            address: RESERVE_BALANCE_ADDRESS,
-            data: dippedIntoReserveCall::SELECTOR.to_vec().into(),
+            address: monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+            data: monad_revm::reserve_balance::interface::IReserveBalance::dippedIntoReserveCall::SELECTOR
+                .to_vec()
+                .into(),
             output: true.abi_encode().into(),
             success: true,
             ..Default::default()
@@ -2882,7 +2906,10 @@ mod tests {
             ],
             (U256::from(1000), 9_u64).abi_encode().into(),
         );
-        for address in [STAKING_ADDRESS, RESERVE_BALANCE_ADDRESS] {
+        for address in [
+            monad_revm::staking::STAKING_ADDRESS,
+            monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+        ] {
             let decoded = decoder.decode_event_with_address(address, &log).await;
             assert_eq!(decoded.name, None);
         }
@@ -2894,15 +2921,27 @@ mod tests {
         let mut monad_eight = monad_decoder(MonadHardfork::MonadEight);
         monad_eight.clear_addresses();
         assert_eq!(
-            monad_eight.labels.get(&MONAD_CHEATCODE_ADDRESS).map(String::as_str),
+            monad_eight
+                .labels
+                .get(&foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS)
+                .map(String::as_str),
             Some("MonadVM")
         );
-        assert_eq!(monad_eight.labels.get(&STAKING_ADDRESS).map(String::as_str), Some("Staking"));
-        assert!(!monad_eight.labels.contains_key(&RESERVE_BALANCE_ADDRESS));
+        assert_eq!(
+            monad_eight.labels.get(&monad_revm::staking::STAKING_ADDRESS).map(String::as_str),
+            Some("Staking")
+        );
+        assert!(
+            !monad_eight
+                .labels
+                .contains_key(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
+        );
 
         let trace = CallTrace {
-            address: RESERVE_BALANCE_ADDRESS,
-            data: dippedIntoReserveCall::SELECTOR.to_vec().into(),
+            address: monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+            data: monad_revm::reserve_balance::interface::IReserveBalance::dippedIntoReserveCall::SELECTOR
+                .to_vec()
+                .into(),
             output: true.abi_encode().into(),
             success: true,
             ..Default::default()
@@ -2916,7 +2955,10 @@ mod tests {
         let mut monad_nine = monad_decoder(MonadHardfork::MonadNine);
         monad_nine.clear_addresses();
         assert_eq!(
-            monad_nine.labels.get(&RESERVE_BALANCE_ADDRESS).map(String::as_str),
+            monad_nine
+                .labels
+                .get(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
+                .map(String::as_str),
             Some("ReserveBalance")
         );
         let after = monad_nine.decode_function(&trace).await;
@@ -2930,8 +2972,10 @@ mod tests {
     #[cfg(feature = "monad")]
     async fn test_monad_metadata_refreshes_across_hardforks() {
         let trace = CallTrace {
-            address: RESERVE_BALANCE_ADDRESS,
-            data: dippedIntoReserveCall::SELECTOR.to_vec().into(),
+            address: monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+            data: monad_revm::reserve_balance::interface::IReserveBalance::dippedIntoReserveCall::SELECTOR
+                .to_vec()
+                .into(),
             output: true.abi_encode().into(),
             success: true,
             ..Default::default()
@@ -2941,7 +2985,10 @@ mod tests {
         decoder.set_monad_hardfork(Some(MonadHardfork::MonadNine));
         assert_eq!(decoder.monad_hardfork(), Some(MonadHardfork::MonadNine));
         assert_eq!(
-            decoder.labels.get(&RESERVE_BALANCE_ADDRESS).map(String::as_str),
+            decoder
+                .labels
+                .get(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
+                .map(String::as_str),
             Some("ReserveBalance")
         );
         let monad_nine = decoder.decode_function(&trace).await;
@@ -2952,8 +2999,15 @@ mod tests {
 
         decoder.set_monad_hardfork(Some(MonadHardfork::MonadEight));
         assert_eq!(decoder.monad_hardfork(), Some(MonadHardfork::MonadEight));
-        assert!(!decoder.labels.contains_key(&RESERVE_BALANCE_ADDRESS));
-        assert_eq!(decoder.labels.get(&STAKING_ADDRESS).map(String::as_str), Some("Staking"));
+        assert!(
+            !decoder
+                .labels
+                .contains_key(&monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS)
+        );
+        assert_eq!(
+            decoder.labels.get(&monad_revm::staking::STAKING_ADDRESS).map(String::as_str),
+            Some("Staking")
+        );
         let monad_eight = decoder.decode_function(&trace).await;
         assert_ne!(
             monad_eight.call_data.as_ref().map(|call| call.signature.as_str()),
@@ -3745,7 +3799,7 @@ mod tests {
 
         arena.nodes_mut().push(CallTraceNode {
             trace: CallTrace {
-                address: STAKING_ADDRESS,
+                address: monad_revm::staking::STAKING_ADDRESS,
                 depth: 1,
                 maybe_precompile: None,
                 ..Default::default()
@@ -3755,7 +3809,7 @@ mod tests {
         });
         arena.nodes_mut().push(CallTraceNode {
             trace: CallTrace {
-                address: RESERVE_BALANCE_ADDRESS,
+                address: monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
                 depth: 1,
                 maybe_precompile: None,
                 ..Default::default()
@@ -3781,7 +3835,7 @@ mod tests {
 
         arena.nodes_mut().push(CallTraceNode {
             trace: CallTrace {
-                address: STAKING_ADDRESS,
+                address: monad_revm::staking::STAKING_ADDRESS,
                 depth: 1,
                 maybe_precompile: None,
                 ..Default::default()
@@ -3791,7 +3845,7 @@ mod tests {
         });
         arena.nodes_mut().push(CallTraceNode {
             trace: CallTrace {
-                address: RESERVE_BALANCE_ADDRESS,
+                address: monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
                 depth: 1,
                 maybe_precompile: None,
                 ..Default::default()
@@ -3805,7 +3859,11 @@ mod tests {
 
         assert_eq!(
             identifier.queried,
-            vec![regular_addr, STAKING_ADDRESS, RESERVE_BALANCE_ADDRESS]
+            vec![
+                regular_addr,
+                monad_revm::staking::STAKING_ADDRESS,
+                monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
+            ]
         );
     }
 
@@ -3813,7 +3871,7 @@ mod tests {
     #[cfg(feature = "monad")]
     fn execution_network_overrides_nested_source_monad_precompile_detection() {
         assert!(!precompiles::is_known_precompile(
-            RESERVE_BALANCE_ADDRESS,
+            monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
             Some(NetworkVariant::Ethereum.into()),
             Some(143),
             None,

--- a/crates/evm/traces/src/decoder/precompiles.rs
+++ b/crates/evm/traces/src/decoder/precompiles.rs
@@ -13,11 +13,7 @@ use foundry_evm_core::{
 };
 use foundry_evm_hardforks::TempoHardfork;
 use foundry_evm_networks::NetworkConfigs;
-#[cfg(feature = "monad")]
-use foundry_evm_networks::is_monad_precompile_active_at;
 use itertools::Itertools;
-#[cfg(feature = "monad")]
-use monad_revm::{reserve_balance::abi::RESERVE_BALANCE_ADDRESS, staking::STAKING_ADDRESS};
 use revm_inspectors::tracing::types::DecodedCallTrace;
 
 sol! {
@@ -129,12 +125,13 @@ pub(crate) fn is_known_precompile(
             |networks| networks.is_monad(),
         );
         if is_monad_context {
-            if address == STAKING_ADDRESS {
+            if address == monad_revm::staking::STAKING_ADDRESS {
                 return true;
             }
-            if address == RESERVE_BALANCE_ADDRESS
-                && monad_hardfork
-                    .is_none_or(|hardfork| is_monad_precompile_active_at(address, hardfork))
+            if address == monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS
+                && monad_hardfork.is_none_or(|hardfork| {
+                    foundry_evm_networks::is_monad_precompile_active_at(address, hardfork)
+                })
             {
                 return true;
             }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -59,12 +59,8 @@ use foundry_config::{
     fs_permissions::FsAccessPermission,
 };
 use foundry_debugger::{Debugger, DebuggerLayout};
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::MonadEvmNetwork;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
-#[cfg(feature = "monad")]
-use foundry_evm::hardforks::MonadHardfork;
 use foundry_evm::{
     core::evm::{
         BlockEnvFor, EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor,
@@ -2683,7 +2679,7 @@ impl TestArgs {
             }
             #[cfg(feature = "monad")]
             NetworkDispatchKind::Monad => {
-                self.build_and_run_tests::<MonadEvmNetwork>(
+                self.build_and_run_tests::<foundry_evm::core::evm::MonadEvmNetwork>(
                     config, evm_opts, output, filter, execution,
                 )
                 .await
@@ -2720,7 +2716,9 @@ impl TestArgs {
                 .map(|runner| fuzz_minimize_replay(runner, filter)),
             #[cfg(feature = "monad")]
             NetworkDispatchKind::Monad => self
-                .build_fuzz_minimize_runner::<MonadEvmNetwork>(config, evm_opts, output, options)
+                .build_fuzz_minimize_runner::<foundry_evm::core::evm::MonadEvmNetwork>(
+                    config, evm_opts, output, options,
+                )
                 .await
                 .map(|runner| fuzz_minimize_replay(runner, filter)),
             #[cfg(feature = "optimism")]
@@ -2958,7 +2956,8 @@ impl TestArgs {
         #[cfg(feature = "monad")]
         {
             builder = builder.with_monad_hardfork(
-                resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork),
+                resolved_hardfork
+                    .and_then(foundry_evm::hardforks::MonadHardfork::from_foundry_hardfork),
             );
         }
         // Signatures are of no value for gas reports.

--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -21,8 +21,6 @@ use eyre::Result;
 use foundry_common::{compile::ProjectCompiler, sh_eprintln, sh_println};
 use foundry_compilers::compilers::multi::MultiCompiler;
 use foundry_config::{Config, InlineConfig};
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::MonadEvmNetwork;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -638,7 +636,7 @@ fn compile_and_test(
     } else {
         #[cfg(feature = "monad")]
         if evm_opts.networks.is_monad() {
-            return compile_and_test_inner::<MonadEvmNetwork>(
+            return compile_and_test_inner::<foundry_evm::core::evm::MonadEvmNetwork>(
                 config,
                 evm_opts,
                 create2_deployer_available,

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -1,7 +1,5 @@
 use crate::utils::generate_large_init_contract;
 use foundry_compilers::artifacts::EvmVersion;
-#[cfg(feature = "monad")]
-use foundry_evm_networks::NetworkConfigs;
 use foundry_test_utils::{forgetest, forgetest_init, snapbox::IntoData, str, util::OutputExt};
 use globset::Glob;
 use std::{
@@ -455,7 +453,7 @@ forgetest!(build_sizes_respects_configured_code_size_limit, |prj, cmd| {
 forgetest!(build_sizes_respects_monad_network_code_size_limit, |prj, cmd| {
     prj.add_source("LargeContract.sol", generate_large_init_contract(50_000).as_str());
     prj.update_config(|config| {
-        config.networks = NetworkConfigs::with_monad();
+        config.networks = foundry_evm_networks::NetworkConfigs::with_monad();
     });
 
     cmd.args(["build", "--sizes", "--json"]).assert_success().stdout_eq(

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -1,35 +1,12 @@
-#[cfg(feature = "monad")]
-use alloy_consensus::{SignableTransaction, TxEip1559};
-#[cfg(feature = "monad")]
-use alloy_network::{Ethereum, Network, ReceiptResponse, TransactionBuilder, TxSignerSync};
-#[cfg(feature = "monad")]
-use alloy_primitives::{Address, B256, TxKind, U256, address, hex, keccak256};
-#[cfg(feature = "monad")]
-use alloy_provider::Provider;
-#[cfg(feature = "monad")]
-use anvil::{NodeConfig, spawn};
-#[cfg(feature = "monad")]
-use axum::{Router, body::Bytes as BodyBytes};
 use foundry_compilers::artifacts::EvmVersion;
-#[cfg(feature = "monad")]
-use foundry_evm::hardforks::MonadHardfork;
 use foundry_evm::hardforks::{FoundryHardfork, TempoHardfork};
-#[cfg(feature = "monad")]
-use foundry_test_utils::rpc::spawn_canonical_monad_system_rpc;
 use foundry_test_utils::{rpc, util::OTHER_SOLC_VERSION};
-#[cfg(feature = "monad")]
-use serde_json::{Value, json};
-#[cfg(feature = "monad")]
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicUsize, Ordering},
-};
 
 #[cfg(feature = "monad")]
-async fn rpc_request(endpoint: &str, method: &str, params: Value) -> Value {
+async fn rpc_request(endpoint: &str, method: &str, params: serde_json::Value) -> serde_json::Value {
     reqwest::Client::new()
         .post(endpoint)
-        .json(&json!({
+        .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": method,
@@ -44,60 +21,65 @@ async fn rpc_request(endpoint: &str, method: &str, params: Value) -> Value {
 }
 
 #[cfg(feature = "monad")]
-fn monad_staking_reward_input(block_author: Address) -> Vec<u8> {
-    let mut input = keccak256("syscallReward(address)")[..4].to_vec();
+fn monad_staking_reward_input(block_author: alloy_primitives::Address) -> Vec<u8> {
+    let mut input = alloy_primitives::keccak256("syscallReward(address)")[..4].to_vec();
     input.extend_from_slice(&[0u8; 12]);
     input.extend_from_slice(block_author.as_slice());
     input
 }
 
 #[cfg(feature = "monad")]
-fn monad_staking_validator_id_key(address: Address) -> U256 {
+fn monad_staking_validator_id_key(address: alloy_primitives::Address) -> alloy_primitives::U256 {
     let mut key = [0u8; 32];
     key[0] = 0x06;
     key[1..21].copy_from_slice(address.as_slice());
-    U256::from_be_bytes(key)
+    alloy_primitives::U256::from_be_bytes(key)
 }
 
 #[cfg(feature = "monad")]
-fn monad_staking_validator_key(namespace: u8, validator_id: u64, offset: u8) -> U256 {
+fn monad_staking_validator_key(
+    namespace: u8,
+    validator_id: u64,
+    offset: u8,
+) -> alloy_primitives::U256 {
     let mut key = [0u8; 32];
     key[0] = namespace;
     key[1..9].copy_from_slice(&validator_id.to_be_bytes());
-    U256::from_be_bytes(key) + U256::from(offset)
+    alloy_primitives::U256::from_be_bytes(key) + alloy_primitives::U256::from(offset)
 }
 
 #[cfg(feature = "monad")]
-fn left_aligned_u64(value: u64) -> U256 {
+fn left_aligned_u64(value: u64) -> alloy_primitives::U256 {
     let mut bytes = [0u8; 32];
     bytes[..8].copy_from_slice(&value.to_be_bytes());
-    U256::from_be_bytes(bytes)
+    alloy_primitives::U256::from_be_bytes(bytes)
 }
 
 #[cfg(feature = "monad")]
-fn address_and_flags(address: Address, flags: u64) -> U256 {
+fn address_and_flags(address: alloy_primitives::Address, flags: u64) -> alloy_primitives::U256 {
     let mut bytes = [0u8; 32];
     bytes[..20].copy_from_slice(address.as_slice());
     bytes[20..28].copy_from_slice(&flags.to_be_bytes());
-    U256::from_be_bytes(bytes)
+    alloy_primitives::U256::from_be_bytes(bytes)
 }
 
 #[cfg(feature = "monad")]
-fn storage_value(value: U256) -> B256 {
-    B256::from(value.to_be_bytes::<32>())
+fn storage_value(value: alloy_primitives::U256) -> alloy_primitives::B256 {
+    alloy_primitives::B256::from(value.to_be_bytes::<32>())
 }
 
 #[cfg(feature = "monad")]
-fn override_rpc_transaction_chain_id(value: &mut Value, target: &str, chain_id: &str) {
+fn override_rpc_transaction_chain_id(value: &mut serde_json::Value, target: &str, chain_id: &str) {
     match value {
-        Value::Array(values) => {
+        serde_json::Value::Array(values) => {
             for value in values {
                 override_rpc_transaction_chain_id(value, target, chain_id);
             }
         }
-        Value::Object(object) => {
-            if object.get("hash").and_then(Value::as_str) == Some(target) {
-                object.insert("chainId".to_string(), Value::String(chain_id.to_string()));
+        serde_json::Value::Object(object) => {
+            if object.get("hash").and_then(serde_json::Value::as_str) == Some(target) {
+                object
+                    .insert("chainId".to_string(), serde_json::Value::String(chain_id.to_string()));
             }
             for value in object.values_mut() {
                 override_rpc_transaction_chain_id(value, target, chain_id);
@@ -391,7 +373,8 @@ contract MonadEvmVersionTest is Test {
 
 #[cfg(feature = "monad")]
 forgetest_async!(fork_resolves_monad_hardfork_from_timestamp, |prj, cmd| {
-    let activation = MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+    let activation =
+        foundry_evm::hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
     prj.add_test(
         "MonadForkHardfork.t.sol",
         r#"
@@ -421,8 +404,10 @@ contract MonadForkHardforkTest {
    "#,
     );
 
-    let (_api, before) = spawn(
-        NodeConfig::test().with_chain_id(Some(143u64)).with_genesis_timestamp(Some(activation - 1)),
+    let (_api, before) = anvil::spawn(
+        anvil::NodeConfig::test()
+            .with_chain_id(Some(143u64))
+            .with_genesis_timestamp(Some(activation - 1)),
     )
     .await;
     cmd.args([
@@ -438,8 +423,10 @@ contract MonadForkHardforkTest {
     ])
     .assert_success();
 
-    let (_api, after) = spawn(
-        NodeConfig::test().with_chain_id(Some(143u64)).with_genesis_timestamp(Some(activation)),
+    let (_api, after) = anvil::spawn(
+        anvil::NodeConfig::test()
+            .with_chain_id(Some(143u64))
+            .with_genesis_timestamp(Some(activation)),
     )
     .await;
     cmd.forge_fuse()
@@ -456,11 +443,11 @@ contract MonadForkHardforkTest {
         ])
         .assert_success();
 
-    let (_api, overridden) = spawn(
-        NodeConfig::test_monad()
+    let (_api, overridden) = anvil::spawn(
+        anvil::NodeConfig::test_monad()
             .with_chain_id(Some(143u64))
             .with_genesis_timestamp(Some(activation))
-            .with_hardfork(Some(MonadHardfork::MonadEight.into())),
+            .with_hardfork(Some(foundry_evm::hardforks::MonadHardfork::MonadEight.into())),
     )
     .await;
     cmd.forge_fuse()
@@ -542,30 +529,34 @@ contract MonadMemoryLimitTest is Test {
 
 #[cfg(feature = "monad")]
 forgetest_async!(execute_transaction_uses_monad_fork_context, |prj, cmd| {
+    use alloy_consensus::SignableTransaction as _;
+    use alloy_network::TxSignerSync as _;
+    use alloy_provider::Provider as _;
+
     const CHAIN_ID: u64 = 31_337;
     const GAS_LIMIT: u64 = 100_000;
     const MAX_FEE_PER_GAS: u128 = 2_000_000_000;
     const MAX_PRIORITY_FEE_PER_GAS: u128 = 1_000_000_000;
 
-    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let (_api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
     let provider = handle.http_provider();
     let wallets = handle.dev_wallets().collect::<Vec<_>>();
     let ancestor = wallets[0].address();
     let control = wallets[1].address();
     let tracked = wallets[3].address();
     let nested_only = wallets[5].address();
-    let probe = Address::with_last_byte(0x20);
-    let receiver = Address::with_last_byte(0x21);
+    let probe = alloy_primitives::Address::with_last_byte(0x20);
+    let receiver = alloy_primitives::Address::with_last_byte(0x21);
 
     // Mine the ancestor in the block Forge will fork. The synthetic transaction should execute
     // in a child of this block, making this sender ineligible to dip into its reserve.
-    let mut ancestor_marker = TxEip1559 {
+    let mut ancestor_marker = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: 21_000,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
-        to: TxKind::Call(wallets[2].address()),
-        value: U256::ONE,
+        to: alloy_primitives::TxKind::Call(wallets[2].address()),
+        value: alloy_primitives::U256::ONE,
         ..Default::default()
     };
     let signature = wallets[0].sign_transaction_sync(&mut ancestor_marker).unwrap();
@@ -573,14 +564,14 @@ forgetest_async!(execute_transaction_uses_monad_fork_context, |prj, cmd| {
     ancestor_marker.into_signed(signature).eip2718_encode(&mut encoded);
     provider.send_raw_transaction(&encoded).await.unwrap().get_receipt().await.unwrap();
 
-    let value = U256::from(3_000_000_000_000_000_000u128);
-    let mut ancestor_tx = TxEip1559 {
+    let value = alloy_primitives::U256::from(3_000_000_000_000_000_000u128);
+    let mut ancestor_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         nonce: 1,
         gas_limit: GAS_LIMIT,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
-        to: TxKind::Call(probe),
+        to: alloy_primitives::TxKind::Call(probe),
         value,
         ..Default::default()
     };
@@ -588,13 +579,13 @@ forgetest_async!(execute_transaction_uses_monad_fork_context, |prj, cmd| {
     let mut ancestor_raw = Vec::new();
     ancestor_tx.into_signed(signature).eip2718_encode(&mut ancestor_raw);
 
-    let mut control_tx = TxEip1559 {
+    let mut control_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         nonce: 0,
         gas_limit: GAS_LIMIT,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
-        to: TxKind::Call(probe),
+        to: alloy_primitives::TxKind::Call(probe),
         value,
         ..Default::default()
     };
@@ -602,13 +593,13 @@ forgetest_async!(execute_transaction_uses_monad_fork_context, |prj, cmd| {
     let mut control_raw = Vec::new();
     control_tx.into_signed(signature).eip2718_encode(&mut control_raw);
 
-    let mut credit_tx = TxEip1559 {
+    let mut credit_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         nonce: 0,
         gas_limit: GAS_LIMIT,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
-        to: TxKind::Call(tracked),
+        to: alloy_primitives::TxKind::Call(tracked),
         value,
         ..Default::default()
     };
@@ -616,14 +607,14 @@ forgetest_async!(execute_transaction_uses_monad_fork_context, |prj, cmd| {
     let mut credit_raw = Vec::new();
     credit_tx.into_signed(signature).eip2718_encode(&mut credit_raw);
 
-    let mut preserve_tx = TxEip1559 {
+    let mut preserve_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         nonce: 0,
         gas_limit: GAS_LIMIT,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
-        to: TxKind::Call(receiver),
-        value: U256::ONE,
+        to: alloy_primitives::TxKind::Call(receiver),
+        value: alloy_primitives::U256::ONE,
         ..Default::default()
     };
     let signature = wallets[4].sign_transaction_sync(&mut preserve_tx).unwrap();
@@ -631,14 +622,14 @@ forgetest_async!(execute_transaction_uses_monad_fork_context, |prj, cmd| {
     preserve_tx.into_signed(signature).eip2718_encode(&mut preserve_raw);
 
     let nested_only_balance = provider.get_balance(nested_only).await.unwrap();
-    let nested_only_remaining = U256::from(7_000_000_000_000_000_000u128);
-    let mut nested_only_tx = TxEip1559 {
+    let nested_only_remaining = alloy_primitives::U256::from(7_000_000_000_000_000_000u128);
+    let mut nested_only_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         nonce: 0,
         gas_limit: GAS_LIMIT,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
-        to: TxKind::Call(receiver),
+        to: alloy_primitives::TxKind::Call(receiver),
         value: nested_only_balance - nested_only_remaining,
         ..Default::default()
     };
@@ -733,11 +724,11 @@ contract ExecuteTransactionMonadContextTest {
     .replace("<probe>", &probe.to_string())
     .replace("<receiver>", &receiver.to_string())
     .replace("<rpc>", &handle.http_endpoint())
-    .replace("<ancestor_raw>", &hex::encode(ancestor_raw))
-    .replace("<control_raw>", &hex::encode(control_raw))
-    .replace("<credit_raw>", &hex::encode(credit_raw))
-    .replace("<preserve_raw>", &hex::encode(preserve_raw))
-    .replace("<nested_only_raw>", &hex::encode(nested_only_raw));
+    .replace("<ancestor_raw>", &alloy_primitives::hex::encode(ancestor_raw))
+    .replace("<control_raw>", &alloy_primitives::hex::encode(control_raw))
+    .replace("<credit_raw>", &alloy_primitives::hex::encode(credit_raw))
+    .replace("<preserve_raw>", &alloy_primitives::hex::encode(preserve_raw))
+    .replace("<nested_only_raw>", &alloy_primitives::hex::encode(nested_only_raw));
     prj.add_test("ExecuteTransactionMonadContext.t.sol", &source);
     prj.update_config(|config| {
         config.hardfork = Some("monad:MonadNine".parse().unwrap());
@@ -749,81 +740,85 @@ contract ExecuteTransactionMonadContextTest {
 
 #[cfg(feature = "monad")]
 forgetest_async!(transaction_fork_excludes_future_monad_participants, |prj, cmd| {
+    use alloy_consensus::SignableTransaction as _;
+    use alloy_network::{ReceiptResponse as _, TxSignerSync as _};
+    use alloy_provider::Provider as _;
+
     const CHAIN_ID: u64 = 31_337;
     const GAS_LIMIT: u64 = 100_000;
     const MAX_FEE_PER_GAS: u128 = 3_000_000_000;
 
-    let (api, handle) = spawn(NodeConfig::test()).await;
+    let (api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
     let provider = handle.http_provider();
     let wallets = handle.dev_wallets().collect::<Vec<_>>();
     let target_sender = wallets[3].address();
     let future_sender = wallets[0].address();
-    let probe = Address::with_last_byte(0x21);
-    let target_recipient = Address::with_last_byte(0x22);
-    let future_recipient = Address::with_last_byte(0x23);
+    let probe = alloy_primitives::Address::with_last_byte(0x21);
+    let target_recipient = alloy_primitives::Address::with_last_byte(0x22);
+    let future_recipient = alloy_primitives::Address::with_last_byte(0x23);
     let parent_block = provider.get_block_number().await.unwrap();
 
-    let mut target_tx = TxEip1559 {
+    let mut target_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: 21_000,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 2_000_000_000,
-        to: TxKind::Call(target_recipient),
-        value: U256::ONE,
+        to: alloy_primitives::TxKind::Call(target_recipient),
+        value: alloy_primitives::U256::ONE,
         ..Default::default()
     };
     let signature = wallets[3].sign_transaction_sync(&mut target_tx).unwrap();
     let mut target_raw = Vec::new();
     target_tx.into_signed(signature).eip2718_encode(&mut target_raw);
 
-    let mut future_marker = TxEip1559 {
+    let mut future_marker = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: 21_000,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 1_000_000_000,
-        to: TxKind::Call(future_recipient),
-        value: U256::ONE,
+        to: alloy_primitives::TxKind::Call(future_recipient),
+        value: alloy_primitives::U256::ONE,
         ..Default::default()
     };
     let signature = wallets[0].sign_transaction_sync(&mut future_marker).unwrap();
     let mut future_marker_raw = Vec::new();
     future_marker.into_signed(signature).eip2718_encode(&mut future_marker_raw);
 
-    let mut future_probe = TxEip1559 {
+    let mut future_probe = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: GAS_LIMIT,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 1_000_000_000,
-        to: TxKind::Call(probe),
-        value: U256::from(3_000_000_000_000_000_000u128),
+        to: alloy_primitives::TxKind::Call(probe),
+        value: alloy_primitives::U256::from(3_000_000_000_000_000_000u128),
         ..Default::default()
     };
     let signature = wallets[0].sign_transaction_sync(&mut future_probe).unwrap();
     let mut future_probe_raw = Vec::new();
     future_probe.into_signed(signature).eip2718_encode(&mut future_probe_raw);
 
-    let mut target_probe = TxEip1559 {
+    let mut target_probe = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         nonce: 1,
         gas_limit: GAS_LIMIT,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 1_000_000_000,
-        to: TxKind::Call(probe),
-        value: U256::from(3_000_000_000_000_000_000u128),
+        to: alloy_primitives::TxKind::Call(probe),
+        value: alloy_primitives::U256::from(3_000_000_000_000_000_000u128),
         ..Default::default()
     };
     let signature = wallets[3].sign_transaction_sync(&mut target_probe).unwrap();
     let mut target_probe_raw = Vec::new();
     target_probe.into_signed(signature).eip2718_encode(&mut target_probe_raw);
 
-    let mut replayed_future_probe = TxEip1559 {
+    let mut replayed_future_probe = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         nonce: 1,
         gas_limit: GAS_LIMIT,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 1_000_000_000,
-        to: TxKind::Call(probe),
-        value: U256::from(3_000_000_000_000_000_000u128),
+        to: alloy_primitives::TxKind::Call(probe),
+        value: alloy_primitives::U256::from(3_000_000_000_000_000_000u128),
         ..Default::default()
     };
     let signature = wallets[0].sign_transaction_sync(&mut replayed_future_probe).unwrap();
@@ -978,9 +973,12 @@ contract TransactionForkMonadContextTest {
     .replace("<target_hash>", &target_hash.to_string())
     .replace("<future_hash>", &future_hash.to_string())
     .replace("<parent_block>", &parent_block.to_string())
-    .replace("<future_probe_raw>", &hex::encode(future_probe_raw))
-    .replace("<target_probe_raw>", &hex::encode(target_probe_raw))
-    .replace("<replayed_future_probe_raw>", &hex::encode(replayed_future_probe_raw));
+    .replace("<future_probe_raw>", &alloy_primitives::hex::encode(future_probe_raw))
+    .replace("<target_probe_raw>", &alloy_primitives::hex::encode(target_probe_raw))
+    .replace(
+        "<replayed_future_probe_raw>",
+        &alloy_primitives::hex::encode(replayed_future_probe_raw),
+    );
     prj.add_test("TransactionForkMonadContext.t.sol", &source);
     prj.update_config(|config| {
         config.hardfork = Some("monad:MonadNine".parse().unwrap());
@@ -992,10 +990,14 @@ contract TransactionForkMonadContextTest {
 
 #[cfg(feature = "monad")]
 forgetest_async!(monad_fork_aux_lifecycle_tracks_outer_context, |prj, cmd| {
+    use alloy_consensus::SignableTransaction as _;
+    use alloy_network::{ReceiptResponse as _, TxSignerSync as _};
+    use alloy_provider::Provider as _;
+
     const CHAIN_ID: u64 = 31_337;
     const MAX_FEE_PER_GAS: u128 = 3_000_000_000;
 
-    let (api, handle) = spawn(NodeConfig::test()).await;
+    let (api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
     let provider = handle.http_provider();
     let wallets = handle.dev_wallets().collect::<Vec<_>>();
     let sender = wallets[0].address();
@@ -1004,44 +1006,44 @@ forgetest_async!(monad_fork_aux_lifecycle_tracks_outer_context, |prj, cmd| {
     let marker_recipient = wallets[4].address();
     let target_recipient = wallets[5].address();
     let receiver = wallets[6].address();
-    let later_marker_recipient = Address::with_last_byte(0x30);
-    let later_replay_recipient = Address::with_last_byte(0x31);
-    let later_target_recipient = Address::with_last_byte(0x32);
+    let later_marker_recipient = alloy_primitives::Address::with_last_byte(0x30);
+    let later_replay_recipient = alloy_primitives::Address::with_last_byte(0x31);
+    let later_target_recipient = alloy_primitives::Address::with_last_byte(0x32);
     let fresh_block = provider.get_block_number().await.unwrap();
 
-    let mut marker_tx = TxEip1559 {
+    let mut marker_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: 21_000,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 2_000_000_000,
-        to: TxKind::Call(marker_recipient),
-        value: U256::ONE,
+        to: alloy_primitives::TxKind::Call(marker_recipient),
+        value: alloy_primitives::U256::ONE,
         ..Default::default()
     };
     let signature = wallets[0].sign_transaction_sync(&mut marker_tx).unwrap();
     let mut marker_raw = Vec::new();
     marker_tx.into_signed(signature).eip2718_encode(&mut marker_raw);
 
-    let mut target_tx = TxEip1559 {
+    let mut target_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: 21_000,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 1_000_000_000,
-        to: TxKind::Call(target_recipient),
-        value: U256::ONE,
+        to: alloy_primitives::TxKind::Call(target_recipient),
+        value: alloy_primitives::U256::ONE,
         ..Default::default()
     };
     let signature = wallets[1].sign_transaction_sync(&mut target_tx).unwrap();
     let mut target_raw = Vec::new();
     target_tx.into_signed(signature).eip2718_encode(&mut target_raw);
 
-    let mut credit_tx = TxEip1559 {
+    let mut credit_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: 21_000,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 1_000_000_000,
-        to: TxKind::Call(spender),
-        value: U256::from(3_000_000_000_000_000_000u128),
+        to: alloy_primitives::TxKind::Call(spender),
+        value: alloy_primitives::U256::from(3_000_000_000_000_000_000u128),
         ..Default::default()
     };
     let signature = wallets[2].sign_transaction_sync(&mut credit_tx).unwrap();
@@ -1063,39 +1065,39 @@ forgetest_async!(monad_fork_aux_lifecycle_tracks_outer_context, |prj, cmd| {
     assert_eq!(target_receipt.block_number(), Some(restricted_block));
     assert_eq!(target_receipt.transaction_index(), Some(1));
 
-    let mut later_marker_tx = TxEip1559 {
+    let mut later_marker_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: 21_000,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 2_000_000_000,
-        to: TxKind::Call(later_marker_recipient),
-        value: U256::ONE,
+        to: alloy_primitives::TxKind::Call(later_marker_recipient),
+        value: alloy_primitives::U256::ONE,
         ..Default::default()
     };
     let signature = wallets[7].sign_transaction_sync(&mut later_marker_tx).unwrap();
     let mut later_marker_raw = Vec::new();
     later_marker_tx.into_signed(signature).eip2718_encode(&mut later_marker_raw);
 
-    let mut later_replay_tx = TxEip1559 {
+    let mut later_replay_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: 21_000,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 1_000_000_000,
-        to: TxKind::Call(later_replay_recipient),
-        value: U256::ONE,
+        to: alloy_primitives::TxKind::Call(later_replay_recipient),
+        value: alloy_primitives::U256::ONE,
         ..Default::default()
     };
     let signature = wallets[8].sign_transaction_sync(&mut later_replay_tx).unwrap();
     let mut later_replay_raw = Vec::new();
     later_replay_tx.into_signed(signature).eip2718_encode(&mut later_replay_raw);
 
-    let mut later_target_tx = TxEip1559 {
+    let mut later_target_tx = alloy_consensus::TxEip1559 {
         chain_id: CHAIN_ID,
         gas_limit: 21_000,
         max_fee_per_gas: MAX_FEE_PER_GAS,
         max_priority_fee_per_gas: 1_000_000_000,
-        to: TxKind::Call(later_target_recipient),
-        value: U256::ONE,
+        to: alloy_primitives::TxKind::Call(later_target_recipient),
+        value: alloy_primitives::U256::ONE,
         ..Default::default()
     };
     let signature = wallets[9].sign_transaction_sync(&mut later_target_tx).unwrap();
@@ -1122,36 +1124,40 @@ forgetest_async!(monad_fork_aux_lifecycle_tracks_outer_context, |prj, cmd| {
 
     let upstream = handle.http_endpoint();
     let failing_replay_hash_string = later_replay_hash.to_string();
-    let block_requests_armed = Arc::new(AtomicBool::new(false));
-    let block_requests = Arc::new(AtomicUsize::new(0));
-    let corrupt_replay_chain_id = Arc::new(AtomicBool::new(false));
+    let block_requests_armed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let block_requests = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let corrupt_replay_chain_id = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let client = reqwest::Client::new();
-    let proxy_armed = Arc::clone(&block_requests_armed);
-    let proxy_requests = Arc::clone(&block_requests);
-    let proxy_corrupt_chain_id = Arc::clone(&corrupt_replay_chain_id);
-    let app = Router::new().fallback(move |body: BodyBytes| {
+    let proxy_armed = std::sync::Arc::clone(&block_requests_armed);
+    let proxy_requests = std::sync::Arc::clone(&block_requests);
+    let proxy_corrupt_chain_id = std::sync::Arc::clone(&corrupt_replay_chain_id);
+    let app = axum::Router::new().fallback(move |body: axum::body::Bytes| {
         let upstream = upstream.clone();
         let failing_replay_hash = failing_replay_hash_string.clone();
         let client = client.clone();
-        let armed = Arc::clone(&proxy_armed);
-        let block_requests = Arc::clone(&proxy_requests);
-        let corrupt_chain_id = Arc::clone(&proxy_corrupt_chain_id);
+        let armed = std::sync::Arc::clone(&proxy_armed);
+        let block_requests = std::sync::Arc::clone(&proxy_requests);
+        let corrupt_chain_id = std::sync::Arc::clone(&proxy_corrupt_chain_id);
         async move {
-            let request: Value = serde_json::from_slice(&body).unwrap();
-            match request.get("method").and_then(Value::as_str) {
-                Some("test_armBlockRequests") => armed.store(true, Ordering::SeqCst),
-                Some("test_corruptReplayChainId") => corrupt_chain_id.store(true, Ordering::SeqCst),
+            let request: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            match request.get("method").and_then(serde_json::Value::as_str) {
+                Some("test_armBlockRequests") => {
+                    armed.store(true, std::sync::atomic::Ordering::SeqCst)
+                }
+                Some("test_corruptReplayChainId") => {
+                    corrupt_chain_id.store(true, std::sync::atomic::Ordering::SeqCst)
+                }
                 Some("test_restoreReplayChainId") => {
-                    corrupt_chain_id.store(false, Ordering::SeqCst)
+                    corrupt_chain_id.store(false, std::sync::atomic::Ordering::SeqCst)
                 }
                 _ => {
-                    if armed.load(Ordering::SeqCst) {
+                    if armed.load(std::sync::atomic::Ordering::SeqCst) {
                         let count = request.as_array().map_or_else(
                             || {
                                 usize::from(
                                     request
                                         .get("method")
-                                        .and_then(Value::as_str)
+                                        .and_then(serde_json::Value::as_str)
                                         .is_some_and(|method| method.starts_with("eth_getBlockBy")),
                                 )
                             },
@@ -1159,14 +1165,17 @@ forgetest_async!(monad_fork_aux_lifecycle_tracks_outer_context, |prj, cmd| {
                                 requests
                                     .iter()
                                     .filter(|request| {
-                                        request.get("method").and_then(Value::as_str).is_some_and(
-                                            |method| method.starts_with("eth_getBlockBy"),
-                                        )
+                                        request
+                                            .get("method")
+                                            .and_then(serde_json::Value::as_str)
+                                            .is_some_and(|method| {
+                                                method.starts_with("eth_getBlockBy")
+                                            })
                                     })
                                     .count()
                             },
                         );
-                        block_requests.fetch_add(count, Ordering::SeqCst);
+                        block_requests.fetch_add(count, std::sync::atomic::Ordering::SeqCst);
                     }
 
                     let response = client
@@ -1179,20 +1188,21 @@ forgetest_async!(monad_fork_aux_lifecycle_tracks_outer_context, |prj, cmd| {
                         .bytes()
                         .await
                         .unwrap();
-                    if !corrupt_chain_id.load(Ordering::SeqCst) {
+                    if !corrupt_chain_id.load(std::sync::atomic::Ordering::SeqCst) {
                         return response;
                     }
 
-                    let mut response: Value = serde_json::from_slice(&response).unwrap();
+                    let mut response: serde_json::Value =
+                        serde_json::from_slice(&response).unwrap();
                     override_rpc_transaction_chain_id(&mut response, &failing_replay_hash, "0x1");
-                    return BodyBytes::from(serde_json::to_vec(&response).unwrap());
+                    return axum::body::Bytes::from(serde_json::to_vec(&response).unwrap());
                 }
             }
 
-            BodyBytes::from(
-                serde_json::to_vec(&json!({
+            axum::body::Bytes::from(
+                serde_json::to_vec(&serde_json::json!({
                     "jsonrpc": "2.0",
-                    "id": request.get("id").cloned().unwrap_or(Value::Null),
+                    "id": request.get("id").cloned().unwrap_or(serde_json::Value::Null),
                     "result": "0x",
                 }))
                 .unwrap(),
@@ -1577,7 +1587,7 @@ contract MonadForkAuxLifecycleTest {
     .replace("<marker_hash>", &marker_hash.to_string())
     .replace("<target_hash>", &target_hash.to_string())
     .replace("<later_target_hash>", &later_target_hash.to_string())
-    .replace("<credit_raw>", &hex::encode(credit_raw));
+    .replace("<credit_raw>", &alloy_primitives::hex::encode(credit_raw));
     prj.add_test("MonadForkAuxLifecycle.t.sol", &source);
     prj.update_config(|config| {
         config.hardfork = Some("monad:MonadNine".parse().unwrap());
@@ -1587,8 +1597,8 @@ contract MonadForkAuxLifecycleTest {
     cmd.args(["test", "--network", "monad", "--mc", "MonadForkAuxLifecycleTest", "--threads", "1"])
         .assert_success();
 
-    block_requests_armed.store(false, Ordering::SeqCst);
-    block_requests.store(0, Ordering::SeqCst);
+    block_requests_armed.store(false, std::sync::atomic::Ordering::SeqCst);
+    block_requests.store(0, std::sync::atomic::Ordering::SeqCst);
     cmd.forge_fuse()
         .args([
             "test",
@@ -1600,7 +1610,11 @@ contract MonadForkAuxLifecycleTest {
             "test_fork_select_same_id_preserves_tracker",
         ])
         .assert_success();
-    assert_eq!(block_requests.load(Ordering::SeqCst), 0, "same-active select fetched a block");
+    assert_eq!(
+        block_requests.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "same-active select fetched a block"
+    );
 
     cmd.forge_fuse()
         .args([
@@ -1618,21 +1632,29 @@ contract MonadForkAuxLifecycleTest {
 
 #[cfg(feature = "monad")]
 forgetest_async!(transact_replays_monad_protocol_system_target_forks, |prj, cmd| {
-    const SYSTEM_ADDRESS: Address = address!("0x6f49a8F621353f12378d0046E7d7e4b9B249DC9e");
-    const STAKING_ADDRESS: Address = address!("0x0000000000000000000000000000000000001000");
-    const BLOCK_AUTHOR: Address = address!("0x1111111111111111111111111111111111111111");
-    const VALIDATOR_AUTH: Address = address!("0x2222222222222222222222222222222222222222");
-    const UNKNOWN_BLOCK_AUTHOR: Address = address!("0x3333333333333333333333333333333333333333");
+    use alloy_network::{ReceiptResponse as _, TransactionBuilder as _};
+    use alloy_provider::Provider as _;
+
+    const SYSTEM_ADDRESS: alloy_primitives::Address =
+        alloy_primitives::address!("0x6f49a8F621353f12378d0046E7d7e4b9B249DC9e");
+    const STAKING_ADDRESS: alloy_primitives::Address =
+        alloy_primitives::address!("0x0000000000000000000000000000000000001000");
+    const BLOCK_AUTHOR: alloy_primitives::Address =
+        alloy_primitives::address!("0x1111111111111111111111111111111111111111");
+    const VALIDATOR_AUTH: alloy_primitives::Address =
+        alloy_primitives::address!("0x2222222222222222222222222222222222222222");
+    const UNKNOWN_BLOCK_AUTHOR: alloy_primitives::Address =
+        alloy_primitives::address!("0x3333333333333333333333333333333333333333");
     const VALIDATOR_ID: u64 = 7;
 
-    let (api, handle) = spawn(NodeConfig::test()).await;
+    let (api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
     let provider = handle.http_provider();
-    let mon = U256::from(1_000_000_000_000_000_000u128);
-    let reward = U256::from(25) * mon;
-    let initial_system_balance = U256::from(100) * mon;
-    let initial_staking_balance = U256::from(3) * mon;
+    let mon = alloy_primitives::U256::from(1_000_000_000_000_000_000u128);
+    let reward = alloy_primitives::U256::from(25) * mon;
+    let initial_system_balance = alloy_primitives::U256::from(100) * mon;
+    let initial_staking_balance = alloy_primitives::U256::from(3) * mon;
     api.anvil_impersonate_account(SYSTEM_ADDRESS).await.unwrap();
-    api.anvil_set_nonce(SYSTEM_ADDRESS, U256::from(11)).await.unwrap();
+    api.anvil_set_nonce(SYSTEM_ADDRESS, alloy_primitives::U256::from(11)).await.unwrap();
     api.anvil_set_balance(SYSTEM_ADDRESS, initial_system_balance).await.unwrap();
     api.anvil_set_balance(STAKING_ADDRESS, initial_staking_balance).await.unwrap();
     api.anvil_set_storage_at(
@@ -1645,14 +1667,14 @@ forgetest_async!(transact_replays_monad_protocol_system_target_forks, |prj, cmd|
     api.anvil_set_storage_at(
         STAKING_ADDRESS,
         monad_staking_validator_key(0x04, VALIDATOR_ID, 0),
-        storage_value(U256::from(100) * mon),
+        storage_value(alloy_primitives::U256::from(100) * mon),
     )
     .await
     .unwrap();
     api.anvil_set_storage_at(
         STAKING_ADDRESS,
         monad_staking_validator_key(0x04, VALIDATOR_ID, 1),
-        B256::ZERO,
+        alloy_primitives::B256::ZERO,
     )
     .await
     .unwrap();
@@ -1667,22 +1689,27 @@ forgetest_async!(transact_replays_monad_protocol_system_target_forks, |prj, cmd|
     api.mine_one().await.unwrap();
     let parent_block = provider.get_block_number().await.unwrap();
 
-    let request = <Ethereum as Network>::TransactionRequest::default()
-        .with_from(SYSTEM_ADDRESS)
-        .with_to(STAKING_ADDRESS)
-        .with_value(reward)
-        .with_input(monad_staking_reward_input(BLOCK_AUTHOR))
-        .with_gas_limit(1_000_000)
-        .with_gas_price(2_000_000_000);
+    let request =
+        <alloy_network::Ethereum as alloy_network::Network>::TransactionRequest::default()
+            .with_from(SYSTEM_ADDRESS)
+            .with_to(STAKING_ADDRESS)
+            .with_value(reward)
+            .with_input(monad_staking_reward_input(BLOCK_AUTHOR))
+            .with_gas_limit(1_000_000)
+            .with_gas_price(2_000_000_000);
     let receipt =
         provider.send_transaction(request.into()).await.unwrap().get_receipt().await.unwrap();
     assert!(receipt.status());
     assert_eq!(receipt.block_number(), Some(parent_block + 1));
 
     let target_hash = receipt.transaction_hash;
-    let endpoint = spawn_canonical_monad_system_rpc(handle.http_endpoint(), target_hash).await;
+    let endpoint = foundry_test_utils::rpc::spawn_canonical_monad_system_rpc(
+        handle.http_endpoint(),
+        target_hash,
+    )
+    .await;
     let transaction =
-        rpc_request(&endpoint, "eth_getTransactionByHash", json!([target_hash])).await;
+        rpc_request(&endpoint, "eth_getTransactionByHash", serde_json::json!([target_hash])).await;
     assert_eq!(transaction["result"]["gas"], "0x0");
     assert_eq!(transaction["result"]["gasPrice"], "0x0");
     assert_ne!(transaction["result"]["r"], "0x0");
@@ -1692,7 +1719,7 @@ forgetest_async!(transact_replays_monad_protocol_system_target_forks, |prj, cmd|
     assert_eq!(transaction["result"]["value"], format!("{reward:#x}"));
 
     let canonical_receipt =
-        rpc_request(&endpoint, "eth_getTransactionReceipt", json!([target_hash])).await;
+        rpc_request(&endpoint, "eth_getTransactionReceipt", serde_json::json!([target_hash])).await;
     assert_eq!(canonical_receipt["result"]["status"], "0x1");
     assert_eq!(canonical_receipt["result"]["gasUsed"], "0x0");
     assert_eq!(canonical_receipt["result"]["effectiveGasPrice"], "0x0");
@@ -1700,7 +1727,7 @@ forgetest_async!(transact_replays_monad_protocol_system_target_forks, |prj, cmd|
     let target_block = rpc_request(
         &endpoint,
         "eth_getBlockByNumber",
-        json!([format!("{:#x}", parent_block + 1), true]),
+        serde_json::json!([format!("{:#x}", parent_block + 1), true]),
     )
     .await;
     assert_ne!(target_block["result"]["baseFeePerGas"], "0x0");
@@ -1711,21 +1738,22 @@ forgetest_async!(transact_replays_monad_protocol_system_target_forks, |prj, cmd|
     assert_eq!(target_block["result"]["transactions"][0]["s"], transaction["result"]["s"]);
     assert_eq!(target_block["result"]["transactions"][0]["v"], transaction["result"]["v"]);
 
-    let (failed_api, failed_handle) = spawn(NodeConfig::test()).await;
+    let (failed_api, failed_handle) = anvil::spawn(anvil::NodeConfig::test()).await;
     let failed_provider = failed_handle.http_provider();
     failed_api.anvil_impersonate_account(SYSTEM_ADDRESS).await.unwrap();
-    failed_api.anvil_set_nonce(SYSTEM_ADDRESS, U256::from(11)).await.unwrap();
+    failed_api.anvil_set_nonce(SYSTEM_ADDRESS, alloy_primitives::U256::from(11)).await.unwrap();
     failed_api.anvil_set_balance(SYSTEM_ADDRESS, initial_system_balance).await.unwrap();
     failed_api.anvil_set_balance(STAKING_ADDRESS, initial_staking_balance).await.unwrap();
     failed_api.mine_one().await.unwrap();
     let failed_parent_block = failed_provider.get_block_number().await.unwrap();
-    let failed_request = <Ethereum as Network>::TransactionRequest::default()
-        .with_from(SYSTEM_ADDRESS)
-        .with_to(STAKING_ADDRESS)
-        .with_value(reward)
-        .with_input(monad_staking_reward_input(UNKNOWN_BLOCK_AUTHOR))
-        .with_gas_limit(1_000_000)
-        .with_gas_price(2_000_000_000);
+    let failed_request =
+        <alloy_network::Ethereum as alloy_network::Network>::TransactionRequest::default()
+            .with_from(SYSTEM_ADDRESS)
+            .with_to(STAKING_ADDRESS)
+            .with_value(reward)
+            .with_input(monad_staking_reward_input(UNKNOWN_BLOCK_AUTHOR))
+            .with_gas_limit(1_000_000)
+            .with_gas_price(2_000_000_000);
     let failed_receipt = failed_provider
         .send_transaction(failed_request.into())
         .await
@@ -1736,8 +1764,11 @@ forgetest_async!(transact_replays_monad_protocol_system_target_forks, |prj, cmd|
     assert!(failed_receipt.status());
     assert_eq!(failed_receipt.block_number(), Some(failed_parent_block + 1));
     let failed_target_hash = failed_receipt.transaction_hash;
-    let failed_endpoint =
-        spawn_canonical_monad_system_rpc(failed_handle.http_endpoint(), failed_target_hash).await;
+    let failed_endpoint = foundry_test_utils::rpc::spawn_canonical_monad_system_rpc(
+        failed_handle.http_endpoint(),
+        failed_target_hash,
+    )
+    .await;
 
     let source = r#"
 interface Vm {

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -23,8 +23,6 @@ use foundry_common::{
 };
 use foundry_config::{Chain, NamedChain};
 use foundry_debugger::Debugger;
-#[cfg(feature = "monad")]
-use foundry_evm::hardforks::MonadHardfork;
 use foundry_evm::{
     core::evm::FoundryEvmNetwork,
     decode::decode_console_logs,
@@ -465,8 +463,10 @@ pub(crate) fn build_trace_decoder_for_context<FEN: FoundryEvmNetwork>(
         .with_tempo_hardfork(resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork));
     #[cfg(feature = "monad")]
     {
-        builder = builder
-            .with_monad_hardfork(resolved_hardfork.and_then(MonadHardfork::from_foundry_hardfork));
+        builder = builder.with_monad_hardfork(
+            resolved_hardfork
+                .and_then(foundry_evm::hardforks::MonadHardfork::from_foundry_hardfork),
+        );
     }
     let mut decoder = builder.build();
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -46,8 +46,6 @@ use foundry_config::{
     },
 };
 use foundry_debugger::DebuggerLayout;
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::MonadEvmNetwork;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -413,7 +411,12 @@ impl ScriptArgs {
 
         #[cfg(feature = "monad")]
         if evm_opts.networks.is_monad() {
-            return Box::pin(self.run_generic_script::<MonadEvmNetwork>(config, evm_opts)).await;
+            return Box::pin(
+                self.run_generic_script::<foundry_evm::core::evm::MonadEvmNetwork>(
+                    config, evm_opts,
+                ),
+            )
+            .await;
         }
 
         #[cfg(feature = "optimism")]
@@ -1152,8 +1155,6 @@ mod tests {
         upsert_session_entry,
     };
     use foundry_config::UnresolvedEnvVarError;
-    #[cfg(feature = "monad")]
-    use foundry_evm::hardforks::MonadHardfork;
     use foundry_evm::{
         revm::context::Block as _,
         traces::{
@@ -1919,7 +1920,7 @@ mod tests {
         let (_origin_api, origin_handle) = spawn(
             NodeConfig::test_monad()
                 .with_chain_id(Some(NamedChain::MonadTestnet as u64))
-                .with_hardfork(Some(MonadHardfork::MonadNine.into())),
+                .with_hardfork(Some(foundry_evm::hardforks::MonadHardfork::MonadNine.into())),
         )
         .await;
         let (_fork_api, fork_handle) = spawn(
@@ -1934,7 +1935,7 @@ mod tests {
             EvmOpts { fork_url: Some(fork_handle.http_endpoint()), ..Default::default() };
         evm_opts.infer_network_from_fork().await.unwrap();
         let config = Config { networks: evm_opts.networks, ..Default::default() };
-        let mut script = ScriptConfig::<MonadEvmNetwork>::new(
+        let mut script = ScriptConfig::<foundry_evm::core::evm::MonadEvmNetwork>::new(
             config,
             evm_opts,
             false,
@@ -1947,7 +1948,10 @@ mod tests {
         let _runner = script._get_runner(None, false, false).await.unwrap();
 
         assert_eq!(script.source_chain_id, Some(NamedChain::MonadTestnet as u64));
-        assert_eq!(script.hardfork, Some(FoundryHardfork::Monad(MonadHardfork::MonadNine)));
+        assert_eq!(
+            script.hardfork,
+            Some(FoundryHardfork::Monad(foundry_evm::hardforks::MonadHardfork::MonadNine))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2323,7 +2327,10 @@ mod tests {
             ScriptArgs::parse_from(["foundry-cli", "script", "script/Test.s.sol:TestScript"]);
         let evm_opts = EvmOpts { networks: NetworkConfigs::with_monad(), ..Default::default() };
 
-        let limits = args.contract_size_limits::<MonadEvmNetwork>(&Config::default(), &evm_opts);
+        let limits = args.contract_size_limits::<foundry_evm::core::evm::MonadEvmNetwork>(
+            &Config::default(),
+            &evm_opts,
+        );
 
         assert!(limits.runtime > ContractSizeLimits::default().runtime);
         assert!(limits.initcode > ContractSizeLimits::default().initcode);
@@ -2342,7 +2349,9 @@ mod tests {
         let mut config = Config { code_size_limit: Some(128), ..Default::default() };
         let evm_opts = EvmOpts { networks: NetworkConfigs::with_monad(), ..Default::default() };
         assert_eq!(
-            args.contract_size_limits::<MonadEvmNetwork>(&config, &evm_opts),
+            args.contract_size_limits::<foundry_evm::core::evm::MonadEvmNetwork>(
+                &config, &evm_opts,
+            ),
             ContractSizeLimits::with_runtime_limit(64)
         );
 
@@ -2350,7 +2359,9 @@ mod tests {
             ScriptArgs::parse_from(["foundry-cli", "script", "script/Test.s.sol:TestScript"]);
         config.code_size_limit = Some(128);
         assert_eq!(
-            args.contract_size_limits::<MonadEvmNetwork>(&config, &evm_opts),
+            args.contract_size_limits::<foundry_evm::core::evm::MonadEvmNetwork>(
+                &config, &evm_opts,
+            ),
             ContractSizeLimits::with_runtime_limit(128)
         );
     }

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -32,8 +32,6 @@ use foundry_common::{
 };
 use foundry_compilers::info::ContractInfo;
 use foundry_config::{Chain, Config, figment, impl_figment_convert};
-#[cfg(feature = "monad")]
-use foundry_evm::core::evm::MonadEvmNetwork;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -276,7 +274,7 @@ impl VerifyBytecodeArgs {
             }
             #[cfg(feature = "monad")]
             NetworkVariant::Monad => {
-                self.run_with_network_and_config::<MonadEvmNetwork>(
+                self.run_with_network_and_config::<foundry_evm::core::evm::MonadEvmNetwork>(
                     config,
                     endpoint_identity,
                     network_was_inferred,

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -575,27 +575,22 @@ mod tests {
     use crate::verify::VerifierArgs;
     use foundry_cli::opts::EtherscanOpts;
     use foundry_compilers::PathStyle;
-    #[cfg(feature = "monad")]
-    use foundry_compilers::artifacts::EvmVersion;
     use foundry_config::NamedChain;
-    #[cfg(feature = "monad")]
-    use foundry_evm::{
-        core::{FoundryTransaction as _, evm::MonadEvmNetwork},
-        hardforks::MonadHardfork,
-    };
     use foundry_test_utils::TestProject;
 
     #[cfg(feature = "monad")]
-    fn monad_env(timestamp: u64) -> EvmEnvFor<MonadEvmNetwork> {
-        let mut env = EvmEnvFor::<MonadEvmNetwork>::default();
+    fn monad_env(timestamp: u64) -> EvmEnvFor<foundry_evm::core::evm::MonadEvmNetwork> {
+        let mut env = EvmEnvFor::<foundry_evm::core::evm::MonadEvmNetwork>::default();
         env.cfg_env.chain_id = NamedChain::Monad as u64;
         env.block_env.set_timestamp(U256::from(timestamp));
         env
     }
 
     #[cfg(feature = "monad")]
-    fn monad_tx(caller: Address) -> TxEnvFor<MonadEvmNetwork> {
-        let mut tx = TxEnvFor::<MonadEvmNetwork>::default();
+    fn monad_tx(caller: Address) -> TxEnvFor<foundry_evm::core::evm::MonadEvmNetwork> {
+        use foundry_evm::core::FoundryTransaction as _;
+
+        let mut tx = TxEnvFor::<foundry_evm::core::evm::MonadEvmNetwork>::default();
         tx.set_caller(caller);
         tx
     }
@@ -660,12 +655,17 @@ contract Broken {
     #[test]
     #[cfg(feature = "monad")]
     fn runtime_spec_uses_monad_source_chain_timestamp() {
-        let monad_nine_timestamp = MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+        let monad_nine_timestamp = foundry_evm::hardforks::MonadHardfork::MonadNine
+            .mainnet_activation_timestamp()
+            .unwrap();
 
-        let before_config = Config { evm_version: EvmVersion::Osaka, ..Default::default() };
+        let before_config = Config {
+            evm_version: foundry_compilers::artifacts::EvmVersion::Osaka,
+            ..Default::default()
+        };
         let mut before_env = monad_env(monad_nine_timestamp - 1);
         before_env.cfg_env.chain_id = NamedChain::Mainnet as u64;
-        let before = resolve_runtime_spec::<MonadEvmNetwork>(
+        let before = resolve_runtime_spec::<foundry_evm::core::evm::MonadEvmNetwork>(
             &before_config,
             NetworkConfigs::with_monad(),
             NamedChain::Monad as u64,
@@ -673,13 +673,19 @@ contract Broken {
             &mut before_env,
         );
 
-        assert_eq!(before, Some(FoundryHardfork::Monad(MonadHardfork::MonadEight)));
-        assert_eq!(before_env.cfg_env.spec, MonadHardfork::MonadEight);
+        assert_eq!(
+            before,
+            Some(FoundryHardfork::Monad(foundry_evm::hardforks::MonadHardfork::MonadEight))
+        );
+        assert_eq!(before_env.cfg_env.spec, foundry_evm::hardforks::MonadHardfork::MonadEight);
         assert_eq!(before_env.cfg_env.chain_id, NamedChain::Mainnet as u64);
 
-        let after_config = Config { evm_version: EvmVersion::Prague, ..Default::default() };
+        let after_config = Config {
+            evm_version: foundry_compilers::artifacts::EvmVersion::Prague,
+            ..Default::default()
+        };
         let mut after_env = monad_env(monad_nine_timestamp);
-        let after = resolve_runtime_spec::<MonadEvmNetwork>(
+        let after = resolve_runtime_spec::<foundry_evm::core::evm::MonadEvmNetwork>(
             &after_config,
             NetworkConfigs::with_monad(),
             NamedChain::Monad as u64,
@@ -687,33 +693,45 @@ contract Broken {
             &mut after_env,
         );
 
-        assert_eq!(after, Some(FoundryHardfork::Monad(MonadHardfork::MonadNine)));
-        assert_eq!(after_env.cfg_env.spec, MonadHardfork::MonadNine);
+        assert_eq!(
+            after,
+            Some(FoundryHardfork::Monad(foundry_evm::hardforks::MonadHardfork::MonadNine))
+        );
+        assert_eq!(after_env.cfg_env.spec, foundry_evm::hardforks::MonadHardfork::MonadNine);
     }
 
     #[test]
     #[cfg(feature = "monad")]
     fn runtime_spec_and_labels_prefer_explicit_monad_hardfork() {
-        let mut config =
-            Config { hardfork: Some(MonadHardfork::MonadEight.into()), ..Default::default() };
-        let mut env = monad_env(MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap());
+        let mut config = Config {
+            hardfork: Some(foundry_evm::hardforks::MonadHardfork::MonadEight.into()),
+            ..Default::default()
+        };
+        let mut env = monad_env(
+            foundry_evm::hardforks::MonadHardfork::MonadNine
+                .mainnet_activation_timestamp()
+                .unwrap(),
+        );
         let networks = NetworkConfigs::with_monad();
 
-        let resolved = resolve_runtime_spec::<MonadEvmNetwork>(
+        let resolved = resolve_runtime_spec::<foundry_evm::core::evm::MonadEvmNetwork>(
             &config,
             networks,
             NamedChain::Monad as u64,
-            Some(MonadHardfork::MonadNine.into()),
+            Some(foundry_evm::hardforks::MonadHardfork::MonadNine.into()),
             &mut env,
         );
-        TracingExecutor::<MonadEvmNetwork>::extend_precompile_labels(
+        TracingExecutor::<foundry_evm::core::evm::MonadEvmNetwork>::extend_precompile_labels(
             &mut config,
             networks,
             resolved,
         );
 
-        assert_eq!(resolved, Some(FoundryHardfork::Monad(MonadHardfork::MonadEight)));
-        assert_eq!(env.cfg_env.spec, MonadHardfork::MonadEight);
+        assert_eq!(
+            resolved,
+            Some(FoundryHardfork::Monad(foundry_evm::hardforks::MonadHardfork::MonadEight))
+        );
+        assert_eq!(env.cfg_env.spec, foundry_evm::hardforks::MonadHardfork::MonadEight);
         assert!(config.labels.values().any(|label| label == "Staking"));
         assert!(!config.labels.values().any(|label| label == "ReserveBalance"));
     }
@@ -725,15 +743,17 @@ contract Broken {
         let child_grandparent = Address::repeat_byte(0x22);
         let child_parent = Address::repeat_byte(0x33);
         let synthetic_sender = Address::repeat_byte(0x44);
-        let context = BlockContext::<MonadEvmNetwork>::new(
+        let context = BlockContext::<foundry_evm::core::evm::MonadEvmNetwork>::new(
             vec![monad_tx(discarded_grandparent)],
             vec![monad_tx(child_grandparent)],
             vec![monad_tx(child_parent)],
         );
         let synthetic_tx = monad_tx(synthetic_sender);
 
-        let chain_context =
-            synthetic_deployment_context::<MonadEvmNetwork>(Some(&context), &synthetic_tx);
+        let chain_context = synthetic_deployment_context::<foundry_evm::core::evm::MonadEvmNetwork>(
+            Some(&context),
+            &synthetic_tx,
+        );
 
         assert!(chain_context.grandparent_senders_and_authorities.contains(&child_grandparent));
         assert!(chain_context.parent_senders_and_authorities.contains(&child_parent));
@@ -747,7 +767,10 @@ contract Broken {
         let synthetic_sender = Address::repeat_byte(0x44);
         let synthetic_tx = monad_tx(synthetic_sender);
 
-        let chain_context = synthetic_deployment_context::<MonadEvmNetwork>(None, &synthetic_tx);
+        let chain_context = synthetic_deployment_context::<foundry_evm::core::evm::MonadEvmNetwork>(
+            None,
+            &synthetic_tx,
+        );
 
         assert!(chain_context.grandparent_senders_and_authorities.is_empty());
         assert!(chain_context.parent_senders_and_authorities.is_empty());


### PR DESCRIPTION
Foundry had 93 `#[cfg(feature = "monad")]` import declarations scattered across 38 Rust files. This replaces ordinary imports with fully qualified paths at their gated use sites and moves method-resolution trait imports into the narrow feature-gated bodies that need them. The only two gated `use` declarations left are public re-exports that define feature-dependent API surfaces; paired feature-dependent type aliases remain where shared code needs a type in both configurations.

This is a mechanical cleanup with no intended behavior change. Optional Monad references remain behind their existing feature gates, while their dependencies are now visible where they are used.

AI assistance disclosure: Codex generated the implementation and this pull request description, reviewed the resulting diff, and ran the validation for this change.
