### PR TITLE
test(cast): skip cache-isolated call test on Windows

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -7009,6 +7009,8 @@ forgetest_async!(cast_call_debug_trace_call_local_artifacts_json_stdout, |prj, c
     });
 });
 
+// `dirs::home_dir()` ignores `HOME` on Windows, so the signature cache cannot be isolated there.
+#[cfg(not(windows))]
 casttest!(cast_call_decodes_custom_error, async |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;
 


### PR DESCRIPTION
## Motivation

The Windows `test all` job fails because `cast_call_decodes_custom_error` overrides `HOME` to isolate its signatures cache. `dirs::home_dir()` ignores `HOME` on Windows, so Cast reads the runner profile cache instead and misses the signature seeded by the test.

Failure: https://github.com/foundry-rs/foundry/actions/runs/32827352975/job/97738260853

## Solution

Exclude this cache-isolation test on Windows and document the platform limitation. Unix platforms continue to exercise the full custom-error decoding path, while the test avoids mutating or racing on the real Windows profile cache.

## Testing

- `cargo fmt --all -- --check`
- `cargo test --locked -p cast@1.8.0 --test cli cast_call_decodes_custom_error -- --exact`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
