### PR TITLE
fix(ci): skip Tempo checks for Dependabot

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -39,10 +39,11 @@ env:
 
 jobs:
   tempo-check:
-    # Skip on PRs from forks (only run for branches in foundry-rs/foundry, i.e. maintainer PRs).
+    # Skip on PRs from forks and Dependabot, which cannot access the RPC secrets.
     if: |
       github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
Dependabot pull requests cannot access repository RPC secrets, so the Tempo workflow receives an empty devnet URL and fails deterministically. This skips the secret-dependent Tempo job for Dependabot while preserving it for maintainer branches, pushes, schedules, and manual runs.

This CI-only change requires the `L-ignore` label instead of a changelog entry.

This PR was authored with Codex.

Prompted by: @DaniPopes