### PR TITLE
refactor(anvil): isolate header construction

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -210,6 +210,35 @@ use tempo_revm::{
 };
 use tokio::{sync::RwLock as AsyncRwLock, task::JoinSet};
 
+/// Creates an Ethereum-shaped genesis header from the EVM environment.
+fn genesis_header(
+    evm_env: &EvmEnv,
+    base_fee: Option<u64>,
+    timestamp: u64,
+    genesis_number: u64,
+) -> Header {
+    let spec_id = *evm_env.spec_id();
+    Header {
+        timestamp,
+        base_fee_per_gas: base_fee,
+        gas_limit: evm_env.block_env.gas_limit,
+        beneficiary: evm_env.block_env.beneficiary,
+        difficulty: evm_env.block_env.difficulty,
+        blob_gas_used: evm_env.block_env.blob_excess_gas_and_price.as_ref().map(|_| 0),
+        excess_blob_gas: evm_env.block_env.blob_excess_gas(),
+        number: genesis_number,
+        parent_beacon_block_root: (spec_id >= SpecId::CANCUN).then_some(Default::default()),
+        withdrawals_root: (spec_id >= SpecId::SHANGHAI).then_some(EMPTY_WITHDRAWALS),
+        requests_hash: (spec_id >= SpecId::PRAGUE).then_some(EMPTY_REQUESTS_HASH),
+        ..Default::default()
+    }
+}
+
+/// Wraps an Ethereum-shaped header in the selected network's consensus header.
+fn foundry_header(networks: &NetworkConfigs, header: Header) -> FoundryHeader {
+    if networks.is_tempo() { FoundryHeader::tempo(header) } else { header.into() }
+}
+
 /// Side-channel container for OP-specific deposit info produced by
 /// [`Backend::build_call_env_with_base`] and consumed by the OP transact path.
 ///
@@ -3876,13 +3905,13 @@ impl<N: Network> Backend<N> {
             trace!(target: "backend", "using forked blockchain at {}", fork.block_number());
             Blockchain::forked(fork.block_number(), fork.block_hash(), fork.total_difficulty())
         } else {
-            Blockchain::new(
+            let header = genesis_header(
                 &env.read(),
                 fees.is_eip1559().then(|| fees.base_fee()),
                 genesis.timestamp,
                 genesis.number,
-                networks.is_tempo(),
-            )
+            );
+            Blockchain::new(foundry_header(&networks, header))
         };
 
         // Sync EVM block.number with genesis for non-fork mode.
@@ -4595,13 +4624,8 @@ impl<N: Network> Backend<N> {
         );
 
         let base_fee = staged_fees.is_eip1559().then_some(genesis_base_fee);
-        let staged_storage = BlockchainStorage::new(
-            &staged_env,
-            base_fee,
-            genesis_timestamp,
-            genesis_number,
-            self.is_tempo(),
-        );
+        let header = genesis_header(&staged_env, base_fee, genesis_timestamp, genesis_number);
+        let staged_storage = BlockchainStorage::new(foundry_header(&self.networks, header));
 
         // Seed the next block's fee state. Tempo always advances through its hardfork rule, an
         // implicit in-memory Ethereum reset restores Anvil's default, and explicit or
@@ -5340,7 +5364,7 @@ where
             slot_number: None,
         };
 
-        let block = create_block(FoundryHeader::new(header, self.is_tempo()), transactions);
+        let block = create_block(foundry_header(&self.networks, header), transactions);
         BlockInfo { block, transactions: transaction_infos, receipts: block_result.receipts }
     }
 
@@ -7415,7 +7439,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
                     requests_hash: (spec_id >= SpecId::PRAGUE).then_some(EMPTY_REQUESTS_HASH),
                     ..Default::default()
                 };
-                let header = FoundryHeader::new(header, self.is_tempo());
+                let header = foundry_header(&self.networks, header);
                 let best_hash = header.hash_slow();
                 selected_header = Some(header.clone());
                 checkpoint = Some(create_block(

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -9,9 +9,9 @@ use crate::eth::{
     },
     pool::transactions::PoolTransaction,
 };
-use alloy_consensus::{BlockHeader, Header, constants::EMPTY_WITHDRAWALS};
-use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
-use alloy_evm::EvmEnv;
+use alloy_consensus::BlockHeader;
+#[cfg(test)]
+use alloy_consensus::Header;
 use alloy_network::Network;
 use alloy_primitives::{
     B256, Bytes, U256,
@@ -36,7 +36,6 @@ use foundry_evm::{
 use foundry_primitives::FoundryNetwork;
 use foundry_primitives::{FoundryHeader, FoundryReceiptEnvelope, FoundryTxEnvelope};
 use parking_lot::RwLock;
-use revm::{context::Block as RevmBlock, primitives::hardfork::SpecId};
 use std::{collections::VecDeque, fmt, path::PathBuf, sync::Arc, time::Duration};
 // use yansi::Paint;
 
@@ -331,40 +330,13 @@ impl<N: Network> BlockchainStorage<N> {
         self.monad_block_replay_profiles.remove(block_hash);
     }
 
-    /// Creates a new storage with a genesis block
-    pub fn new(
-        evm_env: &EvmEnv,
-        base_fee: Option<u64>,
-        timestamp: u64,
-        genesis_number: u64,
-        is_tempo: bool,
-    ) -> Self {
-        let is_shanghai = *evm_env.spec_id() >= SpecId::SHANGHAI;
-        let is_cancun = *evm_env.spec_id() >= SpecId::CANCUN;
-        let is_prague = *evm_env.spec_id() >= SpecId::PRAGUE;
-
-        // create a dummy genesis block
-        let header = Header {
-            timestamp,
-            base_fee_per_gas: base_fee,
-            gas_limit: evm_env.block_env.gas_limit,
-            beneficiary: evm_env.block_env.beneficiary,
-            difficulty: evm_env.block_env.difficulty,
-            blob_gas_used: evm_env.block_env.blob_excess_gas_and_price.as_ref().map(|_| 0),
-            excess_blob_gas: evm_env.block_env.blob_excess_gas(),
-            number: genesis_number,
-            parent_beacon_block_root: is_cancun.then_some(Default::default()),
-            withdrawals_root: is_shanghai.then_some(EMPTY_WITHDRAWALS),
-            requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
-            ..Default::default()
-        };
-        let block = create_block(
-            FoundryHeader::new(header, is_tempo),
-            Vec::<MaybeImpersonatedTransaction<FoundryTxEnvelope>>::new(),
-        );
+    /// Creates a new storage with a genesis block.
+    pub fn new(header: FoundryHeader) -> Self {
+        let block =
+            create_block(header, Vec::<MaybeImpersonatedTransaction<FoundryTxEnvelope>>::new());
         let genesis_hash = block.header.hash_slow();
         let best_hash = genesis_hash;
-        let best_number = genesis_number;
+        let best_number = block.header.number();
 
         let mut blocks = B256HashMap::default();
         blocks.insert(genesis_hash, block);
@@ -377,7 +349,7 @@ impl<N: Network> BlockchainStorage<N> {
             best_hash,
             best_number,
             genesis_hash,
-            genesis_number,
+            genesis_number: best_number,
             transactions: Default::default(),
             total_difficulty: Default::default(),
             #[cfg(feature = "monad")]
@@ -560,23 +532,9 @@ pub struct Blockchain<N: Network> {
 }
 
 impl<N: Network> Blockchain<N> {
-    /// Creates a new storage with a genesis block
-    pub fn new(
-        evm_env: &EvmEnv,
-        base_fee: Option<u64>,
-        timestamp: u64,
-        genesis_number: u64,
-        is_tempo: bool,
-    ) -> Self {
-        Self {
-            storage: Arc::new(RwLock::new(BlockchainStorage::new(
-                evm_env,
-                base_fee,
-                timestamp,
-                genesis_number,
-                is_tempo,
-            ))),
-        }
+    /// Creates a new storage with a genesis block.
+    pub fn new(header: FoundryHeader) -> Self {
+        Self { storage: Arc::new(RwLock::new(BlockchainStorage::new(header))) }
     }
 
     pub fn forked(block_number: u64, block_hash: B256, total_difficulty: U256) -> Self {

--- a/crates/primitives/src/network/header.rs
+++ b/crates/primitives/src/network/header.rs
@@ -26,11 +26,6 @@ impl Default for FoundryHeader {
 }
 
 impl FoundryHeader {
-    /// Creates a header for the selected network.
-    pub const fn new(inner: Header, is_tempo: bool) -> Self {
-        if is_tempo { Self::tempo(inner) } else { Self::Ethereum(inner) }
-    }
-
     /// Creates a Tempo header from its Ethereum-shaped fields.
     pub const fn tempo(inner: Header) -> Self {
         Self::Tempo(TempoHeader {


### PR DESCRIPTION
Moves header construction out of in-memory blockchain storage and centralizes network-specific header selection at the backend boundary. Storage now receives a completed `FoundryHeader`, removing `is_tempo` plumbing and the boolean-based header constructor while preserving existing block behavior.