### PR TITLE
chore(foundryup): deprecate legacy installer

### DIFF
--- a/foundryup/install
+++ b/foundryup/install
@@ -1,64 +1,38 @@
-#!/usr/bin/env bash
-set -eo pipefail
+#!/bin/sh
 
-echo "Installing foundryup..."
+# Deprecated compatibility entrypoint. The canonical foundryup installer now
+# lives in foundry-rs/foundryup.
 
-BASE_DIR="${XDG_CONFIG_HOME:-$HOME}"
-FOUNDRY_DIR="${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}"
-FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
-FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
+set -eu
 
-BIN_URL="https://raw.githubusercontent.com/foundry-rs/foundry/HEAD/foundryup/foundryup"
-BIN_PATH="$FOUNDRY_BIN_DIR/foundryup"
+FOUNDRYUP_INIT_URL="${FOUNDRYUP_INIT_URL:-https://raw.githubusercontent.com/foundry-rs/foundryup/HEAD/foundryup-init.sh}"
 
-# Create the .foundry bin directory and foundryup binary if it doesn't exist.
-mkdir -p "$FOUNDRY_BIN_DIR"
-curl -sSf -L "$BIN_URL" -o "$BIN_PATH"
-chmod +x "$BIN_PATH"
+warn() {
+    printf 'foundryup: warning: foundryup/install is deprecated; use %s instead\n' \
+        "$FOUNDRYUP_INIT_URL" >&2
+}
 
-# Create the man directory for future man files if it doesn't exist.
-mkdir -p "$FOUNDRY_MAN_DIR"
-
-# Store the correct profile file (i.e. .profile for bash or .zshenv for ZSH).
-case $SHELL in
-*/zsh)
-    PROFILE="${ZDOTDIR-"$HOME"}/.zshenv"
-    PREF_SHELL=zsh
-    ;;
-*/bash)
-    PROFILE=$HOME/.bashrc
-    PREF_SHELL=bash
-    ;;
-*/fish)
-    PROFILE=$HOME/.config/fish/config.fish
-    PREF_SHELL=fish
-    ;;
-*/ash)
-    PROFILE=$HOME/.profile
-    PREF_SHELL=ash
-    ;;
-*)
-    echo "foundryup: could not detect shell, manually add ${FOUNDRY_BIN_DIR} to your PATH."
-    exit 1
-esac
-
-# Only add foundryup if it isn't already in PATH.
-if [[ ":$PATH:" != *":${FOUNDRY_BIN_DIR}:"* ]]; then
-    # Add the foundryup directory to the path and ensure the old PATH variables remain.
-    # If the shell is fish, echo fish_add_path instead of export.
-    if [[ "$PREF_SHELL" == "fish" ]]; then
-        echo >> "$PROFILE" && echo "fish_add_path -a \"$FOUNDRY_BIN_DIR\"" >> "$PROFILE"
+download() {
+    if command -v curl >/dev/null 2>&1; then
+        curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location \
+            "$FOUNDRYUP_INIT_URL" --output "$1"
+    elif command -v wget >/dev/null 2>&1; then
+        wget --https-only --secure-protocol=TLSv1_2 --quiet \
+            "$FOUNDRYUP_INIT_URL" --output-document="$1"
     else
-        echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$FOUNDRY_BIN_DIR\"" >> "$PROFILE"
+        printf 'foundryup: error: need curl or wget to download foundryup\n' >&2
+        return 1
     fi
-fi
+}
 
-# Warn MacOS users that they may need to manually install libusb via Homebrew:
-if [[ "$OSTYPE" =~ ^darwin ]] && [[ ! -f /usr/local/opt/libusb/lib/libusb-1.0.0.dylib ]] && [[ ! -f /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib ]]; then
-    echo && echo "warning: libusb not found. You may need to install it manually on MacOS via Homebrew (brew install libusb)."
-fi
+main() {
+    warn
 
-echo
-echo "Detected your preferred shell is $PREF_SHELL and added foundryup to PATH."
-echo "Run 'source $PROFILE' or start a new terminal session to use foundryup."
-echo "Then, simply run 'foundryup' to install Foundry."
+    installer="$(mktemp "${TMPDIR:-/tmp}/foundryup-init.XXXXXX")"
+    trap 'rm -f "$installer"' 0
+
+    download "$installer"
+    sh "$installer" "$@"
+}
+
+main "$@"

--- a/foundryup/test.sh
+++ b/foundryup/test.sh
@@ -150,6 +150,54 @@ check_eq "failed validation leaves launcher untouched" \
 check_eq "failed validation does not exec" "" "$(cat "$exec_marker")"
 teardown_case
 
+# --- deprecated installer compatibility entrypoint -----------------------
+
+install_test_dir="$(mktemp -d)"
+mkdir -p "$install_test_dir/bin"
+install_args_marker="$install_test_dir/args"
+
+cat > "$install_test_dir/bin/curl" <<'EOF'
+#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then
+    output="$2"
+    break
+  fi
+  shift
+done
+cat > "$output" <<'INSTALLER'
+#!/bin/sh
+printf '%s\n' "$*" > "$INSTALL_ARGS_MARKER"
+printf 'installer ran\n'
+INSTALLER
+EOF
+chmod +x "$install_test_dir/bin/curl"
+
+install_out="$(
+  PATH="$install_test_dir/bin:$PATH" \
+    FOUNDRYUP_INIT_URL="https://example.com/foundryup-init.sh" \
+    INSTALL_ARGS_MARKER="$install_args_marker" \
+    "$SCRIPT_DIR/install" --yes --version 2> "$install_test_dir/stderr"
+)"
+check_eq "deprecated installer delegates to the canonical installer" \
+  "installer ran" "$install_out"
+check_eq "deprecated installer forwards arguments" \
+  "--yes --version" "$(cat "$install_args_marker")"
+check_eq "deprecated installer warns with the canonical installer URL" \
+  "foundryup: warning: foundryup/install is deprecated; use https://example.com/foundryup-init.sh instead" \
+  "$(cat "$install_test_dir/stderr")"
+
+cat > "$install_test_dir/bin/curl" <<'EOF'
+#!/bin/sh
+exit 22
+EOF
+chmod +x "$install_test_dir/bin/curl"
+rc=0
+PATH="$install_test_dir/bin:$PATH" "$SCRIPT_DIR/install" >/dev/null 2>/dev/null || rc=$?
+check_eq "deprecated installer propagates download failures" "22" "$rc"
+
+rm -rf "$install_test_dir"
+
 # --- summary --------------------------------------------------------------
 
 if [ "$failures" -ne 0 ]; then


### PR DESCRIPTION
## Summary

- replace the legacy `foundryup/install` implementation with a deprecated compatibility shim
- delegate installation to the canonical `foundry-rs/foundryup` installer while forwarding arguments
- test delegation, warning output, argument forwarding, and download failures without network access

Stacked onto #15498 and addresses [the outstanding installer deprecation feedback](https://github.com/foundry-rs/foundry/pull/15498#pullrequestreview-4645227615).

Prompted by: @DaniPopes
