### PR TITLE
fix(cli): make project trust warnings non-blocking

### DIFF
--- a/.changelog/local-compiler-approval.md
+++ b/.changelog/local-compiler-approval.md
@@ -5,4 +5,4 @@ anvil: minor
 chisel: minor
 ---
 
-Added confirmation prompts before executing project-configured local Solc and Vyper binaries and before loading project dotenv files, with `--allow-local-compiler` and `--allow-project-env` for explicit automation opt-in.
+Added warnings before executing project-configured local Solc and Vyper binaries and before loading project dotenv files.

--- a/crates/anvil/src/args.rs
+++ b/crates/anvil/src/args.rs
@@ -18,7 +18,7 @@ pub fn run() -> Result<()> {
 
 /// Setup the exception handler and other utilities.
 pub fn setup() -> Result<()> {
-    utils::common_setup::<Anvil>()?;
+    utils::common_setup();
 
     Ok(())
 }

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -53,7 +53,7 @@ pub fn run() -> Result<()> {
 
 /// Setup the global logger and other utilities.
 pub fn setup() -> Result<()> {
-    utils::common_setup::<CastArgs>()?;
+    utils::common_setup();
     utils::subscriber();
 
     Ok(())

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -139,14 +139,6 @@ Display options:
           and
             backtraces with line numbers.
 
-Compiler options:
-      --allow-local-compiler
-          Allow use of local compiler executables without prompting
-
-Project options:
-      --allow-project-env
-          Allow loading project dotenv files without prompting
-
 Find more information in the book: https://getfoundry.sh/cast/overview
 
 "#]]);

--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -31,7 +31,7 @@ pub fn run() -> Result<()> {
 
 /// Setup the global logger and other utilities.
 pub fn setup() -> Result<()> {
-    utils::common_setup::<Chisel>()?;
+    utils::common_setup();
     utils::subscriber();
 
     Ok(())

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -3,55 +3,8 @@ use foundry_common::{
     shell::{ColorChoice, OutputFormat, OutputMode, Shell, Verbosity},
     version::{IS_NIGHTLY_VERSION, NIGHTLY_VERSION_WARNING_MESSAGE},
 };
-use foundry_compilers::error::{Result as CompilerResult, SolcError};
 use foundry_config::{Config, figment::Profile};
 use serde::{Deserialize, Serialize};
-use std::{
-    io::{self, IsTerminal, Write},
-    path::{Path, PathBuf},
-    sync::Mutex,
-};
-
-static LOCAL_COMPILER_APPROVALS: Mutex<Vec<(PathBuf, bool)>> = Mutex::new(Vec::new());
-
-fn ensure_local_compiler_approved(path: &Path) -> CompilerResult<()> {
-    let mut approvals = LOCAL_COMPILER_APPROVALS.lock().unwrap_or_else(|err| err.into_inner());
-    if let Some((_, approved)) = approvals.iter().find(|(approved_path, _)| approved_path == path) {
-        return if *approved { Ok(()) } else { Err(local_compiler_not_approved(path)) };
-    }
-
-    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
-        return Err(local_compiler_not_approved(path));
-    }
-
-    let mut stderr = io::stderr().lock();
-    writeln!(
-        stderr,
-        "Warning: this project is configured to use a local compiler executable:\n  {path:?}\n\
-         Running this executable may execute arbitrary code.",
-    )
-    .map_err(|err| SolcError::msg(format!("failed to write compiler approval prompt: {err}")))?;
-    write!(stderr, "Do you trust this compiler and want to continue? [y/N] ")
-        .and_then(|_| stderr.flush())
-        .map_err(|err| {
-            SolcError::msg(format!("failed to write compiler approval prompt: {err}"))
-        })?;
-
-    let mut response = String::new();
-    io::stdin()
-        .read_line(&mut response)
-        .map_err(|err| SolcError::msg(format!("failed to read compiler approval: {err}")))?;
-    let approved = matches!(response.trim().to_ascii_lowercase().as_str(), "y" | "yes");
-    approvals.push((path.to_path_buf(), approved));
-
-    if approved { Ok(()) } else { Err(local_compiler_not_approved(path)) }
-}
-
-fn local_compiler_not_approved(path: &Path) -> SolcError {
-    SolcError::msg(format!(
-        "refusing to run unapproved local compiler {path:?}; pass `--allow-local-compiler` if you trust this executable"
-    ))
-}
 
 /// Global arguments for the CLI.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Parser)]
@@ -100,14 +53,6 @@ pub struct GlobalArgs {
     /// The configuration profile to use.
     #[arg(global = true, long, value_name = "PROFILE")]
     profile: Option<Profile>,
-
-    /// Allow use of local compiler executables without prompting.
-    #[arg(global = true, long, help_heading = "Compiler options")]
-    allow_local_compiler: bool,
-
-    /// Allow loading project dotenv files without prompting.
-    #[arg(global = true, long, help_heading = "Project options")]
-    allow_project_env: bool,
 }
 
 impl GlobalArgs {
@@ -134,11 +79,6 @@ impl GlobalArgs {
             );
         }
         let _ = Config::selected_profile();
-
-        let allow_local_compiler = self.allow_local_compiler;
-        foundry_compilers::set_compiler_approval_handler(move |path| {
-            if allow_local_compiler { Ok(()) } else { ensure_local_compiler_approved(path) }
-        });
 
         // Set the global shell.
         let shell = self.shell();

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -11,7 +11,6 @@ use serde::de::DeserializeOwned;
 use std::{
     collections::{BTreeMap, BTreeSet},
     ffi::{OsStr, OsString},
-    io::{self, IsTerminal, Write},
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
     str::FromStr,
@@ -199,30 +198,18 @@ pub fn now() -> Duration {
 }
 
 /// Common setup for all CLI tools. Does not include [tracing subscriber](subscriber).
-pub fn common_setup<C: clap::CommandFactory>() -> Result<()> {
+pub fn common_setup() {
     install_crypto_provider();
     crate::handler::install();
-    // Use the concrete command grammar so option-like positional values cannot grant approval.
-    // Ignore unrelated errors because dotenv may supply values before the strict CLI parse.
-    let allow_project_env = C::command()
-        .ignore_errors(true)
-        .try_get_matches()
-        .ok()
-        .and_then(|matches| matches.get_one::<bool>("allow_project_env").copied())
-        .unwrap_or(false);
-    load_dotenv(allow_project_env)?;
+    load_dotenv();
     enable_paint();
-    Ok(())
 }
 
-/// Loads dotenv files from the cwd and project root after approval, ignoring parse failures.
+/// Loads dotenv files from the cwd and project root after warning, ignoring parse failures.
 ///
-/// We could use `warn!` here, but that would imply that the dotenv file can't configure
-/// the logging behavior of Foundry.
-///
-/// Similarly, we could just use `eprintln!`, but colors are off limits otherwise dotenv is implied
-/// to not be able to configure the colors. It would also mess up the JSON output.
-pub fn load_dotenv(allow_project_env: bool) -> Result<()> {
+/// The warning is written directly because dotenv may configure logging before the tracing
+/// subscriber is initialized.
+pub fn load_dotenv() {
     // we only want the .env file of the cwd and project root
     // `find_project_root` calls `current_dir` internally so both paths are either both `Ok` or
     // both `Err`
@@ -242,52 +229,27 @@ pub fn load_dotenv(allow_project_env: bool) -> Result<()> {
     }
 
     if paths.is_empty() {
-        return Ok(());
+        return;
     }
 
-    if !allow_project_env {
-        ensure_dotenv_approved(&paths)?;
+    {
+        use std::io::Write as _;
+
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "Warning: loading project dotenv files:");
+        for path in &paths {
+            let _ = writeln!(stderr, "  {path:?}");
+        }
+        let _ = writeln!(
+            stderr,
+            "Project environment variables can affect executable and library loading. Only run \
+             commands in projects you trust."
+        );
     }
 
     for path in paths {
         dotenvy::from_path(path).ok();
     }
-    Ok(())
-}
-
-fn ensure_dotenv_approved(paths: &[PathBuf]) -> Result<()> {
-    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
-        return Err(dotenv_not_approved(paths));
-    }
-
-    let mut stderr = io::stderr().lock();
-    writeln!(stderr, "Warning: this project contains dotenv files:")?;
-    for path in paths {
-        writeln!(stderr, "  {path:?}")?;
-    }
-    writeln!(
-        stderr,
-        "Dotenv files can configure executable and library loading through process environment \
-         variables. Loading an untrusted dotenv file may execute arbitrary code."
-    )?;
-    write!(stderr, "Do you trust these dotenv files and want to continue? [y/N] ")?;
-    stderr.flush()?;
-
-    let mut response = String::new();
-    io::stdin().read_line(&mut response)?;
-    if matches!(response.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
-        Ok(())
-    } else {
-        Err(dotenv_not_approved(paths))
-    }
-}
-
-fn dotenv_not_approved(paths: &[PathBuf]) -> eyre::Report {
-    let paths = paths.iter().map(|path| format!("{path:?}")).join(", ");
-    eyre::eyre!(
-        "refusing to load unapproved project dotenv files {paths}; pass `--allow-project-env` if \
-         you trust them"
-    )
 }
 
 /// Sets the default [`yansi`] color output condition.
@@ -1263,7 +1225,7 @@ impl<'a> IntoIterator for &'a Submodules {
 mod tests {
     use super::*;
     use foundry_common::fs;
-    use std::{env, fs::File};
+    use std::{env, fs::File, io::Write};
     use tempfile::tempdir;
 
     #[test]
@@ -1397,7 +1359,7 @@ mod tests {
         unsafe { env::remove_var("BROWSER") };
         let cwd = env::current_dir().unwrap();
         env::set_current_dir(&nested).unwrap();
-        load_dotenv(true).unwrap();
+        load_dotenv();
         env::set_current_dir(cwd).unwrap();
 
         let loaded_browser = env::var_os("BROWSER");

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -47,9 +47,11 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::{
     borrow::Cow,
     collections::BTreeMap,
-    fs, io,
+    fs,
+    io::{self, Write as _},
     path::{Path, PathBuf},
     str::FromStr,
+    sync::Mutex,
 };
 
 mod macros;
@@ -153,6 +155,22 @@ pub use semver;
 
 #[cfg(not(test))]
 static SELECTED_PROFILE: std::sync::OnceLock<Profile> = std::sync::OnceLock::new();
+static WARNED_LOCAL_COMPILERS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+fn warn_local_compiler(path: &Path) {
+    let mut warned = WARNED_LOCAL_COMPILERS.lock().unwrap_or_else(|err| err.into_inner());
+    if warned.iter().any(|warned_path| warned_path == path) {
+        return;
+    }
+    warned.push(path.to_path_buf());
+
+    let mut stderr = io::stderr().lock();
+    let _ = writeln!(
+        stderr,
+        "Warning: this project is configured to use a local compiler executable:\n  {path:?}\n\
+         Running this executable may execute arbitrary code."
+    );
+}
 
 /// Foundry configuration
 ///
@@ -1503,7 +1521,8 @@ impl Config {
                     if !solc.is_file() {
                         return Err(SolcError::msg(format!("`solc` {solc:?} does not exist")));
                     }
-                    Solc::new_with_approval(solc)?
+                    warn_local_compiler(solc);
+                    Solc::new(solc)?
                 }
             };
             return Ok(Some(solc));
@@ -1591,7 +1610,8 @@ impl Config {
             return Ok(None);
         }
         let vyper = if let Some(path) = &self.vyper.path {
-            Some(Vyper::new_with_approval(path)?)
+            warn_local_compiler(path);
+            Some(Vyper::new(path)?)
         } else {
             Vyper::new("vyper").ok()
         };
@@ -3108,7 +3128,10 @@ impl SolcReq {
     pub fn try_version(&self) -> Result<Version, SolcError> {
         match self {
             Self::Version(version) => Ok(version.clone()),
-            Self::Local(path) => Solc::new_with_approval(path).map(|solc| solc.version),
+            Self::Local(path) => {
+                warn_local_compiler(path);
+                Solc::new(path).map(|solc| solc.version)
+            }
         }
     }
 }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -23,7 +23,7 @@ pub fn run() -> Result<()> {
 
 /// Setup the global logger and other utilities.
 pub fn setup() -> Result<()> {
-    utils::common_setup::<Forge>()?;
+    utils::common_setup();
     utils::subscriber();
 
     Ok(())

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -33,7 +33,7 @@ fn add_local_submodule(root: &Path, path: &str) -> String {
 }
 
 #[cfg(unix)]
-forgetest!(local_compiler_requires_approval, |prj, cmd| {
+forgetest!(local_compiler_warns_and_runs, |prj, cmd| {
     let solc = prj.root().join("payload");
     let invoked = prj.root().join("payload.invoked");
     fs::write(
@@ -59,33 +59,16 @@ exit 1
 
     let output = cmd.arg("build").assert_failure();
     let stderr = output.get_output().stderr_lossy();
-    assert!(stderr.contains("refusing to run unapproved local compiler"), "{stderr}");
-    assert!(stderr.contains("--allow-local-compiler"), "{stderr}");
-    assert!(!invoked.exists(), "local compiler ran without approval");
-
-    cmd.forge_fuse().args(["build", "--allow-local-compiler"]).assert_failure();
-    assert!(invoked.exists(), "approved local compiler did not run");
+    assert!(stderr.contains("configured to use a local compiler executable"), "{stderr}");
+    assert!(invoked.exists(), "local compiler did not run after warning");
 });
 
-forgetest!(project_dotenv_requires_approval, |prj, cmd| {
+forgetest!(project_dotenv_loads_with_warning, |prj, cmd| {
     fs::write(prj.root().join(".env"), "FOUNDRY_SRC=dotenv-src").unwrap();
 
-    let output = cmd.args(["config", "--json"]).assert_failure();
+    let output = cmd.args(["config", "--json"]).assert_success();
     let stderr = output.get_output().stderr_lossy();
-    assert!(stderr.contains("refusing to load unapproved project dotenv"), "{stderr}");
-    assert!(stderr.contains("--allow-project-env"), "{stderr}");
-
-    let output = cmd.forge_fuse().args([
-        "create",
-        "src/Contract.sol:Contract",
-        "--constructor-args",
-        "--allow-project-env",
-    ]);
-    let stderr = output.assert_failure().get_output().stderr_lossy();
-    assert!(stderr.contains("refusing to load unapproved project dotenv"), "{stderr}");
-
-    let output =
-        cmd.forge_fuse().args(["config", "--json", "--allow-project-env"]).assert_success();
+    assert!(stderr.contains("Warning: loading project dotenv"), "{stderr}");
     let config: serde_json::Value = serde_json::from_slice(&output.get_output().stdout).unwrap();
     assert_eq!(config["src"], "dotenv-src");
 });

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -77,14 +77,6 @@ Display options:
           and
             backtraces with line numbers.
 
-Compiler options:
-      --allow-local-compiler
-          Allow use of local compiler executables without prompting
-
-Project options:
-      --allow-project-env
-          Allow loading project dotenv files without prompting
-
 Find more information in the book: https://getfoundry.sh/forge/overview
 
 "#]]);

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -1,6 +1,6 @@
 //! Tests for the `forge compiler` command.
 
-use foundry_compilers::compilers::{solc::Solc, vyper::Vyper};
+use foundry_compilers::compilers::solc::Solc;
 use foundry_test_utils::{
     snapbox::IntoData,
     util::{SOLC_VERSION, get_vyper},
@@ -103,15 +103,13 @@ forgetest_init!(can_print_resolved_compiler_path, |prj, cmd| {
 
 forgetest!(can_print_resolved_vyper_path, |prj, cmd| {
     let vyper = get_vyper();
-    foundry_compilers::set_compiler_approval_handler(|_| Ok(()));
-    let resolved_vyper = Vyper::new_with_approval(&vyper.path).unwrap();
     prj.add_raw_source("ICounter.vyi", VYPER_INTERFACE);
     prj.add_raw_source("Counter.vy", VYPER_CONTRACT);
     prj.update_config(|config| config.vyper.path = Some(vyper.path.clone()));
 
-    cmd.args(["compiler", "resolve", "--path", "--allow-local-compiler"])
+    cmd.args(["compiler", "resolve", "--path"])
         .assert_success()
-        .stdout_eq(format!("{}\n", resolved_vyper.path.display()));
+        .stdout_eq(format!("{}\n", vyper.path.display()));
 });
 
 forgetest!(compiler_path_requires_single_version, |prj, cmd| {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -806,7 +806,7 @@ Error: `solc` "this/solc/does/not/exist" does not exist
     // `OTHER_SOLC_VERSION` was installed in previous step, so we can use the path to this directly
     let local_solc = Solc::find_or_install(&OTHER_SOLC_VERSION.parse().unwrap()).unwrap();
     cmd.forge_fuse()
-        .args(["build", "--force", "--allow-local-compiler", "--use"])
+        .args(["build", "--force", "--use"])
         .arg(local_solc.solc)
         .root_arg()
         .assert_success()

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -144,7 +144,7 @@ exit 1
         config.skip = vec!["*Skipped*".parse().unwrap()];
     });
 
-    cmd.args(["doc", "--allow-local-compiler"]).assert_success();
+    cmd.arg("doc").assert_success();
     assert!(!invoked.exists(), "forge doc invoked the configured solc binary");
     assert!(!prj.root().join("docs/src/pages/src/contract.Skipped.mdx").exists());
 });

--- a/crates/forge/tests/cli/fmt_integration.rs
+++ b/crates/forge/tests/cli/fmt_integration.rs
@@ -7,7 +7,7 @@ macro_rules! fmt_test {
         #[test]
         fn $name() {
             let (_, mut cmd) = ExtTester::new($org, $repo, $commit).setup_forge_prj(false);
-            cmd.args(["fmt", "--allow-project-env"]).assert_success();
+            cmd.arg("fmt").assert_success();
             cmd.arg("--check").assert_success();
         }
     };

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -860,7 +860,7 @@ async fn uni_v4_core_sync_foundry_lock() {
     let submod_solmate =
         submodules.into_iter().find(|s| s.path() == &PathBuf::from("lib/solmate")).unwrap();
 
-    cmd.args(["install", "--allow-project-env"]).assert_success();
+    cmd.arg("install").assert_success();
 
     let forge_std = lockfile_get(prj.root(), &PathBuf::from("lib/forge-std")).unwrap();
     assert!(matches!(forge_std, DepIdentifier::Rev { .. }));
@@ -877,7 +877,7 @@ async fn uni_v4_core_sync_foundry_lock() {
     git.commit("Foundry lock").unwrap();
 
     // Try update. Nothing should get updated everything is pinned tag/rev.
-    cmd.forge_fuse().args(["update", "--allow-project-env"]).assert_success();
+    cmd.forge_fuse().arg("update").assert_success();
 
     let forge_std = lockfile_get(prj.root(), &PathBuf::from("lib/forge-std")).unwrap();
     assert!(matches!(forge_std, DepIdentifier::Rev { .. }));

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -49,7 +49,6 @@ fn setup_testdata_cmd(cmd: &mut TestCommand) {
     let testdata =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../testdata").canonicalize().unwrap();
     cmd.current_dir(&testdata);
-    cmd.arg("--allow-project-env");
 
     let mut dotenv = std::fs::File::create(testdata.join(".env")).unwrap();
     for (name, endpoint) in rpc_endpoints().iter() {

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -31,10 +31,8 @@ exit 1
         config.solc = Some(foundry_config::SolcReq::Local(solc));
     });
 
-    let output = cmd
-        .forge_fuse()
-        .args(["test", "--match-contract", "CounterTest", "--allow-local-compiler"])
-        .assert_success();
+    let output =
+        cmd.forge_fuse().args(["test", "--match-contract", "CounterTest"]).assert_success();
     let stdout = output.get_output().stdout_lossy();
     assert!(
         stdout.contains("Ran 2 tests for test/Counter.t.sol:CounterTest"),
@@ -42,7 +40,7 @@ exit 1
     );
     assert!(!invoked.exists(), "filtered test compilation did not reuse the preprocessed cache");
 
-    cmd.forge_fuse().args(["selectors", "list", "--allow-local-compiler"]).assert_success();
+    cmd.forge_fuse().args(["selectors", "list"]).assert_success();
     assert!(!invoked.exists(), "selector compilation did not reuse the preprocessed cache");
 });
 


### PR DESCRIPTION
## Motivation

The interactive project trust gates added in #16113 make non-interactive commands fail whenever a project has a `.env` file or configures a local compiler. That breaks programmatic integrations such as the embedded Forge LSP in #16254, while the opt-in flags do not provide a meaningful security boundary for a process that can load the dotenv file or invoke the executable itself.

## Changes

- remove the local compiler and project dotenv approval prompts and opt-in flags
- warn before loading project-root/current-directory dotenv files, then load them normally
- warn once per configured local Solc or Vyper path before invoking it
- retain escaped path rendering in compiler warnings and update the CLI snapshots and behavior tests

Companion: foundry-rs/foundry-core#168 removes the now-unused compiler approval hooks.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo test -p foundry-cli can_load_dotenv -- --nocapture`
- `cargo test -p forge --test cli local_compiler_ -- --nocapture`
- `cargo test -p forge --test cli project_dotenv_loads_with_warning -- --nocapture`
- `cargo test -p forge --test cli can_print_resolved_vyper_path -- --nocapture`
- `cargo test -p forge --test cli print_help -- --nocapture`
- `cargo test -p cast@1.8.0 --test cli print_help -- --nocapture`
