### PR TITLE
refactor(cast): stream event decoding

### DIFF
--- a/.changelog/cast-event-streams.md
+++ b/.changelog/cast-event-streams.md
@@ -1,0 +1,6 @@
+---
+cast: patch
+foundry-evm-traces: patch
+---
+
+Refactored Cast event ABI discovery and decoding around reusable ordered streams.

--- a/crates/cast/src/cmd/events.rs
+++ b/crates/cast/src/cmd/events.rs
@@ -21,7 +21,7 @@ use foundry_common::{fmt::serialize_value_as_json, shell};
 use foundry_config::{Chain, Config};
 use futures::StreamExt;
 use serde::{Serialize, Serializer};
-use std::{collections::BTreeSet, fmt::Write as _};
+use std::fmt::Write as _;
 
 foundry_config::impl_figment_convert!(EventsArgs, etherscan, rpc);
 
@@ -111,9 +111,8 @@ async fn decode_logs(
         .with_chain_id(config.chain.map(|chain| chain.id()));
 
     if let Some(mut identifier) = ExternalIdentifier::new(config, Some(explorer_chain))? {
-        let addresses =
-            logs.iter().map(Log::address).collect::<BTreeSet<_>>().into_iter().collect::<Vec<_>>();
-        for (address, result) in identifier.get_abis(&addresses).await {
+        let mut abis = std::pin::pin!(identifier.get_abis(logs.iter().map(Log::address)));
+        while let Some((address, result)) = abis.next().await {
             match result {
                 Ok((abis, complete)) => {
                     if !complete {
@@ -129,15 +128,18 @@ async fn decode_logs(
     }
 
     let decoder = builder.build();
-    let events = futures::stream::iter(logs)
-        .map(|log| async {
-            let decoded =
-                decoder.decode_event_with_address_signature(log.address(), log.data()).await;
-            EventOutput::new(log, decoded)
-        })
-        .buffered(MAX_CONCURRENT_RPC_REQUESTS)
-        .collect()
+    let decoded = decoder
+        .decode_events_with_address_signature(
+            logs.iter().map(|log| (log.address(), log.data())),
+            MAX_CONCURRENT_RPC_REQUESTS,
+        )
+        .collect::<Vec<_>>()
         .await;
+    let events = logs
+        .into_iter()
+        .zip(decoded)
+        .map(|(log, decoded)| EventOutput::new(log, decoded))
+        .collect();
     Ok(events)
 }
 

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -31,6 +31,7 @@ use foundry_evm_core::{
 type MonadHardfork = foundry_evm_hardforks::MonadHardfork;
 use foundry_evm_hardforks::TempoHardfork;
 use foundry_evm_networks::{NetworkConfigs, NetworkVariant, celo::transfer::CELO_TRANSFER_LABEL};
+use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
 use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
@@ -1423,6 +1424,23 @@ impl CallTraceDecoder {
         self.decode_event_inner(Some(address), log, true).await
     }
 
+    /// Decodes events emitted by known addresses concurrently.
+    ///
+    /// Decoded events are yielded in input order.
+    pub fn decode_events_with_address_signature<'a, I>(
+        &'a self,
+        events: I,
+        max_concurrent: usize,
+    ) -> impl Stream<Item = DecodedEvent> + 'a
+    where
+        I: IntoIterator<Item = (Address, &'a LogData)> + 'a,
+        I::IntoIter: 'a,
+    {
+        futures::stream::iter(events)
+            .map(|(address, log)| self.decode_event_with_address_signature(address, log))
+            .buffered(max_concurrent.max(1))
+    }
+
     async fn decode_event_inner(
         &self,
         address: Option<Address>,
@@ -1981,6 +1999,32 @@ mod tests {
         let decoded = decoder.decode_event_with_address_signature(address, &log).await;
         assert!(decoded.name.is_none());
         assert!(decoded.params.is_none());
+    }
+
+    #[tokio::test]
+    async fn event_stream_preserves_items_and_order() {
+        let address = Address::from([0x12; 20]);
+        let abi = JsonAbi::parse(["event First()", "event Second(uint256 value)"]).unwrap();
+        let decoder = CallTraceDecoderBuilder::new().with_address_events(address, &abi).build();
+        let first = abi.event("First").unwrap().first().unwrap();
+        let second = abi.event("Second").unwrap().first().unwrap();
+        let events = vec![
+            (
+                1,
+                address,
+                LogData::new_unchecked(vec![second.selector()], (42_u64,).abi_encode().into()),
+            ),
+            (0, address, LogData::new_unchecked(vec![first.selector()], Default::default())),
+        ];
+
+        let decoded = decoder
+            .decode_events_with_address_signature(events.iter().map(|event| (event.1, &event.2)), 2)
+            .collect::<Vec<_>>()
+            .await;
+
+        assert_eq!(events.iter().map(|event| event.0).collect::<Vec<_>>(), [1, 0]);
+        assert_eq!(decoded[0].name.as_deref(), Some("Second(uint256)"));
+        assert_eq!(decoded[1].name.as_deref(), Some("First()"));
     }
 
     #[tokio::test]

--- a/crates/evm/traces/src/identifier/external.rs
+++ b/crates/evm/traces/src/identifier/external.rs
@@ -18,6 +18,7 @@ use revm_inspectors::tracing::types::CallTraceNode;
 use serde::Deserialize;
 use std::{
     borrow::Cow,
+    collections::BTreeSet,
     pin::Pin,
     sync::{
         Arc,
@@ -210,10 +211,21 @@ impl ExternalIdentifier {
         }
     }
 
-    /// Fetches all verified ABIs and whether each proxy chain was fully resolved.
-    pub async fn get_abis(
+    /// Streams all verified ABIs and whether each proxy chain was fully resolved.
+    ///
+    /// Duplicate addresses are resolved once and results are yielded in address order.
+    pub fn get_abis(
         &mut self,
-        addresses: &[Address],
+        addresses: impl IntoIterator<Item = Address>,
+    ) -> impl Stream<Item = (Address, eyre::Result<(Vec<JsonAbi>, bool)>)> + '_ {
+        let addresses =
+            addresses.into_iter().collect::<BTreeSet<_>>().into_iter().collect::<Vec<_>>();
+        futures::stream::once(self.resolve_abis(addresses)).flat_map(futures::stream::iter)
+    }
+
+    async fn resolve_abis(
+        &mut self,
+        addresses: Vec<Address>,
     ) -> Vec<(Address, eyre::Result<(Vec<JsonAbi>, bool)>)> {
         const MAX_PROXY_DEPTH: usize = 16;
 
@@ -275,7 +287,7 @@ impl ExternalIdentifier {
 
         chains
             .into_iter()
-            .zip(addresses.iter().copied())
+            .zip(addresses)
             .map(|(mut chain, address)| {
                 chain.complete &= chain.current.is_none();
                 let result = if chain.abis.is_empty() {
@@ -941,7 +953,7 @@ mod tests {
         identifier
             .cache_fetched(implementation_address, (FetcherKind::Etherscan, Some(implementation)));
 
-        let mut results = identifier.get_abis(&[proxy]).await;
+        let mut results = identifier.get_abis([proxy]).collect::<Vec<_>>().await;
         let (result_address, result) = results.pop().unwrap();
         let (abis, complete) = result.unwrap();
         let event_names =
@@ -952,9 +964,37 @@ mod tests {
         assert_eq!(event_names, ["ImplementationEvent", "ProxyEvent"]);
 
         identifier.contracts.remove(&implementation_address);
-        let (_, result) = identifier.get_abis(&[proxy]).await.pop().unwrap();
+        let (_, result) = identifier.get_abis([proxy]).collect::<Vec<_>>().await.pop().unwrap();
         let (abis, complete) = result.unwrap();
         assert_eq!(abis.len(), 1);
         assert!(!complete);
+    }
+
+    #[tokio::test]
+    async fn abi_stream_deduplicates_and_orders_addresses() {
+        let first = Address::with_last_byte(1);
+        let second = Address::with_last_byte(2);
+        let mut identifier = test_identifier(Vec::new(), Duration::ZERO);
+        let mut first_metadata = metadata("First");
+        first_metadata.abi =
+            r#"[{"anonymous":false,"inputs":[],"name":"FirstEvent","type":"event"}]"#.to_string();
+        let mut second_metadata = metadata("Second");
+        second_metadata.abi =
+            r#"[{"anonymous":false,"inputs":[],"name":"SecondEvent","type":"event"}]"#.to_string();
+        identifier.cache_fetched(first, (FetcherKind::Etherscan, Some(first_metadata)));
+        identifier.cache_fetched(second, (FetcherKind::Etherscan, Some(second_metadata)));
+
+        let results = identifier
+            .get_abis([second, first, second])
+            .map(|(address, result)| (address, result.unwrap().0[0].clone()))
+            .collect::<Vec<_>>()
+            .await;
+
+        assert_eq!(
+            results.iter().map(|(address, _)| *address).collect::<Vec<_>>(),
+            [first, second]
+        );
+        assert_eq!(results[0].1.events().next().unwrap().name, "FirstEvent");
+        assert_eq!(results[1].1.events().next().unwrap().name, "SecondEvent");
     }
 }


### PR DESCRIPTION
Extracts the two asynchronous pipelines introduced in #16238 into reusable trace APIs. `ExternalIdentifier::get_abis` now accepts an address iterator, deduplicates and orders addresses internally, and exposes results as a stream. `CallTraceDecoder::decode_events_with_address_signature` owns bounded ordered concurrency while returning each caller-owned input alongside its decoded event.

`cast events` now composes those APIs directly, preserving output order, warning behavior, and the existing request limit while removing CLI-specific stream plumbing.

AI assistance disclosure: This PR was implemented with Codex, including code generation and test updates.
