### PR TITLE
refactor(evm): reorder module helpers

### DIFF
--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -33,50 +33,6 @@ use crate::{
 // Will be removed when the next revm release includes bluealloy/revm#3518.
 pub type TempoRevmEvm<'db, I> = tempo_revm::TempoEvm<&'db mut dyn DatabaseExt<TempoEvmFactory>, I>;
 
-/// Initialize Tempo precompiles and contracts for a newly created EVM.
-///
-/// In non-fork mode, runs full genesis initialization (precompile sentinel bytecode,
-/// TIP20 fee tokens, standard contracts) via [`StorageCtx::enter_evm`].
-///
-/// In fork mode, warms up precompile and TIP20 token addresses with sentinel bytecode
-/// to prevent repeated RPC round-trips for addresses that are Rust-native precompiles
-/// on Tempo nodes (no real EVM bytecode on-chain).
-pub(crate) fn initialize_tempo_evm<
-    'db,
-    I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>,
->(
-    evm: &mut TempoEvm<&'db mut dyn DatabaseExt<TempoEvmFactory>, I>,
-    is_forked: bool,
-) {
-    let ctx = evm.ctx_mut();
-    StorageCtx::enter_evm(
-        &mut ctx.journaled_state,
-        &ctx.block,
-        &ctx.cfg,
-        &ctx.tx,
-        StorageActions::disabled(),
-        || {
-            if is_forked {
-                // In fork mode, warm up precompile accounts to avoid repeated RPC fetches.
-                let mut sctx = StorageCtx;
-                let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
-                for addr in TEMPO_PRECOMPILE_ADDRESSES
-                    .iter()
-                    .copied()
-                    .chain(TEMPO_TIP20_TOKENS.iter().copied())
-                {
-                    sctx.set_code(addr, sentinel.clone())
-                        .expect("failed to warm tempo precompile address");
-                }
-            } else {
-                // In non-fork mode, run full genesis initialization.
-                initialize_tempo_test_genesis_inner(TEST_CONTRACT_ADDRESS, CALLER)
-                    .expect("tempo genesis initialization failed");
-            }
-        },
-    );
-}
-
 impl FoundryEvmFactory for TempoEvmFactory {
     type Chain = ();
     type FoundryContext<'db> = TempoContext<&'db mut dyn DatabaseExt<Self>>;
@@ -221,4 +177,48 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
     fn to_evm_env(&self) -> EvmEnv<Self::Spec, Self::Block> {
         self.ctx_ref().evm_clone()
     }
+}
+
+/// Initialize Tempo precompiles and contracts for a newly created EVM.
+///
+/// In non-fork mode, runs full genesis initialization (precompile sentinel bytecode,
+/// TIP20 fee tokens, standard contracts) via [`StorageCtx::enter_evm`].
+///
+/// In fork mode, warms up precompile and TIP20 token addresses with sentinel bytecode
+/// to prevent repeated RPC round-trips for addresses that are Rust-native precompiles
+/// on Tempo nodes (no real EVM bytecode on-chain).
+pub(crate) fn initialize_tempo_evm<
+    'db,
+    I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmFactory>>>,
+>(
+    evm: &mut TempoEvm<&'db mut dyn DatabaseExt<TempoEvmFactory>, I>,
+    is_forked: bool,
+) {
+    let ctx = evm.ctx_mut();
+    StorageCtx::enter_evm(
+        &mut ctx.journaled_state,
+        &ctx.block,
+        &ctx.cfg,
+        &ctx.tx,
+        StorageActions::disabled(),
+        || {
+            if is_forked {
+                // In fork mode, warm up precompile accounts to avoid repeated RPC fetches.
+                let mut sctx = StorageCtx;
+                let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
+                for addr in TEMPO_PRECOMPILE_ADDRESSES
+                    .iter()
+                    .copied()
+                    .chain(TEMPO_TIP20_TOKENS.iter().copied())
+                {
+                    sctx.set_code(addr, sentinel.clone())
+                        .expect("failed to warm tempo precompile address");
+                }
+            } else {
+                // In non-fork mode, run full genesis initialization.
+                initialize_tempo_test_genesis_inner(TEST_CONTRACT_ADDRESS, CALLER)
+                    .expect("tempo genesis initialization failed");
+            }
+        },
+    );
 }

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -28,13 +28,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Write;
 use url::Url;
 
-fn fork_endpoint_description(endpoint: &str) -> String {
-    Url::parse(endpoint)
-        .ok()
-        .and_then(|url| url.host_str().map(|host| format!("provider {host}")))
-        .unwrap_or_else(|| "configured provider".to_string())
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EvmOpts {
     /// The EVM environment configuration.
@@ -1542,6 +1535,13 @@ pub struct Env {
     /// EIP-170: Contract code size limit in bytes. Useful to increase this because of tests.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code_size_limit: Option<usize>,
+}
+
+fn fork_endpoint_description(endpoint: &str) -> String {
+    Url::parse(endpoint)
+        .ok()
+        .and_then(|url| url.host_str().map(|host| format!("provider {host}")))
+        .unwrap_or_else(|| "configured provider".to_string())
 }
 
 async fn option_try_or_else<T, E>(

--- a/crates/evm/evm/src/executors/corpus_io.rs
+++ b/crates/evm/evm/src/executors/corpus_io.rs
@@ -14,27 +14,6 @@ const MAX_CORPUS_TREE_DEPTH: usize = 64;
 const MAX_CORPUS_TREE_DIRS: usize = 10_000;
 const MAX_CORPUS_ENTRIES: usize = 1_000_000;
 
-/// Returns every `worker*/corpus/` under `root`, or `[root]` if none exist.
-pub fn canonical_replay_dirs(root: &Path) -> Vec<PathBuf> {
-    let mut dirs: Vec<PathBuf> = std::fs::read_dir(root)
-        .into_iter()
-        .flatten()
-        .flatten()
-        .filter_map(|e| {
-            let p = e.path();
-            let name = p.file_name()?.to_str()?;
-            (e.file_type().ok()?.is_dir() && name.starts_with(WORKER_DIR_PREFIX))
-                .then(|| p.join(CORPUS_SUBDIR))
-                .filter(|d| is_dir_no_symlink(d))
-        })
-        .collect();
-    dirs.sort();
-    if dirs.is_empty() {
-        dirs.push(root.to_path_buf());
-    }
-    dirs
-}
-
 /// A single corpus file on disk.
 pub struct CorpusDirEntry {
     pub path: PathBuf,
@@ -223,6 +202,27 @@ pub fn parse_corpus_filename(name: &str) -> Result<(Uuid, u64)> {
     let (uuid_str, timestamp_str) =
         name.rsplit_once('-').ok_or_else(|| eyre!("invalid corpus filename format: {name}"))?;
     Ok((Uuid::parse_str(uuid_str)?, timestamp_str.parse()?))
+}
+
+/// Returns every `worker*/corpus/` under `root`, or `[root]` if none exist.
+pub fn canonical_replay_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = std::fs::read_dir(root)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            let name = p.file_name()?.to_str()?;
+            (e.file_type().ok()?.is_dir() && name.starts_with(WORKER_DIR_PREFIX))
+                .then(|| p.join(CORPUS_SUBDIR))
+                .filter(|d| is_dir_no_symlink(d))
+        })
+        .collect();
+    dirs.sort();
+    if dirs.is_empty() {
+        dirs.push(root.to_path_buf());
+    }
+    dirs
 }
 
 #[cfg(test)]

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -96,22 +96,6 @@ pub use trace::TracingExecutor;
 
 const DURATION_BETWEEN_METRICS_REPORT: Duration = Duration::from_secs(5);
 
-/// Returns whether a nested revert can be ignored when fail-on-revert is disabled.
-#[inline]
-pub fn should_ignore_revert(
-    fail_on_revert: bool,
-    target: Address,
-    reverter: Option<Address>,
-    extra_cheatcode_addresses: &[Address],
-) -> bool {
-    !fail_on_revert
-        && reverter.is_some_and(|reverter| {
-            reverter != target
-                && reverter != CHEATCODE_ADDRESS
-                && !extra_cheatcode_addresses.contains(&reverter)
-        })
-}
-
 sol! {
     interface ITest {
         function setUp() external;
@@ -1790,6 +1774,22 @@ impl EvmExecutionCancellation {
             Self::EarlyExit(early_exit) | Self::Campaign { early_exit, .. } => early_exit,
         }
     }
+}
+
+/// Returns whether a nested revert can be ignored when fail-on-revert is disabled.
+#[inline]
+pub fn should_ignore_revert(
+    fail_on_revert: bool,
+    target: Address,
+    reverter: Option<Address>,
+    extra_cheatcode_addresses: &[Address],
+) -> bool {
+    !fail_on_revert
+        && reverter.is_some_and(|reverter| {
+            reverter != target
+                && reverter != CHEATCODE_ADDRESS
+                && !extra_cheatcode_addresses.contains(&reverter)
+        })
 }
 
 #[cfg(test)]

--- a/crates/evm/evm/src/inspectors/revert_diagnostic.rs
+++ b/crates/evm/evm/src/inspectors/revert_diagnostic.rs
@@ -10,11 +10,6 @@ use revm::{
 
 const IGNORE: [Address; 2] = [HARDHAT_CONSOLE_ADDRESS, CHEATCODE_ADDRESS];
 
-/// Checks if the call scheme corresponds to any sort of delegate call
-pub const fn is_delegatecall(scheme: CallScheme) -> bool {
-    matches!(scheme, CallScheme::DelegateCall | CallScheme::CallCode)
-}
-
 /// An inspector that tracks call context to enhances revert diagnostics.
 /// Useful for understanding reverts that are not linked to custom errors or revert strings.
 ///
@@ -203,4 +198,9 @@ impl<CTX: ContextTr> Inspector<CTX> for RevertDiagnostic {
             self.handle_extcodesize_output(interp);
         }
     }
+}
+
+/// Checks if the call scheme corresponds to any sort of delegate call
+pub const fn is_delegatecall(scheme: CallScheme) -> bool {
+    matches!(scheme, CallScheme::DelegateCall | CallScheme::CallCode)
 }

--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -25,12 +25,6 @@ type DynamicTargetArtifactMatchCache =
 type FuzzedFunction = (Address, Function);
 type FunctionLookup = HashMap<Selector, Function>;
 
-/// Returns true if the function returns `int256`, indicating optimization mode.
-/// In optimization mode, the fuzzer maximizes the return value instead of checking invariants.
-pub fn is_optimization_invariant(func: &Function) -> bool {
-    func.outputs.len() == 1 && func.outputs[0].ty == "int256"
-}
-
 /// Contracts identified as targets during a fuzz run.
 ///
 /// During execution, any newly created contract is added as target and used through the rest of
@@ -654,6 +648,12 @@ impl fmt::Display for InvariantSettings {
             self.fail_on_revert,
         )
     }
+}
+
+/// Returns true if the function returns `int256`, indicating optimization mode.
+/// In optimization mode, the fuzzer maximizes the return value instead of checking invariants.
+pub fn is_optimization_invariant(func: &Function) -> bool {
+    func.outputs.len() == 1 && func.outputs[0].ty == "int256"
 }
 
 #[cfg(test)]

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -87,24 +87,6 @@ const BSC_TESTNET_HABER_TIMESTAMP: u64 = 1_716_962_820;
 const BSC_MAINNET_OSAKA_TIMESTAMP: u64 = 1_777_343_400;
 const BSC_TESTNET_OSAKA_TIMESTAMP: u64 = 1_774_319_400;
 
-/// Returns the BSC P256 precompile for the given timestamp. The outer option distinguishes BSC
-/// chains from unrelated chains, while the inner option disables P256 before Haber.
-const fn bsc_p256_precompile(chain_id: ChainId, timestamp: u64) -> Option<Option<RevmPrecompile>> {
-    let (haber_timestamp, osaka_timestamp) = match chain_id {
-        BSC_MAINNET_CHAIN_ID => (BSC_MAINNET_HABER_TIMESTAMP, BSC_MAINNET_OSAKA_TIMESTAMP),
-        BSC_TESTNET_CHAIN_ID => (BSC_TESTNET_HABER_TIMESTAMP, BSC_TESTNET_OSAKA_TIMESTAMP),
-        _ => return None,
-    };
-
-    if timestamp < haber_timestamp {
-        Some(None)
-    } else if timestamp < osaka_timestamp {
-        Some(Some(P256VERIFY))
-    } else {
-        Some(Some(P256VERIFY_OSAKA))
-    }
-}
-
 /// All well-known Tempo precompile addresses.
 pub const TEMPO_PRECOMPILE_ADDRESSES: &[Address] = &[
     NONCE_PRECOMPILE_ADDRESS,
@@ -122,39 +104,6 @@ pub const TEMPO_PRECOMPILE_ADDRESSES: &[Address] = &[
     STORAGE_CREDITS_ADDRESS,
     CURRENT_COMMITTEE_ADDRESS,
 ];
-
-/// Returns whether a well-known Tempo precompile address is active at `hardfork`.
-pub fn is_tempo_precompile_active_at(address: Address, hardfork: TempoHardfork) -> bool {
-    if address == CURRENT_COMMITTEE_ADDRESS {
-        hardfork.is_t8()
-    } else if address == TIP20_CHANNEL_RESERVE_ADDRESS {
-        hardfork.is_t5()
-    } else if address == RECEIVE_POLICY_GUARD_ADDRESS {
-        hardfork.is_t6()
-    } else if address == STORAGE_CREDITS_ADDRESS {
-        hardfork.is_t7()
-    } else if address == ADDRESS_REGISTRY_ADDRESS || address == SIGNATURE_VERIFIER_ADDRESS {
-        hardfork.is_t3()
-    } else {
-        true
-    }
-}
-
-/// Returns the well-known Tempo precompile addresses active at `hardfork`.
-pub fn active_tempo_precompile_addresses(hardfork: TempoHardfork) -> impl Iterator<Item = Address> {
-    TEMPO_PRECOMPILE_ADDRESSES
-        .iter()
-        .copied()
-        .filter(move |&address| is_tempo_precompile_active_at(address, hardfork))
-}
-
-/// Returns whether a well-known Monad precompile address is active at `hardfork`.
-#[cfg(feature = "monad")]
-pub fn is_monad_precompile_active_at(address: Address, hardfork: MonadHardfork) -> bool {
-    address == monad_revm::staking::STAKING_ADDRESS
-        || (address == monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS
-            && MonadHardfork::MonadNine.is_enabled_in(hardfork))
-}
 
 #[derive(
     Clone,
@@ -914,6 +863,57 @@ impl From<NetworkVariant> for NetworkConfigs {
             }
         }
     }
+}
+
+/// Returns the BSC P256 precompile for the given timestamp. The outer option distinguishes BSC
+/// chains from unrelated chains, while the inner option disables P256 before Haber.
+const fn bsc_p256_precompile(chain_id: ChainId, timestamp: u64) -> Option<Option<RevmPrecompile>> {
+    let (haber_timestamp, osaka_timestamp) = match chain_id {
+        BSC_MAINNET_CHAIN_ID => (BSC_MAINNET_HABER_TIMESTAMP, BSC_MAINNET_OSAKA_TIMESTAMP),
+        BSC_TESTNET_CHAIN_ID => (BSC_TESTNET_HABER_TIMESTAMP, BSC_TESTNET_OSAKA_TIMESTAMP),
+        _ => return None,
+    };
+
+    if timestamp < haber_timestamp {
+        Some(None)
+    } else if timestamp < osaka_timestamp {
+        Some(Some(P256VERIFY))
+    } else {
+        Some(Some(P256VERIFY_OSAKA))
+    }
+}
+
+/// Returns whether a well-known Tempo precompile address is active at `hardfork`.
+pub fn is_tempo_precompile_active_at(address: Address, hardfork: TempoHardfork) -> bool {
+    if address == CURRENT_COMMITTEE_ADDRESS {
+        hardfork.is_t8()
+    } else if address == TIP20_CHANNEL_RESERVE_ADDRESS {
+        hardfork.is_t5()
+    } else if address == RECEIVE_POLICY_GUARD_ADDRESS {
+        hardfork.is_t6()
+    } else if address == STORAGE_CREDITS_ADDRESS {
+        hardfork.is_t7()
+    } else if address == ADDRESS_REGISTRY_ADDRESS || address == SIGNATURE_VERIFIER_ADDRESS {
+        hardfork.is_t3()
+    } else {
+        true
+    }
+}
+
+/// Returns the well-known Tempo precompile addresses active at `hardfork`.
+pub fn active_tempo_precompile_addresses(hardfork: TempoHardfork) -> impl Iterator<Item = Address> {
+    TEMPO_PRECOMPILE_ADDRESSES
+        .iter()
+        .copied()
+        .filter(move |&address| is_tempo_precompile_active_at(address, hardfork))
+}
+
+/// Returns whether a well-known Monad precompile address is active at `hardfork`.
+#[cfg(feature = "monad")]
+pub fn is_monad_precompile_active_at(address: Address, hardfork: MonadHardfork) -> bool {
+    address == monad_revm::staking::STAKING_ADDRESS
+        || (address == monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS
+            && MonadHardfork::MonadNine.is_enabled_in(hardfork))
 }
 
 #[cfg(test)]

--- a/crates/evm/traces/src/decoder/precompiles.rs
+++ b/crates/evm/traces/src/decoder/precompiles.rs
@@ -57,156 +57,6 @@ interface Precompiles {
 }
 use Precompiles::*;
 
-pub(crate) fn is_known_precompile(
-    address: Address,
-    networks: Option<NetworkConfigs>,
-    chain_id: Option<u64>,
-    tempo_hardfork: Option<TempoHardfork>,
-    monad_hardfork: Option<MonadHardfork>,
-) -> bool {
-    #[cfg(not(feature = "monad"))]
-    let _ = monad_hardfork;
-
-    // Standard EVM precompiles (all chains).
-    // An 18-byte zero prefix, as `P256_VERIFY` (0x..0100) occupies the two lowest bytes.
-    let is_standard = address[..18].iter().all(|&x| x == 0)
-        && matches!(
-            address,
-            EC_RECOVER
-                | SHA_256
-                | RIPEMD_160
-                | IDENTITY
-                | MOD_EXP
-                | EC_ADD
-                | EC_MUL
-                | EC_PAIRING
-                | BLAKE_2F
-                | POINT_EVALUATION
-                | BLS12_G1ADD
-                | BLS12_G1MSM
-                | BLS12_G2ADD
-                | BLS12_G2MSM
-                | BLS12_PAIRING_CHECK
-                | BLS12_MAP_FP_TO_G1
-                | BLS12_MAP_FP2_TO_G2
-                | P256_VERIFY
-        );
-    if is_standard {
-        return true;
-    }
-    // Tempo precompiles and TIP20 fee tokens (only on Tempo chains).
-    let is_tempo_precompile = match tempo_hardfork {
-        Some(hardfork) => active_tempo_precompile_addresses(hardfork).any(|addr| addr == address),
-        None => TEMPO_PRECOMPILE_ADDRESSES.contains(&address),
-    };
-    let is_tempo_context = networks.map_or_else(
-        || {
-            chain_id
-                .map(|id| Chain::from_id(id).is_tempo())
-                .unwrap_or_else(|| tempo_hardfork.is_some())
-        },
-        |networks| networks.is_tempo(),
-    );
-    if is_tempo_context && (is_tempo_precompile || TEMPO_TIP20_TOKENS.contains(&address)) {
-        return true;
-    }
-    // Monad precompiles (only on a Monad chain or in an explicitly configured Monad context).
-    #[cfg(feature = "monad")]
-    {
-        let is_monad_context = networks.map_or_else(
-            || {
-                chain_id.is_some_and(|id| {
-                    matches!(
-                        Chain::from_id(id).named(),
-                        Some(NamedChain::Monad | NamedChain::MonadTestnet)
-                    )
-                }) || monad_hardfork.is_some()
-            },
-            |networks| networks.is_monad(),
-        );
-        if is_monad_context {
-            if address == monad_revm::staking::STAKING_ADDRESS {
-                return true;
-            }
-            if address == monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS
-                && monad_hardfork.is_none_or(|hardfork| {
-                    foundry_evm_networks::is_monad_precompile_active_at(address, hardfork)
-                })
-            {
-                return true;
-            }
-        }
-    }
-    // Celo transfer precompile (only on Celo chains).
-    let is_celo_context = networks.map_or_else(
-        || {
-            chain_id.is_some_and(|id| {
-                matches!(
-                    Chain::from_id(id).named(),
-                    Some(NamedChain::Celo | NamedChain::CeloSepolia)
-                )
-            })
-        },
-        |networks| networks.is_celo(),
-    );
-    is_celo_context && address == CELO_TRANSFER
-}
-
-pub(crate) fn is_known_precompile_call(
-    trace: &CallTrace,
-    networks: Option<NetworkConfigs>,
-    chain_id: Option<u64>,
-    tempo_hardfork: Option<TempoHardfork>,
-    monad_hardfork: Option<MonadHardfork>,
-) -> bool {
-    // Unlike the long-established low addresses, P256 is hardfork-dependent. Traces without an
-    // execution classification, such as RPC callTracer frames, cannot safely infer it by address.
-    if trace.address == P256_VERIFY && trace.maybe_precompile != Some(true) {
-        return false;
-    }
-    is_known_precompile(trace.address, networks, chain_id, tempo_hardfork, monad_hardfork)
-}
-
-/// Tries to decode a precompile call. Returns `Some` if successful.
-pub(super) fn decode(
-    trace: &CallTrace,
-    networks: Option<NetworkConfigs>,
-    chain_id: Option<u64>,
-    tempo_hardfork: Option<TempoHardfork>,
-    monad_hardfork: Option<MonadHardfork>,
-) -> Option<DecodedCallTrace> {
-    if !is_known_precompile_call(trace, networks, chain_id, tempo_hardfork, monad_hardfork) {
-        return None;
-    }
-
-    for &precompile in PRECOMPILES {
-        if trace.address == precompile.address() {
-            let signature = precompile.signature(&trace.data);
-
-            let args = precompile
-                .decode_call(&trace.data)
-                .unwrap_or_else(|_| vec![trace.data.to_string()]);
-
-            let return_data = precompile
-                .decode_return(&trace.output)
-                .unwrap_or_else(|_| vec![trace.output.to_string()]);
-            let return_data = if return_data.len() == 1 {
-                return_data.into_iter().next().unwrap()
-            } else {
-                format!("({})", return_data.join(", "))
-            };
-
-            return Some(DecodedCallTrace {
-                label: Some("PRECOMPILES".to_string()),
-                call_data: Some(DecodedCallData { signature: signature.to_string(), args }),
-                return_data: Some(return_data),
-            });
-        }
-    }
-
-    None
-}
-
 pub(super) trait Precompile {
     fn address(&self) -> Address;
     fn signature(&self, data: &[u8]) -> &'static str;
@@ -620,6 +470,156 @@ impl Precompile for P256Verify {
 fn take_at_most(data: &[u8], n: usize) -> (&[u8], &[u8]) {
     let n = n.min(data.len());
     data.split_at(n)
+}
+
+pub(crate) fn is_known_precompile(
+    address: Address,
+    networks: Option<NetworkConfigs>,
+    chain_id: Option<u64>,
+    tempo_hardfork: Option<TempoHardfork>,
+    monad_hardfork: Option<MonadHardfork>,
+) -> bool {
+    #[cfg(not(feature = "monad"))]
+    let _ = monad_hardfork;
+
+    // Standard EVM precompiles (all chains).
+    // An 18-byte zero prefix, as `P256_VERIFY` (0x..0100) occupies the two lowest bytes.
+    let is_standard = address[..18].iter().all(|&x| x == 0)
+        && matches!(
+            address,
+            EC_RECOVER
+                | SHA_256
+                | RIPEMD_160
+                | IDENTITY
+                | MOD_EXP
+                | EC_ADD
+                | EC_MUL
+                | EC_PAIRING
+                | BLAKE_2F
+                | POINT_EVALUATION
+                | BLS12_G1ADD
+                | BLS12_G1MSM
+                | BLS12_G2ADD
+                | BLS12_G2MSM
+                | BLS12_PAIRING_CHECK
+                | BLS12_MAP_FP_TO_G1
+                | BLS12_MAP_FP2_TO_G2
+                | P256_VERIFY
+        );
+    if is_standard {
+        return true;
+    }
+    // Tempo precompiles and TIP20 fee tokens (only on Tempo chains).
+    let is_tempo_precompile = match tempo_hardfork {
+        Some(hardfork) => active_tempo_precompile_addresses(hardfork).any(|addr| addr == address),
+        None => TEMPO_PRECOMPILE_ADDRESSES.contains(&address),
+    };
+    let is_tempo_context = networks.map_or_else(
+        || {
+            chain_id
+                .map(|id| Chain::from_id(id).is_tempo())
+                .unwrap_or_else(|| tempo_hardfork.is_some())
+        },
+        |networks| networks.is_tempo(),
+    );
+    if is_tempo_context && (is_tempo_precompile || TEMPO_TIP20_TOKENS.contains(&address)) {
+        return true;
+    }
+    // Monad precompiles (only on a Monad chain or in an explicitly configured Monad context).
+    #[cfg(feature = "monad")]
+    {
+        let is_monad_context = networks.map_or_else(
+            || {
+                chain_id.is_some_and(|id| {
+                    matches!(
+                        Chain::from_id(id).named(),
+                        Some(NamedChain::Monad | NamedChain::MonadTestnet)
+                    )
+                }) || monad_hardfork.is_some()
+            },
+            |networks| networks.is_monad(),
+        );
+        if is_monad_context {
+            if address == monad_revm::staking::STAKING_ADDRESS {
+                return true;
+            }
+            if address == monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS
+                && monad_hardfork.is_none_or(|hardfork| {
+                    foundry_evm_networks::is_monad_precompile_active_at(address, hardfork)
+                })
+            {
+                return true;
+            }
+        }
+    }
+    // Celo transfer precompile (only on Celo chains).
+    let is_celo_context = networks.map_or_else(
+        || {
+            chain_id.is_some_and(|id| {
+                matches!(
+                    Chain::from_id(id).named(),
+                    Some(NamedChain::Celo | NamedChain::CeloSepolia)
+                )
+            })
+        },
+        |networks| networks.is_celo(),
+    );
+    is_celo_context && address == CELO_TRANSFER
+}
+
+pub(crate) fn is_known_precompile_call(
+    trace: &CallTrace,
+    networks: Option<NetworkConfigs>,
+    chain_id: Option<u64>,
+    tempo_hardfork: Option<TempoHardfork>,
+    monad_hardfork: Option<MonadHardfork>,
+) -> bool {
+    // Unlike the long-established low addresses, P256 is hardfork-dependent. Traces without an
+    // execution classification, such as RPC callTracer frames, cannot safely infer it by address.
+    if trace.address == P256_VERIFY && trace.maybe_precompile != Some(true) {
+        return false;
+    }
+    is_known_precompile(trace.address, networks, chain_id, tempo_hardfork, monad_hardfork)
+}
+
+/// Tries to decode a precompile call. Returns `Some` if successful.
+pub(super) fn decode(
+    trace: &CallTrace,
+    networks: Option<NetworkConfigs>,
+    chain_id: Option<u64>,
+    tempo_hardfork: Option<TempoHardfork>,
+    monad_hardfork: Option<MonadHardfork>,
+) -> Option<DecodedCallTrace> {
+    if !is_known_precompile_call(trace, networks, chain_id, tempo_hardfork, monad_hardfork) {
+        return None;
+    }
+
+    for &precompile in PRECOMPILES {
+        if trace.address == precompile.address() {
+            let signature = precompile.signature(&trace.data);
+
+            let args = precompile
+                .decode_call(&trace.data)
+                .unwrap_or_else(|_| vec![trace.data.to_string()]);
+
+            let return_data = precompile
+                .decode_return(&trace.output)
+                .unwrap_or_else(|_| vec![trace.output.to_string()]);
+            let return_data = if return_data.len() == 1 {
+                return_data.into_iter().next().unwrap()
+            } else {
+                format!("({})", return_data.join(", "))
+            };
+
+            return Some(DecodedCallTrace {
+                label: Some("PRECOMPILES".to_string()),
+                call_data: Some(DecodedCallData { signature: signature.to_string(), args }),
+                return_data: Some(return_data),
+            });
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/crates/evm/traces/src/folded_stack_trace.rs
+++ b/crates/evm/traces/src/folded_stack_trace.rs
@@ -4,15 +4,6 @@ use revm_inspectors::tracing::{
     types::{CallTraceNode, CallTraceStep, DecodedTraceStep, TraceMemberOrder},
 };
 
-/// Builds a folded stack trace from a call trace arena.
-pub fn build(arena: &CallTraceArena, isolate: bool) -> Vec<String> {
-    let mut fst = EvmFoldedStackTraceBuilder::new(isolate);
-    if !arena.nodes().is_empty() {
-        fst.process_call_node(arena.nodes(), 0);
-    }
-    fst.build()
-}
-
 /// Wrapper for building a folded stack trace using EVM call trace node.
 #[derive(Default)]
 pub struct EvmFoldedStackTraceBuilder {
@@ -226,6 +217,15 @@ impl FoldedStackTraceBuilder {
             }
         }
     }
+}
+
+/// Builds a folded stack trace from a call trace arena.
+pub fn build(arena: &CallTraceArena, isolate: bool) -> Vec<String> {
+    let mut fst = EvmFoldedStackTraceBuilder::new(isolate);
+    if !arena.nodes().is_empty() {
+        fst.process_call_node(arena.nodes(), 0);
+    }
+    fst.build()
 }
 
 #[cfg(test)]

--- a/crates/evm/traces/src/speedscope/builder.rs
+++ b/crates/evm/traces/src/speedscope/builder.rs
@@ -11,25 +11,6 @@ use revm_inspectors::tracing::{
 };
 use std::{borrow::Cow, collections::HashMap};
 
-/// Builds a speedscope profile from a call trace arena.
-///
-/// Walks the trace arena directly so the Time Order view preserves execution order.
-pub fn build<'a>(
-    arena: &CallTraceArena,
-    test_name: &str,
-    contract_name: &str,
-    isolate: bool,
-) -> SpeedscopeFile<'a> {
-    let name = format!("{contract_name}::{test_name}");
-    let mut builder = SpeedscopeBuilder::new(name);
-
-    if !arena.nodes().is_empty() {
-        builder.process_call_node(arena.nodes(), 0, isolate);
-    }
-
-    builder.build()
-}
-
 struct SpeedscopeBuilder<'a> {
     file: SpeedscopeFile<'a>,
     profile: EventedProfile<'a>,
@@ -129,6 +110,25 @@ impl<'a> SpeedscopeBuilder<'a> {
 struct StepExit {
     step_idx: usize,
     frame_idx: usize,
+}
+
+/// Builds a speedscope profile from a call trace arena.
+///
+/// Walks the trace arena directly so the Time Order view preserves execution order.
+pub fn build<'a>(
+    arena: &CallTraceArena,
+    test_name: &str,
+    contract_name: &str,
+    isolate: bool,
+) -> SpeedscopeFile<'a> {
+    let name = format!("{contract_name}::{test_name}");
+    let mut builder = SpeedscopeBuilder::new(name);
+
+    if !arena.nodes().is_empty() {
+        builder.process_call_node(arena.nodes(), 0, isolate);
+    }
+
+    builder.build()
 }
 
 fn call_frame_name(node: &CallTraceNode) -> String {


### PR DESCRIPTION
This is the non-symbolic EVM slice split from #16373, covering core execution, fuzzing, networks, and traces. It moves incidental module helpers below their primary declarations. The patch only reorders existing items: signatures, bodies, attributes, comments, and behavior are unchanged, and every touched file retains the same line multiset.

Codex assisted with the repository scan and mechanical relocation of existing functions. No function logic was generated or changed. This is maintenance-only and has no release-note impact, so `L-ignore` applies.
