### PR TITLE
chore: unpin docs nightly toolchain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
-          toolchain: nightly-2026-07-01
+          toolchain: nightly
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items --locked


### PR DESCRIPTION
Updates the docs workflow to track the latest Rust nightly instead of pinning `nightly-2026-07-01`. The Clippy and rustfmt jobs already use the unpinned nightly channel, so this makes all Rust nightly toolchain declarations consistent.

This is repository maintenance with no user-facing release impact, so maintainers should apply `L-ignore` instead of requiring a changelog entry.

This PR was authored with Codex.

Prompted by: @DaniPopes
