### PR TITLE
refactor(anvil): isolate Tempo admission

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -29,7 +29,7 @@ use alloy_evm::{
     },
 };
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
-use alloy_primitives::{Address, B256, Bytes, Log, U256};
+use alloy_primitives::{Address, B256, Bytes, Log};
 use anvil_core::eth::transaction::{
     MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo,
 };
@@ -506,6 +506,8 @@ pub struct PoolTxGasConfig {
 
 /// Hooks invoked around each candidate transaction's execution.
 pub struct PoolTransactionHooks<BeforeTransaction, ExecuteTransaction, OnExecutionError> {
+    /// Defers candidates that must remain queued until a later block.
+    pub defer_transaction: Option<fn(&FoundryTxEnvelope, u64) -> bool>,
     /// Runs after validation and immediately before execution.
     pub before_transaction: BeforeTransaction,
     /// Executes the candidate through the network-specific transaction entry point.
@@ -573,12 +575,10 @@ where
     for pool_tx in pool_transactions {
         let pending = &pool_tx.pending_transaction;
         let sender = *pending.sender();
-        let block_timestamp = executor.evm().block().timestamp();
 
-        if let FoundryTxEnvelope::Tempo(aa_tx) = pending.transaction.as_ref()
-            && let Some(valid_after) = aa_tx.tx().valid_after
-            && U256::from(valid_after.get()) > block_timestamp
-        {
+        if hooks.defer_transaction.is_some_and(|defer| {
+            defer(pending.transaction.as_ref(), executor.evm().block().timestamp().saturating_to())
+        }) {
             trace!(target: "backend", "[{:?}] transaction not valid yet, will retry later", pool_tx.hash());
             not_yet_valid.push(pool_tx.clone());
             continue;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -31,7 +31,7 @@ use crate::{
                 PreparedForkTransactionReplay, execute_historical_replay,
                 prepare_fork_transaction_replay,
             },
-            tempo::AnvilStorageProvider,
+            tempo::{AnvilStorageProvider, is_transaction_not_yet_valid},
             time::{TimeManager, utc_from_secs},
             validate::TransactionValidator,
         },
@@ -2669,6 +2669,11 @@ impl<N: Network> Backend<N> {
                     .apply_pre_execution_changes()
                     .map_err(|err| BlockchainError::Internal(err.to_string()))?;
                 let mut hooks = PoolTransactionHooks {
+                    defer_transaction: if self.is_tempo() {
+                        Some(is_transaction_not_yet_valid as fn(&FoundryTxEnvelope, u64) -> bool)
+                    } else {
+                        None
+                    },
                     before_transaction: $before_transaction,
                     execute_transaction: $execute_transaction,
                     on_execution_error: $on_execution_error,

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -184,6 +184,7 @@ impl<N: Network> Backend<N> {
             .apply_pre_execution_changes()
             .map_err(|err| BlockchainError::Internal(err.to_string()))?;
         let mut hooks = PoolTransactionHooks {
+            defer_transaction: None,
             before_transaction: prepare_transaction,
             execute_transaction: |executor: &mut AnvilBlockExecutor<_>,
                                   tx_env: TxEnv,

--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -12,6 +12,7 @@ use foundry_evm::core::tempo::{
     ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
     initialize_tempo_genesis_at_hardfork,
 };
+use foundry_primitives::FoundryTxEnvelope;
 use revm::{
     DatabaseRef,
     context::{BlockEnv, journaled_state::JournalCheckpoint},
@@ -38,6 +39,12 @@ use super::db::Db;
 const SENDER: Address = address!("0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38");
 /// Admin address used for genesis initialization.
 const ADMIN: Address = address!("0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f");
+
+/// Returns whether a Tempo transaction must wait for a later block timestamp.
+pub(crate) fn is_transaction_not_yet_valid(tx: &FoundryTxEnvelope, block_timestamp: u64) -> bool {
+    let FoundryTxEnvelope::Tempo(tx) = tx else { return false };
+    tx.tx().valid_after.is_some_and(|valid_after| valid_after.get() > block_timestamp)
+}
 
 /// Storage provider adapter for Anvil's Db to work with Tempo precompiles.
 pub struct AnvilStorageProvider<'a> {


### PR DESCRIPTION
Moves Tempo’s `valid_after` admission rule out of the shared pool executor and into the Tempo backend. The generic executor now handles transaction deferral through its existing hook boundary without knowing Tempo transaction internals.