### PR TITLE
perf(cheatcodes): keep vm.record on the opcode fast path

### DIFF
--- a/.changelog/record-accesses-fast-path.md
+++ b/.changelog/record-accesses-fast-path.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-evm: patch
+foundry-cheatcodes: patch
+---
+
+Sped up `forge test` in suites that use `stdstore` or `deal` by keeping non-storage opcodes on the fast path while `vm.record` is active.

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -394,6 +394,8 @@ impl OpcodeHooks {
     const STEP: u8 = 1 << 1;
     /// [`Cheatcodes::has_step_end_hooks`] was true when last computed.
     const STEP_END: u8 = 1 << 2;
+    /// [`Cheatcodes::has_recording_accesses_only_step_hook`] was true when last computed.
+    const STEP_RECORD_ONLY: u8 = 1 << 3;
 
     #[inline(always)]
     const fn maybe_step(self) -> bool {
@@ -403,6 +405,11 @@ impl OpcodeHooks {
     #[inline(always)]
     const fn maybe_step_end(self) -> bool {
         self.0 & (Self::DIRTY | Self::STEP_END) != 0
+    }
+
+    #[inline(always)]
+    const fn record_accesses_only(self) -> bool {
+        self.0 & Self::STEP_RECORD_ONLY != 0
     }
 
     #[inline(always)]
@@ -2101,6 +2108,19 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         self.opcode_hooks.maybe_step()
     }
 
+    /// Cheap, conservative gate for the per-opcode `step` hook, given the opcode about to run.
+    ///
+    /// `vm.record` on its own only observes `SLOAD` and `SSTORE`, so when it is the only active
+    /// hook every other opcode can stay on the fast path. `forge-std`'s `stdStorage` leaves
+    /// recording enabled for the rest of the test, which makes this the common case in suites
+    /// that use `stdstore` or `deal`.
+    #[inline(always)]
+    pub const fn needs_step_for(&self, opcode: u8) -> bool {
+        self.opcode_hooks.maybe_step()
+            && (!self.opcode_hooks.record_accesses_only()
+                || matches!(opcode, op::SLOAD | op::SSTORE))
+    }
+
     /// Cheap, conservative gate for the per-opcode `step_end` hook.
     ///
     /// May report `true` when [`Self::has_step_end_hooks`] is `false`; never the other way round.
@@ -2127,6 +2147,9 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             }
             if self.has_step_end_hooks() {
                 bits |= OpcodeHooks::STEP_END;
+            }
+            if self.has_recording_accesses_only_step_hook() {
+                bits |= OpcodeHooks::STEP_RECORD_ONLY;
             }
             self.opcode_hooks = OpcodeHooks(bits);
         }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1246,14 +1246,17 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
 
     /// Whether [`Self::step_slow`] has anything to do for the current opcode.
     #[inline(always)]
-    fn needs_step_slow(&self) -> bool {
+    fn needs_step_slow(&self, interpreter: &Interpreter) -> bool {
         #[cfg(test)]
         if self.inner.early_exit_test_gate.is_some() {
             return true;
         }
         self.inner.static_step_dispatch != OpcodeStepDispatch::None
             || self.inner.execution_cancellation.is_some()
-            || self.cheatcodes.as_ref().is_some_and(|cheats| cheats.maybe_has_step_hooks())
+            || self
+                .cheatcodes
+                .as_ref()
+                .is_some_and(|cheats| cheats.needs_step_for(interpreter.bytecode.opcode()))
     }
 
     #[inline(always)]
@@ -1262,12 +1265,14 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         interpreter: &mut Interpreter,
         ecx: &mut FoundryContextFor<'_, FEN>,
     ) {
-        if self.needs_step_slow() {
+        if self.needs_step_slow(interpreter) {
             return self.step_slow(interpreter, ecx);
         }
 
         debug_assert!(
-            self.cheatcodes.as_ref().is_none_or(|cheats| !cheats.has_step_hooks()),
+            self.cheatcodes.as_ref().is_none_or(|cheats| !cheats.has_step_hooks()
+                || (cheats.has_recording_accesses_only_step_hook()
+                    && !matches!(interpreter.bytecode.opcode(), op::SLOAD | op::SSTORE))),
             "opcode hook cache missed a cheatcode state change"
         );
 


### PR DESCRIPTION
Stacked on #16374.

`forge-std`'s `stdStorage::find` calls `vm.record()` and reads the result back with `vm.accesses()`, but never calls `vm.stopRecord()`. Any test that touches `stdstore` — or `deal` on an ERC20, which goes through it — therefore runs with `recording_accesses` set for the rest of the test. That makes `has_step_hooks` true for every opcode, so the whole suite lands on the inspector slow path. On aave-v4, whose shared test base uses `stdstore`, `step_slow` accounted for 31% of total CPU after the two parent PRs, which is why aave saw far less of their benefit than Solady did.

`vm.record` only observes `SLOAD` and `SSTORE`, and the slow path already skipped every other opcode once it got there — it just had to walk the whole prologue first to find that out. This caches "recording accesses is the only active step hook" as a third bit next to the existing gates, so the fast path can decide from the opcode alone.

This is worth doing independently of the forge-std bug: `vm.record` is a supported cheatcode and users call it directly too. Fixing `stdStorage` to stop recording is a separate change in that repo.

### Results

Local `profiling` builds, four alternating paired runs on 12 cores, against `mattsse/cheatcode-hook-cache`:

| Benchmark | #16374 | this PR | delta |
| --- | ---: | ---: | ---: |
| `forge_test/aave-v4` (hub subset) user CPU | 43.27 s | 30.27 s | -30.0% |
| `forge_test/aave-v4` (hub subset) wall | 4.62 s | 3.32 s | -28.2% |

Against `master`, all three PRs together:

| Benchmark | master | all three | delta |
| --- | ---: | ---: | ---: |
| `forge_test/aave-v4` (hub subset) user CPU | 47.41 s | 30.24 s | -36.2% |
| `forge_test/aave-v4` (hub subset) wall | 5.04 s | 3.30 s | -34.5% |
| `forge_test/vectorized-solady` user CPU | 19.45 s | 12.73 s | -34.5% |
| `forge_test/ithacaxyz-account` user CPU | 17.32 s | 12.56 s | -27.5% |
| `forge_test/ithacaxyz-account` wall | 2.64 s | 1.84 s | -30.3% |

> AI assistance: Claude profiled the hot path, implemented the change and ran the local benchmarks.
