### PR TITLE
refactor(anvil): reorder module helpers

### DIFF
--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -35,50 +35,6 @@ mod ws;
 #[cfg(feature = "ipc")]
 pub mod ipc;
 
-/// Configures an [`axum::Router`] that handles JSON-RPC calls via both HTTP and WS.
-pub fn http_ws_router<Http, Ws>(config: ServerConfig, http: Http, ws: Ws) -> Router
-where
-    Http: RpcHandler,
-    Ws: PubSubRpcHandler,
-{
-    router_inner(config, post(handler::handle).get(ws::handle_ws), (http, ws))
-}
-
-/// Configures an [`axum::Router`] that handles JSON-RPC calls via HTTP.
-pub fn http_router<Http>(config: ServerConfig, http: Http) -> Router
-where
-    Http: RpcHandler,
-{
-    router_inner(config, post(handler::handle), (http, ()))
-}
-
-fn router_inner<S: Clone + Send + Sync + 'static>(
-    config: ServerConfig,
-    root_method_router: MethodRouter<S>,
-    state: S,
-) -> Router {
-    let ServerConfig { allow_origin, no_cors, no_request_size_limit } = config;
-
-    let mut router = Router::new()
-        .route("/", root_method_router)
-        .with_state(state)
-        .layer(TraceLayer::new_for_http());
-    if !no_cors {
-        // See [`tower_http::cors`](https://docs.rs/tower-http/latest/tower_http/cors/index.html)
-        // for more details.
-        router = router.layer(
-            CorsLayer::new()
-                .allow_origin(allow_origin.0)
-                .allow_headers([header::CONTENT_TYPE])
-                .allow_methods([Method::GET, Method::POST]),
-        );
-    }
-    if no_request_size_limit {
-        router = router.layer(DefaultBodyLimit::disable());
-    }
-    router
-}
-
 /// Helper trait that is used to execute ethereum rpc calls
 pub trait RpcHandler: Clone + Send + Sync + 'static {
     /// The request type to expect
@@ -129,4 +85,48 @@ pub trait RpcHandler: Clone + Send + Sync + 'static {
             }
         }
     }
+}
+
+/// Configures an [`axum::Router`] that handles JSON-RPC calls via both HTTP and WS.
+pub fn http_ws_router<Http, Ws>(config: ServerConfig, http: Http, ws: Ws) -> Router
+where
+    Http: RpcHandler,
+    Ws: PubSubRpcHandler,
+{
+    router_inner(config, post(handler::handle).get(ws::handle_ws), (http, ws))
+}
+
+/// Configures an [`axum::Router`] that handles JSON-RPC calls via HTTP.
+pub fn http_router<Http>(config: ServerConfig, http: Http) -> Router
+where
+    Http: RpcHandler,
+{
+    router_inner(config, post(handler::handle), (http, ()))
+}
+
+fn router_inner<S: Clone + Send + Sync + 'static>(
+    config: ServerConfig,
+    root_method_router: MethodRouter<S>,
+    state: S,
+) -> Router {
+    let ServerConfig { allow_origin, no_cors, no_request_size_limit } = config;
+
+    let mut router = Router::new()
+        .route("/", root_method_router)
+        .with_state(state)
+        .layer(TraceLayer::new_for_http());
+    if !no_cors {
+        // See [`tower_http::cors`](https://docs.rs/tower-http/latest/tower_http/cors/index.html)
+        // for more details.
+        router = router.layer(
+            CorsLayer::new()
+                .allow_origin(allow_origin.0)
+                .allow_headers([header::CONTENT_TYPE])
+                .allow_methods([Method::GET, Method::POST]),
+        );
+    }
+    if no_request_size_limit {
+        router = router.layer(DefaultBodyLimit::disable());
+    }
+    router
 }

--- a/crates/anvil/server/src/ws.rs
+++ b/crates/anvil/server/src/ws.rs
@@ -13,16 +13,6 @@ use std::{
     task::{Context, Poll},
 };
 
-/// Handles incoming Websocket upgrade
-///
-/// This is the entrypoint invoked by the axum server for a websocket request
-pub async fn handle_ws<Http, Ws: PubSubRpcHandler>(
-    ws: WebSocketUpgrade,
-    State((_, handler)): State<(Http, Ws)>,
-) -> Response {
-    ws.on_upgrade(|socket| PubSubConnection::new(SocketConn(socket), handler))
-}
-
 #[pin_project::pin_project]
 struct SocketConn(#[pin] WebSocket);
 
@@ -71,4 +61,14 @@ fn on_message(msg: Result<Message, axum::Error>) -> Result<Option<Request>, Requ
         }
         _ => Ok(None),
     }
+}
+
+/// Handles incoming Websocket upgrade
+///
+/// This is the entrypoint invoked by the axum server for a websocket request
+pub async fn handle_ws<Http, Ws: PubSubRpcHandler>(
+    ws: WebSocketUpgrade,
+    State((_, handler)): State<(Http, Ws)>,
+) -> Response {
+    ws.on_upgrade(|socket| PubSubConnection::new(SocketConn(socket), handler))
 }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -212,35 +212,6 @@ use tempo_revm::{
 };
 use tokio::{sync::RwLock as AsyncRwLock, task::JoinSet};
 
-/// Creates an Ethereum-shaped genesis header from the EVM environment.
-fn genesis_header(
-    evm_env: &EvmEnv,
-    base_fee: Option<u64>,
-    timestamp: u64,
-    genesis_number: u64,
-) -> Header {
-    let spec_id = *evm_env.spec_id();
-    Header {
-        timestamp,
-        base_fee_per_gas: base_fee,
-        gas_limit: evm_env.block_env.gas_limit,
-        beneficiary: evm_env.block_env.beneficiary,
-        difficulty: evm_env.block_env.difficulty,
-        blob_gas_used: evm_env.block_env.blob_excess_gas_and_price.as_ref().map(|_| 0),
-        excess_blob_gas: evm_env.block_env.blob_excess_gas(),
-        number: genesis_number,
-        parent_beacon_block_root: (spec_id >= SpecId::CANCUN).then_some(Default::default()),
-        withdrawals_root: (spec_id >= SpecId::SHANGHAI).then_some(EMPTY_WITHDRAWALS),
-        requests_hash: (spec_id >= SpecId::PRAGUE).then_some(EMPTY_REQUESTS_HASH),
-        ..Default::default()
-    }
-}
-
-/// Wraps an Ethereum-shaped header in the selected network's consensus header.
-fn foundry_header(networks: &NetworkConfigs, header: Header) -> FoundryHeader {
-    if networks.is_tempo() { FoundryHeader::tempo(header) } else { header.into() }
-}
-
 /// Side-channel container for OP-specific deposit info produced by
 /// [`Backend::build_call_env_with_base`] and consumed by the OP transact path.
 ///
@@ -9379,6 +9350,35 @@ fn arbitrum_replay_block_number(block: &AnyRpcBlock) -> U256 {
 /// Abstracts over network-specific halt reason types (`HaltReason`, `OpHaltReason`)
 /// so that anvil code doesn't need to match on each variant directly.
 pub use foundry_evm::core::evm::IntoInstructionResult;
+
+/// Creates an Ethereum-shaped genesis header from the EVM environment.
+fn genesis_header(
+    evm_env: &EvmEnv,
+    base_fee: Option<u64>,
+    timestamp: u64,
+    genesis_number: u64,
+) -> Header {
+    let spec_id = *evm_env.spec_id();
+    Header {
+        timestamp,
+        base_fee_per_gas: base_fee,
+        gas_limit: evm_env.block_env.gas_limit,
+        beneficiary: evm_env.block_env.beneficiary,
+        difficulty: evm_env.block_env.difficulty,
+        blob_gas_used: evm_env.block_env.blob_excess_gas_and_price.as_ref().map(|_| 0),
+        excess_blob_gas: evm_env.block_env.blob_excess_gas(),
+        number: genesis_number,
+        parent_beacon_block_root: (spec_id >= SpecId::CANCUN).then_some(Default::default()),
+        withdrawals_root: (spec_id >= SpecId::SHANGHAI).then_some(EMPTY_WITHDRAWALS),
+        requests_hash: (spec_id >= SpecId::PRAGUE).then_some(EMPTY_REQUESTS_HASH),
+        ..Default::default()
+    }
+}
+
+/// Wraps an Ethereum-shaped header in the selected network's consensus header.
+fn foundry_header(networks: &NetworkConfigs, header: Header) -> FoundryHeader {
+    if networks.is_tempo() { FoundryHeader::tempo(header) } else { header.into() }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -61,20 +61,6 @@ use revm::{
 use std::sync::Arc;
 use tracing::debug;
 
-pub(super) fn store_block_metadata<N: Network>(
-    storage: &mut BlockchainStorage<N>,
-    block_hash: B256,
-    participants: MonadBlockParticipants,
-    execution_chain_id: u64,
-    hardfork: FoundryHardfork,
-) {
-    storage.monad_block_participants.insert(block_hash, participants);
-    storage.monad_block_replay_profiles.insert(
-        block_hash,
-        MonadBlockReplayProfile { execution_chain_id, hardfork: MonadHardfork::from(hardfork) },
-    );
-}
-
 pub(super) struct PreparedExecution {
     pub(super) context: Option<MonadChainContext>,
     pub(super) kind: EnvelopeExecutionKind,
@@ -663,4 +649,18 @@ impl<N: Network> Backend<N> {
             }
         }
     }
+}
+
+pub(super) fn store_block_metadata<N: Network>(
+    storage: &mut BlockchainStorage<N>,
+    block_hash: B256,
+    participants: MonadBlockParticipants,
+    execution_chain_id: u64,
+    hardfork: FoundryHardfork,
+) {
+    storage.monad_block_participants.insert(block_hash, participants);
+    storage.monad_block_replay_profiles.insert(
+        block_hash,
+        MonadBlockReplayProfile { execution_chain_id, hardfork: MonadHardfork::from(hardfork) },
+    );
 }

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -5,11 +5,6 @@ use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use std::{sync::Arc, time::Duration};
 
-/// Returns the `Utc` datetime for the given seconds since unix epoch
-pub fn utc_from_secs(secs: u64) -> DateTime<Utc> {
-    DateTime::from_timestamp(secs as i64, 0).unwrap_or(DateTime::<Utc>::MAX_UTC)
-}
-
 /// Manages block time
 #[derive(Clone, Debug)]
 pub struct TimeManager {
@@ -234,6 +229,11 @@ impl TimeManager {
     pub fn current_call_timestamp(&self) -> u64 {
         self.prepare_next_timestamp().timestamp
     }
+}
+
+/// Returns the `Utc` datetime for the given seconds since unix epoch
+pub fn utc_from_secs(secs: u64) -> DateTime<Utc> {
+    DateTime::from_timestamp(secs as i64, 0).unwrap_or(DateTime::<Utc>::MAX_UTC)
 }
 
 /// Returns the current duration since unix epoch.

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -21,14 +21,6 @@ pub type TxMarker = Vec<u8>;
 /// unlock.
 type ReplacedTransactions<T> = (Vec<Arc<PoolTransaction<T>>>, Vec<TxHash>);
 
-/// creates an unique identifier for aan (`nonce` + `Address`) combo
-pub fn to_marker(nonce: u64, from: Address) -> TxMarker {
-    let mut data = [0u8; 28];
-    data[..8].copy_from_slice(&nonce.to_le_bytes()[..]);
-    data[8..].copy_from_slice(&from.0[..]);
-    data.to_vec()
-}
-
 /// Modes that determine the transaction ordering of the mempool
 ///
 /// This type controls the transaction order via the priority metric of a transaction
@@ -784,6 +776,14 @@ impl<T: Transaction> ReadyTransaction<T> {
     pub fn max_fee_per_gas(&self) -> u128 {
         self.transaction.transaction.max_fee_per_gas()
     }
+}
+
+/// creates an unique identifier for aan (`nonce` + `Address`) combo
+pub fn to_marker(nonce: u64, from: Address) -> TxMarker {
+    let mut data = [0u8; 28];
+    data[..8].copy_from_slice(&nonce.to_le_bytes()[..]);
+    data[8..].copy_from_slice(&from.0[..]);
+    data.to_vec()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Following the module-ordering cleanup in #16303, this moves incidental Anvil module helpers below their primary declarations. The patch only reorders existing items: signatures, bodies, attributes, comments, and behavior are unchanged, and every touched file retains the same line multiset.

The original repository-wide audit was split into independent subsystem PRs for review. This PR contains only the six Anvil files; the remaining slices are Common (#16382), symbolic execution (#16383), the rest of EVM (#16384), Forge/script/lint (#16385), and supporting crates (#16386).

Codex assisted with the repository scan and mechanical relocation of existing functions. No function logic was generated or changed. This is maintenance-only and has no release-note impact, so `L-ignore` applies.
