### PR TITLE
fix(forge): generate typed enum bindings

### DIFF
--- a/.changelog/forge-bind-enum-variants.md
+++ b/.changelog/forge-bind-enum-variants.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `forge bind` to generate typed enum variants when Solidity enum definitions are available.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5502,6 +5502,7 @@ dependencies = [
 name = "forge-sol-macro-gen"
 version = "1.8.0"
 dependencies = [
+ "alloy-json-abi",
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "eyre",

--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -9,7 +9,7 @@ use foundry_common::{
     fs::json_files,
 };
 use foundry_compilers::{
-    Graph, Project,
+    Graph, ProjectPathsConfig,
     cache::CompilerCache,
     multi::{MultiCompilerParser, MultiCompilerSettings},
 };
@@ -128,19 +128,17 @@ impl BindArgs {
             eyre::bail!("`--ethers` bindings have been removed. Use `--alloy` (default) instead.");
         }
 
-        let mut project = self.build.project()?;
+        let config = self.load_config()?;
+        let artifacts = config.out.clone();
         let enum_definitions = if self.skip_build {
-            cached_enum_definitions(
-                &project,
-                self.get_json_files(&project.paths.artifacts)?.map(|(_, path)| path),
-            )
+            let paths = config.project_paths();
+            cached_enum_definitions(&paths, self.get_json_files(&artifacts)?.map(|(_, path)| path))
         } else {
+            let mut project = config.project()?;
             let output = compile_abi_project(&mut project, ProjectCompiler::new())?;
             enum_definitions(output.parser())
         };
 
-        let config = self.load_config()?;
-        let artifacts = config.out;
         let bindings_root = self.bindings.clone().unwrap_or_else(|| artifacts.join("bindings"));
         let sol_config = ToSolConfig::new().enum_definitions(enum_definitions);
 
@@ -148,9 +146,7 @@ impl BindArgs {
             if !self.overwrite {
                 sh_status!("Bindings found. Checking for consistency.")?;
                 let mut bindings = self.get_solmacrogen(&artifacts)?;
-                bindings.generate_bindings(!self.skip_extra_derives, |input| {
-                    input.normalize_json_with_config(sol_config.clone())
-                })?;
+                bindings.generate_bindings(!self.skip_extra_derives, &sol_config)?;
                 return self.check_existing_bindings(&bindings, &bindings_root);
             }
 
@@ -270,7 +266,7 @@ impl BindArgs {
                 bindings_root,
                 self.single_file,
                 !self.skip_extra_derives,
-                |input| input.normalize_json_with_config(sol_config.clone()),
+                sol_config,
             )?;
         } else {
             trace!(single_file = self.single_file, "generating crate");
@@ -284,7 +280,7 @@ impl BindArgs {
                 self.alloy_version.clone(),
                 self.alloy_rev.clone(),
                 !self.skip_extra_derives,
-                |input| input.normalize_json_with_config(sol_config.clone()),
+                sol_config,
             )?;
         }
 
@@ -293,13 +289,13 @@ impl BindArgs {
 }
 
 fn cached_enum_definitions(
-    project: &Project,
+    paths: &ProjectPathsConfig,
     artifacts: impl Iterator<Item = PathBuf>,
 ) -> BTreeMap<String, Vec<String>> {
-    let Ok(graph) = Graph::<MultiCompilerParser>::resolve(&project.paths) else {
+    let Ok(graph) = Graph::<MultiCompilerParser>::resolve(paths) else {
         return BTreeMap::default();
     };
-    let Ok(cache) = CompilerCache::<MultiCompilerSettings>::read_joined(&project.paths) else {
+    let Ok(cache) = CompilerCache::<MultiCompilerSettings>::read_joined(paths) else {
         return BTreeMap::default();
     };
     let sources_are_fresh = graph.nodes.iter().all(|node| {

--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -1,3 +1,4 @@
+use alloy_json_abi::ToSolConfig;
 use alloy_primitives::map::HashSet;
 use clap::{Parser, ValueHint};
 use eyre::Result;
@@ -7,9 +8,16 @@ use foundry_common::{
     compile::{ProjectCompiler, compile_abi_project},
     fs::json_files,
 };
+use foundry_compilers::{
+    Graph, Project,
+    cache::CompilerCache,
+    multi::{MultiCompilerParser, MultiCompilerSettings},
+};
 use foundry_config::impl_figment_convert;
 use regex::Regex;
+use solar::ast::{Item, ItemKind};
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -120,26 +128,37 @@ impl BindArgs {
             eyre::bail!("`--ethers` bindings have been removed. Use `--alloy` (default) instead.");
         }
 
-        if !self.skip_build {
-            let mut project = self.build.project()?;
-            let _ = compile_abi_project(&mut project, ProjectCompiler::new())?;
-        }
+        let mut project = self.build.project()?;
+        let enum_definitions = if self.skip_build {
+            cached_enum_definitions(
+                &project,
+                self.get_json_files(&project.paths.artifacts)?.map(|(_, path)| path),
+            )
+        } else {
+            let output = compile_abi_project(&mut project, ProjectCompiler::new())?;
+            enum_definitions(output.parser())
+        };
 
         let config = self.load_config()?;
         let artifacts = config.out;
         let bindings_root = self.bindings.clone().unwrap_or_else(|| artifacts.join("bindings"));
+        let sol_config = ToSolConfig::new().enum_definitions(enum_definitions);
 
         if bindings_root.exists() {
             if !self.overwrite {
                 sh_status!("Bindings found. Checking for consistency.")?;
-                return self.check_existing_bindings(&artifacts, &bindings_root);
+                let mut bindings = self.get_solmacrogen(&artifacts)?;
+                bindings.generate_bindings(!self.skip_extra_derives, |input| {
+                    input.normalize_json_with_config(sol_config.clone())
+                })?;
+                return self.check_existing_bindings(&bindings, &bindings_root);
             }
 
             trace!(?artifacts, "Removing existing bindings");
             fs::remove_dir_all(&bindings_root)?;
         }
 
-        self.generate_bindings(&artifacts, &bindings_root)?;
+        self.generate_bindings(&artifacts, &bindings_root, &sol_config)?;
 
         sh_status!("Bindings have been generated to {}", bindings_root.display())?;
         Ok(())
@@ -215,9 +234,11 @@ impl BindArgs {
     }
 
     /// Check that the existing bindings match the expected abigen output
-    fn check_existing_bindings(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
-        let mut bindings = self.get_solmacrogen(artifacts)?;
-        bindings.generate_bindings(!self.skip_extra_derives)?;
+    fn check_existing_bindings(
+        &self,
+        bindings: &MultiSolMacroGen,
+        bindings_root: &Path,
+    ) -> Result<()> {
         sh_status!("Checking bindings for {} contracts", bindings.instances.len())?;
         bindings.check_consistency(
             &self.crate_name,
@@ -234,20 +255,26 @@ impl BindArgs {
     }
 
     /// Generate the bindings
-    fn generate_bindings(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
-        let mut solmacrogen = self.get_solmacrogen(artifacts)?;
-        sh_status!("Generating bindings for {} contracts", solmacrogen.instances.len())?;
+    fn generate_bindings(
+        &self,
+        artifacts: &Path,
+        bindings_root: &Path,
+        sol_config: &ToSolConfig,
+    ) -> Result<()> {
+        let mut bindings = self.get_solmacrogen(artifacts)?;
+        sh_status!("Generating bindings for {} contracts", bindings.instances.len())?;
 
         if self.module {
             trace!(single_file = self.single_file, "generating module");
-            solmacrogen.write_to_module(
+            bindings.write_to_module(
                 bindings_root,
                 self.single_file,
                 !self.skip_extra_derives,
+                |input| input.normalize_json_with_config(sol_config.clone()),
             )?;
         } else {
             trace!(single_file = self.single_file, "generating crate");
-            solmacrogen.write_to_crate(
+            bindings.write_to_crate(
                 &self.crate_name,
                 &self.crate_version,
                 &self.crate_description,
@@ -257,10 +284,88 @@ impl BindArgs {
                 self.alloy_version.clone(),
                 self.alloy_rev.clone(),
                 !self.skip_extra_derives,
+                |input| input.normalize_json_with_config(sol_config.clone()),
             )?;
         }
 
         Ok(())
+    }
+}
+
+fn cached_enum_definitions(
+    project: &Project,
+    artifacts: impl Iterator<Item = PathBuf>,
+) -> BTreeMap<String, Vec<String>> {
+    let Ok(graph) = Graph::<MultiCompilerParser>::resolve(&project.paths) else {
+        return BTreeMap::default();
+    };
+    let Ok(cache) = CompilerCache::<MultiCompilerSettings>::read_joined(&project.paths) else {
+        return BTreeMap::default();
+    };
+    let sources_are_fresh = graph.nodes.iter().all(|node| {
+        cache
+            .entry(node.path())
+            .is_some_and(|entry| entry.content_hash == node.unpack().1.content_hash())
+    });
+    if !sources_are_fresh || !cache.all_artifacts_exist() {
+        return BTreeMap::default();
+    }
+    let cached_artifacts = cache
+        .entries()
+        .flat_map(|entry| entry.artifacts.values())
+        .flat_map(|versions| versions.values())
+        .flat_map(|profiles| profiles.values())
+        .map(|artifact| artifact.path.clone())
+        .collect::<HashSet<_>>();
+    if artifacts.into_iter().any(|artifact| !cached_artifacts.contains(&artifact)) {
+        return BTreeMap::default();
+    }
+    enum_definitions(graph.parser())
+}
+
+fn enum_definitions(parser: &MultiCompilerParser) -> BTreeMap<String, Vec<String>> {
+    parser.solc().compiler().enter(|compiler| {
+        let mut definitions = BTreeMap::default();
+        let mut ambiguous = HashSet::default();
+        for source in compiler.sources().iter() {
+            if let Some(ast) = &source.ast {
+                collect_enum_definitions(ast.items.iter(), None, &mut definitions, &mut ambiguous);
+            }
+        }
+        definitions
+    })
+}
+
+fn collect_enum_definitions<'ast>(
+    items: impl Iterator<Item = &'ast Item<'ast>>,
+    owner: Option<&str>,
+    definitions: &mut BTreeMap<String, Vec<String>>,
+    ambiguous: &mut HashSet<String>,
+) {
+    for item in items {
+        match &item.kind {
+            ItemKind::Enum(enum_item) => {
+                let name = enum_item.name.to_string();
+                let key = owner.map_or_else(|| name.clone(), |owner| format!("{owner}.{name}"));
+                let variants = enum_item.variants.iter().map(ToString::to_string).collect();
+                if definitions.get(&key).is_some_and(|existing| existing != &variants) {
+                    definitions.remove(&key);
+                    ambiguous.insert(key);
+                } else if !ambiguous.contains(&key) {
+                    definitions.insert(key, variants);
+                }
+            }
+            ItemKind::Contract(contract) => {
+                let owner = contract.name.to_string();
+                collect_enum_definitions(
+                    contract.body.iter(),
+                    Some(&owner),
+                    definitions,
+                    ambiguous,
+                );
+            }
+            _ => {}
+        }
     }
 }
 

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -1,4 +1,5 @@
 use foundry_compilers::utils::read_json_file;
+use foundry_config::SolcReq;
 use foundry_test_utils::TestProject;
 use std::{fs, path::Path, process::Command};
 
@@ -225,6 +226,26 @@ contract EnumUser {
     let binding = fs::read_to_string(bindings_path.join("src/enum_user.rs")).unwrap();
     assert!(binding.contains("pub struct Status"), "{binding}");
     assert!(!binding.contains("pub enum Status"), "{binding}");
+});
+
+forgetest!(bind_skip_build_does_not_require_compiler, |prj, cmd| {
+    prj.add_source(
+        "EnumUser.sol",
+        r#"
+contract EnumUser {
+    enum Status { Pending, Active }
+    function echo(Status status) external pure returns (Status) { return status; }
+}
+"#,
+    );
+    cmd.arg("build").assert_success();
+
+    let missing_solc = prj.root().join("missing-solc");
+    prj.update_config(|config| config.solc = Some(SolcReq::Local(missing_solc)));
+    cmd.forge_fuse().args(["bind", "--skip-build", "--select", "^EnumUser$"]).assert_success();
+
+    let binding = fs::read_to_string(prj.root().join("out/bindings/src/enum_user.rs")).unwrap();
+    assert!(binding.contains("pub enum Status"), "{binding}");
 });
 
 forgetest!(bind_stale_untracked_enum_artifacts_fall_back_to_udvt, |prj, cmd| {

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -172,6 +172,120 @@ contract BindTarget {
     assert!(artifact["deployedBytecode"]["object"].as_str().is_none());
 });
 
+// <https://github.com/foundry-rs/foundry/issues/10441>
+forgetest!(bind_generates_enum_variants, |prj, cmd| {
+    prj.add_source(
+        "EnumUser.sol",
+        r#"
+contract EnumUser {
+    enum Status { Pending, Active }
+
+    function echo(Status status) external pure returns (Status) {
+        return status;
+    }
+}
+"#,
+    );
+
+    cmd.args(["bind", "--select", "^EnumUser$"]).assert_success();
+
+    let bindings_path = prj.root().join("out/bindings");
+    let tests_path = bindings_path.join("tests");
+    let enum_test = r#"
+use foundry_contracts::enum_user::EnumUser::{Status, echoCall};
+
+#[test]
+fn enum_variants_are_typed() {
+    let call = echoCall { status: Status::Active };
+    assert_eq!(call.status, Status::Active);
+}
+"#;
+    fs::create_dir_all(&tests_path).unwrap();
+    fs::write(tests_path.join("enums.rs"), enum_test).unwrap();
+    assert_bindings_compile(&bindings_path);
+
+    cmd.forge_fuse().args(["bind", "--skip-build", "--select", "^EnumUser$"]).assert_success();
+
+    prj.add_source(
+        "EnumUser.sol",
+        r#"
+contract EnumUser {
+    enum Status { Active, Pending }
+
+    function echo(Status status) external pure returns (Status) {
+        return status;
+    }
+}
+"#,
+    );
+    cmd.forge_fuse()
+        .args(["bind", "--skip-build", "--overwrite", "--select", "^EnumUser$"])
+        .assert_success();
+
+    let binding = fs::read_to_string(bindings_path.join("src/enum_user.rs")).unwrap();
+    assert!(binding.contains("pub struct Status"), "{binding}");
+    assert!(!binding.contains("pub enum Status"), "{binding}");
+});
+
+forgetest!(bind_stale_untracked_enum_artifacts_fall_back_to_udvt, |prj, cmd| {
+    prj.add_source(
+        "A.sol",
+        r#"
+contract EnumUser {
+    enum Status { Pending, Active }
+    function echo(Status status) external pure returns (Status) { return status; }
+}
+"#,
+    );
+    cmd.arg("build").assert_success();
+
+    fs::remove_file(prj.paths().sources.join("A.sol")).unwrap();
+    prj.add_source(
+        "Z.sol",
+        r#"
+contract EnumUser {
+    enum Status { Active, Pending }
+    function echo(Status status) external pure returns (Status) { return status; }
+}
+"#,
+    );
+    cmd.forge_fuse().arg("build").assert_success();
+    cmd.forge_fuse()
+        .args(["bind", "--skip-build", "--overwrite", "--select", "^EnumUser$"])
+        .assert_success();
+
+    let binding = fs::read_to_string(prj.root().join("out/bindings/src/enum_user.rs")).unwrap();
+    assert!(binding.contains("pub struct Status"), "{binding}");
+    assert!(!binding.contains("pub enum Status"), "{binding}");
+});
+
+forgetest!(bind_ambiguous_enum_definitions_fall_back_to_udvt, |prj, cmd| {
+    prj.add_source(
+        "A.sol",
+        r#"
+contract Duplicate {
+    enum Status { A }
+    function status(Status value) external pure returns (Status) { return value; }
+}
+"#,
+    );
+    prj.add_source(
+        "B.sol",
+        r#"
+contract Duplicate {
+    enum Status { B }
+    function status(Status value) external pure returns (Status) { return value; }
+}
+"#,
+    );
+
+    cmd.args(["bind", "--select", "^Duplicate$"]).assert_success();
+
+    let binding = fs::read_to_string(prj.root().join("out/bindings/src/duplicate.rs")).unwrap();
+    assert!(binding.contains("pub struct Status"), "{binding}");
+    assert!(!binding.contains("pub enum Status"), "{binding}");
+});
+
 // <https://github.com/foundry-rs/foundry/issues/11177>
 forgetest!(bind_event_module_name_shadowing, |prj, cmd| {
     prj.add_source(

--- a/crates/sol-macro-gen/Cargo.toml
+++ b/crates/sol-macro-gen/Cargo.toml
@@ -15,6 +15,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+alloy-json-abi.workspace = true
 alloy-sol-macro-input.workspace = true
 alloy-sol-macro-expander = { workspace = true, features = ["json"] }
 foundry-common.workspace = true

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -81,9 +81,17 @@ impl MultiSolMacroGen {
         Ok(())
     }
 
-    pub fn generate_bindings(&mut self, all_derives: bool) -> Result<()> {
+    pub fn generate_bindings(
+        &mut self,
+        all_derives: bool,
+        normalize: impl Fn(SolInput) -> syn::Result<SolInput> + Sync,
+    ) -> Result<()> {
         self.instances.par_iter_mut().try_for_each(|instance| {
-            Self::generate_binding(instance, all_derives).wrap_err_with(|| {
+            let result = instance
+                .get_sol_input()
+                .and_then(|input| normalize(input).map_err(Into::into))
+                .and_then(|input| Self::generate_binding(instance, input, all_derives));
+            result.wrap_err_with(|| {
                 format!(
                     "failed to generate bindings for {}:{}",
                     instance.path.display(),
@@ -93,8 +101,11 @@ impl MultiSolMacroGen {
         })
     }
 
-    fn generate_binding(instance: &mut SolMacroGen, all_derives: bool) -> Result<()> {
-        let input = instance.get_sol_input()?.normalize_json()?;
+    fn generate_binding(
+        instance: &mut SolMacroGen,
+        input: SolInput,
+        all_derives: bool,
+    ) -> Result<()> {
         let SolInput { attrs: _, path: _, kind } = input;
 
         let tokens = match kind {
@@ -137,8 +148,9 @@ impl MultiSolMacroGen {
         alloy_version: Option<String>,
         alloy_rev: Option<String>,
         all_derives: bool,
+        normalize: impl Fn(SolInput) -> syn::Result<SolInput> + Sync,
     ) -> Result<()> {
-        self.generate_bindings(all_derives)?;
+        self.generate_bindings(all_derives, normalize)?;
 
         let src = bindings_path.join("src");
         fs::create_dir_all(&src)?;
@@ -226,8 +238,9 @@ edition = "2021"
         bindings_path: &Path,
         single_file: bool,
         all_derives: bool,
+        normalize: impl Fn(SolInput) -> syn::Result<SolInput> + Sync,
     ) -> Result<()> {
-        self.generate_bindings(all_derives)?;
+        self.generate_bindings(all_derives, normalize)?;
 
         fs::create_dir_all(bindings_path)?;
 

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -9,6 +9,7 @@
 //! It contains methods to read the json abi, generate rust bindings from the abi and ultimately
 //! write the bindings to a crate or modules.
 
+use alloy_json_abi::ToSolConfig;
 use alloy_sol_macro_expander::expand::expand;
 use alloy_sol_macro_input::{SolInput, SolInputKind};
 use eyre::{Context, OptionExt, Result};
@@ -81,17 +82,9 @@ impl MultiSolMacroGen {
         Ok(())
     }
 
-    pub fn generate_bindings(
-        &mut self,
-        all_derives: bool,
-        normalize: impl Fn(SolInput) -> syn::Result<SolInput> + Sync,
-    ) -> Result<()> {
+    pub fn generate_bindings(&mut self, all_derives: bool, sol_config: &ToSolConfig) -> Result<()> {
         self.instances.par_iter_mut().try_for_each(|instance| {
-            let result = instance
-                .get_sol_input()
-                .and_then(|input| normalize(input).map_err(Into::into))
-                .and_then(|input| Self::generate_binding(instance, input, all_derives));
-            result.wrap_err_with(|| {
+            Self::generate_binding(instance, all_derives, sol_config).wrap_err_with(|| {
                 format!(
                     "failed to generate bindings for {}:{}",
                     instance.path.display(),
@@ -103,9 +96,10 @@ impl MultiSolMacroGen {
 
     fn generate_binding(
         instance: &mut SolMacroGen,
-        input: SolInput,
         all_derives: bool,
+        sol_config: &ToSolConfig,
     ) -> Result<()> {
+        let input = instance.get_sol_input()?.normalize_json_with_config(sol_config.clone())?;
         let SolInput { attrs: _, path: _, kind } = input;
 
         let tokens = match kind {
@@ -148,9 +142,9 @@ impl MultiSolMacroGen {
         alloy_version: Option<String>,
         alloy_rev: Option<String>,
         all_derives: bool,
-        normalize: impl Fn(SolInput) -> syn::Result<SolInput> + Sync,
+        sol_config: &ToSolConfig,
     ) -> Result<()> {
-        self.generate_bindings(all_derives, normalize)?;
+        self.generate_bindings(all_derives, sol_config)?;
 
         let src = bindings_path.join("src");
         fs::create_dir_all(&src)?;
@@ -238,9 +232,9 @@ edition = "2021"
         bindings_path: &Path,
         single_file: bool,
         all_derives: bool,
-        normalize: impl Fn(SolInput) -> syn::Result<SolInput> + Sync,
+        sol_config: &ToSolConfig,
     ) -> Result<()> {
-        self.generate_bindings(all_derives, normalize)?;
+        self.generate_bindings(all_derives, sol_config)?;
 
         fs::create_dir_all(bindings_path)?;
 


### PR DESCRIPTION
`forge bind` previously generated Solidity enums as `uint8` wrappers because ABI artifacts do not retain variant names. This change supplements ABI generation with enum definitions collected from the parsed Solidity AST, producing typed Rust variants such as `Status::Active`.

Conflicting enum definitions and stale or untracked artifacts conservatively fall back to the existing `uint8` representation to avoid assigning incorrect discriminants. `--skip-build` uses typed variants only when sources and selected artifacts match the compiler cache.

Fixes #10441.