### PR TITLE
refactor(anvil): use native handler futures

### DIFF
--- a/.changelog/anvil-native-handler-futures.md
+++ b/.changelog/anvil-native-handler-futures.md
@@ -1,0 +1,6 @@
+---
+anvil: patch
+anvil-server: patch
+---
+
+Migrated Anvil RPC handlers from `async-trait` boxing to native Rust futures.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,7 +1356,6 @@ name = "anvil-server"
 version = "1.8.0"
 dependencies = [
  "anvil-rpc",
- "async-trait",
  "axum",
  "bytes",
  "clap",

--- a/crates/anvil/server/Cargo.toml
+++ b/crates/anvil/server/Cargo.toml
@@ -35,7 +35,6 @@ tokio-util = { version = "0.7", features = ["codec"], optional = true }
 # misc
 serde_json.workspace = true
 serde.workspace = true
-async-trait.workspace = true
 thiserror.workspace = true
 
 clap = { version = "4", features = ["derive", "env"], optional = true }

--- a/crates/anvil/server/src/handler.rs
+++ b/crates/anvil/server/src/handler.rs
@@ -130,7 +130,6 @@ mod tests {
     #[derive(Clone)]
     struct TypedHandler;
 
-    #[async_trait::async_trait]
     impl RpcHandler for TestHandler {
         type Request = serde_json::Value;
 
@@ -140,7 +139,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
     impl RpcHandler for TypedHandler {
         type Request = TypedRequest;
 

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -80,13 +80,12 @@ fn router_inner<S: Clone + Send + Sync + 'static>(
 }
 
 /// Helper trait that is used to execute ethereum rpc calls
-#[async_trait::async_trait]
 pub trait RpcHandler: Clone + Send + Sync + 'static {
     /// The request type to expect
     type Request: DeserializeOwned + Send + Sync + fmt::Debug;
 
     /// Invoked when the request was received
-    async fn on_request(&self, request: Self::Request) -> ResponseResult;
+    fn on_request(&self, request: Self::Request) -> impl Future<Output = ResponseResult> + Send;
 
     /// Invoked for every incoming [`RpcMethodCall`]. Notifications are adapted to method calls
     /// with an [`anvil_rpc::request::Id::Null`] identifier, and their responses are discarded.
@@ -97,33 +96,35 @@ pub trait RpcHandler: Clone + Send + Sync + 'static {
     ///
     /// **Note**: override this function if the expected `Request` deviates from `{ "method" :
     /// "<name>", "params": "<params>" }`
-    async fn on_call(&self, call: RpcMethodCall) -> RpcResponse {
-        trace!(target: "rpc",  id = ?call.id , method = ?call.method, params = ?call.params, "received method call");
-        let RpcMethodCall { method, params, id, .. } = call;
+    fn on_call(&self, call: RpcMethodCall) -> impl Future<Output = RpcResponse> + Send {
+        async move {
+            trace!(target: "rpc",  id = ?call.id , method = ?call.method, params = ?call.params, "received method call");
+            let RpcMethodCall { method, params, id, .. } = call;
 
-        let params: serde_json::Value = params.into();
-        let call = serde_json::json!({
-            "method": &method,
-            "params": params
-        });
+            let params: serde_json::Value = params.into();
+            let call = serde_json::json!({
+                "method": &method,
+                "params": params
+            });
 
-        match serde_json::from_value::<Self::Request>(call) {
-            Ok(req) => {
-                let result = self.on_request(req).await;
-                RpcResponse::new(id, result)
-            }
-            Err(err) => {
-                let err = err.to_string();
-                let method_not_found = serde_json::from_value::<Self::Request>(
-                    serde_json::json!({ "method": &method }),
-                )
-                .is_err_and(|err| err.to_string().contains("unknown variant"));
-                if method_not_found {
-                    error!(target: "rpc", ?method, "failed to deserialize method due to unknown variant");
-                    RpcResponse::new(id, RpcError::method_not_found())
-                } else {
-                    error!(target: "rpc", ?method, ?err, "failed to deserialize method");
-                    RpcResponse::new(id, RpcError::invalid_params(err))
+            match serde_json::from_value::<Self::Request>(call) {
+                Ok(req) => {
+                    let result = self.on_request(req).await;
+                    RpcResponse::new(id, result)
+                }
+                Err(err) => {
+                    let err = err.to_string();
+                    let method_not_found = serde_json::from_value::<Self::Request>(
+                        serde_json::json!({ "method": &method }),
+                    )
+                    .is_err_and(|err| err.to_string().contains("unknown variant"));
+                    if method_not_found {
+                        error!(target: "rpc", ?method, "failed to deserialize method due to unknown variant");
+                        RpcResponse::new(id, RpcError::method_not_found())
+                    } else {
+                        error!(target: "rpc", ?method, ?err, "failed to deserialize method");
+                        RpcResponse::new(id, RpcError::invalid_params(err))
+                    }
                 }
             }
         }

--- a/crates/anvil/server/src/pubsub.rs
+++ b/crates/anvil/server/src/pubsub.rs
@@ -18,7 +18,6 @@ use std::{
 };
 
 /// The general purpose trait for handling RPC requests and subscriptions
-#[async_trait::async_trait]
 pub trait PubSubRpcHandler: Clone + Send + Sync + Unpin + 'static {
     /// The request type to expect
     type Request: DeserializeOwned + Send + Sync + fmt::Debug;
@@ -28,7 +27,11 @@ pub trait PubSubRpcHandler: Clone + Send + Sync + Unpin + 'static {
     type Subscription: Stream<Item = serde_json::Value> + Send + Sync + Unpin;
 
     /// Invoked when the request was received
-    async fn on_request(&self, request: Self::Request, cx: PubSubContext<Self>) -> ResponseResult;
+    fn on_request(
+        &self,
+        request: Self::Request,
+        cx: PubSubContext<Self>,
+    ) -> impl Future<Output = ResponseResult> + Send;
 }
 
 type Subscriptions<SubscriptionId, Subscription> = Arc<Mutex<Vec<(SubscriptionId, Subscription)>>>;
@@ -97,12 +100,11 @@ impl<Handler: PubSubRpcHandler> Clone for ContextAwareHandler<Handler> {
     }
 }
 
-#[async_trait::async_trait]
 impl<Handler: PubSubRpcHandler> RpcHandler for ContextAwareHandler<Handler> {
     type Request = Handler::Request;
 
-    async fn on_request(&self, request: Self::Request) -> ResponseResult {
-        self.handler.on_request(request, self.context.clone()).await
+    fn on_request(&self, request: Self::Request) -> impl Future<Output = ResponseResult> + Send {
+        self.handler.on_request(request, self.context.clone())
     }
 }
 
@@ -281,7 +283,6 @@ mod tests {
         requests: Arc<AtomicUsize>,
     }
 
-    #[async_trait::async_trait]
     impl PubSubRpcHandler for TestHandler {
         type Request = serde_json::Value;
         type SubscriptionId = u64;

--- a/crates/anvil/src/server/rpc_handlers.rs
+++ b/crates/anvil/src/server/rpc_handlers.rs
@@ -27,12 +27,11 @@ impl HttpEthRpcHandler {
     }
 }
 
-#[async_trait::async_trait]
 impl RpcHandler for HttpEthRpcHandler {
     type Request = EthRequest;
 
-    async fn on_request(&self, request: Self::Request) -> ResponseResult {
-        self.api.execute(request).await
+    fn on_request(&self, request: Self::Request) -> impl Future<Output = ResponseResult> + Send {
+        self.api.execute(request)
     }
 }
 
@@ -148,7 +147,6 @@ impl PubSubEthRpcHandler {
     }
 }
 
-#[async_trait::async_trait]
 impl PubSubRpcHandler for PubSubEthRpcHandler {
     type Request = EthRpcCall;
     type SubscriptionId = SubscriptionId;


### PR DESCRIPTION
Replaces the `async-trait`-based `RpcHandler` and `PubSubRpcHandler` methods with native `impl Future + Send` return types. Concrete handlers either forward their existing future directly or use native `async fn`, eliminating boxed handler futures and allowing `anvil-server` to drop its `async-trait` dependency.

This is an independent modernization now supported by the workspace MSRV. It builds on the recursion-limit adjustment in #16326, which lets the latest nightly prove the native pub-sub future is `Send` without a crate-wide lint allowance.

This PR was written with Codex, including code generation and validation.
