### PR TITLE
feat(monad): support MonadTen MIP-8

### DIFF
--- a/.changelog/monad-ten-mip-8.md
+++ b/.changelog/monad-ten-mip-8.md
@@ -1,0 +1,14 @@
+---
+anvil: minor
+cast: minor
+chisel: minor
+forge: minor
+foundry-cheatcodes: minor
+foundry-config: minor
+foundry-evm: minor
+foundry-evm-core: minor
+foundry-evm-hardforks: minor
+foundry-evm-networks: minor
+---
+
+Added MonadTen as the default Monad hardfork, including MIP-8 page-based storage gas and canonical mainnet and testnet timestamp activation.

--- a/.changelog/monad-ten-mip-8.md
+++ b/.changelog/monad-ten-mip-8.md
@@ -11,4 +11,4 @@ foundry-evm-hardforks: minor
 foundry-evm-networks: minor
 ---
 
-Added MonadTen as the default Monad hardfork, including MIP-8 page-based storage gas and canonical mainnet and testnet timestamp activation.
+Added MonadTen as the default Monad hardfork, including MIP-8 page-based storage gas, page-aware access-list generation, and canonical mainnet and testnet timestamp activation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,8 +404,7 @@ dependencies = [
 [[package]]
 name = "alloy-monad-evm"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b488e1dd0352b471aecfc903657c5505125490442ecbb63494c885ed1c0188d6"
+source = "git+https://github.com/category-labs/alloy-monad-evm?rev=239dba8ba39d5442146925e25c09c26acce111f8#239dba8ba39d5442146925e25c09c26acce111f8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8054,8 +8053,7 @@ dependencies = [
 [[package]]
 name = "monad-revm"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b640502c0bcc1ac08d9eb2555467ba47fb9071715b0c53592d64f8a5fade2a41"
+source = "git+https://github.com/category-labs/monad-revm?rev=f512e36cdd9abffc63c519f2c6b2d0a47d0898e1#f512e36cdd9abffc63c519f2c6b2d0a47d0898e1"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,8 +403,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-monad-evm"
-version = "0.6.0"
-source = "git+https://github.com/category-labs/alloy-monad-evm?rev=239dba8ba39d5442146925e25c09c26acce111f8#239dba8ba39d5442146925e25c09c26acce111f8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "073fc2352af298651092274df4390a83ffe4abd05d68e88a0974dfa6a5e96a45"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8052,8 +8053,9 @@ dependencies = [
 
 [[package]]
 name = "monad-revm"
-version = "0.6.0"
-source = "git+https://github.com/category-labs/monad-revm?rev=f512e36cdd9abffc63c519f2c6b2d0a47d0898e1#f512e36cdd9abffc63c519f2c6b2d0a47d0898e1"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45140c3d02697754087d1b9cfcfca63a1edf6bd61bdb6e53eba0bfb451ffb387"
 dependencies = [
  "alloy-sol-types",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -544,11 +544,11 @@ tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "d656ef5581
 tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "d656ef5581505b59f1611b358e611f5a602d399e" }
 
 # Monad
-alloy-monad-evm = { version = "0.6.0", default-features = false, features = [
+alloy-monad-evm = { version = "0.7.0", default-features = false, features = [
     "std",
     "memory_limit",
 ] }
-monad-revm = { version = "0.6.0", default-features = false, features = [
+monad-revm = { version = "0.7.0", default-features = false, features = [
     "std",
     "serde",
     "memory_limit",

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -538,16 +538,6 @@ const fn next_monad_context(_context: &mut MonadReplayContext) -> MonadExecution
     MonadExecutionContext { _marker: std::marker::PhantomData }
 }
 
-#[cfg(feature = "monad")]
-fn deduplicate_monad_storage_pages(access_list: &mut AccessList) {
-    for item in &mut access_list.0 {
-        item.storage_keys.sort_unstable();
-        item.storage_keys.dedup_by_key(|slot| {
-            monad_revm::page::page_index(U256::from_be_slice(slot.as_slice()))
-        });
-    }
-}
-
 const fn noop_before_transaction<E, T>(_evm: &mut E, _tx: &T) {}
 
 const fn noop_on_execution_error<E>(_evm: &mut E) {}
@@ -3345,13 +3335,13 @@ impl<N: Network> Backend<N> {
             monad_context.as_mut().map(next_monad_context),
         )?;
         let (exit_reason, gas_used, out, _logs) = unpack_execution_result(result);
-        let mut access_list = inspector.access_list();
+        let access_list = inspector.access_list();
         #[cfg(feature = "monad")]
-        if self.is_monad()
-            && monad_revm::MonadHardfork::MonadTen.is_enabled_in(self.monad_hardfork())
-        {
-            deduplicate_monad_storage_pages(&mut access_list);
-        }
+        let access_list = if self.is_monad() {
+            monad::normalize_access_list(access_list, self.monad_hardfork())
+        } else {
+            access_list
+        };
         Ok((exit_reason, out, gas_used, access_list))
     }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -162,6 +162,7 @@ use revm::{
         JournalTr,
         block::BlobExcessGasAndPrice,
         result::{ExecutionResult, HaltReason, Output, ResultAndState},
+        transaction::TransactionType,
     },
     database::{AccountState, CacheDB, DbAccount, WrapDatabaseRef},
     handler::{
@@ -535,6 +536,16 @@ const fn next_monad_context(context: &mut MonadReplayContext) -> MonadExecutionC
 #[cfg(not(feature = "monad"))]
 const fn next_monad_context(_context: &mut MonadReplayContext) -> MonadExecutionContext<'_> {
     MonadExecutionContext { _marker: std::marker::PhantomData }
+}
+
+#[cfg(feature = "monad")]
+fn deduplicate_monad_storage_pages(access_list: &mut AccessList) {
+    for item in &mut access_list.0 {
+        item.storage_keys.sort_unstable();
+        item.storage_keys.dedup_by_key(|slot| {
+            monad_revm::page::page_index(U256::from_be_slice(slot.as_slice()))
+        });
+    }
 }
 
 const fn noop_before_transaction<E, T>(_evm: &mut E, _tx: &T) {}
@@ -3285,7 +3296,11 @@ impl<N: Network> Backend<N> {
             tx_env.base_mut().gas_limit = gas_limit;
         }
         if let Some(access_list) = overrides.access_list {
-            tx_env.base_mut().access_list = access_list;
+            let tx_env = tx_env.base_mut();
+            tx_env.access_list = access_list;
+            if tx_env.tx_type == TransactionType::Legacy as u8 {
+                tx_env.tx_type = TransactionType::Eip2930 as u8;
+            }
         }
         let ResultAndState { result, state } = self.transact_call_with_inspector_ref(
             state,
@@ -3330,7 +3345,13 @@ impl<N: Network> Backend<N> {
             monad_context.as_mut().map(next_monad_context),
         )?;
         let (exit_reason, gas_used, out, _logs) = unpack_execution_result(result);
-        let access_list = inspector.access_list();
+        let mut access_list = inspector.access_list();
+        #[cfg(feature = "monad")]
+        if self.is_monad()
+            && monad_revm::MonadHardfork::MonadTen.is_enabled_in(self.monad_hardfork())
+        {
+            deduplicate_monad_storage_pages(&mut access_list);
+        }
         Ok((exit_reason, out, gas_used, access_list))
     }
 

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -25,8 +25,8 @@ use alloy_evm::{
 };
 use alloy_monad_evm::{MonadContext, MonadEvm, MonadEvmFactory};
 use alloy_network::{BlockResponse, Network};
-use alloy_primitives::B256;
-use alloy_rpc_types::{BlockNumberOrTag as BlockNumber, BlockTransactions};
+use alloy_primitives::{B256, U256};
+use alloy_rpc_types::{AccessList, BlockNumberOrTag as BlockNumber, BlockTransactions};
 use anvil_core::eth::{
     block::Block,
     transaction::{MaybeImpersonatedTransaction, PendingTransaction},
@@ -76,6 +76,21 @@ pub(super) struct PreparedExecution {
     pub(super) context: Option<MonadChainContext>,
     pub(super) kind: EnvelopeExecutionKind,
     pub(super) hardfork: MonadHardfork,
+}
+
+pub(super) fn normalize_access_list(
+    mut access_list: AccessList,
+    hardfork: MonadHardfork,
+) -> AccessList {
+    if MonadHardfork::MonadTen.is_enabled_in(hardfork) {
+        for item in &mut access_list.0 {
+            item.storage_keys.sort_unstable();
+            item.storage_keys.dedup_by_key(|slot| {
+                monad_revm::page::page_index(U256::from_be_slice(slot.as_slice()))
+            });
+        }
+    }
+    access_list
 }
 
 /// Caches the fork blocks needed to construct the next Monad block's ancestor context.

--- a/crates/anvil/tests/it/monad.rs
+++ b/crates/anvil/tests/it/monad.rs
@@ -62,6 +62,7 @@ const RESERVE_PROBE_ADDRESS: Address = address!("0x00000000000000000000000000000
 const BALANCE_PROBE_ADDRESS: Address = address!("0x0000000000000000000000000000000000002001");
 const CHAIN_ID_PROBE_ADDRESS: Address = address!("0x0000000000000000000000000000000000002002");
 const CLZ_PROBE_ADDRESS: Address = address!("0x0000000000000000000000000000000000002003");
+const STORAGE_GAS_PROBE_ADDRESS: Address = address!("0x0000000000000000000000000000000000002004");
 const DIPPED_INTO_RESERVE_SELECTOR: [u8; 4] = hex!("3a61584e");
 const RESERVE_RETURN_PROBE_CODE: [u8; 25] =
     hex!("633a61584e5f5260205f6004601c5f6110015af15060205ff3");
@@ -82,6 +83,40 @@ async fn monad_nine_exposes_reserve_balance_precompile_for_calls() {
     let result = provider.call(tx.into()).await.unwrap();
 
     assert_eq!(result, Bytes::from(vec![0; 32]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn monad_ten_applies_mip8_storage_gas() {
+    for (config, hardfork, read_delta, write_delta) in [
+        (
+            NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into())),
+            MonadHardfork::MonadNine,
+            0,
+            0,
+        ),
+        (NodeConfig::test_monad(), MonadHardfork::MonadTen, 8_000, 10_800),
+    ] {
+        let (api, handle) = spawn(config).await;
+        let provider = handle.http_provider();
+
+        assert_eq!(api.anvil_node_info().await.unwrap().hard_fork, hardfork.to_string());
+
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_read_probe_code(127)).await.unwrap();
+        let same_page_read =
+            storage_probe_gas(provider.call(storage_gas_probe_call()).await.unwrap());
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_read_probe_code(128)).await.unwrap();
+        let different_page_read =
+            storage_probe_gas(provider.call(storage_gas_probe_call()).await.unwrap());
+        assert_eq!(different_page_read - same_page_read, read_delta);
+
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_write_probe_code(1)).await.unwrap();
+        let same_page_write =
+            storage_probe_gas(provider.call(storage_gas_probe_call()).await.unwrap());
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_write_probe_code(128)).await.unwrap();
+        let different_page_write =
+            storage_probe_gas(provider.call(storage_gas_probe_call()).await.unwrap());
+        assert_eq!(different_page_write - same_page_write, write_delta);
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2155,6 +2190,26 @@ fn reserve_balance_call() -> WithOtherFields<TransactionRequest> {
         .with_to(RESERVE_BALANCE_ADDRESS)
         .with_input(DIPPED_INTO_RESERVE_SELECTOR)
         .into()
+}
+
+fn storage_gas_probe_call() -> WithOtherFields<TransactionRequest> {
+    TransactionRequest::default().with_to(STORAGE_GAS_PROBE_ADDRESS).into()
+}
+
+fn storage_probe_gas(result: Bytes) -> u64 {
+    U256::from_be_slice(&result).to::<u64>()
+}
+
+fn storage_read_probe_code(second_slot: u8) -> Bytes {
+    let mut code = hex!("5a5f5450600054505a90035f5260205ff3");
+    code[5] = second_slot;
+    Bytes::from(code)
+}
+
+fn storage_write_probe_code(second_slot: u8) -> Bytes {
+    let mut code = hex!("5a60015f5560016000555a90035f5260205ff3");
+    code[8] = second_slot;
+    Bytes::from(code)
 }
 
 fn reserve_probe_tx(from: Address, nonce: u64, slot: u64, value: U256) -> TransactionRequest {

--- a/crates/anvil/tests/it/monad.rs
+++ b/crates/anvil/tests/it/monad.rs
@@ -12,7 +12,8 @@ use alloy_provider::{
     ext::{DebugApi, TraceApi},
 };
 use alloy_rpc_types::{
-    Authorization, BlockId, BlockNumberOrTag, Index, TransactionRequest,
+    AccessList, AccessListItem, Authorization, BlockId, BlockNumberOrTag, Index,
+    TransactionRequest,
     anvil::Forking,
     simulate::{SimBlock, SimulatePayload},
     state::{AccountOverride, StateOverride},
@@ -116,6 +117,121 @@ async fn monad_ten_applies_mip8_storage_gas() {
         let different_page_write =
             storage_probe_gas(provider.call(storage_gas_probe_call()).await.unwrap());
         assert_eq!(different_page_write - same_page_write, write_delta);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn monad_ten_deduplicates_access_list_storage_pages() {
+    let one = B256::from(U256::ONE.to_be_bytes::<32>());
+    let two = B256::from(U256::from(2).to_be_bytes::<32>());
+    let page_one = B256::from(U256::from(129).to_be_bytes::<32>());
+
+    for (config, expected_same_page_keys, gas_delta) in [
+        (
+            NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into())),
+            vec![one, two],
+            0,
+        ),
+        (NodeConfig::test_monad(), vec![one], 1_900),
+    ] {
+        let (api, handle) = spawn(config).await;
+        let provider = handle.http_provider();
+
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_access_list_probe_code(2, 1))
+            .await
+            .unwrap();
+        let same_page = provider.create_access_list(&storage_gas_probe_call()).await.unwrap();
+        assert_eq!(
+            same_page.access_list,
+            AccessList::from(vec![AccessListItem {
+                address: STORAGE_GAS_PROBE_ADDRESS,
+                storage_keys: expected_same_page_keys,
+            }])
+        );
+
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_access_list_probe_code(129, 1))
+            .await
+            .unwrap();
+        let different_page = provider.create_access_list(&storage_gas_probe_call()).await.unwrap();
+        assert_eq!(
+            different_page.access_list,
+            AccessList::from(vec![AccessListItem {
+                address: STORAGE_GAS_PROBE_ADDRESS,
+                storage_keys: vec![one, page_one],
+            }])
+        );
+        assert_eq!(different_page.gas_used - same_page.gas_used, U256::from(gas_delta));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn monad_ten_rpc_simulations_apply_mip8_storage_gas() {
+    for (config, read_delta, write_delta) in [
+        (NodeConfig::test_monad().with_hardfork(Some(MonadHardfork::MonadNine.into())), 0, 0),
+        (NodeConfig::test_monad(), 8_000, 10_800),
+    ] {
+        let (api, handle) = spawn(config).await;
+        let provider = handle.http_provider();
+
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_read_probe_code(127)).await.unwrap();
+        let same_page_read_estimate =
+            provider.estimate_gas(storage_gas_probe_call()).await.unwrap();
+        let same_page_read_trace: TraceResults = provider
+            .client()
+            .request(
+                "trace_call",
+                (storage_gas_probe_call(), vec![TraceType::Trace], BlockId::latest()),
+            )
+            .await
+            .unwrap();
+
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_read_probe_code(128)).await.unwrap();
+        let different_page_read_estimate =
+            provider.estimate_gas(storage_gas_probe_call()).await.unwrap();
+        let different_page_read_trace: TraceResults = provider
+            .client()
+            .request(
+                "trace_call",
+                (storage_gas_probe_call(), vec![TraceType::Trace], BlockId::latest()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(different_page_read_estimate - same_page_read_estimate, read_delta);
+        assert_eq!(
+            root_trace_gas(&different_page_read_trace) - root_trace_gas(&same_page_read_trace),
+            read_delta
+        );
+
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_write_probe_code(1)).await.unwrap();
+        let same_page_write_estimate =
+            provider.estimate_gas(storage_gas_probe_call()).await.unwrap();
+        let same_page_write_trace: TraceResults = provider
+            .client()
+            .request(
+                "trace_call",
+                (storage_gas_probe_call(), vec![TraceType::Trace], BlockId::latest()),
+            )
+            .await
+            .unwrap();
+
+        api.anvil_set_code(STORAGE_GAS_PROBE_ADDRESS, storage_write_probe_code(128)).await.unwrap();
+        let different_page_write_estimate =
+            provider.estimate_gas(storage_gas_probe_call()).await.unwrap();
+        let different_page_write_trace: TraceResults = provider
+            .client()
+            .request(
+                "trace_call",
+                (storage_gas_probe_call(), vec![TraceType::Trace], BlockId::latest()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(different_page_write_estimate - same_page_write_estimate, write_delta);
+        assert_eq!(
+            root_trace_gas(&different_page_write_trace) - root_trace_gas(&same_page_write_trace),
+            write_delta
+        );
     }
 }
 
@@ -2200,8 +2316,19 @@ fn storage_probe_gas(result: Bytes) -> u64 {
     U256::from_be_slice(&result).to::<u64>()
 }
 
+fn root_trace_gas(result: &TraceResults) -> u64 {
+    result.trace[0].result.as_ref().expect("root call trace should contain a result").gas_used()
+}
+
 fn storage_read_probe_code(second_slot: u8) -> Bytes {
     let mut code = hex!("5a5f5450600054505a90035f5260205ff3");
+    code[5] = second_slot;
+    Bytes::from(code)
+}
+
+fn storage_access_list_probe_code(first_slot: u8, second_slot: u8) -> Bytes {
+    let mut code = hex!("600054506000545000");
+    code[1] = first_slot;
     code[5] = second_slot;
     Bytes::from(code)
 }

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -1887,11 +1887,11 @@ mod tests {
 
     #[test]
     #[cfg(feature = "monad")]
-    fn resolve_execution_spec_uses_monad_activation_timestamp() {
+    fn resolve_execution_spec_uses_monad_ten_activation_timestamp() {
         let config = Config::default();
         let networks = NetworkConfigs::with_monad();
         let activation =
-            foundry_evm_hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+            foundry_evm_hardforks::MonadHardfork::MonadTen.mainnet_activation_timestamp().unwrap();
 
         let mut before = monad_env(activation - 1);
         assert_eq!(
@@ -1903,9 +1903,9 @@ mod tests {
                 None,
                 None,
             ),
-            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight))
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine))
         );
-        assert_eq!(before.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadEight);
+        assert_eq!(before.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadNine);
 
         let mut after = monad_env(activation);
         assert_eq!(
@@ -1917,9 +1917,9 @@ mod tests {
                 None,
                 None,
             ),
-            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine))
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadTen))
         );
-        assert_eq!(after.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadNine);
+        assert_eq!(after.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadTen);
     }
 
     #[test]
@@ -1952,7 +1952,7 @@ mod tests {
         let config = Config::default();
         let networks = NetworkConfigs::with_monad();
         let activation =
-            foundry_evm_hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+            foundry_evm_hardforks::MonadHardfork::MonadTen.mainnet_activation_timestamp().unwrap();
         let mut env = monad_env(activation - 1);
 
         assert_eq!(
@@ -1964,9 +1964,9 @@ mod tests {
                 None,
                 None,
             ),
-            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine))
+            Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadTen))
         );
-        assert_eq!(env.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadNine);
+        assert_eq!(env.cfg_env.spec, foundry_evm_hardforks::MonadHardfork::MonadTen);
     }
 
     #[test]

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -563,6 +563,10 @@ mod tests {
             FoundryHardfork::Monad(MonadHardfork::MonadNine)
         );
         assert_eq!(
+            "monad:MonadTen".parse::<FoundryHardfork>().unwrap(),
+            FoundryHardfork::Monad(MonadHardfork::MonadTen)
+        );
+        assert_eq!(
             "m:MonadNext".parse::<FoundryHardfork>().unwrap(),
             FoundryHardfork::Monad(MonadHardfork::MonadNext)
         );
@@ -584,6 +588,7 @@ mod tests {
     fn test_monad_hardfork_spec_id_mapping() {
         assert_eq!(SpecId::from(FoundryHardfork::Monad(MonadHardfork::MonadEight)), SpecId::PRAGUE);
         assert_eq!(SpecId::from(FoundryHardfork::Monad(MonadHardfork::MonadNine)), SpecId::OSAKA);
+        assert_eq!(SpecId::from(FoundryHardfork::Monad(MonadHardfork::MonadTen)), SpecId::OSAKA);
         assert_eq!(
             MonadHardfork::from(FoundryHardfork::Monad(MonadHardfork::MonadNext)),
             MonadHardfork::MonadNext
@@ -670,6 +675,9 @@ mod tests {
     #[test]
     #[cfg(feature = "monad")]
     fn test_monad_hardfork_from_chain_and_timestamp() {
+        let mainnet_ten = MonadHardfork::MonadTen.mainnet_activation_timestamp().unwrap();
+        let testnet_ten = MonadHardfork::MonadTen.testnet_activation_timestamp().unwrap();
+
         assert_eq!(
             FoundryHardfork::from_chain_and_timestamp(
                 monad_revm::MONAD_MAINNET_CHAIN_ID,
@@ -686,6 +694,20 @@ mod tests {
         );
         assert_eq!(
             FoundryHardfork::from_chain_and_timestamp(
+                monad_revm::MONAD_MAINNET_CHAIN_ID,
+                mainnet_ten - 1,
+            ),
+            Some(FoundryHardfork::Monad(MonadHardfork::MonadNine))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(
+                monad_revm::MONAD_MAINNET_CHAIN_ID,
+                mainnet_ten,
+            ),
+            Some(FoundryHardfork::Monad(MonadHardfork::MonadTen))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(
                 monad_revm::MONAD_TESTNET_CHAIN_ID,
                 1_773_152_999,
             ),
@@ -697,6 +719,20 @@ mod tests {
                 1_773_153_000,
             ),
             Some(FoundryHardfork::Monad(MonadHardfork::MonadNine))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(
+                monad_revm::MONAD_TESTNET_CHAIN_ID,
+                testnet_ten - 1,
+            ),
+            Some(FoundryHardfork::Monad(MonadHardfork::MonadNine))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(
+                monad_revm::MONAD_TESTNET_CHAIN_ID,
+                testnet_ten,
+            ),
+            Some(FoundryHardfork::Monad(MonadHardfork::MonadTen))
         );
     }
 
@@ -713,6 +749,10 @@ mod tests {
             assert_eq!(
                 evm_spec_id_from_str::<MonadHardfork>("MonadNine"),
                 Some(MonadHardfork::MonadNine)
+            );
+            assert_eq!(
+                evm_spec_id_from_str::<MonadHardfork>("MonadTen"),
+                Some(MonadHardfork::MonadTen)
             );
             assert_eq!(
                 evm_spec_id_from_str::<MonadHardfork>("monad:MonadEight"),

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -298,6 +298,31 @@ contract ModexpGasProbe {
     }
 }
 
+contract StorageGasProbe {
+    function measureRead(uint256 secondSlot)
+        external
+        view
+        returns (uint256 gasUsed, uint256 checksum)
+    {
+        assembly {
+            let gasBefore := gas()
+            let first := sload(0)
+            let second := sload(secondSlot)
+            gasUsed := sub(gasBefore, gas())
+            checksum := add(first, second)
+        }
+    }
+
+    function measureWrite(uint256 secondSlot) external returns (uint256 gasUsed) {
+        assembly {
+            let gasBefore := gas()
+            sstore(0, 1)
+            sstore(secondSlot, 1)
+            gasUsed := sub(gasBefore, gas())
+        }
+    }
+}
+
 contract MonadEvmVersionTest is Test {
     EvmVm constant evm = EvmVm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
     address constant CLZ_TARGET = address(uint160(0x0c17));
@@ -306,6 +331,9 @@ contract MonadEvmVersionTest is Test {
     ModexpGasProbe immutable modexpGasProbe = new ModexpGasProbe();
 
     function test_set_monad_evm_version() public {
+        assertEq(evm.getEvmVersion(), "monadten");
+        assertMip8Active();
+
         evm.setEvmVersion("MonadEight");
         vm.etch(CLZ_TARGET, hex"60011e60005260206000f3");
 
@@ -326,6 +354,11 @@ contract MonadEvmVersionTest is Test {
         (ok, output) = CLZ_TARGET.staticcall(hex"");
         assertTrue(ok, "CLZ should be available on MonadNine");
         assertEq(abi.decode(output, (uint256)), 255);
+        assertMip8Inactive();
+
+        evm.setEvmVersion("monad:MonadTen");
+        assertEq(evm.getEvmVersion(), "monadten");
+        assertMip8Active();
 
         evm.setEvmVersion("monad:MonadEight");
         assertEq(evm.getEvmVersion(), "monadeight");
@@ -340,6 +373,26 @@ contract MonadEvmVersionTest is Test {
         );
         (ok,) = CLZ_TARGET.staticcall(hex"");
         assertFalse(ok, "CLZ should be disabled after switching back to MonadEight");
+    }
+
+    function assertMip8Active() internal {
+        assertEq(storageReadGas(128) - storageReadGas(127), 8_000, "MIP-8 page read cost");
+        assertEq(storageWriteGas(128) - storageWriteGas(1), 10_800, "MIP-8 page write cost");
+    }
+
+    function assertMip8Inactive() internal {
+        assertEq(storageReadGas(128), storageReadGas(127), "legacy slot read cost");
+        assertEq(storageWriteGas(128), storageWriteGas(1), "legacy slot write cost");
+    }
+
+    function storageReadGas(uint256 secondSlot) internal returns (uint256 gasUsed) {
+        uint256 checksum;
+        (gasUsed, checksum) = new StorageGasProbe().measureRead(secondSlot);
+        assertEq(checksum, 0);
+    }
+
+    function storageWriteGas(uint256 secondSlot) internal returns (uint256) {
+        return new StorageGasProbe().measureWrite(secondSlot);
     }
 
     function memoryExpansionGasDelta() internal returns (uint256) {
@@ -373,8 +426,12 @@ contract MonadEvmVersionTest is Test {
 
 #[cfg(feature = "monad")]
 forgetest_async!(fork_resolves_monad_hardfork_from_timestamp, |prj, cmd| {
-    let activation =
+    let monad_nine_activation =
         foundry_evm::hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
+    let mainnet_activation =
+        foundry_evm::hardforks::MonadHardfork::MonadTen.mainnet_activation_timestamp().unwrap();
+    let testnet_activation =
+        foundry_evm::hardforks::MonadHardfork::MonadTen.testnet_activation_timestamp().unwrap();
     prj.add_test(
         "MonadForkHardfork.t.sol",
         r#"
@@ -400,6 +457,14 @@ contract MonadForkHardforkTest {
             "expected MonadNine"
         );
     }
+
+    function test_monad_ten() public {
+        require(block.chainid == 1, "expected CHAINID override");
+        require(
+            keccak256(bytes(evm.getEvmVersion())) == keccak256("monadten"),
+            "expected MonadTen"
+        );
+    }
 }
    "#,
     );
@@ -407,7 +472,7 @@ contract MonadForkHardforkTest {
     let (_api, before) = anvil::spawn(
         anvil::NodeConfig::test()
             .with_chain_id(Some(143u64))
-            .with_genesis_timestamp(Some(activation - 1)),
+            .with_genesis_timestamp(Some(monad_nine_activation - 1)),
     )
     .await;
     cmd.args([
@@ -426,7 +491,7 @@ contract MonadForkHardforkTest {
     let (_api, after) = anvil::spawn(
         anvil::NodeConfig::test()
             .with_chain_id(Some(143u64))
-            .with_genesis_timestamp(Some(activation)),
+            .with_genesis_timestamp(Some(monad_nine_activation)),
     )
     .await;
     cmd.forge_fuse()
@@ -443,11 +508,91 @@ contract MonadForkHardforkTest {
         ])
         .assert_success();
 
+    let (_api, before) = anvil::spawn(
+        anvil::NodeConfig::test()
+            .with_chain_id(Some(143u64))
+            .with_genesis_timestamp(Some(mainnet_activation - 1)),
+    )
+    .await;
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--network",
+            "monad",
+            "--fork-url",
+            &before.http_endpoint(),
+            "--chain-id",
+            "1",
+            "--mt",
+            "test_monad_nine",
+        ])
+        .assert_success();
+
+    let (_api, after) = anvil::spawn(
+        anvil::NodeConfig::test()
+            .with_chain_id(Some(143u64))
+            .with_genesis_timestamp(Some(mainnet_activation)),
+    )
+    .await;
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--network",
+            "monad",
+            "--fork-url",
+            &after.http_endpoint(),
+            "--chain-id",
+            "1",
+            "--mt",
+            "test_monad_ten",
+        ])
+        .assert_success();
+
+    let (_api, before) = anvil::spawn(
+        anvil::NodeConfig::test()
+            .with_chain_id(Some(10143u64))
+            .with_genesis_timestamp(Some(testnet_activation - 1)),
+    )
+    .await;
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--network",
+            "monad",
+            "--fork-url",
+            &before.http_endpoint(),
+            "--chain-id",
+            "1",
+            "--mt",
+            "test_monad_nine",
+        ])
+        .assert_success();
+
+    let (_api, after) = anvil::spawn(
+        anvil::NodeConfig::test()
+            .with_chain_id(Some(10143u64))
+            .with_genesis_timestamp(Some(testnet_activation)),
+    )
+    .await;
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--network",
+            "monad",
+            "--fork-url",
+            &after.http_endpoint(),
+            "--chain-id",
+            "1",
+            "--mt",
+            "test_monad_ten",
+        ])
+        .assert_success();
+
     let (_api, overridden) = anvil::spawn(
         anvil::NodeConfig::test_monad()
             .with_chain_id(Some(143u64))
-            .with_genesis_timestamp(Some(activation))
-            .with_hardfork(Some(foundry_evm::hardforks::MonadHardfork::MonadEight.into())),
+            .with_genesis_timestamp(Some(mainnet_activation))
+            .with_hardfork(Some(foundry_evm::hardforks::MonadHardfork::MonadNine.into())),
     )
     .await;
     cmd.forge_fuse()
@@ -458,7 +603,7 @@ contract MonadForkHardforkTest {
             "--chain-id",
             "1",
             "--mt",
-            "test_monad_eight",
+            "test_monad_nine",
         ])
         .assert_success();
 });


### PR DESCRIPTION
## Context

[MIP-8](https://mips.monad.xyz/MIPs/MIP-8) introduces page-based storage access, write, and state-growth accounting in MonadTen. This PR adds MonadTen to Foundry and connects the published [`monad-revm` 0.7.0](https://crates.io/crates/monad-revm/0.7.0) and [`alloy-monad-evm` 0.7.0](https://crates.io/crates/alloy-monad-evm/0.7.0) crates through Forge and Anvil. The underlying monad-revm implementation was introduced in [category-labs/monad-revm#48](https://github.com/category-labs/monad-revm/pull/48), and its Alloy EVM adapter was introduced in [category-labs/alloy-monad-evm#21](https://github.com/category-labs/alloy-monad-evm/pull/21).

`monad-revm` owns the MonadTen hardfork identity, MIP-8 instruction and journal behavior, and transaction- and frame-level page tracking. `alloy-monad-evm` carries that hardfork through EVM construction, precompile selection, and runtime transitions. Foundry selects the Monad execution environment and exposes the resulting behavior consistently across its local execution and RPC surfaces.

## Hardfork behavior

MonadTen is now the default for local Monad execution when no hardfork is configured. Historical and live forks resolve the active hardfork from the source chain ID and block timestamp: Monad mainnet activates MonadTen at Unix timestamp `1788359400` (2026-09-02 14:30 UTC), while Monad testnet activates it at `1786545000` (2026-08-12 14:30 UTC).

## MIP-8 execution and RPC behavior

MIP-8 groups 128 storage words into each page. The first storage read from a page costs `8100` gas, composed of the `100` gas base cost and an `8000` gas page load, while later reads from that page cost `100` gas. `SSTORE` always pays the `100` gas base cost and may additionally pay the `8000` gas first-page load, the `2800` gas first changed-page write, and the `17000` gas net state-growth charge. Read warmth, changed-page state, current growth, and the net-growth high-water mark follow call-frame rollback and transaction boundaries.

Forge applies this schedule through explicit MonadTen selection and through the default Monad environment, while MonadNine retains slot-level accounting. Anvil applies the same rules to `eth_call`, `eth_estimateGas`, and `trace_call`. The integration exercises the canonical `8000` gas read-page delta and `10800` gas write-page delta between same-page and different-page accesses, with MonadNine controls confirming that MIP-8 remains hardfork-gated.

Under MonadTen and later, `eth_createAccessList` emits one minimum touched storage-key representative per page. The generated list is re-executed with EIP-2930 semantics so page warmth and the returned `gasUsed` agree with the list. MonadNine preserves the existing per-slot access-list behavior.

## Scope

This change covers Foundry execution, hardfork routing, access-list generation, gas estimation, and tracing. Monad storage commitments, paged trie proofs, and any Monad-specific `eth_getProof` response semantics remain node-layer work outside this integration.
