### PR TITLE
fix(fuzz): skip rejected corpus inputs

### DIFF
--- a/.changelog/skip-rejected-fuzz-corpus.md
+++ b/.changelog/skip-rejected-fuzz-corpus.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Prevent stateless inputs rejected by `vm.assume` from contributing coverage or being persisted to the fuzz corpus.

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -405,7 +405,6 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         let campaign = FuzzCampaign::new(FuzzCampaignMode::Stateless);
         let mut state = (executor, tx);
         let mut cmp_values = Vec::new();
-        let mut new_coverage = false;
         let mut checked = None;
         campaign
             .run_sequence(
@@ -418,7 +417,6 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                     match event {
                         CampaignEvent::Feedback(call) => {
                             cmp_values = call.evm_cmp_values.take().unwrap_or_default();
-                            new_coverage = coverage_metrics.merge_edge_coverage(call);
                         }
                         CampaignEvent::Check { result, kind, .. } => {
                             checked = Some((
@@ -438,6 +436,13 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             .map_err(|e| TestCaseError::fail(e.to_string()))?;
         let (mut call, kind) = checked.expect("depth-one campaign emits a check event");
         let tx = state.1.clone();
+
+        // Handle `vm.assume` before recording coverage or persisting the input.
+        if kind == CampaignCallKind::AssumptionRejected {
+            return Err(TestCaseError::reject(FuzzError::AssumeReject));
+        }
+
+        let new_coverage = coverage_metrics.merge_edge_coverage(&mut call);
         // `new_coverage` is only meaningful when edge coverage is collected; otherwise
         // `merge_edge_coverage` always returns `false`, so record it as unknown for frontiers.
         let frontier_new_coverage =
@@ -449,11 +454,6 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             new_coverage,
             None,
         );
-
-        // Handle `vm.assume`.
-        if kind == CampaignCallKind::AssumptionRejected {
-            return Err(TestCaseError::reject(FuzzError::AssumeReject));
-        }
 
         let (breakpoints, deprecated_cheatcodes) =
             call.cheatcodes.as_ref().map_or_else(Default::default, |cheats| {

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -439,6 +439,8 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
 
         // Handle `vm.assume` before recording coverage or persisting the input.
         if kind == CampaignCallKind::AssumptionRejected {
+            // Account for the attempted corpus mutation without retaining or crediting the input.
+            coverage_metrics.process_inputs(&[], &[], false, None);
             return Err(TestCaseError::reject(FuzzError::AssumeReject));
         }
 

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -744,6 +744,32 @@ contract ForgeFuzzReplayFailureTest {
     assert!(stdout.contains("[SKIP: not runnable in replay mode] test_unit()"), "{stdout}");
 });
 
+forgetest_init!(stateless_fuzz_does_not_persist_assume_rejects, |prj, cmd| {
+    let corpus_root = prj.root().join("fuzz_corpus");
+    prj.update_config(|config| {
+        config.fuzz.runs = 1;
+        config.fuzz.max_test_rejects = 1;
+        config.fuzz.seed = Some(U256::from(1));
+        config.fuzz.corpus.corpus_dir = Some(corpus_root.clone());
+    });
+    prj.add_test(
+        "StatelessAssumeReject.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract StatelessAssumeRejectTest is Test {
+    function testFuzz_assume(uint256) public view {
+        vm.assume(false);
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "testFuzz_assume", "-q"]).assert_failure();
+
+    assert!(!has_regular_file(&corpus_root));
+});
+
 forgetest_init!(stateless_fuzz_preserves_payable_value, |prj, cmd| {
     let corpus_root = prj.root().join("fuzz_corpus");
     let frontier_root = prj.root().join("fuzz_frontiers");


### PR DESCRIPTION
Prevent stateless inputs rejected by `vm.assume` from contributing coverage or being persisted to the fuzz corpus. Rejected inputs are now discarded before coverage, frontier, and corpus processing.