### PR TITLE
chore(deps): bump alloy-core to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8421a5ee9019b6d89f92935d0f8facd9f6ca088b41d7cc47244a02ccde4545f"
+checksum = "f362c4f45eb0201a18c0ca2081ef2d9c460fb86f8eb71bf9dfb63b36ab57f83b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
+checksum = "abd40dfce46688dab799a455b6d44959ef906f60ff0793be7b44d5c817244245"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cee30dd4c2f4b23f434fdf675e7bf9681b86768141277266c6f548ef25cba0a"
+checksum = "030ea62b48820e79aab497b944ce09b8b23f4215e91e95d414060fed9db9a412"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
+checksum = "7d851d57d6c8a93053eef468864a4f8a777bf6649cd2f833e073942c0d58274b"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
+checksum = "466883cc45d3e86786e73335907c16be5e196921e2dc70a4070b3d9c7fe475aa"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
+checksum = "59dd6ad4734e11bc84a07501d6630620772cca09cb178d606d18593e1f3c70fe"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
+checksum = "0c9ac44ec972e6c13c2be852750b48696c929662af8b09893714ec9ce47a92ef"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -976,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
+checksum = "349148dde7c030cfac13338c8284e178727653851207e8436c8a1d265af75c1f"
 dependencies = [
  "serde",
  "winnow 1.0.4",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
+checksum = "c259e0544bdf185257cc1c18c764093756d964dc392e38e6b89d91fe7f26ed3a"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -12473,9 +12473,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
+checksum = "93b477ecc2e62b565bb6190d451fd8ed5aaddaf25b5df7ee3a2b4aa8e099b1a5"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,17 +383,17 @@ alloy-hardforks = { version = "0.4.8", default-features = false }
 alloy-op-hardforks = { version = "0.5.0", default-features = false }
 
 ## alloy-core
-alloy-dyn-abi = "1.6.1"
-alloy-json-abi = "1.6.1"
-alloy-primitives = { version = "1.6.1", features = [
+alloy-dyn-abi = "1.7.0"
+alloy-json-abi = "1.7.0"
+alloy-primitives = { version = "1.7.0", features = [
     "getrandom",
     "rand",
     "map-fxhash",
     "map-foldhash",
 ] }
-alloy-sol-macro-expander = "1.6.1"
-alloy-sol-macro-input = "1.6.1"
-alloy-sol-types = "1.6.1"
+alloy-sol-macro-expander = "1.7.0"
+alloy-sol-macro-input = "1.7.0"
+alloy-sol-types = "1.7.0"
 
 alloy-chains = "0.2"
 alloy-rlp = "0.3"


### PR DESCRIPTION
Alloy Core 1.7.0 added required bounded-decoder methods to `SolCall` and `SolInterface`. Foundry master still generated bindings with `alloy-sol-macro-expander` 1.6.1, while the generated projects' `alloy = "1.0"` requirement began resolving the 1.7.0 runtime crates. That generator/runtime skew makes the generated implementations fail with E0046 for `abi_decode_returns_with_config` and `abi_decode_raw_with_config`.

This broke the three binding compilation tests in [the master test-all job](https://github.com/foundry-rs/foundry/actions/runs/32866856026/job/97864215427). The triggering Foundry change was unrelated; the failures began after Alloy Core 1.7.0 was published.

This uses the released crates.io version rather than the pre-release git revision proposed for Tempo patch alignment in #16318.
