### PR TITLE
fix(fuzz): include final repeat endpoint

### DIFF
--- a/.changelog/include-invariant-repeat-endpoint.md
+++ b/.changelog/include-invariant-repeat-endpoint.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-fuzz: patch
+---
+
+Allow invariant fuzz repeat mutations to include the final transaction.

--- a/crates/evm/fuzz/src/sequence.rs
+++ b/crates/evm/fuzz/src/sequence.rs
@@ -453,7 +453,7 @@ impl SequenceMutator {
     fn repeat(sequence: &[BasicTxDetails], runner: &mut TestRunner) -> Vec<BasicTxDetails> {
         let rng = runner.rng();
         let start = rng.random_range(0..sequence.len());
-        let end = rng.random_range(start..sequence.len());
+        let end = rng.random_range(start..=sequence.len());
         let repeated = sequence[rng.random_range(0..sequence.len())].clone();
         let mut result = Vec::with_capacity(sequence.len());
         result.extend_from_slice(&sequence[..start]);
@@ -747,6 +747,20 @@ mod tests {
             selected_second_final,
             "splice never selected the second entry's final transaction"
         );
+    }
+
+    #[test]
+    fn repeat_can_replace_final_transaction() {
+        let sequence = [tx(1), tx(2)];
+        let mut runner = TestRunner::deterministic();
+        let mut replaced_final = false;
+
+        for _ in 0..1000 {
+            let result = SequenceMutator::repeat(&sequence, &mut runner);
+            replaced_final |= result[1].sender != sequence[1].sender;
+        }
+
+        assert!(replaced_final, "repeat never replaced the final transaction");
     }
 
     #[test]


### PR DESCRIPTION
The repeat corpus mutator chose its exclusive end from `start..sequence.len()`, which meant the final transaction could never be part of the replaced range. Selecting the final index as the start also guaranteed a no-op mutation.

Allow the end to reach `sequence.len()` and add a deterministic regression test for final-transaction replacement. This preserves the sequence length and the existing repeated-transaction selection behavior.

This is the corresponding repeat-path follow-up to #16320, which fixed endpoint exclusion in splice mutations.

AI assistance disclosure: I used Codex to audit the recent fuzz mutator changes and help prepare this patch.
