### PR TITLE
perf(evm): reduce per-opcode inspector overhead

### DIFF
--- a/.changelog/prune-inactive-env-overrides.md
+++ b/.changelog/prune-inactive-env-overrides.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Reduced per-opcode overhead after reverting state snapshots without active environment overrides.

--- a/.changelog/restore-inspector-inlining.md
+++ b/.changelog/restore-inspector-inlining.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-evm: patch
+foundry-evm-core: patch
+---
+
+Restored Forge test performance in Monad-enabled release builds by keeping per-opcode inspector hooks inline without changing system replay behavior.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1627,6 +1627,7 @@ fn sync_tx_after_env_override_restore<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCt
     let fork_id = ccx.ecx.db().active_fork_id();
     // Clone to avoid borrow conflicts when mutating ecx below.
     let env_overrides = ccx.state.env_overrides.get(&fork_id).cloned().unwrap_or_default();
+    let remove_inactive_entry = !env_overrides.is_any_set();
     match env_overrides.gas_price {
         Some(p) if !ccx.state.in_isolation_context => ccx.ecx.tx_mut().set_gas_price(p),
         None => {
@@ -1653,6 +1654,9 @@ fn sync_tx_after_env_override_restore<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCt
             ccx.ecx.tx_mut().set_tx_type(pre_type);
         }
         _ => {}
+    }
+    if remove_inactive_entry {
+        ccx.state.env_overrides.remove(&fork_id);
     }
 }
 

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -130,7 +130,7 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         evm_env: &mut EvmEnvFor<FEN>,
         tx_env: &mut TxEnvFor<FEN>,
         chain_context: ChainFor<FEN>,
-        inspector: I,
+        inspector: &mut I,
     ) -> eyre::Result<Option<ResultAndState<revm::context_interface::result::HaltReason>>> {
         if !self.backend.networks().is_monad()
             || crate::evm::protocol_system_call(tx_env)?.is_none()
@@ -141,9 +141,8 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind()));
 
         let factory = FEN::EvmFactory::default();
-        let mut inspector = inspector;
         let mut evm =
-            factory.create_foundry_nested_evm(self, evm_env.clone(), chain_context, &mut inspector);
+            factory.create_foundry_nested_evm(self, evm_env.clone(), chain_context, inspector);
         let result = evm.transact_raw(tx_env.clone())?;
 
         // A successful specialized replay replaces the EVM transaction with its synthetic system

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -2309,5 +2309,9 @@ mod tests {
             revert_result.tx_env.blob_hashes, original,
             "pre_override_blob_hashes must be restored to original non-empty hashes, not []",
         );
+        assert!(
+            executor.inspector().cheatcodes.as_ref().unwrap().env_overrides.is_empty(),
+            "inactive env overrides must be removed after restoring their metadata",
+        );
     }
 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1971,10 +1971,12 @@ impl<FEN: FoundryEvmNetwork> InspectorExt for InspectorStackRefMut<'_, FEN> {
 }
 
 impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for InspectorStack<FEN> {
+    #[inline(always)]
     fn step(&mut self, interpreter: &mut Interpreter, ecx: &mut FoundryContextFor<'_, FEN>) {
         self.as_mut().step_inlined(interpreter, ecx)
     }
 
+    #[inline(always)]
     fn step_end(&mut self, interpreter: &mut Interpreter, ecx: &mut FoundryContextFor<'_, FEN>) {
         self.as_mut().step_end_inlined(interpreter, ecx)
     }


### PR DESCRIPTION
PR #16312 made the Monad replay inspector a vtable root in dist builds, causing LLVM to reuse outlined `InspectorStack` step hooks in the ordinary Ethereum loop. Snapshot restoration also retained inactive `EnvOverrides` entries after consuming their metadata, keeping an unnecessary map scan enabled on every opcode. This borrows the replay inspector directly, inlines the two static forwarding hooks, and removes only inactive current-fork override entries after restoration; active overrides, system replay, and snapshot behavior remain unchanged. The fresh rebased Derek comparison against current `master` reported an overall improvement: the three rows below improved and the remaining 20 project/suite comparisons were neutral, with symbolic path and query counts unchanged. The local Aave rows isolate each optimization. AI assistance was used for diagnosis, implementation, testing, benchmarking, and PR text and responses.

### Results

| Comparison | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Inspector / Eth `transact` layout | 7,572 B; 5 outlined calls | 9,368 B; 0 outlined calls | all 5 removed |
| `forge_test/ithacaxyz-account` vs `master` | 3.477s | 3.287s | -5.5% |
| `forge_test/vectorized-solady` vs `master` | 3.059s | 2.972s | -2.9% |
| `forge_fuzz_test/ithacaxyz-account` vs `master` | 3.442s | 3.245s | -5.7% |
| Inspector / focused Aave user CPU | 65.07s | 51.17s | -21.27% |
| Inspector / full Aave user CPU | 3,492.19s | 2,818.24s | -19.30% |
| EnvOverrides / profiling user CPU | 50.09s | 45.50s | -9.17% (95% CI: -10.22% to -8.11%) |
| EnvOverrides / dist user CPU | 60.46s | 55.09s | -8.83% (95% CI: -11.16% to -6.45%) |
