### PR TITLE
refactor(anvil): isolate OP receipts

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -45,6 +45,9 @@ use revm::{
 };
 use std::{fmt, fmt::Debug, mem::take, sync::Arc};
 
+#[cfg(feature = "optimism")]
+pub(crate) mod optimism;
+
 /// Determines whether an executor produces a complete block or a historical transaction prefix.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) enum BlockExecutionKind {
@@ -135,7 +138,7 @@ fn append_deposit_requests(
     Ok(())
 }
 
-/// Receipt builder for Foundry/Anvil that handles all transaction types
+/// Receipt builder for transaction types that do not require network-specific metadata.
 #[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]
 pub struct FoundryReceiptBuilder;
@@ -167,27 +170,10 @@ impl FoundryReceiptBuilder {
         result: &ExecutionResult,
         logs: Vec<Log>,
         cumulative_gas_used: u64,
-        deposit_nonce: Option<u64>,
-        deposit_receipt_version: Option<u64>,
     ) -> FoundryReceiptEnvelope {
         let receipt =
             Receipt { status: Eip658Value::Eip658(result.is_success()), cumulative_gas_used, logs }
                 .with_bloom();
-        #[cfg(feature = "optimism")]
-        if tx_type == FoundryTxType::Deposit {
-            return FoundryReceiptEnvelope::Deposit(
-                op_alloy_consensus::OpDepositReceiptWithBloom {
-                    receipt: op_alloy_consensus::OpDepositReceipt {
-                        inner: receipt.receipt,
-                        deposit_nonce,
-                        deposit_receipt_version,
-                    },
-                    logs_bloom: receipt.logs_bloom,
-                },
-            );
-        }
-        #[cfg(not(feature = "optimism"))]
-        let _ = (deposit_nonce, deposit_receipt_version);
         Self::wrap_receipt(tx_type, receipt)
     }
 }
@@ -428,21 +414,7 @@ where
 
         #[cfg(feature = "optimism")]
         let receipt = if tx_type == FoundryTxType::Deposit {
-            let deposit_nonce = state.get(&sender).map(|acc| acc.info.nonce);
-            let receipt = alloy_consensus::Receipt {
-                status: Eip658Value::Eip658(result.is_success()),
-                cumulative_gas_used: self.gas_used,
-                logs: result.into_logs(),
-            }
-            .with_bloom();
-            FoundryReceiptEnvelope::Deposit(op_alloy_consensus::OpDepositReceiptWithBloom {
-                receipt: op_alloy_consensus::OpDepositReceipt {
-                    inner: receipt.receipt,
-                    deposit_nonce,
-                    deposit_receipt_version: deposit_nonce.map(|_| 1),
-                },
-                logs_bloom: receipt.logs_bloom,
-            })
+            optimism::build_mined_deposit_receipt(result, &state, sender, self.gas_used)
         } else {
             self.receipt_builder.build_receipt(ReceiptBuilderCtx {
                 tx_type,

--- a/crates/anvil/src/eth/backend/executor/optimism.rs
+++ b/crates/anvil/src/eth/backend/executor/optimism.rs
@@ -1,0 +1,66 @@
+//! OP-stack receipt construction for the Anvil block executor.
+
+use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom};
+use alloy_primitives::{Address, Log};
+use foundry_evm::hardfork::{FoundryHardfork, OpHardfork};
+use foundry_primitives::FoundryReceiptEnvelope;
+use op_alloy_consensus::{OpDepositReceipt, OpDepositReceiptWithBloom};
+use revm::{context_interface::result::ExecutionResult, state::EvmState};
+
+/// Builds a mined OP deposit receipt and derives its fork-specific metadata.
+pub(crate) fn build_mined_deposit_receipt<H>(
+    result: ExecutionResult<H>,
+    state: &EvmState,
+    sender: Address,
+    cumulative_gas_used: u64,
+) -> FoundryReceiptEnvelope {
+    let deposit_nonce = state.get(&sender).map(|account| account.info.nonce);
+    build_deposit_receipt(result, cumulative_gas_used, deposit_nonce, deposit_nonce.map(|_| 1))
+}
+
+/// Builds an RPC-simulated OP deposit receipt and derives its fork-specific metadata.
+pub(crate) fn build_simulated_deposit_receipt<H>(
+    hardfork: FoundryHardfork,
+    caller_nonce: u64,
+    result: &ExecutionResult<H>,
+    logs: Vec<Log>,
+    cumulative_gas_used: u64,
+) -> FoundryReceiptEnvelope {
+    let hardfork = OpHardfork::from(hardfork);
+    let deposit_nonce = (hardfork >= OpHardfork::Regolith).then_some(caller_nonce);
+    let deposit_receipt_version = (hardfork >= OpHardfork::Canyon).then_some(1);
+    let receipt =
+        Receipt { status: Eip658Value::Eip658(result.is_success()), cumulative_gas_used, logs }
+            .with_bloom();
+    wrap_deposit_receipt(receipt, deposit_nonce, deposit_receipt_version)
+}
+
+fn build_deposit_receipt<H>(
+    result: ExecutionResult<H>,
+    cumulative_gas_used: u64,
+    deposit_nonce: Option<u64>,
+    deposit_receipt_version: Option<u64>,
+) -> FoundryReceiptEnvelope {
+    let receipt = Receipt {
+        status: Eip658Value::Eip658(result.is_success()),
+        cumulative_gas_used,
+        logs: result.into_logs(),
+    }
+    .with_bloom();
+    wrap_deposit_receipt(receipt, deposit_nonce, deposit_receipt_version)
+}
+
+fn wrap_deposit_receipt(
+    receipt: ReceiptWithBloom<Receipt>,
+    deposit_nonce: Option<u64>,
+    deposit_receipt_version: Option<u64>,
+) -> FoundryReceiptEnvelope {
+    FoundryReceiptEnvelope::Deposit(OpDepositReceiptWithBloom {
+        receipt: OpDepositReceipt {
+            inner: receipt.receipt,
+            deposit_nonce,
+            deposit_receipt_version,
+        },
+        logs_bloom: receipt.logs_bloom,
+    })
+}

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -120,8 +120,6 @@ use anvil_rpc::error::{ErrorCode, RpcError};
 use chrono::Datelike;
 use eyre::{Context, Result};
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
-#[cfg(feature = "optimism")]
-use foundry_evm::hardfork::OpHardfork;
 use foundry_evm::{
     backend::{BlockchainDb, DatabaseError, DatabaseResult, RevertStateSnapshotAction},
     constants::{DEFAULT_CREATE2_DEPLOYER, DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE},
@@ -8237,26 +8235,30 @@ impl Backend<FoundryNetwork> {
                     };
                     let tx_hash = tx.as_ref().hash();
                     #[cfg(feature = "optimism")]
-                    let (deposit_nonce, deposit_receipt_version) =
-                        if matches!(tx.as_ref(), FoundryTxEnvelope::Deposit(_)) {
-                            let hardfork = OpHardfork::from(self.hardfork());
-                            (
-                                (hardfork >= OpHardfork::Regolith).then_some(caller_nonce),
-                                (hardfork >= OpHardfork::Canyon).then_some(1),
-                            )
-                        } else {
-                            (None, None)
-                        };
+                    let receipt = if matches!(tx.as_ref(), FoundryTxEnvelope::Deposit(_)) {
+                        crate::eth::backend::executor::optimism::build_simulated_deposit_receipt(
+                            self.hardfork(),
+                            caller_nonce,
+                            &result,
+                            canonical_logs.clone(),
+                            cumulative_gas_used,
+                        )
+                    } else {
+                        FoundryReceiptBuilder::build_simulated_receipt(
+                            tx.as_ref().tx_type(),
+                            &result,
+                            canonical_logs.clone(),
+                            cumulative_gas_used,
+                        )
+                    };
                     #[cfg(not(feature = "optimism"))]
-                    let (deposit_nonce, deposit_receipt_version) = (None, None);
-                    receipts.push(FoundryReceiptBuilder::build_simulated_receipt(
+                    let receipt = FoundryReceiptBuilder::build_simulated_receipt(
                         tx.as_ref().tx_type(),
                         &result,
                         canonical_logs.clone(),
                         cumulative_gas_used,
-                        deposit_nonce,
-                        deposit_receipt_version,
-                    ));
+                    );
+                    receipts.push(receipt);
                     transaction_envelopes.push(tx.as_ref().clone());
                     let rpc_tx =
                         transaction_build(Some(tx_hash), tx, None, None, Some(block_env.basefee));

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1,6 +1,8 @@
 //! In-memory blockchain backend.
 use self::{in_memory_db::StateRootDb, state::trie_storage};
 
+#[cfg(feature = "optimism")]
+use crate::eth::backend::executor::optimism::build_simulated_deposit_receipt;
 use crate::{
     ForkChoice, NodeConfig, PrecompileFactory,
     config::{ForkTransactionReplay, PruneStateHistoryConfig},
@@ -8236,7 +8238,7 @@ impl Backend<FoundryNetwork> {
                     let tx_hash = tx.as_ref().hash();
                     #[cfg(feature = "optimism")]
                     let receipt = if matches!(tx.as_ref(), FoundryTxEnvelope::Deposit(_)) {
-                        crate::eth::backend::executor::optimism::build_simulated_deposit_receipt(
+                        build_simulated_deposit_receipt(
                             self.hardfork(),
                             caller_nonce,
                             &result,


### PR DESCRIPTION
Moves mined and simulated OP deposit receipt construction into an OP-owned executor module. This keeps OP hardfork rules, deposit metadata, and concrete receipt types out of generic receipt-building paths, giving future networks a cleaner boundary for custom receipts.