### PR TITLE
perf(cheatcodes): cache the per-opcode hook predicates

### DIFF
--- a/.changelog/cheatcode-opcode-hook-cache.md
+++ b/.changelog/cheatcode-opcode-hook-cache.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-evm: patch
+foundry-cheatcodes: patch
+---
+
+Sped up `forge test` further by caching the cheatcode per-opcode hook predicates instead of re-testing them for every executed opcode.

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -370,6 +370,47 @@ pub struct EnvOverrides {
     pending_blobhash_index: Option<u64>,
 }
 
+/// Conservative cache of the per-opcode hook predicates.
+///
+/// [`Cheatcodes::has_step_hooks`] and [`Cheatcodes::has_step_end_hooks`] read ten fields spread
+/// across the inspector, which is too much work to repeat for every executed opcode. This caches
+/// their results so the hot path is a single load, and starts out dirty: anything that can change
+/// one of those fields marks it dirty again, and the next opcode recomputes. Being dirty when
+/// nothing changed only costs one trip through the slow path, so the cache is never wrong in the
+/// direction that would skip a hook.
+#[derive(Clone, Copy, Debug)]
+struct OpcodeHooks(u8);
+
+impl Default for OpcodeHooks {
+    fn default() -> Self {
+        Self(Self::DIRTY)
+    }
+}
+
+impl OpcodeHooks {
+    /// The cached bits are stale and have to be recomputed before they are trusted.
+    const DIRTY: u8 = 1 << 0;
+    /// [`Cheatcodes::has_step_hooks`] was true when last computed.
+    const STEP: u8 = 1 << 1;
+    /// [`Cheatcodes::has_step_end_hooks`] was true when last computed.
+    const STEP_END: u8 = 1 << 2;
+
+    #[inline(always)]
+    const fn maybe_step(self) -> bool {
+        self.0 & (Self::DIRTY | Self::STEP) != 0
+    }
+
+    #[inline(always)]
+    const fn maybe_step_end(self) -> bool {
+        self.0 & (Self::DIRTY | Self::STEP_END) != 0
+    }
+
+    #[inline(always)]
+    const fn is_dirty(self) -> bool {
+        self.0 & Self::DIRTY != 0
+    }
+}
+
 impl EnvOverrides {
     /// Whether any override is set.
     #[inline]
@@ -864,6 +905,8 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     pending_storage_hook: Option<PendingStorageHook>,
     /// Synthetic callback frame currently executing or awaiting parent cleanup.
     active_storage_hook: Option<ActiveStorageHook>,
+    /// Conservative cache of [`Self::has_step_hooks`] and [`Self::has_step_end_hooks`].
+    opcode_hooks: OpcodeHooks,
 
     /// Deprecated cheatcodes mapped to the reason. Used to report warnings on test results.
     pub deprecated: HashMap<&'static str, Option<&'static str>>,
@@ -989,6 +1032,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             storage_hooks_registered: Default::default(),
             pending_storage_hook: Default::default(),
             active_storage_hook: Default::default(),
+            opcode_hooks: Default::default(),
             deprecated: Default::default(),
             wallets: Default::default(),
             private_key_signers: Default::default(),
@@ -2049,6 +2093,45 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         true
     }
 
+    /// Cheap, conservative gate for the per-opcode `step` hook.
+    ///
+    /// May report `true` when [`Self::has_step_hooks`] is `false`; never the other way round.
+    #[inline(always)]
+    pub const fn maybe_has_step_hooks(&self) -> bool {
+        self.opcode_hooks.maybe_step()
+    }
+
+    /// Cheap, conservative gate for the per-opcode `step_end` hook.
+    ///
+    /// May report `true` when [`Self::has_step_end_hooks`] is `false`; never the other way round.
+    #[inline(always)]
+    pub const fn maybe_has_step_end_hooks(&self) -> bool {
+        self.opcode_hooks.maybe_step_end()
+    }
+
+    /// Marks the cached opcode hook gates stale.
+    ///
+    /// Must be called by anything that can change a field the hook predicates read.
+    #[inline(always)]
+    pub const fn mark_opcode_hooks_dirty(&mut self) {
+        self.opcode_hooks = OpcodeHooks(OpcodeHooks::DIRTY);
+    }
+
+    /// Recomputes the cached opcode hook gates if they are stale.
+    #[inline(always)]
+    pub fn refresh_opcode_hooks(&mut self) {
+        if self.opcode_hooks.is_dirty() {
+            let mut bits = 0;
+            if self.has_step_hooks() {
+                bits |= OpcodeHooks::STEP;
+            }
+            if self.has_step_end_hooks() {
+                bits |= OpcodeHooks::STEP_END;
+            }
+            self.opcode_hooks = OpcodeHooks(bits);
+        }
+    }
+
     #[inline(always)]
     pub fn has_step_hooks(&self) -> bool {
         self.broadcast.is_some()
@@ -2117,6 +2200,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         interpreter: &mut Interpreter,
         ecx: &mut FoundryContextFor<'_, FEN>,
     ) {
+        self.mark_opcode_hooks_dirty();
+
         // When the first interpreter is initialized we've circumvented the balance and gas checks,
         // so we apply our actual block data with the correct fees and all.
         if let Some(block) = self.block.take() {
@@ -2321,6 +2406,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
     }
 
     fn log(&mut self, _ecx: &mut FoundryContextFor<'_, FEN>, log: Log) {
+        self.mark_opcode_hooks_dirty();
         if !self.expected_emits.is_empty()
             && let Some(err) = expect::handle_expect_emit(self, &log, None)
         {
@@ -2340,6 +2426,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         _ecx: &mut FoundryContextFor<'_, FEN>,
         log: Log,
     ) {
+        self.mark_opcode_hooks_dirty();
         if !self.expected_emits.is_empty() {
             expect::handle_expect_emit(self, &log, Some(interpreter));
         }
@@ -2353,6 +2440,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         ecx: &mut FoundryContextFor<'_, FEN>,
         inputs: &mut CallInputs,
     ) -> Option<CallOutcome> {
+        self.mark_opcode_hooks_dirty();
         if self.is_storage_hook_callback(ecx, inputs) {
             return None;
         }
@@ -2365,6 +2453,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         call: &CallInputs,
         outcome: &mut CallOutcome,
     ) {
+        self.mark_opcode_hooks_dirty();
         if self.finish_storage_hook_call(ecx, call, outcome) {
             return;
         }
@@ -2831,6 +2920,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         ecx: &mut FoundryContextFor<'_, FEN>,
         mut input: &mut CreateInputs,
     ) -> Option<CreateOutcome> {
+        self.mark_opcode_hooks_dirty();
+
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
             ecx.set_spec_and_gas_params(spec_id);
@@ -2976,6 +3067,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         call: &CreateInputs,
         outcome: &mut CreateOutcome,
     ) {
+        self.mark_opcode_hooks_dirty();
+
         let call = Some(call);
         let curr_depth = ecx.journal().depth();
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1253,7 +1253,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         }
         self.inner.static_step_dispatch != OpcodeStepDispatch::None
             || self.inner.execution_cancellation.is_some()
-            || self.cheatcodes.as_ref().is_some_and(|cheats| cheats.has_step_hooks())
+            || self.cheatcodes.as_ref().is_some_and(|cheats| cheats.maybe_has_step_hooks())
     }
 
     #[inline(always)]
@@ -1266,6 +1266,11 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
             return self.step_slow(interpreter, ecx);
         }
 
+        debug_assert!(
+            self.cheatcodes.as_ref().is_none_or(|cheats| !cheats.has_step_hooks()),
+            "opcode hook cache missed a cheatcode state change"
+        );
+
         // Nothing to dispatch: only the cheatcode program counter has to keep up.
         if let Some(cheats) = self.cheatcodes.as_mut() {
             cheats.pc = interpreter.bytecode.pc();
@@ -1274,6 +1279,10 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
 
     #[inline(never)]
     fn step_slow(&mut self, interpreter: &mut Interpreter, ecx: &mut FoundryContextFor<'_, FEN>) {
+        if let Some(cheats) = self.cheatcodes.as_mut() {
+            cheats.refresh_opcode_hooks();
+        }
+
         let storage_hook_active = if let Some(cheats) = self.cheatcodes.as_mut() {
             if cheats.has_storage_hooks() && cheats.finish_storage_hook_callback(interpreter, ecx) {
                 return;
@@ -1350,6 +1359,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
             {
                 crate::utils::cold_path();
                 cheats.step(interpreter, ecx);
+                cheats.mark_opcode_hooks_dirty();
             }
         }
     }
@@ -1359,7 +1369,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
     fn needs_step_end_slow(&self) -> bool {
         self.has_static_step_end_inspectors
             || self.fuzzer.as_ref().is_some_and(|fuzzer| fuzzer.mapping_slots.is_some())
-            || self.cheatcodes.as_ref().is_some_and(|cheats| cheats.has_step_end_hooks())
+            || self.cheatcodes.as_ref().is_some_and(|cheats| cheats.maybe_has_step_end_hooks())
     }
 
     #[inline(always)]
@@ -1370,7 +1380,13 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
     ) {
         if self.needs_step_end_slow() {
             self.step_end_slow(interpreter, ecx);
+            return;
         }
+
+        debug_assert!(
+            self.cheatcodes.as_ref().is_none_or(|cheats| !cheats.has_step_end_hooks()),
+            "opcode hook cache missed a cheatcode state change"
+        );
     }
 
     #[inline(never)]
@@ -1403,6 +1419,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         {
             crate::utils::cold_path();
             cheats.step_end(interpreter, ecx);
+            cheats.mark_opcode_hooks_dirty();
         }
     }
 }


### PR DESCRIPTION
Stacked on #16372.

That PR left `InspectorStack::step` out of line at 18% of total CPU while `step_end` had already folded into the interpreter loop. The difference is `has_step_hooks`, which reads ten fields spread across the cheatcode inspector — enough work that LLVM will not inline the caller into revm's opcode loop.

This caches both hook predicates in a single byte next to a dirty bit. Every cheatcode inspector callback marks the cache dirty and the next opcode's slow path recomputes it, so the cache is only ever wrong in the direction that costs one extra trip through the slow path, never in the direction that would skip a hook. A debug assertion on the fast path compares the cache against the real predicates on every executed opcode, so a missed invalidation fails loudly in every debug test run.

With this, both `step` and `step_end` inline into the interpreter loop and stop appearing in the profile at all; what is left of the slow path is 1.1%.

### Results

Local `profiling` builds, four alternating paired runs on 12 cores, against `mattsse/inspector-step-fast-path`:

| Benchmark | #16372 | this PR | delta |
| --- | ---: | ---: | ---: |
| `forge_test/vectorized-solady` user CPU | 13.23 s | 11.46 s | -13.4% |
| `forge_test/ithacaxyz-account` user CPU | 14.44 s | 12.08 s | -16.3% |

Against `master`, both PRs together:

| Benchmark | master | both PRs | delta |
| --- | ---: | ---: | ---: |
| `forge_test/vectorized-solady` user CPU | 17.37 s | 11.20 s | -35.5% |
| `forge_test/vectorized-solady` wall | 2.01 s | 1.42 s | -29.2% |
| `forge_test/ithacaxyz-account` user CPU | 16.80 s | 12.04 s | -28.3% |
| `forge_test/ithacaxyz-account` wall | 2.20 s | 1.60 s | -27.2% |
| `forge_test/aave-v4` (hub subset) user CPU | 44.53 s | 40.89 s | -8.2% |

> AI assistance: Claude profiled the hot path, implemented the change and ran the local benchmarks.
