### PR TITLE
refactor(anvil): reuse storage unwind

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4738,26 +4738,8 @@ impl<N: Network> Backend<N> {
             snapshots.remove(&id);
             snapshots.retain(|snapshot_id, _| *snapshot_id < id);
         }
-        {
-            // revert the storage that's newer than the snapshot
-            let current_height = self.best_number();
-            let mut storage = self.blockchain.storage.write();
-
-            for n in ((num + 1)..=current_height).rev() {
-                trace!(target: "backend", "reverting block {}", n);
-                let Some(hash) = storage.hashes.remove(&n) else { continue };
-                if let Some(block) = storage.blocks.remove(&hash) {
-                    for tx in block.body.transactions {
-                        let _ = storage.transactions.remove(&tx.hash());
-                    }
-                }
-                #[cfg(feature = "monad")]
-                storage.remove_monad_block_metadata(&hash);
-            }
-
-            storage.best_number = num;
-            storage.best_hash = hash;
-        }
+        // Revert the storage that's newer than the snapshot.
+        self.blockchain.storage.write().unwind_to(num, hash);
 
         let reset_time = block.header.timestamp();
         self.time.reset(reset_time);

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -325,7 +325,7 @@ pub struct BlockchainStorage<N: Network> {
 impl<N: Network> BlockchainStorage<N> {
     /// Removes all metadata associated with a locally stored Monad block.
     #[cfg(feature = "monad")]
-    pub(super) fn remove_monad_block_metadata(&mut self, block_hash: &B256) {
+    fn remove_monad_block_metadata(&mut self, block_hash: &B256) {
         self.monad_block_participants.remove(block_hash);
         self.monad_block_replay_profiles.remove(block_hash);
     }


### PR DESCRIPTION
Reuses `BlockchainStorage::unwind_to` when reverting snapshots instead of duplicating canonical block, transaction, head, and Monad metadata cleanup. This keeps storage unwinding in one place without changing snapshot behavior.