### PR TITLE
chore: cache docs workflow builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   docs:
@@ -30,6 +31,7 @@ jobs:
         with:
           toolchain: nightly-2026-07-01
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items --locked
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
           toolchain: nightly-2026-07-01
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items --locked
         env:


### PR DESCRIPTION
Configures the docs workflow to use `sccache` and `Swatinem/rust-cache` through the same pinned actions as the other Rust CI jobs. The docs job already runs on Depot; these changes enable compiler and dependency caching for its rustdoc build.

This PR was written primarily by Codex.

This CI-only change requires the `L-ignore` label instead of a changelog entry.

Prompted by: @DaniPopes
