### PR TITLE
refactor(symbolic): reorder module helpers

### DIFF
--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -1,24 +1,6 @@
 use super::*;
 use std::cmp::Reverse;
 
-fn order_roots_by_corpus_seed_count(roots: &mut [PathState], order: SymbolicExplorationOrder) {
-    let Some((first, rest)) = roots.split_first() else {
-        return;
-    };
-    if rest.iter().all(|root| root.corpus_seed_model_count() == first.corpus_seed_model_count()) {
-        return;
-    }
-
-    match order {
-        SymbolicExplorationOrder::Bfs => {
-            roots.sort_by_key(|root| Reverse(root.corpus_seed_model_count()));
-        }
-        SymbolicExplorationOrder::Dfs => {
-            roots.sort_by_key(PathState::corpus_seed_model_count);
-        }
-    }
-}
-
 impl SymbolicExecutor {
     /// Creates a symbolic executor from Foundry's symbolic configuration.
     ///
@@ -778,6 +760,24 @@ impl SymbolicExecutor {
     /// Returns the incomplete reason used when heuristic witnesses cannot certify safety.
     fn hard_arith_heuristic_incomplete_reason() -> String {
         "hard arithmetic heuristic witness used; no replayed counterexample found".to_string()
+    }
+}
+
+fn order_roots_by_corpus_seed_count(roots: &mut [PathState], order: SymbolicExplorationOrder) {
+    let Some((first, rest)) = roots.split_first() else {
+        return;
+    };
+    if rest.iter().all(|root| root.corpus_seed_model_count() == first.corpus_seed_model_count()) {
+        return;
+    }
+
+    match order {
+        SymbolicExplorationOrder::Bfs => {
+            roots.sort_by_key(|root| Reverse(root.corpus_seed_model_count()));
+        }
+        SymbolicExplorationOrder::Dfs => {
+            roots.sort_by_key(PathState::corpus_seed_model_count);
+        }
     }
 }
 

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -60,16 +60,6 @@ mod runtime;
 
 pub use runtime::{PortfolioDiagnostics, SymbolicBranchTarget, SymbolicError, SymbolicRunInput};
 
-/// Returns whether `solver` is one of Foundry's semantic symbolic solver names.
-pub fn symbolic_solver_is_builtin(solver: &str) -> bool {
-    BUILTIN_SYMBOLIC_SOLVERS.contains(&solver)
-}
-
-/// Returns a warning when a configured symbolic solver portfolio has unavailable entries.
-pub fn symbolic_solver_portfolio_availability_warning(config: &SymbolicConfig) -> Option<String> {
-    runtime::solver_portfolio_availability_warning(config)
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SymbolicVmCheatcode {
     CreateAddress,
@@ -145,120 +135,6 @@ impl SymbolicVmCheatcode {
             | Self::SnapshotState => 0,
         }
     }
-}
-
-fn symbolic_create_uint_selectors() -> &'static [(usize, [u8; 4]); 32] {
-    static SELECTORS: [(usize, [u8; 4]); 32] = [
-        (8, SymbolicVm::createUint8Call::SELECTOR),
-        (16, SymbolicVm::createUint16Call::SELECTOR),
-        (24, SymbolicVm::createUint24Call::SELECTOR),
-        (32, SymbolicVm::createUint32Call::SELECTOR),
-        (40, SymbolicVm::createUint40Call::SELECTOR),
-        (48, SymbolicVm::createUint48Call::SELECTOR),
-        (56, SymbolicVm::createUint56Call::SELECTOR),
-        (64, SymbolicVm::createUint64Call::SELECTOR),
-        (72, SymbolicVm::createUint72Call::SELECTOR),
-        (80, SymbolicVm::createUint80Call::SELECTOR),
-        (88, SymbolicVm::createUint88Call::SELECTOR),
-        (96, SymbolicVm::createUint96Call::SELECTOR),
-        (104, SymbolicVm::createUint104Call::SELECTOR),
-        (112, SymbolicVm::createUint112Call::SELECTOR),
-        (120, SymbolicVm::createUint120Call::SELECTOR),
-        (128, SymbolicVm::createUint128Call::SELECTOR),
-        (136, SymbolicVm::createUint136Call::SELECTOR),
-        (144, SymbolicVm::createUint144Call::SELECTOR),
-        (152, SymbolicVm::createUint152Call::SELECTOR),
-        (160, SymbolicVm::createUint160Call::SELECTOR),
-        (168, SymbolicVm::createUint168Call::SELECTOR),
-        (176, SymbolicVm::createUint176Call::SELECTOR),
-        (184, SymbolicVm::createUint184Call::SELECTOR),
-        (192, SymbolicVm::createUint192Call::SELECTOR),
-        (200, SymbolicVm::createUint200Call::SELECTOR),
-        (208, SymbolicVm::createUint208Call::SELECTOR),
-        (216, SymbolicVm::createUint216Call::SELECTOR),
-        (224, SymbolicVm::createUint224Call::SELECTOR),
-        (232, SymbolicVm::createUint232Call::SELECTOR),
-        (240, SymbolicVm::createUint240Call::SELECTOR),
-        (248, SymbolicVm::createUint248Call::SELECTOR),
-        (256, SymbolicVm::createUint256Call::SELECTOR),
-    ];
-    &SELECTORS
-}
-
-fn symbolic_create_int_selectors() -> &'static [(usize, [u8; 4]); 32] {
-    static SELECTORS: [(usize, [u8; 4]); 32] = [
-        (8, SymbolicVm::createInt8Call::SELECTOR),
-        (16, SymbolicVm::createInt16Call::SELECTOR),
-        (24, SymbolicVm::createInt24Call::SELECTOR),
-        (32, SymbolicVm::createInt32Call::SELECTOR),
-        (40, SymbolicVm::createInt40Call::SELECTOR),
-        (48, SymbolicVm::createInt48Call::SELECTOR),
-        (56, SymbolicVm::createInt56Call::SELECTOR),
-        (64, SymbolicVm::createInt64Call::SELECTOR),
-        (72, SymbolicVm::createInt72Call::SELECTOR),
-        (80, SymbolicVm::createInt80Call::SELECTOR),
-        (88, SymbolicVm::createInt88Call::SELECTOR),
-        (96, SymbolicVm::createInt96Call::SELECTOR),
-        (104, SymbolicVm::createInt104Call::SELECTOR),
-        (112, SymbolicVm::createInt112Call::SELECTOR),
-        (120, SymbolicVm::createInt120Call::SELECTOR),
-        (128, SymbolicVm::createInt128Call::SELECTOR),
-        (136, SymbolicVm::createInt136Call::SELECTOR),
-        (144, SymbolicVm::createInt144Call::SELECTOR),
-        (152, SymbolicVm::createInt152Call::SELECTOR),
-        (160, SymbolicVm::createInt160Call::SELECTOR),
-        (168, SymbolicVm::createInt168Call::SELECTOR),
-        (176, SymbolicVm::createInt176Call::SELECTOR),
-        (184, SymbolicVm::createInt184Call::SELECTOR),
-        (192, SymbolicVm::createInt192Call::SELECTOR),
-        (200, SymbolicVm::createInt200Call::SELECTOR),
-        (208, SymbolicVm::createInt208Call::SELECTOR),
-        (216, SymbolicVm::createInt216Call::SELECTOR),
-        (224, SymbolicVm::createInt224Call::SELECTOR),
-        (232, SymbolicVm::createInt232Call::SELECTOR),
-        (240, SymbolicVm::createInt240Call::SELECTOR),
-        (248, SymbolicVm::createInt248Call::SELECTOR),
-        (256, SymbolicVm::createInt256Call::SELECTOR),
-    ];
-    &SELECTORS
-}
-
-fn symbolic_create_bytes_selectors() -> &'static [(usize, [u8; 4]); 32] {
-    static SELECTORS: [(usize, [u8; 4]); 32] = [
-        (1, SymbolicVm::createBytes1Call::SELECTOR),
-        (2, SymbolicVm::createBytes2Call::SELECTOR),
-        (3, SymbolicVm::createBytes3Call::SELECTOR),
-        (4, SymbolicVm::createBytes4Call::SELECTOR),
-        (5, SymbolicVm::createBytes5Call::SELECTOR),
-        (6, SymbolicVm::createBytes6Call::SELECTOR),
-        (7, SymbolicVm::createBytes7Call::SELECTOR),
-        (8, SymbolicVm::createBytes8Call::SELECTOR),
-        (9, SymbolicVm::createBytes9Call::SELECTOR),
-        (10, SymbolicVm::createBytes10Call::SELECTOR),
-        (11, SymbolicVm::createBytes11Call::SELECTOR),
-        (12, SymbolicVm::createBytes12Call::SELECTOR),
-        (13, SymbolicVm::createBytes13Call::SELECTOR),
-        (14, SymbolicVm::createBytes14Call::SELECTOR),
-        (15, SymbolicVm::createBytes15Call::SELECTOR),
-        (16, SymbolicVm::createBytes16Call::SELECTOR),
-        (17, SymbolicVm::createBytes17Call::SELECTOR),
-        (18, SymbolicVm::createBytes18Call::SELECTOR),
-        (19, SymbolicVm::createBytes19Call::SELECTOR),
-        (20, SymbolicVm::createBytes20Call::SELECTOR),
-        (21, SymbolicVm::createBytes21Call::SELECTOR),
-        (22, SymbolicVm::createBytes22Call::SELECTOR),
-        (23, SymbolicVm::createBytes23Call::SELECTOR),
-        (24, SymbolicVm::createBytes24Call::SELECTOR),
-        (25, SymbolicVm::createBytes25Call::SELECTOR),
-        (26, SymbolicVm::createBytes26Call::SELECTOR),
-        (27, SymbolicVm::createBytes27Call::SELECTOR),
-        (28, SymbolicVm::createBytes28Call::SELECTOR),
-        (29, SymbolicVm::createBytes29Call::SELECTOR),
-        (30, SymbolicVm::createBytes30Call::SELECTOR),
-        (31, SymbolicVm::createBytes31Call::SELECTOR),
-        (32, SymbolicVm::createBytes32Call::SELECTOR),
-    ];
-    &SELECTORS
 }
 
 /// Outcome of a symbolic test execution.
@@ -483,6 +359,130 @@ pub struct SymbolicExecutor {
 enum DeferredIncomplete {
     Unsupported(&'static str),
     SolverUnknown,
+}
+
+fn symbolic_create_uint_selectors() -> &'static [(usize, [u8; 4]); 32] {
+    static SELECTORS: [(usize, [u8; 4]); 32] = [
+        (8, SymbolicVm::createUint8Call::SELECTOR),
+        (16, SymbolicVm::createUint16Call::SELECTOR),
+        (24, SymbolicVm::createUint24Call::SELECTOR),
+        (32, SymbolicVm::createUint32Call::SELECTOR),
+        (40, SymbolicVm::createUint40Call::SELECTOR),
+        (48, SymbolicVm::createUint48Call::SELECTOR),
+        (56, SymbolicVm::createUint56Call::SELECTOR),
+        (64, SymbolicVm::createUint64Call::SELECTOR),
+        (72, SymbolicVm::createUint72Call::SELECTOR),
+        (80, SymbolicVm::createUint80Call::SELECTOR),
+        (88, SymbolicVm::createUint88Call::SELECTOR),
+        (96, SymbolicVm::createUint96Call::SELECTOR),
+        (104, SymbolicVm::createUint104Call::SELECTOR),
+        (112, SymbolicVm::createUint112Call::SELECTOR),
+        (120, SymbolicVm::createUint120Call::SELECTOR),
+        (128, SymbolicVm::createUint128Call::SELECTOR),
+        (136, SymbolicVm::createUint136Call::SELECTOR),
+        (144, SymbolicVm::createUint144Call::SELECTOR),
+        (152, SymbolicVm::createUint152Call::SELECTOR),
+        (160, SymbolicVm::createUint160Call::SELECTOR),
+        (168, SymbolicVm::createUint168Call::SELECTOR),
+        (176, SymbolicVm::createUint176Call::SELECTOR),
+        (184, SymbolicVm::createUint184Call::SELECTOR),
+        (192, SymbolicVm::createUint192Call::SELECTOR),
+        (200, SymbolicVm::createUint200Call::SELECTOR),
+        (208, SymbolicVm::createUint208Call::SELECTOR),
+        (216, SymbolicVm::createUint216Call::SELECTOR),
+        (224, SymbolicVm::createUint224Call::SELECTOR),
+        (232, SymbolicVm::createUint232Call::SELECTOR),
+        (240, SymbolicVm::createUint240Call::SELECTOR),
+        (248, SymbolicVm::createUint248Call::SELECTOR),
+        (256, SymbolicVm::createUint256Call::SELECTOR),
+    ];
+    &SELECTORS
+}
+
+fn symbolic_create_int_selectors() -> &'static [(usize, [u8; 4]); 32] {
+    static SELECTORS: [(usize, [u8; 4]); 32] = [
+        (8, SymbolicVm::createInt8Call::SELECTOR),
+        (16, SymbolicVm::createInt16Call::SELECTOR),
+        (24, SymbolicVm::createInt24Call::SELECTOR),
+        (32, SymbolicVm::createInt32Call::SELECTOR),
+        (40, SymbolicVm::createInt40Call::SELECTOR),
+        (48, SymbolicVm::createInt48Call::SELECTOR),
+        (56, SymbolicVm::createInt56Call::SELECTOR),
+        (64, SymbolicVm::createInt64Call::SELECTOR),
+        (72, SymbolicVm::createInt72Call::SELECTOR),
+        (80, SymbolicVm::createInt80Call::SELECTOR),
+        (88, SymbolicVm::createInt88Call::SELECTOR),
+        (96, SymbolicVm::createInt96Call::SELECTOR),
+        (104, SymbolicVm::createInt104Call::SELECTOR),
+        (112, SymbolicVm::createInt112Call::SELECTOR),
+        (120, SymbolicVm::createInt120Call::SELECTOR),
+        (128, SymbolicVm::createInt128Call::SELECTOR),
+        (136, SymbolicVm::createInt136Call::SELECTOR),
+        (144, SymbolicVm::createInt144Call::SELECTOR),
+        (152, SymbolicVm::createInt152Call::SELECTOR),
+        (160, SymbolicVm::createInt160Call::SELECTOR),
+        (168, SymbolicVm::createInt168Call::SELECTOR),
+        (176, SymbolicVm::createInt176Call::SELECTOR),
+        (184, SymbolicVm::createInt184Call::SELECTOR),
+        (192, SymbolicVm::createInt192Call::SELECTOR),
+        (200, SymbolicVm::createInt200Call::SELECTOR),
+        (208, SymbolicVm::createInt208Call::SELECTOR),
+        (216, SymbolicVm::createInt216Call::SELECTOR),
+        (224, SymbolicVm::createInt224Call::SELECTOR),
+        (232, SymbolicVm::createInt232Call::SELECTOR),
+        (240, SymbolicVm::createInt240Call::SELECTOR),
+        (248, SymbolicVm::createInt248Call::SELECTOR),
+        (256, SymbolicVm::createInt256Call::SELECTOR),
+    ];
+    &SELECTORS
+}
+
+fn symbolic_create_bytes_selectors() -> &'static [(usize, [u8; 4]); 32] {
+    static SELECTORS: [(usize, [u8; 4]); 32] = [
+        (1, SymbolicVm::createBytes1Call::SELECTOR),
+        (2, SymbolicVm::createBytes2Call::SELECTOR),
+        (3, SymbolicVm::createBytes3Call::SELECTOR),
+        (4, SymbolicVm::createBytes4Call::SELECTOR),
+        (5, SymbolicVm::createBytes5Call::SELECTOR),
+        (6, SymbolicVm::createBytes6Call::SELECTOR),
+        (7, SymbolicVm::createBytes7Call::SELECTOR),
+        (8, SymbolicVm::createBytes8Call::SELECTOR),
+        (9, SymbolicVm::createBytes9Call::SELECTOR),
+        (10, SymbolicVm::createBytes10Call::SELECTOR),
+        (11, SymbolicVm::createBytes11Call::SELECTOR),
+        (12, SymbolicVm::createBytes12Call::SELECTOR),
+        (13, SymbolicVm::createBytes13Call::SELECTOR),
+        (14, SymbolicVm::createBytes14Call::SELECTOR),
+        (15, SymbolicVm::createBytes15Call::SELECTOR),
+        (16, SymbolicVm::createBytes16Call::SELECTOR),
+        (17, SymbolicVm::createBytes17Call::SELECTOR),
+        (18, SymbolicVm::createBytes18Call::SELECTOR),
+        (19, SymbolicVm::createBytes19Call::SELECTOR),
+        (20, SymbolicVm::createBytes20Call::SELECTOR),
+        (21, SymbolicVm::createBytes21Call::SELECTOR),
+        (22, SymbolicVm::createBytes22Call::SELECTOR),
+        (23, SymbolicVm::createBytes23Call::SELECTOR),
+        (24, SymbolicVm::createBytes24Call::SELECTOR),
+        (25, SymbolicVm::createBytes25Call::SELECTOR),
+        (26, SymbolicVm::createBytes26Call::SELECTOR),
+        (27, SymbolicVm::createBytes27Call::SELECTOR),
+        (28, SymbolicVm::createBytes28Call::SELECTOR),
+        (29, SymbolicVm::createBytes29Call::SELECTOR),
+        (30, SymbolicVm::createBytes30Call::SELECTOR),
+        (31, SymbolicVm::createBytes31Call::SELECTOR),
+        (32, SymbolicVm::createBytes32Call::SELECTOR),
+    ];
+    &SELECTORS
+}
+
+/// Returns whether `solver` is one of Foundry's semantic symbolic solver names.
+pub fn symbolic_solver_is_builtin(solver: &str) -> bool {
+    BUILTIN_SYMBOLIC_SOLVERS.contains(&solver)
+}
+
+/// Returns a warning when a configured symbolic solver portfolio has unavailable entries.
+pub fn symbolic_solver_portfolio_availability_warning(config: &SymbolicConfig) -> Option<String> {
+    runtime::solver_portfolio_availability_warning(config)
 }
 
 #[cfg(test)]

--- a/crates/evm/symbolic/src/runtime/address.rs
+++ b/crates/evm/symbolic/src/runtime/address.rs
@@ -1,22 +1,5 @@
 use super::*;
 
-pub(crate) fn mask_bits(value: U256, bits: usize) -> U256 {
-    if bits >= 256 {
-        value
-    } else {
-        let mask = (U256::from(1) << bits) - U256::from(1);
-        value & mask
-    }
-}
-
-pub(crate) fn address_word(address: Address) -> U256 {
-    U256::from_be_bytes(address.into_word().0)
-}
-
-pub(crate) fn word_to_address(value: U256) -> Address {
-    Address::from_word(value.to_be_bytes::<32>().into())
-}
-
 impl SymExpr {
     pub(crate) fn representative_symbolic_address(&self) -> Address {
         let digest = keccak256(self.symbolic_address_key());
@@ -133,6 +116,23 @@ impl SymExpr {
     fn is_shift_96(&self) -> bool {
         self.as_const() == Some(U256::from(96))
     }
+}
+
+pub(crate) fn mask_bits(value: U256, bits: usize) -> U256 {
+    if bits >= 256 {
+        value
+    } else {
+        let mask = (U256::from(1) << bits) - U256::from(1);
+        value & mask
+    }
+}
+
+pub(crate) fn address_word(address: Address) -> U256 {
+    U256::from_be_bytes(address.into_word().0)
+}
+
+pub(crate) fn word_to_address(value: U256) -> Address {
+    Address::from_word(value.to_be_bytes::<32>().into())
 }
 
 pub(crate) fn stable_symbol(cx: &mut SymCx, prefix: &'static str, input: &[u8]) -> Symbol {

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -4,168 +4,6 @@ use super::{hashcons::HashConsed, *};
 // unique nodes so adversarial expression trees cannot make construction unbounded.
 const MAX_BITWISE_BOOL_WORD_VISITS: usize = 256;
 
-pub(crate) fn keccak_word(cx: &mut SymCx, bytes: Vec<SymExpr>) -> SymExpr {
-    let len = bytes.len();
-    let len = SymExpr::constant(cx, U256::from(len));
-    keccak_word_with_len(cx, bytes, len)
-}
-
-pub(crate) fn keccak_word_with_len(cx: &mut SymCx, bytes: Vec<SymExpr>, len: SymExpr) -> SymExpr {
-    if let Some(len) = len.as_const()
-        && let Ok(len) = usize::try_from(len)
-        && len <= bytes.len()
-        && let Ok(concrete) = concrete_expr_bytes(&bytes[..len], "symbolic keccak input")
-    {
-        let hash = U256::from_be_bytes(keccak256(concrete).0);
-        if len == 64 {
-            cx.record_concrete_keccak_preimage(hash, bytes[..len].to_vec().into());
-        }
-        return SymExpr::constant(cx, hash);
-    }
-
-    let exprs = bytes;
-    let name = stable_symbol(cx, "keccak", format!("{len:?}:{exprs:?}").as_bytes());
-    SymExpr::keccak_symbol(cx, name, len, exprs)
-}
-
-pub(crate) fn symbolic_hash_word_with_len(
-    cx: &mut SymCx,
-    algorithm: &'static str,
-    bytes: Vec<SymExpr>,
-    len: SymExpr,
-) -> SymExpr {
-    let exprs = bytes;
-    let name = stable_symbol(cx, algorithm, format!("{len:?}:{exprs:?}").as_bytes());
-    let mut identity = Vec::with_capacity(exprs.len() + 1);
-    identity.push(len);
-    identity.extend(exprs);
-    SymExpr::hash_symbol(cx, name, algorithm, identity)
-}
-
-pub(crate) fn create2_address_word(
-    cx: &mut SymCx,
-    state: &mut PathState,
-    creator: Address,
-    salt: SymExpr,
-    initcode: &SymCode,
-) -> Result<(SymExpr, Address), SymbolicError> {
-    match (salt.as_const(), initcode.concrete_bytes(cx, "symbolic CREATE2 initcode")) {
-        (Some(salt), Ok(initcode)) => {
-            let address = creator.create2_from_code(salt.to_be_bytes::<32>(), &initcode);
-            Ok((SymExpr::constant(cx, address_word(address)), address))
-        }
-        (None, Ok(initcode)) => {
-            let initcode_hash = keccak256(&initcode);
-            let word = symbolic_create2_address_word(
-                cx,
-                state,
-                format!("{creator:?}"),
-                salt,
-                format!("{initcode_hash:?}"),
-            );
-            let address = state.world.symbolic_address_slot(word.clone());
-            Ok((word, address))
-        }
-        (_, Err(SymbolicError::Unsupported("symbolic CREATE2 initcode"))) => {
-            let initcode_bytes = initcode.read_byte_exprs(cx, 0, initcode.len());
-            let word = symbolic_create2_address_word(
-                cx,
-                state,
-                format!("{creator:?}"),
-                salt,
-                format!("{initcode_bytes:?}"),
-            );
-            let address = state.world.symbolic_address_slot(word.clone());
-            Ok((word, address))
-        }
-        (_, Err(err)) => Err(err),
-    }
-}
-
-pub(crate) fn compute_create2_address_word(
-    cx: &mut SymCx,
-    state: &mut PathState,
-    deployer: SymExpr,
-    salt: SymExpr,
-    init_code_hash: SymExpr,
-) -> Result<SymExpr, SymbolicError> {
-    let deployer_concrete = state.constrained_word(cx, &deployer).map(word_to_address);
-    let salt_concrete = state.constrained_word(cx, &salt);
-    let init_code_hash_concrete = state.constrained_word(cx, &init_code_hash);
-
-    if let (Some(deployer), Some(salt), Some(init_code_hash)) =
-        (deployer_concrete, salt_concrete, init_code_hash_concrete)
-    {
-        let init_code_hash = B256::from(init_code_hash.to_be_bytes::<32>());
-        let address = deployer.create2(B256::from(salt.to_be_bytes::<32>()), init_code_hash);
-        return Ok(SymExpr::constant(cx, address_word(address)));
-    }
-
-    let deployer_identity = deployer_concrete
-        .map(|deployer| format!("{deployer:?}"))
-        .unwrap_or_else(|| format!("{deployer:?}"));
-    let init_code_hash_identity = init_code_hash_concrete
-        .map(|init_code_hash| {
-            let init_code_hash = B256::from(init_code_hash.to_be_bytes::<32>());
-            format!("{init_code_hash:?}")
-        })
-        .unwrap_or_else(|| format!("{init_code_hash:?}"));
-
-    Ok(symbolic_create2_address_word(cx, state, deployer_identity, salt, init_code_hash_identity))
-}
-
-pub(crate) fn compute_create_address_word(
-    cx: &mut SymCx,
-    state: &mut PathState,
-    deployer: SymExpr,
-    nonce: SymExpr,
-) -> Result<SymExpr, SymbolicError> {
-    let deployer_concrete = state.constrained_word(cx, &deployer).map(word_to_address);
-    let nonce_concrete = state.constrained_word(cx, &nonce);
-
-    if let (Some(deployer), Some(nonce)) = (deployer_concrete, nonce_concrete) {
-        let Ok(nonce) = u64::try_from(nonce) else {
-            return Err(SymbolicError::Unsupported("symbolic vm.computeCreateAddress nonce"));
-        };
-        return Ok(SymExpr::constant(cx, address_word(deployer.create(nonce))));
-    }
-
-    let deployer_identity = deployer_concrete
-        .map(|deployer| format!("{deployer:?}"))
-        .unwrap_or_else(|| format!("{deployer:?}"));
-    Ok(symbolic_create_address_word(cx, state, deployer_identity, nonce))
-}
-
-pub(crate) fn symbolic_create_address_word(
-    cx: &mut SymCx,
-    state: &mut PathState,
-    creator_identity: String,
-    nonce: SymExpr,
-) -> SymExpr {
-    let name =
-        stable_symbol(cx, "create_address", format!("{creator_identity}:{nonce:?}").as_bytes());
-    let word = SymExpr::get_var(cx, name);
-    state.constraints.push(SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &word, U256::ONE << 160));
-    word
-}
-
-pub(crate) fn symbolic_create2_address_word(
-    cx: &mut SymCx,
-    state: &mut PathState,
-    creator_identity: String,
-    salt: SymExpr,
-    initcode_identity: String,
-) -> SymExpr {
-    let name = stable_symbol(
-        cx,
-        "create2_address",
-        format!("{creator_identity}:{salt:?}:{initcode_identity}").as_bytes(),
-    );
-    let word = SymExpr::get_var(cx, name);
-    state.constraints.push(SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &word, U256::ONE << 160));
-    word
-}
-
 impl SymExpr {
     pub(crate) fn select_storage_write(
         self,
@@ -2355,6 +2193,168 @@ impl SymBinOp {
             }
         }
     }
+}
+
+pub(crate) fn keccak_word(cx: &mut SymCx, bytes: Vec<SymExpr>) -> SymExpr {
+    let len = bytes.len();
+    let len = SymExpr::constant(cx, U256::from(len));
+    keccak_word_with_len(cx, bytes, len)
+}
+
+pub(crate) fn keccak_word_with_len(cx: &mut SymCx, bytes: Vec<SymExpr>, len: SymExpr) -> SymExpr {
+    if let Some(len) = len.as_const()
+        && let Ok(len) = usize::try_from(len)
+        && len <= bytes.len()
+        && let Ok(concrete) = concrete_expr_bytes(&bytes[..len], "symbolic keccak input")
+    {
+        let hash = U256::from_be_bytes(keccak256(concrete).0);
+        if len == 64 {
+            cx.record_concrete_keccak_preimage(hash, bytes[..len].to_vec().into());
+        }
+        return SymExpr::constant(cx, hash);
+    }
+
+    let exprs = bytes;
+    let name = stable_symbol(cx, "keccak", format!("{len:?}:{exprs:?}").as_bytes());
+    SymExpr::keccak_symbol(cx, name, len, exprs)
+}
+
+pub(crate) fn symbolic_hash_word_with_len(
+    cx: &mut SymCx,
+    algorithm: &'static str,
+    bytes: Vec<SymExpr>,
+    len: SymExpr,
+) -> SymExpr {
+    let exprs = bytes;
+    let name = stable_symbol(cx, algorithm, format!("{len:?}:{exprs:?}").as_bytes());
+    let mut identity = Vec::with_capacity(exprs.len() + 1);
+    identity.push(len);
+    identity.extend(exprs);
+    SymExpr::hash_symbol(cx, name, algorithm, identity)
+}
+
+pub(crate) fn create2_address_word(
+    cx: &mut SymCx,
+    state: &mut PathState,
+    creator: Address,
+    salt: SymExpr,
+    initcode: &SymCode,
+) -> Result<(SymExpr, Address), SymbolicError> {
+    match (salt.as_const(), initcode.concrete_bytes(cx, "symbolic CREATE2 initcode")) {
+        (Some(salt), Ok(initcode)) => {
+            let address = creator.create2_from_code(salt.to_be_bytes::<32>(), &initcode);
+            Ok((SymExpr::constant(cx, address_word(address)), address))
+        }
+        (None, Ok(initcode)) => {
+            let initcode_hash = keccak256(&initcode);
+            let word = symbolic_create2_address_word(
+                cx,
+                state,
+                format!("{creator:?}"),
+                salt,
+                format!("{initcode_hash:?}"),
+            );
+            let address = state.world.symbolic_address_slot(word.clone());
+            Ok((word, address))
+        }
+        (_, Err(SymbolicError::Unsupported("symbolic CREATE2 initcode"))) => {
+            let initcode_bytes = initcode.read_byte_exprs(cx, 0, initcode.len());
+            let word = symbolic_create2_address_word(
+                cx,
+                state,
+                format!("{creator:?}"),
+                salt,
+                format!("{initcode_bytes:?}"),
+            );
+            let address = state.world.symbolic_address_slot(word.clone());
+            Ok((word, address))
+        }
+        (_, Err(err)) => Err(err),
+    }
+}
+
+pub(crate) fn compute_create2_address_word(
+    cx: &mut SymCx,
+    state: &mut PathState,
+    deployer: SymExpr,
+    salt: SymExpr,
+    init_code_hash: SymExpr,
+) -> Result<SymExpr, SymbolicError> {
+    let deployer_concrete = state.constrained_word(cx, &deployer).map(word_to_address);
+    let salt_concrete = state.constrained_word(cx, &salt);
+    let init_code_hash_concrete = state.constrained_word(cx, &init_code_hash);
+
+    if let (Some(deployer), Some(salt), Some(init_code_hash)) =
+        (deployer_concrete, salt_concrete, init_code_hash_concrete)
+    {
+        let init_code_hash = B256::from(init_code_hash.to_be_bytes::<32>());
+        let address = deployer.create2(B256::from(salt.to_be_bytes::<32>()), init_code_hash);
+        return Ok(SymExpr::constant(cx, address_word(address)));
+    }
+
+    let deployer_identity = deployer_concrete
+        .map(|deployer| format!("{deployer:?}"))
+        .unwrap_or_else(|| format!("{deployer:?}"));
+    let init_code_hash_identity = init_code_hash_concrete
+        .map(|init_code_hash| {
+            let init_code_hash = B256::from(init_code_hash.to_be_bytes::<32>());
+            format!("{init_code_hash:?}")
+        })
+        .unwrap_or_else(|| format!("{init_code_hash:?}"));
+
+    Ok(symbolic_create2_address_word(cx, state, deployer_identity, salt, init_code_hash_identity))
+}
+
+pub(crate) fn compute_create_address_word(
+    cx: &mut SymCx,
+    state: &mut PathState,
+    deployer: SymExpr,
+    nonce: SymExpr,
+) -> Result<SymExpr, SymbolicError> {
+    let deployer_concrete = state.constrained_word(cx, &deployer).map(word_to_address);
+    let nonce_concrete = state.constrained_word(cx, &nonce);
+
+    if let (Some(deployer), Some(nonce)) = (deployer_concrete, nonce_concrete) {
+        let Ok(nonce) = u64::try_from(nonce) else {
+            return Err(SymbolicError::Unsupported("symbolic vm.computeCreateAddress nonce"));
+        };
+        return Ok(SymExpr::constant(cx, address_word(deployer.create(nonce))));
+    }
+
+    let deployer_identity = deployer_concrete
+        .map(|deployer| format!("{deployer:?}"))
+        .unwrap_or_else(|| format!("{deployer:?}"));
+    Ok(symbolic_create_address_word(cx, state, deployer_identity, nonce))
+}
+
+pub(crate) fn symbolic_create_address_word(
+    cx: &mut SymCx,
+    state: &mut PathState,
+    creator_identity: String,
+    nonce: SymExpr,
+) -> SymExpr {
+    let name =
+        stable_symbol(cx, "create_address", format!("{creator_identity}:{nonce:?}").as_bytes());
+    let word = SymExpr::get_var(cx, name);
+    state.constraints.push(SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &word, U256::ONE << 160));
+    word
+}
+
+pub(crate) fn symbolic_create2_address_word(
+    cx: &mut SymCx,
+    state: &mut PathState,
+    creator_identity: String,
+    salt: SymExpr,
+    initcode_identity: String,
+) -> SymExpr {
+    let name = stable_symbol(
+        cx,
+        "create2_address",
+        format!("{creator_identity}:{salt:?}:{initcode_identity}").as_bytes(),
+    );
+    let word = SymExpr::get_var(cx, name);
+    state.constraints.push(SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &word, U256::ONE << 160));
+    word
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is the symbolic-execution slice split from #16373. It moves incidental module helpers below their primary declarations. The patch only reorders existing items: signatures, bodies, attributes, comments, and behavior are unchanged, and every touched file retains the same line multiset.

Codex assisted with the repository scan and mechanical relocation of existing functions. No function logic was generated or changed. This is maintenance-only and has no release-note impact, so `L-ignore` applies.
