### PR TITLE
perf(cheatcodes): prune inactive env overrides

### DIFF
--- a/.changelog/prune-inactive-env-overrides.md
+++ b/.changelog/prune-inactive-env-overrides.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Reduced per-opcode overhead after reverting state snapshots without active environment overrides.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1627,6 +1627,7 @@ fn sync_tx_after_env_override_restore<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCt
     let fork_id = ccx.ecx.db().active_fork_id();
     // Clone to avoid borrow conflicts when mutating ecx below.
     let env_overrides = ccx.state.env_overrides.get(&fork_id).cloned().unwrap_or_default();
+    let remove_inactive_entry = !env_overrides.is_any_set();
     match env_overrides.gas_price {
         Some(p) if !ccx.state.in_isolation_context => ccx.ecx.tx_mut().set_gas_price(p),
         None => {
@@ -1653,6 +1654,9 @@ fn sync_tx_after_env_override_restore<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCt
             ccx.ecx.tx_mut().set_tx_type(pre_type);
         }
         _ => {}
+    }
+    if remove_inactive_entry {
+        ccx.state.env_overrides.remove(&fork_id);
     }
 }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -2309,5 +2309,9 @@ mod tests {
             revert_result.tx_env.blob_hashes, original,
             "pre_override_blob_hashes must be restored to original non-empty hashes, not []",
         );
+        assert!(
+            executor.inspector().cheatcodes.as_ref().unwrap().env_overrides.is_empty(),
+            "inactive env overrides must be removed after restoring their metadata",
+        );
     }
 }


### PR DESCRIPTION
Snapshot reverts retain a default `EnvOverrides` entry only to restore pre-override gas and blob-hash metadata. Once that metadata has been applied and no override remains active, this removes the current fork's entry so the per-opcode hook check no longer scans stale state. Active overrides and entries for other forks are preserved. The focused Aave v4 `SmallPosition::ManyCollaterals_ManyDebts_UserInsolvent` replay used eight alternating AB/BA pairs with identical seeds, 2,000 fuzz runs, isolation disabled, and dynamic test linking disabled; user CPU was lower in all eight pairs in both profiles. This follow-up is stacked on #16367. AI assistance was used for code analysis, implementation, testing, benchmarking, and PR text.

### Results

| Profile / metric | #16367 | This PR | Paired delta |
| --- | ---: | ---: | ---: |
| Profiling / user CPU mean | 50.09s | 45.50s | -9.17% (95% CI: -10.22% to -8.11%) |
| Profiling / wall-time mean | 3.55s | 3.04s | -13.71% (95% CI: -22.62% to -3.79%; noisy) |
| Dist / user CPU mean | 60.46s | 55.09s | -8.83% (95% CI: -11.16% to -6.45%) |
| Dist / wall-time mean | 6.14s | 5.96s | -3.28% (95% CI: -10.18% to +4.15%; neutral) |
