### PR TITLE
refactor(common): reorder module helpers

### DIFF
--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -34,21 +34,6 @@ const CALL_PROTECTION_BYTECODE_PREFIX: [u8; 21] =
 /// `address(uint160(uint256(keccak256("foundry library deployer"))))`
 pub const LIBRARY_DEPLOYER: Address = address!("0x1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
 
-/// Returns whether `creation_code` is exactly this contract's linked creation bytecode followed by
-/// a complete, canonically encoded constructor argument tuple.
-pub fn matches_contract_creation(contract: &ContractData, creation_code: &[u8]) -> bool {
-    let Some(bytecode) = contract.bytecode() else { return false };
-    let Some(arguments) = creation_code.strip_prefix(bytecode.as_ref()) else { return false };
-    match contract.abi.constructor() {
-        Some(constructor) => constructor
-            .abi_decode_input(arguments)
-            .ok()
-            .and_then(|values| constructor.abi_encode_input(&values).ok())
-            .is_some_and(|encoded| encoded == arguments),
-        None => arguments.is_empty(),
-    }
-}
-
 /// Subset of [CompactBytecode] excluding sourcemaps.
 #[expect(missing_docs)]
 #[derive(Debug, Clone)]
@@ -473,6 +458,21 @@ pub type ContractsByAddress = BTreeMap<Address, (String, JsonAbi)>;
 /// Very simple fuzzy matching of contract bytecode.
 ///
 /// Returns a value between `0.0` (identical) and `1.0` (completely different).
+/// Returns whether `creation_code` is exactly this contract's linked creation bytecode followed by
+/// a complete, canonically encoded constructor argument tuple.
+pub fn matches_contract_creation(contract: &ContractData, creation_code: &[u8]) -> bool {
+    let Some(bytecode) = contract.bytecode() else { return false };
+    let Some(arguments) = creation_code.strip_prefix(bytecode.as_ref()) else { return false };
+    match contract.abi.constructor() {
+        Some(constructor) => constructor
+            .abi_decode_input(arguments)
+            .ok()
+            .and_then(|values| constructor.abi_encode_input(&values).ok())
+            .is_some_and(|encoded| encoded == arguments),
+        None => arguments.is_empty(),
+    }
+}
+
 pub fn bytecode_diff_score<'a>(mut a: &'a [u8], mut b: &'a [u8]) -> f64 {
     // Make sure `a` is the longer one.
     if a.len() < b.len() {

--- a/crates/common/src/preprocessor/data.rs
+++ b/crates/common/src/preprocessor/data.rs
@@ -15,40 +15,6 @@ use std::{
 /// Contract id -> Contract data definition mapping.
 pub type PreprocessorData = BTreeMap<ContractId, ContractData>;
 
-/// Collects preprocessor data from referenced contracts.
-pub(crate) fn collect_preprocessor_data(
-    gcx: Gcx<'_>,
-    referenced_contracts: &HashSet<ContractId>,
-) -> PreprocessorData {
-    let mut data = PreprocessorData::default();
-    for contract_id in referenced_contracts {
-        let contract = gcx.hir.contract(*contract_id);
-        let source = gcx.hir.source(contract.source);
-
-        let FileName::Real(path) = &source.file.name else {
-            continue;
-        };
-
-        let contract_data = ContractData::new(gcx, *contract_id, contract, path, source);
-        data.insert(*contract_id, contract_data);
-    }
-    data
-}
-
-/// Creates helper libraries for contracts with a non-empty constructor.
-///
-/// See [`ContractData::build_helper`] for more details.
-pub(crate) fn create_deploy_helpers(data: &BTreeMap<ContractId, ContractData>) -> Sources {
-    let mut deploy_helpers = Sources::new();
-    for (contract_id, contract) in data {
-        if let Some(code) = contract.build_helper() {
-            let path = format!("foundry-pp/DeployHelper{}.sol", contract_id.index());
-            deploy_helpers.insert(path.into(), Source::new(code));
-        }
-    }
-    deploy_helpers
-}
-
 /// Keeps data about a contract constructor.
 #[derive(Debug)]
 pub struct ContractConstructorData {
@@ -196,4 +162,38 @@ function encodeArgs{contract_id}(DeployHelper{contract_id}.FoundryPpConstructorA
 
         Some(helper)
     }
+}
+
+/// Collects preprocessor data from referenced contracts.
+pub(crate) fn collect_preprocessor_data(
+    gcx: Gcx<'_>,
+    referenced_contracts: &HashSet<ContractId>,
+) -> PreprocessorData {
+    let mut data = PreprocessorData::default();
+    for contract_id in referenced_contracts {
+        let contract = gcx.hir.contract(*contract_id);
+        let source = gcx.hir.source(contract.source);
+
+        let FileName::Real(path) = &source.file.name else {
+            continue;
+        };
+
+        let contract_data = ContractData::new(gcx, *contract_id, contract, path, source);
+        data.insert(*contract_id, contract_data);
+    }
+    data
+}
+
+/// Creates helper libraries for contracts with a non-empty constructor.
+///
+/// See [`ContractData::build_helper`] for more details.
+pub(crate) fn create_deploy_helpers(data: &BTreeMap<ContractId, ContractData>) -> Sources {
+    let mut deploy_helpers = Sources::new();
+    for (contract_id, contract) in data {
+        if let Some(code) = contract.build_helper() {
+            let path = format!("foundry-pp/DeployHelper{}.sol", contract_id.index());
+            deploy_helpers.insert(path.into(), Source::new(code));
+        }
+    }
+    deploy_helpers
 }

--- a/crates/common/src/preprocessor/mod.rs
+++ b/crates/common/src/preprocessor/mod.rs
@@ -20,12 +20,6 @@ use data::{collect_preprocessor_data, create_deploy_helpers};
 mod deps;
 use deps::{PreprocessorDependencies, remove_bytecode_dependencies};
 
-/// Returns the range of the given span in the source map.
-#[track_caller]
-fn span_to_range(source_map: &SourceMap, span: Span) -> Range<usize> {
-    source_map.span_to_range(span).unwrap()
-}
-
 /// Preprocessor that replaces static bytecode linking in tests and scripts (`new Contract`) with
 /// dynamic linkage through (`Vm.create*`).
 ///
@@ -130,4 +124,10 @@ impl Preprocessor<MultiCompiler> for DynamicTestLinkingPreprocessor {
         let paths = paths.clone().with_language::<SolcLanguage>();
         self.preprocess(solc, input, &paths, mocks)
     }
+}
+
+/// Returns the range of the given span in the source map.
+#[track_caller]
+fn span_to_range(source_map: &SourceMap, span: Span) -> Range<usize> {
+    source_map.span_to_range(span).unwrap()
 }

--- a/crates/common/src/provider/curl_transport.rs
+++ b/crates/common/src/provider/curl_transport.rs
@@ -8,68 +8,6 @@ use serde_json::Value;
 use tower::Service;
 use url::Url;
 
-/// Escapes a string for use in a single-quoted shell argument.
-fn shell_escape(s: &str) -> String {
-    s.replace('\'', "'\"'\"'")
-}
-
-/// Build a JWT using a secret
-fn build_jwt(jwt_secret: &str) -> eyre::Result<String> {
-    // Decode jwt from hex, then generate claims (iat with current timestamp)
-    let secret = JwtSecret::from_hex(jwt_secret)?;
-    let claims = Claims::default();
-    let token = secret.encode(&claims)?;
-    Ok(token)
-}
-
-/// Appends a JWT Authorization header to a curl command.
-fn append_jwt_auth(cmd: &mut String, jwt_secret: &str) -> eyre::Result<()> {
-    let jwt = build_jwt(jwt_secret).wrap_err("Invalid --jwt-secret provided")?;
-
-    cmd.push_str(&format!(" -H 'Authorization: Bearer {}'", shell_escape(jwt.as_str())));
-
-    Ok(())
-}
-
-/// Generates a curl command for an RPC request.
-///
-/// This is a standalone helper that can be used to generate curl commands
-/// without going through the transport layer.
-pub fn generate_curl_command(
-    url: &str,
-    method: &str,
-    params: Value,
-    headers: Option<&[String]>,
-    jwt_secret: Option<&str>,
-) -> eyre::Result<String> {
-    let payload = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-    let payload_str = serde_json::to_string(&payload).unwrap_or_default();
-    let escaped_payload = shell_escape(&payload_str);
-
-    let mut cmd = String::from("curl -X POST");
-    cmd.push_str(" -H 'Content-Type: application/json'");
-
-    if let Some(secret) = jwt_secret {
-        append_jwt_auth(&mut cmd, secret)?;
-    }
-
-    if let Some(hdrs) = headers {
-        for h in hdrs {
-            cmd.push_str(&format!(" -H '{}'", shell_escape(h)));
-        }
-    }
-
-    cmd.push_str(&format!(" --data-raw '{escaped_payload}'"));
-    cmd.push_str(&format!(" '{}'", shell_escape(url)));
-
-    Ok(cmd)
-}
-
 /// A transport that prints curl commands instead of executing RPC requests.
 ///
 /// When a request is made through this transport, it will print the equivalent
@@ -179,6 +117,68 @@ impl Service<RequestPacket> for &CurlTransport {
     fn call(&mut self, req: RequestPacket) -> Self::Future {
         self.request(req)
     }
+}
+
+/// Escapes a string for use in a single-quoted shell argument.
+fn shell_escape(s: &str) -> String {
+    s.replace('\'', "'\"'\"'")
+}
+
+/// Build a JWT using a secret
+fn build_jwt(jwt_secret: &str) -> eyre::Result<String> {
+    // Decode jwt from hex, then generate claims (iat with current timestamp)
+    let secret = JwtSecret::from_hex(jwt_secret)?;
+    let claims = Claims::default();
+    let token = secret.encode(&claims)?;
+    Ok(token)
+}
+
+/// Appends a JWT Authorization header to a curl command.
+fn append_jwt_auth(cmd: &mut String, jwt_secret: &str) -> eyre::Result<()> {
+    let jwt = build_jwt(jwt_secret).wrap_err("Invalid --jwt-secret provided")?;
+
+    cmd.push_str(&format!(" -H 'Authorization: Bearer {}'", shell_escape(jwt.as_str())));
+
+    Ok(())
+}
+
+/// Generates a curl command for an RPC request.
+///
+/// This is a standalone helper that can be used to generate curl commands
+/// without going through the transport layer.
+pub fn generate_curl_command(
+    url: &str,
+    method: &str,
+    params: Value,
+    headers: Option<&[String]>,
+    jwt_secret: Option<&str>,
+) -> eyre::Result<String> {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let payload_str = serde_json::to_string(&payload).unwrap_or_default();
+    let escaped_payload = shell_escape(&payload_str);
+
+    let mut cmd = String::from("curl -X POST");
+    cmd.push_str(" -H 'Content-Type: application/json'");
+
+    if let Some(secret) = jwt_secret {
+        append_jwt_auth(&mut cmd, secret)?;
+    }
+
+    if let Some(hdrs) = headers {
+        for h in hdrs {
+            cmd.push_str(&format!(" -H '{}'", shell_escape(h)));
+        }
+    }
+
+    cmd.push_str(&format!(" --data-raw '{escaped_payload}'"));
+    cmd.push_str(&format!(" '{}'", shell_escape(url)));
+
+    Ok(cmd)
 }
 
 #[cfg(test)]

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -49,78 +49,12 @@ const POLL_INTERVAL_BLOCK_TIME_SCALE_FACTOR: f32 = 0.6;
 /// Helper type alias for a retry provider
 pub type RetryProvider<N = AnyNetwork> = RootProvider<N>;
 
-/// Returns whether an RPC transport error reports JSON-RPC method-not-found.
-///
-/// Some providers encode JSON-RPC errors inside an HTTP error response instead of returning a
-/// normal JSON-RPC response. Only the exact `-32601` code is treated as method unavailability;
-/// authentication, internal, and transport errors must remain visible to callers.
-pub fn is_rpc_method_not_found(error: &TransportError) -> bool {
-    if error.as_error_resp().is_some_and(|response| response.code == -32601) {
-        return true;
-    }
-    let TransportError::Transport(error) = error else { return false };
-    error
-        .as_http_error()
-        .and_then(|error| rpc_error_code(&error.body))
-        .is_some_and(|code| code == -32601)
-}
-
-/// Returns an RPC URL safe for display by retaining only its scheme, host, and port.
-pub fn redact_url(raw: &str) -> String {
-    let Ok(mut redacted) = Url::parse(raw) else {
-        return "<redacted>".to_owned();
-    };
-    let _ = redacted.set_username("");
-    let _ = redacted.set_password(None);
-    redacted.set_path("");
-    redacted.set_query(None);
-    redacted.set_fragment(None);
-    redacted.to_string()
-}
-
-fn rpc_error_code(body: &str) -> Option<i64> {
-    // HTTP transports may append human-readable diagnostics after the JSON-RPC body. Parse the
-    // first complete JSON value instead of requiring the entire body to be JSON.
-    let value =
-        serde_json::Deserializer::from_str(body).into_iter::<serde_json::Value>().next()?.ok()?;
-    value.get("error").unwrap_or(&value).get("code")?.as_i64()
-}
-
 /// Helper type alias for a retry provider with a signer
 pub type RetryProviderWithSigner<N = AnyNetwork, W = EthereumWallet> = FillProvider<
     JoinFill<JoinFill<Identity, <N as RecommendedFillers>::RecommendedFillers>, WalletFiller<W>>,
     RootProvider<N>,
     N,
 >;
-
-/// Constructs a provider with a 100 millisecond interval poll if it's a localhost URL (most likely
-/// an anvil or other dev node) and with the default, or 7 second otherwise.
-///
-/// See [`try_get_http_provider`] for more details.
-///
-/// # Panics
-///
-/// Panics if the URL is invalid.
-///
-/// # Examples
-///
-/// ```
-/// use foundry_common::provider::get_http_provider;
-///
-/// let retry_provider = get_http_provider("http://localhost:8545");
-/// ```
-#[inline]
-#[track_caller]
-pub fn get_http_provider(builder: impl AsRef<str>) -> RetryProvider {
-    try_get_http_provider(builder).unwrap()
-}
-
-/// Constructs a provider with a 100 millisecond interval poll if it's a localhost URL (most likely
-/// an anvil or other dev node) and with the default, or 7 second otherwise.
-#[inline]
-pub fn try_get_http_provider(builder: impl AsRef<str>) -> Result<RetryProvider> {
-    ProviderBuilder::new(builder.as_ref()).build()
-}
 
 /// A round-robin transport that distributes requests across multiple transports.
 ///
@@ -605,6 +539,72 @@ impl<N: Network> ProviderBuilder<N> {
 
         Ok(provider)
     }
+}
+
+/// Returns whether an RPC transport error reports JSON-RPC method-not-found.
+///
+/// Some providers encode JSON-RPC errors inside an HTTP error response instead of returning a
+/// normal JSON-RPC response. Only the exact `-32601` code is treated as method unavailability;
+/// authentication, internal, and transport errors must remain visible to callers.
+pub fn is_rpc_method_not_found(error: &TransportError) -> bool {
+    if error.as_error_resp().is_some_and(|response| response.code == -32601) {
+        return true;
+    }
+    let TransportError::Transport(error) = error else { return false };
+    error
+        .as_http_error()
+        .and_then(|error| rpc_error_code(&error.body))
+        .is_some_and(|code| code == -32601)
+}
+
+/// Returns an RPC URL safe for display by retaining only its scheme, host, and port.
+pub fn redact_url(raw: &str) -> String {
+    let Ok(mut redacted) = Url::parse(raw) else {
+        return "<redacted>".to_owned();
+    };
+    let _ = redacted.set_username("");
+    let _ = redacted.set_password(None);
+    redacted.set_path("");
+    redacted.set_query(None);
+    redacted.set_fragment(None);
+    redacted.to_string()
+}
+
+fn rpc_error_code(body: &str) -> Option<i64> {
+    // HTTP transports may append human-readable diagnostics after the JSON-RPC body. Parse the
+    // first complete JSON value instead of requiring the entire body to be JSON.
+    let value =
+        serde_json::Deserializer::from_str(body).into_iter::<serde_json::Value>().next()?.ok()?;
+    value.get("error").unwrap_or(&value).get("code")?.as_i64()
+}
+
+/// Constructs a provider with a 100 millisecond interval poll if it's a localhost URL (most likely
+/// an anvil or other dev node) and with the default, or 7 second otherwise.
+///
+/// See [`try_get_http_provider`] for more details.
+///
+/// # Panics
+///
+/// Panics if the URL is invalid.
+///
+/// # Examples
+///
+/// ```
+/// use foundry_common::provider::get_http_provider;
+///
+/// let retry_provider = get_http_provider("http://localhost:8545");
+/// ```
+#[inline]
+#[track_caller]
+pub fn get_http_provider(builder: impl AsRef<str>) -> RetryProvider {
+    try_get_http_provider(builder).unwrap()
+}
+
+/// Constructs a provider with a 100 millisecond interval poll if it's a localhost URL (most likely
+/// an anvil or other dev node) and with the default, or 7 second otherwise.
+#[inline]
+pub fn try_get_http_provider(builder: impl AsRef<str>) -> Result<RetryProvider> {
+    ProviderBuilder::new(builder.as_ref()).build()
 }
 
 #[cfg(not(windows))]

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -41,11 +41,6 @@ const KNOWN_MPP_HOSTS: &[&str] = &[".mpp.tempo.xyz", ".mpp.moderato.tempo.xyz"];
 static HTTP_URL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?i)https?://[^\s<>"']+"#).expect("valid URL regex"));
 
-/// Returns `true` if `url` points to a known MPP-enabled RPC service.
-fn is_known_mpp_endpoint(url: &Url) -> bool {
-    url.host_str().is_some_and(|host| KNOWN_MPP_HOSTS.iter().any(|suffix| host.ends_with(suffix)))
-}
-
 /// An enum representing the different transports that can be used to connect to a runtime.
 /// Only meant to be used internally by [RuntimeTransport].
 #[derive(Clone, Debug)]
@@ -370,6 +365,11 @@ impl RuntimeTransport {
     {
         BoxTransport::new(self)
     }
+}
+
+/// Returns `true` if `url` points to a known MPP-enabled RPC service.
+fn is_known_mpp_endpoint(url: &Url) -> bool {
+    url.host_str().is_some_and(|host| KNOWN_MPP_HOSTS.iter().any(|suffix| host.ends_with(suffix)))
 }
 
 fn redact_http_transport_error(error: TransportError, endpoint: &Url) -> TransportError {

--- a/crates/common/src/tempo/auth.rs
+++ b/crates/common/src/tempo/auth.rs
@@ -27,11 +27,6 @@ use tokio::sync::Mutex;
 /// Default device-code service URL (production wallet.tempo.xyz).
 const DEFAULT_CLI_AUTH_URL: &str = "https://wallet.tempo.xyz/cli-auth";
 
-/// Returns `true` if `url`'s host is `tempo.xyz` or a subdomain of it.
-pub(crate) fn is_known_tempo_endpoint(url: &url::Url) -> bool {
-    url.host_str().is_some_and(|host| host == "tempo.xyz" || host.ends_with(".tempo.xyz"))
-}
-
 /// Env var to override the device-code service URL (for tests / staging).
 const TEMPO_CLI_AUTH_URL_ENV: &str = "TEMPO_CLI_AUTH_URL";
 
@@ -337,6 +332,11 @@ impl PollKeyAuthorization {
             Self::Legacy(encoded) => decode_key_authorization(&encoded),
         }
     }
+}
+
+/// Returns `true` if `url`'s host is `tempo.xyz` or a subdomain of it.
+pub(crate) fn is_known_tempo_endpoint(url: &url::Url) -> bool {
+    url.host_str().is_some_and(|host| host == "tempo.xyz" || host.ends_with(".tempo.xyz"))
 }
 
 #[cfg(test)]

--- a/crates/common/src/tempo/lane.rs
+++ b/crates/common/src/tempo/lane.rs
@@ -4,23 +4,6 @@ use alloy_eips::eip2718::Decodable2718;
 use serde::{Deserialize, Serialize};
 use tempo_primitives::TempoTxEnvelope;
 
-/// Classifies a raw EIP-2718 encoded transaction with Tempo's T5 payment-lane classifier.
-///
-/// Bytes that do not decode as a Tempo envelope (e.g. EIP-4844 or Optimism deposit
-/// transactions) classify as [`PaymentLaneReason::UnsupportedTransactionType`]; callers that
-/// need to reject invalid transactions should validate the bytes beforehand.
-pub fn classify_payment_lane(mut raw: &[u8]) -> PaymentLaneClassification {
-    let Ok(tx) = TempoTxEnvelope::decode_2718(&mut raw) else {
-        return PaymentLaneClassification::general(PaymentLaneReason::UnsupportedTransactionType);
-    };
-
-    if tx.is_payment_v2() {
-        PaymentLaneClassification::payment()
-    } else {
-        PaymentLaneClassification::general(PaymentLaneReason::NotPaymentLane)
-    }
-}
-
 /// Structured T5 payment-lane classification for Foundry-facing APIs.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -66,6 +49,23 @@ pub enum PaymentLaneReason {
     UnsupportedTransactionType,
     /// Tempo's T5 classifier classified the transaction as general.
     NotPaymentLane,
+}
+
+/// Classifies a raw EIP-2718 encoded transaction with Tempo's T5 payment-lane classifier.
+///
+/// Bytes that do not decode as a Tempo envelope (e.g. EIP-4844 or Optimism deposit
+/// transactions) classify as [`PaymentLaneReason::UnsupportedTransactionType`]; callers that
+/// need to reject invalid transactions should validate the bytes beforehand.
+pub fn classify_payment_lane(mut raw: &[u8]) -> PaymentLaneClassification {
+    let Ok(tx) = TempoTxEnvelope::decode_2718(&mut raw) else {
+        return PaymentLaneClassification::general(PaymentLaneReason::UnsupportedTransactionType);
+    };
+
+    if tx.is_payment_v2() {
+        PaymentLaneClassification::payment()
+    } else {
+        PaymentLaneClassification::general(PaymentLaneReason::NotPaymentLane)
+    }
 }
 
 #[cfg(test)]

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -46,11 +46,6 @@ pub(crate) use test_utils::test_env_mutex;
 #[cfg(test)]
 mod tests;
 
-/// Placeholder rendered by `Debug` impls in place of secret key material.
-fn redacted_debug(value: &str) -> &'static str {
-    if value.trim().is_empty() { "<empty>" } else { "<redacted>" }
-}
-
 /// Reserved Tempo TIP20 fee-token addresses created during Foundry genesis.
 ///
 /// Unlike [`PATH_USD_ADDRESS`], these tokens are not defined by the canonical
@@ -59,6 +54,206 @@ fn redacted_debug(value: &str) -> &'static str {
 pub const ALPHA_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000001");
 pub const BETA_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000002");
 pub const THETA_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000003");
+
+/// Gas sponsor configuration for Tempo fee-payer signatures.
+#[derive(Clone, Debug)]
+pub struct TempoSponsor {
+    sponsor: Address,
+    signer: Option<Arc<WalletSigner>>,
+    signature: Option<Signature>,
+}
+
+impl TempoSponsor {
+    pub const fn new(
+        sponsor: Address,
+        signer: Option<Arc<WalletSigner>>,
+        signature: Option<Signature>,
+    ) -> Self {
+        Self { sponsor, signer, signature }
+    }
+
+    pub const fn sponsor(&self) -> Address {
+        self.sponsor
+    }
+
+    /// Resolves the fee token paid by this sponsor and applies it to the transaction request.
+    ///
+    /// This must happen before computing a sponsor digest, because Tempo sponsor signatures commit
+    /// to the fee token.
+    pub async fn resolve_and_set_fee_token<N>(
+        &self,
+        provider: Option<&dyn Provider<N>>,
+        chain: Option<Chain>,
+        tx: &mut N::TransactionRequest,
+    ) -> Result<Option<Address>>
+    where
+        N: Network,
+        N::TransactionRequest: Default + FoundryTransactionBuilder<N>,
+    {
+        resolve_and_set_fee_token(provider, chain, tx, Some(self.sponsor)).await
+    }
+
+    pub async fn attach_and_print<N: Network>(
+        &self,
+        tx: &mut N::TransactionRequest,
+        sender: Address,
+    ) -> Result<TempoSponsorPreview>
+    where
+        N::TransactionRequest: FoundryTransactionBuilder<N>,
+    {
+        if self.sponsor == sender {
+            eyre::bail!(
+                "invalid Tempo sponsorship: sponsor {} must not equal transaction sender",
+                self.sponsor
+            );
+        }
+
+        let digest = tx.compute_sponsor_hash(sender).ok_or_else(|| {
+            eyre::eyre!(
+                "failed to compute Tempo sponsor digest; make sure this is a complete Tempo AA transaction"
+            )
+        })?;
+
+        let preview = TempoSponsorPreview {
+            sponsor: self.sponsor,
+            fee_token: tx.fee_token(),
+            valid_before: tx.valid_before().map(|v| v.get()),
+            valid_after: tx.valid_after().map(|v| v.get()),
+            digest,
+        };
+        preview.print()?;
+
+        let signature = if let Some(signature) = self.signature {
+            signature
+        } else if let Some(signer) = &self.signer {
+            signer.sign_hash(&digest).await.context("failed to sign Tempo sponsor digest")?
+        } else {
+            eyre::bail!("missing Tempo sponsor signature or signer");
+        };
+
+        let recovered = signature
+            .recover_address_from_prehash(&digest)
+            .context("failed to recover Tempo sponsor signature")?;
+        if recovered != self.sponsor {
+            eyre::bail!(
+                "Tempo sponsor signature recovered {recovered}, expected {}; the signature must \
+                 cover this exact transaction's sponsor digest — when signing a digest produced \
+                 with `--tempo.print-sponsor-hash`, pin --nonce, --gas-limit, --gas-price and \
+                 --priority-gas-price on both commands so the digest does not change in between",
+                self.sponsor
+            );
+        }
+        if recovered == sender {
+            eyre::bail!(
+                "invalid Tempo sponsorship: recovered fee payer {recovered} must not equal transaction sender"
+            );
+        }
+
+        tx.set_fee_payer_signature(signature);
+        Ok(preview)
+    }
+}
+
+/// User-visible sponsor digest metadata for a single outgoing Tempo transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TempoSponsorPreview {
+    pub sponsor: Address,
+    pub fee_token: Option<Address>,
+    pub valid_before: Option<u64>,
+    pub valid_after: Option<u64>,
+    pub digest: B256,
+}
+
+impl TempoSponsorPreview {
+    pub fn print(&self) -> Result<()> {
+        crate::sh_eprintln!("Tempo sponsor: {}", self.sponsor)?;
+        crate::sh_eprintln!(
+            "Tempo fee token: {}",
+            self.fee_token.map_or_else(|| "network default".to_string(), |addr| addr.to_string())
+        )?;
+        crate::sh_eprintln!(
+            "Tempo validity: after {}, before {}",
+            self.valid_after.map_or_else(|| "none".to_string(), |v| v.to_string()),
+            self.valid_before.map_or_else(|| "none".to_string(), |v| v.to_string())
+        )?;
+        crate::sh_eprintln!("Tempo sponsor digest: {:?}", self.digest)?;
+        Ok(())
+    }
+}
+
+/// Resolves a `--tempo.sponsor-signer` URI into a Foundry wallet signer.
+pub async fn resolve_tempo_sponsor_signer(spec: &str) -> Result<WalletSigner> {
+    let spec = spec.trim();
+    let (scheme, value) = spec
+        .split_once("://")
+        .map(|(scheme, value)| (scheme.to_ascii_lowercase(), value))
+        .unwrap_or_else(|| (spec.to_ascii_lowercase(), ""));
+
+    match scheme.as_str() {
+        "env" => {
+            if value.is_empty() {
+                eyre::bail!("env:// sponsor signer requires an environment variable name");
+            }
+            let private_key = std::env::var(value)
+                .wrap_err_with(|| format!("{value} environment variable is required"))?;
+            foundry_wallets::utils::create_private_key_signer(&private_key)
+        }
+        "private-key" => {
+            if value.is_empty() {
+                eyre::bail!("private-key:// sponsor signer requires a private key");
+            }
+            foundry_wallets::utils::create_private_key_signer(value)
+        }
+        "keystore" => {
+            if value.is_empty() {
+                eyre::bail!("keystore:// sponsor signer requires a keystore path");
+            }
+            WalletOpts { keystore_path: Some(value.to_string()), ..Default::default() }
+                .signer()
+                .await
+        }
+        "account" => {
+            if value.is_empty() {
+                eyre::bail!("account:// sponsor signer requires an account name");
+            }
+            WalletOpts { keystore_account_name: Some(value.to_string()), ..Default::default() }
+                .signer()
+                .await
+        }
+        "ledger" => {
+            let raw = RawWalletOpts {
+                hd_path: (!value.is_empty()).then(|| value.to_string()),
+                ..Default::default()
+            };
+            WalletOpts { ledger: true, raw, ..Default::default() }.signer().await
+        }
+        "trezor" => {
+            let raw = RawWalletOpts {
+                hd_path: (!value.is_empty()).then(|| value.to_string()),
+                ..Default::default()
+            };
+            WalletOpts { trezor: true, raw, ..Default::default() }.signer().await
+        }
+        "aws" => WalletOpts { aws: true, ..Default::default() }.signer().await,
+        "gcp" => WalletOpts { gcp: true, ..Default::default() }.signer().await,
+        "turnkey" => WalletOpts { turnkey: true, ..Default::default() }.signer().await,
+        "browser" => {
+            eyre::bail!(
+                "browser:// sponsor signing is not supported by the current browser wallet API; use --tempo.sponsor-sig or another sponsor signer"
+            );
+        }
+        _ => {
+            eyre::bail!(
+                "unsupported Tempo sponsor signer `{spec}`; expected env://VAR, keystore://PATH, account://NAME, ledger://, trezor://, aws://, gcp://, turnkey://, or private-key://KEY"
+            );
+        }
+    }
+}
+
+/// Placeholder rendered by `Debug` impls in place of secret key material.
+fn redacted_debug(value: &str) -> &'static str {
+    if value.trim().is_empty() { "<empty>" } else { "<redacted>" }
+}
 
 /// Resolves and applies the Tempo fee token selected by the network.
 ///
@@ -270,199 +465,4 @@ where
         }
     }
     Ok(())
-}
-
-/// Gas sponsor configuration for Tempo fee-payer signatures.
-#[derive(Clone, Debug)]
-pub struct TempoSponsor {
-    sponsor: Address,
-    signer: Option<Arc<WalletSigner>>,
-    signature: Option<Signature>,
-}
-
-impl TempoSponsor {
-    pub const fn new(
-        sponsor: Address,
-        signer: Option<Arc<WalletSigner>>,
-        signature: Option<Signature>,
-    ) -> Self {
-        Self { sponsor, signer, signature }
-    }
-
-    pub const fn sponsor(&self) -> Address {
-        self.sponsor
-    }
-
-    /// Resolves the fee token paid by this sponsor and applies it to the transaction request.
-    ///
-    /// This must happen before computing a sponsor digest, because Tempo sponsor signatures commit
-    /// to the fee token.
-    pub async fn resolve_and_set_fee_token<N>(
-        &self,
-        provider: Option<&dyn Provider<N>>,
-        chain: Option<Chain>,
-        tx: &mut N::TransactionRequest,
-    ) -> Result<Option<Address>>
-    where
-        N: Network,
-        N::TransactionRequest: Default + FoundryTransactionBuilder<N>,
-    {
-        resolve_and_set_fee_token(provider, chain, tx, Some(self.sponsor)).await
-    }
-
-    pub async fn attach_and_print<N: Network>(
-        &self,
-        tx: &mut N::TransactionRequest,
-        sender: Address,
-    ) -> Result<TempoSponsorPreview>
-    where
-        N::TransactionRequest: FoundryTransactionBuilder<N>,
-    {
-        if self.sponsor == sender {
-            eyre::bail!(
-                "invalid Tempo sponsorship: sponsor {} must not equal transaction sender",
-                self.sponsor
-            );
-        }
-
-        let digest = tx.compute_sponsor_hash(sender).ok_or_else(|| {
-            eyre::eyre!(
-                "failed to compute Tempo sponsor digest; make sure this is a complete Tempo AA transaction"
-            )
-        })?;
-
-        let preview = TempoSponsorPreview {
-            sponsor: self.sponsor,
-            fee_token: tx.fee_token(),
-            valid_before: tx.valid_before().map(|v| v.get()),
-            valid_after: tx.valid_after().map(|v| v.get()),
-            digest,
-        };
-        preview.print()?;
-
-        let signature = if let Some(signature) = self.signature {
-            signature
-        } else if let Some(signer) = &self.signer {
-            signer.sign_hash(&digest).await.context("failed to sign Tempo sponsor digest")?
-        } else {
-            eyre::bail!("missing Tempo sponsor signature or signer");
-        };
-
-        let recovered = signature
-            .recover_address_from_prehash(&digest)
-            .context("failed to recover Tempo sponsor signature")?;
-        if recovered != self.sponsor {
-            eyre::bail!(
-                "Tempo sponsor signature recovered {recovered}, expected {}; the signature must \
-                 cover this exact transaction's sponsor digest — when signing a digest produced \
-                 with `--tempo.print-sponsor-hash`, pin --nonce, --gas-limit, --gas-price and \
-                 --priority-gas-price on both commands so the digest does not change in between",
-                self.sponsor
-            );
-        }
-        if recovered == sender {
-            eyre::bail!(
-                "invalid Tempo sponsorship: recovered fee payer {recovered} must not equal transaction sender"
-            );
-        }
-
-        tx.set_fee_payer_signature(signature);
-        Ok(preview)
-    }
-}
-
-/// User-visible sponsor digest metadata for a single outgoing Tempo transaction.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct TempoSponsorPreview {
-    pub sponsor: Address,
-    pub fee_token: Option<Address>,
-    pub valid_before: Option<u64>,
-    pub valid_after: Option<u64>,
-    pub digest: B256,
-}
-
-impl TempoSponsorPreview {
-    pub fn print(&self) -> Result<()> {
-        crate::sh_eprintln!("Tempo sponsor: {}", self.sponsor)?;
-        crate::sh_eprintln!(
-            "Tempo fee token: {}",
-            self.fee_token.map_or_else(|| "network default".to_string(), |addr| addr.to_string())
-        )?;
-        crate::sh_eprintln!(
-            "Tempo validity: after {}, before {}",
-            self.valid_after.map_or_else(|| "none".to_string(), |v| v.to_string()),
-            self.valid_before.map_or_else(|| "none".to_string(), |v| v.to_string())
-        )?;
-        crate::sh_eprintln!("Tempo sponsor digest: {:?}", self.digest)?;
-        Ok(())
-    }
-}
-
-/// Resolves a `--tempo.sponsor-signer` URI into a Foundry wallet signer.
-pub async fn resolve_tempo_sponsor_signer(spec: &str) -> Result<WalletSigner> {
-    let spec = spec.trim();
-    let (scheme, value) = spec
-        .split_once("://")
-        .map(|(scheme, value)| (scheme.to_ascii_lowercase(), value))
-        .unwrap_or_else(|| (spec.to_ascii_lowercase(), ""));
-
-    match scheme.as_str() {
-        "env" => {
-            if value.is_empty() {
-                eyre::bail!("env:// sponsor signer requires an environment variable name");
-            }
-            let private_key = std::env::var(value)
-                .wrap_err_with(|| format!("{value} environment variable is required"))?;
-            foundry_wallets::utils::create_private_key_signer(&private_key)
-        }
-        "private-key" => {
-            if value.is_empty() {
-                eyre::bail!("private-key:// sponsor signer requires a private key");
-            }
-            foundry_wallets::utils::create_private_key_signer(value)
-        }
-        "keystore" => {
-            if value.is_empty() {
-                eyre::bail!("keystore:// sponsor signer requires a keystore path");
-            }
-            WalletOpts { keystore_path: Some(value.to_string()), ..Default::default() }
-                .signer()
-                .await
-        }
-        "account" => {
-            if value.is_empty() {
-                eyre::bail!("account:// sponsor signer requires an account name");
-            }
-            WalletOpts { keystore_account_name: Some(value.to_string()), ..Default::default() }
-                .signer()
-                .await
-        }
-        "ledger" => {
-            let raw = RawWalletOpts {
-                hd_path: (!value.is_empty()).then(|| value.to_string()),
-                ..Default::default()
-            };
-            WalletOpts { ledger: true, raw, ..Default::default() }.signer().await
-        }
-        "trezor" => {
-            let raw = RawWalletOpts {
-                hd_path: (!value.is_empty()).then(|| value.to_string()),
-                ..Default::default()
-            };
-            WalletOpts { trezor: true, raw, ..Default::default() }.signer().await
-        }
-        "aws" => WalletOpts { aws: true, ..Default::default() }.signer().await,
-        "gcp" => WalletOpts { gcp: true, ..Default::default() }.signer().await,
-        "turnkey" => WalletOpts { turnkey: true, ..Default::default() }.signer().await,
-        "browser" => {
-            eyre::bail!(
-                "browser:// sponsor signing is not supported by the current browser wallet API; use --tempo.sponsor-sig or another sponsor signer"
-            );
-        }
-        _ => {
-            eyre::bail!(
-                "unsupported Tempo sponsor signer `{spec}`; expected env://VAR, keystore://PATH, account://NAME, ledger://, trezor://, aws://, gcp://, turnkey://, or private-key://KEY"
-            );
-        }
-    }
 }


### PR DESCRIPTION
This is the Common slice split from #16373. It moves incidental module helpers below their primary declarations. The patch only reorders existing items: signatures, bodies, attributes, comments, and behavior are unchanged, and every touched file retains the same line multiset.

Codex assisted with the repository scan and mechanical relocation of existing functions. No function logic was generated or changed. This is maintenance-only and has no release-note impact, so `L-ignore` applies.
