### PR TITLE
fix: syn lockfile reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11533,7 +11533,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]


### PR DESCRIPTION
Updates the stale `serde_repr` dependency reference from `syn 3.0.3` to `syn 3.0.4`.