### PR TITLE
fix(evm): refresh fork state after vm.rpc

### DIFF
--- a/.changelog/refresh-vm-rpc-fork-journal.md
+++ b/.changelog/refresh-vm-rpc-fork-journal.md
@@ -1,0 +1,7 @@
+---
+foundry-cheatcodes: patch
+foundry-evm-core: patch
+forge: patch
+---
+
+Fixed state-mutating `vm.rpc` calls such as `anvil_setCode` leaving already-loaded fork accounts stale during the same execution.

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -237,7 +237,7 @@ impl Cheatcode for rpc_0Call {
         let url =
             ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
         let result = rpc_call(&url, method, params)?;
-        invalidate_active_fork_cache(ccx, method, params);
+        refresh_active_fork_state(ccx, method, params)?;
         Ok(result)
     }
 }
@@ -256,7 +256,7 @@ impl Cheatcode for rpcJson_0Call {
         let url =
             ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
         let result = rpc_json_call(&url, method, params)?;
-        invalidate_active_fork_cache(ccx, method, params);
+        refresh_active_fork_state(ccx, method, params)?;
         Ok(result)
     }
 }
@@ -552,15 +552,14 @@ fn rpc_json_call(url: &str, method: &str, params: &str) -> Result {
     Ok(serde_json::to_string(&result)?.abi_encode())
 }
 
-/// Invalidates the fork DB cache after a `vm.rpc` call on the active fork that mutates the node
-/// directly (bypassing the cache), so later DB reads (e.g. the broadcast simulation runner)
-/// re-fetch the new value. Only well-known Anvil/Hardhat account/storage setters are handled;
-/// chain-advancing methods (e.g. `eth_sendTransaction`) need re-forking, not eviction.
-fn invalidate_active_fork_cache<FEN: FoundryEvmNetwork>(
+/// Refreshes cached fork and journal state after a `vm.rpc` call on the active fork that mutates
+/// the node directly. Only well-known Anvil/Hardhat account/storage setters are handled;
+/// chain-advancing methods (e.g. `eth_sendTransaction`) need re-forking, not synchronization.
+fn refresh_active_fork_state<FEN: FoundryEvmNetwork>(
     ccx: &mut CheatsCtxt<'_, '_, FEN>,
     method: &str,
     params: &str,
-) {
+) -> Result<()> {
     const ACCOUNT_SETTERS: &[&str] = &[
         "anvil_setBalance",
         "hardhat_setBalance",
@@ -576,26 +575,28 @@ fn invalidate_active_fork_cache<FEN: FoundryEvmNetwork>(
     ];
     let is_storage_setter = matches!(method, "anvil_setStorageAt" | "hardhat_setStorageAt");
     if !is_storage_setter && !ACCOUNT_SETTERS.contains(&method) {
-        return;
+        return Ok(());
     }
 
-    let Ok(params) = serde_json::from_str::<serde_json::Value>(params) else { return };
+    let Ok(params) = serde_json::from_str::<serde_json::Value>(params) else { return Ok(()) };
     let Some(address) =
         params.get(0).and_then(|v| v.as_str()).and_then(|s| s.parse::<Address>().ok())
     else {
-        return;
+        return Ok(());
     };
 
+    let (db, journaled_state) = ccx.ecx.db_journal_inner_mut();
     if is_storage_setter {
         let Some(slot) =
             params.get(1).and_then(|v| v.as_str()).and_then(|s| s.parse::<U256>().ok())
         else {
-            return;
+            return Ok(());
         };
-        ccx.ecx.db_mut().invalidate_fork_cache_storage(address, slot);
+        db.refresh_fork_storage(address, slot, journaled_state)?;
     } else {
-        ccx.ecx.db_mut().invalidate_fork_cache_account(address);
+        db.refresh_fork_account(address, journaled_state)?;
     }
+    Ok(())
 }
 
 fn rpc_result(url: &str, method: &str, params: &str) -> Result<serde_json::Value> {

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -12,7 +12,7 @@ use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
 use foundry_evm_core::{
     FoundryContextExt,
-    backend::{ContextUpdateFor, JournaledState, LocalForkId},
+    backend::{ContextUpdateFor, ForkAccountField, JournaledState, LocalForkId},
     evm::{BlockEnvFor, EvmFactoryFor, FoundryContextFor, FoundryEvmNetwork, SpecFor, TxEnvFor},
     fork::CreateFork,
 };
@@ -560,23 +560,20 @@ fn refresh_active_fork_state<FEN: FoundryEvmNetwork>(
     method: &str,
     params: &str,
 ) -> Result<()> {
-    const ACCOUNT_SETTERS: &[&str] = &[
-        "anvil_setBalance",
-        "hardhat_setBalance",
-        "tenderly_setBalance",
-        "anvil_addBalance",
-        "hardhat_addBalance",
-        "tenderly_addBalance",
-        "anvil_setNonce",
-        "hardhat_setNonce",
-        "evm_setAccountNonce",
-        "anvil_setCode",
-        "hardhat_setCode",
-    ];
-    let is_storage_setter = matches!(method, "anvil_setStorageAt" | "hardhat_setStorageAt");
-    if !is_storage_setter && !ACCOUNT_SETTERS.contains(&method) {
-        return Ok(());
-    }
+    let account_field = match method {
+        "anvil_setBalance"
+        | "hardhat_setBalance"
+        | "tenderly_setBalance"
+        | "anvil_addBalance"
+        | "hardhat_addBalance"
+        | "tenderly_addBalance" => Some(ForkAccountField::Balance),
+        "anvil_setNonce" | "hardhat_setNonce" | "evm_setAccountNonce" => {
+            Some(ForkAccountField::Nonce)
+        }
+        "anvil_setCode" | "hardhat_setCode" => Some(ForkAccountField::Code),
+        "anvil_setStorageAt" | "hardhat_setStorageAt" => None,
+        _ => return Ok(()),
+    };
 
     let Ok(params) = serde_json::from_str::<serde_json::Value>(params) else { return Ok(()) };
     let Some(address) =
@@ -586,15 +583,15 @@ fn refresh_active_fork_state<FEN: FoundryEvmNetwork>(
     };
 
     let (db, journaled_state) = ccx.ecx.db_journal_inner_mut();
-    if is_storage_setter {
+    if let Some(field) = account_field {
+        db.refresh_fork_account(address, field, journaled_state)?;
+    } else {
         let Some(slot) =
             params.get(1).and_then(|v| v.as_str()).and_then(|s| s.parse::<U256>().ok())
         else {
             return Ok(());
         };
         db.refresh_fork_storage(address, slot, journaled_state)?;
-    } else {
-        db.refresh_fork_account(address, journaled_state)?;
     }
     Ok(())
 }

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -4,7 +4,7 @@ use super::BackendError;
 use crate::{
     FoundryInspectorExt,
     backend::{
-        Backend, ContextUpdateFor, DatabaseExt, JournaledState, LocalForkId,
+        Backend, ContextUpdateFor, DatabaseExt, ForkAccountField, JournaledState, LocalForkId,
         RevertStateSnapshotAction, diagnostic::RevertDiagnostic,
     },
     evm::{
@@ -354,9 +354,10 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN
     fn refresh_fork_account(
         &mut self,
         address: Address,
+        field: ForkAccountField,
         journaled_state: &mut JournaledState,
     ) -> Result<(), BackendError> {
-        self.backend.to_mut().refresh_fork_account(address, journaled_state)
+        self.backend.to_mut().refresh_fork_account(address, field, journaled_state)
     }
 
     fn refresh_fork_storage(

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -351,12 +351,21 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN
         self.backend.is_persistent(acc)
     }
 
-    fn invalidate_fork_cache_account(&mut self, address: Address) {
-        self.backend.to_mut().invalidate_fork_cache_account(address)
+    fn refresh_fork_account(
+        &mut self,
+        address: Address,
+        journaled_state: &mut JournaledState,
+    ) -> Result<(), BackendError> {
+        self.backend.to_mut().refresh_fork_account(address, journaled_state)
     }
 
-    fn invalidate_fork_cache_storage(&mut self, address: Address, slot: U256) {
-        self.backend.to_mut().invalidate_fork_cache_storage(address, slot)
+    fn refresh_fork_storage(
+        &mut self,
+        address: Address,
+        slot: U256,
+        journaled_state: &mut JournaledState,
+    ) -> Result<(), BackendError> {
+        self.backend.to_mut().refresh_fork_storage(address, slot, journaled_state)
     }
 
     fn remove_persistent_account(&mut self, account: &Address) -> bool {

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -189,6 +189,27 @@ pub const GLOBAL_FAIL_SLOT: U256 =
 
 pub type JournaledState = JournalInner<JournalEntry>;
 
+/// Account field changed by an out-of-band fork RPC mutation.
+#[derive(Clone, Copy, Debug)]
+pub enum ForkAccountField {
+    Balance,
+    Nonce,
+    Code,
+}
+
+impl ForkAccountField {
+    fn update(self, target: &mut AccountInfo, refreshed: &AccountInfo) {
+        match self {
+            Self::Balance => target.balance = refreshed.balance,
+            Self::Nonce => target.nonce = refreshed.nonce,
+            Self::Code => {
+                target.code_hash = refreshed.code_hash;
+                target.code = refreshed.code.clone();
+            }
+        }
+    }
+}
+
 /// An extension trait that allows us to easily extend the `revm::Inspector` capabilities
 #[auto_impl::auto_impl(&mut)]
 pub trait DatabaseExt<F: FoundryEvmFactory>:
@@ -433,12 +454,12 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
     /// Returns true if the given account is currently marked as persistent.
     fn is_persistent(&self, acc: &Address) -> bool;
 
-    /// Drops cached account info for `address` on the active fork and refreshes any already-loaded
-    /// journal entries from the node (used after out-of-band mutations like `anvil_setCode` via
-    /// `vm.rpc`).
+    /// Refreshes an account field changed out-of-band on the active fork in any already-loaded
+    /// cache and journal entries.
     fn refresh_fork_account(
         &mut self,
         address: Address,
+        field: ForkAccountField,
         journaled_state: &mut JournaledState,
     ) -> Result<(), BackendError>;
 
@@ -2403,34 +2424,45 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
     fn refresh_fork_account(
         &mut self,
         address: Address,
+        field: ForkAccountField,
         journaled_state: &mut JournaledState,
     ) -> Result<(), BackendError> {
         let Some(fork) = self.active_fork_mut() else { return Ok(()) };
-        trace!(?address, "refresh fork account");
+        trace!(?address, ?field, "refresh fork account");
         fork.db.db.data().accounts.write().remove(&address);
-        // Keep the local entry if it holds in-script modifications (e.g. `vm.deal`).
-        if fork
+
+        let cache_modified = fork
             .db
             .cache
             .accounts
             .get(&address)
-            .is_some_and(|account| account.account_state == AccountState::None)
-        {
+            .is_some_and(|account| account.account_state != AccountState::None);
+        if !cache_modified {
             fork.db.cache.accounts.remove(&address);
         }
 
-        if !journaled_state.state.contains_key(&address)
+        if !cache_modified
+            && !journaled_state.state.contains_key(&address)
             && !fork.journaled_state.state.contains_key(&address)
         {
             return Ok(());
         }
 
-        let account = Database::basic(&mut fork.db, address)?.unwrap_or_default();
+        let mut refreshed = DatabaseRef::basic_ref(&fork.db.db, address)?.unwrap_or_default();
+        if matches!(field, ForkAccountField::Code) {
+            fork.db.insert_contract(&mut refreshed);
+        }
+        if let Some(cached) = fork.db.cache.accounts.get_mut(&address) {
+            field.update(&mut cached.info, &refreshed);
+            if cached.account_state == AccountState::NotExisting && !refreshed.is_empty() {
+                cached.account_state = AccountState::None;
+            }
+        }
         if let Some(journaled_account) = journaled_state.state.get_mut(&address) {
-            journaled_account.info = account.clone();
+            field.update(&mut journaled_account.info, &refreshed);
         }
         if let Some(journaled_account) = fork.journaled_state.state.get_mut(&address) {
-            journaled_account.info = account;
+            field.update(&mut journaled_account.info, &refreshed);
         }
         Ok(())
     }
@@ -2446,10 +2478,13 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         if let Some(storage) = fork.db.db.data().storage.write().get_mut(&address) {
             storage.remove(&slot);
         }
-        // Keep the local slot if the account holds in-script modifications.
-        if let Some(account) = fork.db.cache.accounts.get_mut(&address)
-            && account.account_state == AccountState::None
-        {
+        let cache_modified = fork
+            .db
+            .cache
+            .accounts
+            .get(&address)
+            .is_some_and(|account| account.account_state != AccountState::None);
+        if !cache_modified && let Some(account) = fork.db.cache.accounts.get_mut(&address) {
             account.storage.remove(&slot);
         }
 
@@ -2462,11 +2497,17 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
             .state
             .get(&address)
             .is_some_and(|account| account.storage.contains_key(&slot));
-        if !outer_loaded && !fork_loaded {
+        if !cache_modified && !outer_loaded && !fork_loaded {
             return Ok(());
         }
 
-        let value = Database::storage(&mut fork.db, address, slot)?;
+        let value = DatabaseRef::storage_ref(&fork.db.db, address, slot)?;
+        if let Some(account) = fork.db.cache.accounts.get_mut(&address) {
+            account.storage.insert(slot, value);
+            if account.account_state == AccountState::NotExisting && !value.is_zero() {
+                account.account_state = AccountState::None;
+            }
+        }
         if let Some(storage) = journaled_state
             .state
             .get_mut(&address)
@@ -3211,7 +3252,9 @@ fn apply_state_changeset<N: Network, B: ForkBlockEnv>(
 
 #[cfg(test)]
 mod tests {
-    use super::{Fork, apply_state_changeset, ensure_block_identity, update_env_block};
+    use super::{
+        Fork, ForkAccountField, apply_state_changeset, ensure_block_identity, update_env_block,
+    };
     use crate::{
         backend::{Backend, DatabaseExt, ForkPosition},
         evm::EthEvmNetwork,
@@ -3374,21 +3417,31 @@ mod tests {
 
         let mut journaled_state = JournalInner::new();
         journaled_state.load_account(&mut backend, target).unwrap();
+        journaled_state.state.get_mut(&target).unwrap().info.balance = U256::from(1);
         let fork = backend.active_fork_mut().unwrap();
         fork.journaled_state.load_account(&mut fork.db, target).unwrap();
+        fork.journaled_state.state.get_mut(&target).unwrap().info.balance = U256::from(2);
+        let cached = fork.db.cache.accounts.get_mut(&target).unwrap();
+        cached.info.balance = U256::from(3);
+        cached.account_state = AccountState::Touched;
         assert_eq!(journaled_state.state[&target].info.code_hash, KECCAK_EMPTY);
         assert_eq!(fork.journaled_state.state[&target].info.code_hash, KECCAK_EMPTY);
 
         api.anvil_set_code(target, code.clone()).await.unwrap();
-        backend.refresh_fork_account(target, &mut journaled_state).unwrap();
+        backend.refresh_fork_account(target, ForkAccountField::Code, &mut journaled_state).unwrap();
 
         let expected_hash = keccak256(&code);
         let refreshed = &journaled_state.state[&target].info;
         assert_eq!(refreshed.code_hash, expected_hash);
         assert_eq!(refreshed.code.as_ref().unwrap().original_bytes(), code);
+        assert_eq!(refreshed.balance, U256::from(1));
         let refreshed = &backend.active_fork().unwrap().journaled_state.state[&target].info;
         assert_eq!(refreshed.code_hash, expected_hash);
         assert_eq!(refreshed.code.as_ref().unwrap().original_bytes(), code);
+        assert_eq!(refreshed.balance, U256::from(2));
+        let cached = &backend.active_fork().unwrap().db.cache.accounts[&target];
+        assert_eq!(cached.info.code_hash, expected_hash);
+        assert_eq!(cached.info.balance, U256::from(3));
     }
 
     #[test]

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -433,13 +433,22 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
     /// Returns true if the given account is currently marked as persistent.
     fn is_persistent(&self, acc: &Address) -> bool;
 
-    /// Drops cached account info for `address` on the active fork so the next read re-fetches it
-    /// from the node (used after out-of-band mutations like `anvil_setBalance` via `vm.rpc`).
-    fn invalidate_fork_cache_account(&mut self, address: Address);
+    /// Drops cached account info for `address` on the active fork and refreshes any already-loaded
+    /// journal entries from the node (used after out-of-band mutations like `anvil_setCode` via
+    /// `vm.rpc`).
+    fn refresh_fork_account(
+        &mut self,
+        address: Address,
+        journaled_state: &mut JournaledState,
+    ) -> Result<(), BackendError>;
 
-    /// Like [`invalidate_fork_cache_account`](Self::invalidate_fork_cache_account), but for a
-    /// single storage slot.
-    fn invalidate_fork_cache_storage(&mut self, address: Address, slot: U256);
+    /// Like [`refresh_fork_account`](Self::refresh_fork_account), but for a single storage slot.
+    fn refresh_fork_storage(
+        &mut self,
+        address: Address,
+        slot: U256,
+        journaled_state: &mut JournaledState,
+    ) -> Result<(), BackendError>;
 
     /// Revokes persistent status from the given account.
     fn remove_persistent_account(&mut self, account: &Address) -> bool;
@@ -2391,33 +2400,89 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         self.inner.persistent_accounts.insert(account)
     }
 
-    fn invalidate_fork_cache_account(&mut self, address: Address) {
-        let Some(fork_db) = self.active_fork_db_mut() else { return };
-        trace!(?address, "invalidate fork cache account");
-        fork_db.db.data().accounts.write().remove(&address);
+    fn refresh_fork_account(
+        &mut self,
+        address: Address,
+        journaled_state: &mut JournaledState,
+    ) -> Result<(), BackendError> {
+        let Some(fork) = self.active_fork_mut() else { return Ok(()) };
+        trace!(?address, "refresh fork account");
+        fork.db.db.data().accounts.write().remove(&address);
         // Keep the local entry if it holds in-script modifications (e.g. `vm.deal`).
-        if fork_db
+        if fork
+            .db
             .cache
             .accounts
             .get(&address)
             .is_some_and(|account| account.account_state == AccountState::None)
         {
-            fork_db.cache.accounts.remove(&address);
+            fork.db.cache.accounts.remove(&address);
         }
+
+        if !journaled_state.state.contains_key(&address)
+            && !fork.journaled_state.state.contains_key(&address)
+        {
+            return Ok(());
+        }
+
+        let account = Database::basic(&mut fork.db, address)?.unwrap_or_default();
+        if let Some(journaled_account) = journaled_state.state.get_mut(&address) {
+            journaled_account.info = account.clone();
+        }
+        if let Some(journaled_account) = fork.journaled_state.state.get_mut(&address) {
+            journaled_account.info = account;
+        }
+        Ok(())
     }
 
-    fn invalidate_fork_cache_storage(&mut self, address: Address, slot: U256) {
-        let Some(fork_db) = self.active_fork_db_mut() else { return };
-        trace!(?address, ?slot, "invalidate fork cache storage");
-        if let Some(storage) = fork_db.db.data().storage.write().get_mut(&address) {
+    fn refresh_fork_storage(
+        &mut self,
+        address: Address,
+        slot: U256,
+        journaled_state: &mut JournaledState,
+    ) -> Result<(), BackendError> {
+        let Some(fork) = self.active_fork_mut() else { return Ok(()) };
+        trace!(?address, ?slot, "refresh fork storage");
+        if let Some(storage) = fork.db.db.data().storage.write().get_mut(&address) {
             storage.remove(&slot);
         }
         // Keep the local slot if the account holds in-script modifications.
-        if let Some(account) = fork_db.cache.accounts.get_mut(&address)
+        if let Some(account) = fork.db.cache.accounts.get_mut(&address)
             && account.account_state == AccountState::None
         {
             account.storage.remove(&slot);
         }
+
+        let outer_loaded = journaled_state
+            .state
+            .get(&address)
+            .is_some_and(|account| account.storage.contains_key(&slot));
+        let fork_loaded = fork
+            .journaled_state
+            .state
+            .get(&address)
+            .is_some_and(|account| account.storage.contains_key(&slot));
+        if !outer_loaded && !fork_loaded {
+            return Ok(());
+        }
+
+        let value = Database::storage(&mut fork.db, address, slot)?;
+        if let Some(storage) = journaled_state
+            .state
+            .get_mut(&address)
+            .and_then(|account| account.storage.get_mut(&slot))
+        {
+            storage.present_value = value;
+        }
+        if let Some(storage) = fork
+            .journaled_state
+            .state
+            .get_mut(&address)
+            .and_then(|account| account.storage.get_mut(&slot))
+        {
+            storage.present_value = value;
+        }
+        Ok(())
     }
 
     fn remove_persistent_account(&mut self, account: &Address) -> bool {
@@ -3159,7 +3224,7 @@ mod tests {
         AnyHeader, AnyNetwork, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction, AnyTxEnvelope,
         AnyTxType, UnknownTxEnvelope, UnknownTypedTransaction,
     };
-    use alloy_primitives::{Address, B256, U256, address};
+    use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
     use alloy_provider::{Provider, ProviderBuilder, mock::Asserter};
     use alloy_rpc_types::{Block, BlockTransactions, Transaction as RpcTransaction};
     use alloy_serde::WithOtherFields;
@@ -3174,7 +3239,7 @@ mod tests {
     use revm::{
         context::{BlockEnv, JournalInner, TxEnv},
         database::{AccountState, CacheDB, DatabaseRef, DbAccount},
-        primitives::hardfork::SpecId,
+        primitives::{KECCAK_EMPTY, hardfork::SpecId},
         state::{Account, AccountInfo, EvmState, EvmStorageSlot, TransactionId},
     };
     use std::collections::HashSet;
@@ -3290,6 +3355,40 @@ mod tests {
             journaled_state.state[&address].storage[&missing_slot].present_value(),
             U256::from(7)
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn refresh_fork_account_updates_loaded_journals() {
+        let (api, handle) = spawn(NodeConfig::test()).await;
+        let target = address!("0x0000000000000000000000000000000000001331");
+        let code =
+            Bytes::from_static(&[0x60, 0x2a, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3]);
+
+        let provider = handle.http_provider();
+        let block_number = provider.get_block_number().await.unwrap();
+        let mut evm_opts = Config::figment().extract::<EvmOpts>().unwrap();
+        evm_opts.fork_url = Some(handle.http_endpoint());
+        evm_opts.fork_block_number = Some(block_number);
+        let fork = evm_opts.get_fork(&Config::default(), 31_337, Some(block_number)).unwrap();
+        let mut backend = Backend::<EthEvmNetwork>::spawn(Some(fork)).unwrap();
+
+        let mut journaled_state = JournalInner::new();
+        journaled_state.load_account(&mut backend, target).unwrap();
+        let fork = backend.active_fork_mut().unwrap();
+        fork.journaled_state.load_account(&mut fork.db, target).unwrap();
+        assert_eq!(journaled_state.state[&target].info.code_hash, KECCAK_EMPTY);
+        assert_eq!(fork.journaled_state.state[&target].info.code_hash, KECCAK_EMPTY);
+
+        api.anvil_set_code(target, code.clone()).await.unwrap();
+        backend.refresh_fork_account(target, &mut journaled_state).unwrap();
+
+        let expected_hash = keccak256(&code);
+        let refreshed = &journaled_state.state[&target].info;
+        assert_eq!(refreshed.code_hash, expected_hash);
+        assert_eq!(refreshed.code.as_ref().unwrap().original_bytes(), code);
+        let refreshed = &backend.active_fork().unwrap().journaled_state.state[&target].info;
+        assert_eq!(refreshed.code_hash, expected_hash);
+        assert_eq!(refreshed.code.as_ref().unwrap().original_bytes(), code);
     }
 
     #[test]

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -5157,3 +5157,49 @@ contract FundViaRpc is Script {
     let balance = api.balance(recipient, None).await.unwrap();
     assert_eq!(balance, U256::from(500) * U256::from(10).pow(U256::from(18)));
 });
+
+// Regression test for https://github.com/foundry-rs/foundry/issues/13312: an account loaded before
+// `anvil_setCode` must be refreshed before the next call in the same script execution.
+forgetest_async!(can_call_contract_after_vm_rpc_set_code_on_fork, |prj, cmd| {
+    prj.add_script(
+        "SetCodeViaRpc.s.sol",
+        r#"
+interface Vm {
+    function rpc(string calldata method, string calldata params) external returns (bytes memory);
+    function toString(address value) external pure returns (string memory);
+}
+
+interface ITarget {
+    function value() external view returns (uint256);
+}
+
+contract SetCodeViaRpc {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    address constant TARGET = 0x0000000000000000000000000000000000001331;
+
+    function run() external {
+        require(TARGET.code.length == 0, "target already has code");
+
+        vm.rpc(
+            "anvil_setCode",
+            string.concat("[\"", vm.toString(TARGET), "\", \"0x602a60005260206000f3\"]")
+        );
+
+        require(ITarget(TARGET).value() == 42, "unexpected value");
+    }
+}
+"#,
+    );
+
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    cmd.arg("script")
+        .args(["SetCodeViaRpc", "--rpc-url", &handle.http_endpoint()])
+        .assert_success();
+
+    let target = address!("0x0000000000000000000000000000000000001331");
+    assert_eq!(
+        api.get_code(target, None).await.unwrap(),
+        Bytes::from(hex!("602a60005260206000f3"))
+    );
+});

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -5165,6 +5165,7 @@ forgetest_async!(can_call_contract_after_vm_rpc_set_code_on_fork, |prj, cmd| {
         "SetCodeViaRpc.s.sol",
         r#"
 interface Vm {
+    function deal(address account, uint256 newBalance) external;
     function rpc(string calldata method, string calldata params) external returns (bytes memory);
     function toString(address value) external pure returns (string memory);
 }
@@ -5177,8 +5178,14 @@ contract SetCodeViaRpc {
     Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
     address constant TARGET = 0x0000000000000000000000000000000000001331;
 
+    function setUp() external {
+        vm.deal(TARGET, 123);
+    }
+
     function run() external {
         require(TARGET.code.length == 0, "target already has code");
+        require(TARGET.balance == 123, "setup balance missing");
+        vm.deal(TARGET, 456);
 
         vm.rpc(
             "anvil_setCode",
@@ -5186,6 +5193,7 @@ contract SetCodeViaRpc {
         );
 
         require(ITarget(TARGET).value() == 42, "unexpected value");
+        require(TARGET.balance == 456, "local balance was lost");
     }
 }
 "#,
@@ -5202,4 +5210,50 @@ contract SetCodeViaRpc {
         api.get_code(target, None).await.unwrap(),
         Bytes::from(hex!("602a60005260206000f3"))
     );
+});
+
+// An out-of-band storage mutation must replace the same locally modified slot.
+forgetest_async!(vm_rpc_set_storage_overrides_local_fork_slot, |prj, cmd| {
+    prj.add_script(
+        "SetStorageViaRpc.s.sol",
+        r#"
+interface Vm {
+    function load(address target, bytes32 slot) external view returns (bytes32);
+    function rpc(string calldata method, string calldata params) external returns (bytes memory);
+    function store(address target, bytes32 slot, bytes32 value) external;
+    function toString(address value) external pure returns (string memory);
+    function toString(bytes32 value) external pure returns (string memory);
+}
+
+contract SetStorageViaRpc {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    address constant TARGET = 0x0000000000000000000000000000000000001331;
+    bytes32 constant SLOT = bytes32(0);
+
+    function setUp() external {
+        vm.store(TARGET, SLOT, bytes32(uint256(1)));
+    }
+
+    function run() external {
+        require(vm.load(TARGET, SLOT) == bytes32(uint256(1)), "setup value missing");
+
+        vm.rpc(
+            "anvil_setStorageAt",
+            string.concat(
+                "[\"", vm.toString(TARGET), "\", \"", vm.toString(SLOT), "\", \"",
+                vm.toString(bytes32(uint256(42))), "\"]"
+            )
+        );
+
+        require(vm.load(TARGET, SLOT) == bytes32(uint256(42)), "storage stayed stale");
+    }
+}
+"#,
+    );
+
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+
+    cmd.arg("script")
+        .args(["SetStorageViaRpc", "--rpc-url", &handle.http_endpoint()])
+        .assert_success();
 });


### PR DESCRIPTION
Fixes #13312.

State-mutating `vm.rpc` calls already evicted affected entries from the active fork database after #15507, but accounts and storage slots loaded earlier in the same execution remained stale in REVM's active and saved fork journals. As a result, reading an empty account before `anvil_setCode` made an immediate contract call fail even though Anvil had accepted the new bytecode.

This change makes supported account and storage setters synchronize loaded journal entries immediately after the RPC succeeds. It preserves local in-script database changes, avoids a remote re-fetch when neither journal loaded the entry, and adds both a backend regression test and an end-to-end `forge script` reproduction against Anvil.

This PR was written with Codex, which investigated the issue and generated the implementation and tests under my direction.
