### PR TITLE
perf(evm): fast-path the per-opcode inspector hooks

### DIFF
--- a/.changelog/inspector-step-fast-path.md
+++ b/.changelog/inspector-step-fast-path.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-evm: patch
+foundry-cheatcodes: patch
+---
+
+Sped up `forge test` by giving the per-opcode inspector hooks a small fast path that inlines into the interpreter loop.

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2094,6 +2094,14 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
 
     #[inline(always)]
     fn has_active_env_overrides(&self) -> bool {
+        // The map stays empty unless `vm.fee`, `vm.txGasPrice` or `vm.blobhashes` ran, so the
+        // per-opcode path is a single length check and the scan is kept out of line.
+        !self.env_overrides.is_empty() && self.any_env_override_set()
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn any_env_override_set(&self) -> bool {
         self.env_overrides.values().any(EnvOverrides::is_any_set)
     }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1244,12 +1244,36 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
     // We want to `#[inline(always)]` these functions so that `InspectorStack` does not
     // delegate to `InspectorStackRefMut` in this case.
 
+    /// Whether [`Self::step_slow`] has anything to do for the current opcode.
+    #[inline(always)]
+    fn needs_step_slow(&self) -> bool {
+        #[cfg(test)]
+        if self.inner.early_exit_test_gate.is_some() {
+            return true;
+        }
+        self.inner.static_step_dispatch != OpcodeStepDispatch::None
+            || self.inner.execution_cancellation.is_some()
+            || self.cheatcodes.as_ref().is_some_and(|cheats| cheats.has_step_hooks())
+    }
+
     #[inline(always)]
     fn step_inlined(
         &mut self,
         interpreter: &mut Interpreter,
         ecx: &mut FoundryContextFor<'_, FEN>,
     ) {
+        if self.needs_step_slow() {
+            return self.step_slow(interpreter, ecx);
+        }
+
+        // Nothing to dispatch: only the cheatcode program counter has to keep up.
+        if let Some(cheats) = self.cheatcodes.as_mut() {
+            cheats.pc = interpreter.bytecode.pc();
+        }
+    }
+
+    #[inline(never)]
+    fn step_slow(&mut self, interpreter: &mut Interpreter, ecx: &mut FoundryContextFor<'_, FEN>) {
         let storage_hook_active = if let Some(cheats) = self.cheatcodes.as_mut() {
             if cheats.has_storage_hooks() && cheats.finish_storage_hook_callback(interpreter, ecx) {
                 return;
@@ -1330,8 +1354,27 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         }
     }
 
+    /// Whether [`Self::step_end_slow`] has anything to do for the current opcode.
+    #[inline(always)]
+    fn needs_step_end_slow(&self) -> bool {
+        self.has_static_step_end_inspectors
+            || self.fuzzer.as_ref().is_some_and(|fuzzer| fuzzer.mapping_slots.is_some())
+            || self.cheatcodes.as_ref().is_some_and(|cheats| cheats.has_step_end_hooks())
+    }
+
     #[inline(always)]
     fn step_end_inlined(
+        &mut self,
+        interpreter: &mut Interpreter,
+        ecx: &mut FoundryContextFor<'_, FEN>,
+    ) {
+        if self.needs_step_end_slow() {
+            self.step_end_slow(interpreter, ecx);
+        }
+    }
+
+    #[inline(never)]
+    fn step_end_slow(
         &mut self,
         interpreter: &mut Interpreter,
         ecx: &mut FoundryContextFor<'_, FEN>,


### PR DESCRIPTION
`InspectorStack::step` and `step_end` run once per executed opcode. Both had grown large enough that LLVM kept them out of line, so every opcode paid a call plus the full set of hook checks. Profiling `forge test` with samply put 24% of total CPU in `step`, 11% in `step_end` and another 2% in the `EnvOverrides` scan reached from `has_step_hooks` on Solady, and 26% / 13% / 2% on aave-v4.

This splits each hook into a small predicate that decides whether any work is due and an `#[inline(never)]` body that does it. The predicate is the union of the conditions the slow path already tested, so behaviour is unchanged, but with no tracer, no coverage collector and no active cheatcode hooks the per-opcode cost is now a few flag loads that inline into the interpreter loop, plus the program counter update `vm.breakpoint` depends on. `has_active_env_overrides` gets the same treatment: the map stays empty unless `vm.fee`, `vm.txGasPrice` or `vm.blobhashes` ran, so the common case is a length check and the scan is outlined.

### Results

Local `profiling` builds, five alternating paired runs on 12 cores:

| Benchmark | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `forge_test/vectorized-solady` user CPU | 17.65 s | 13.57 s | -23.1% |
| `forge_test/vectorized-solady` wall | 2.27 s | 1.94 s | -14.6% |
| `forge_test/ithacaxyz-account` user CPU | 17.52 s | 14.76 s | -15.8% |
| `forge_test/ithacaxyz-account` wall | 3.10 s | 2.96 s | -4.3% |

The aave-v4 runs on this machine were thermally noisy over their eight-minute duration, so they are left out here in favour of the bench bot numbers.

> AI assistance: Claude profiled the hot path, implemented the change and ran the local benchmarks.
