### PR TITLE
refactor(forge): reorder workflow helpers

### DIFF
--- a/crates/forge/src/brutalizer/visitor.rs
+++ b/crates/forge/src/brutalizer/visitor.rs
@@ -8,15 +8,6 @@ use super::{
     value::{brutalize_cast, brutalize_payable_address, deterministic_mask},
 };
 
-pub(super) fn collect_transforms<'ast>(
-    source: &str,
-    ast: &'ast SourceUnit<'ast>,
-) -> Vec<Transform> {
-    let mut visitor = BrutalizerVisitor::new(source);
-    let _ = visitor.visit_source_unit(ast);
-    visitor.transforms
-}
-
 struct BrutalizerVisitor<'src> {
     transforms: Vec<Transform>,
     source: &'src str,
@@ -74,4 +65,13 @@ fn cast_call<'ast, 'src>(
     let CallArgsKind::Unnamed(args_exprs) = &call_args.kind else { return None };
     let arg_text = span_text(source, args_exprs.first()?.span)?;
     (!arg_text.is_empty()).then_some((ty, arg_text))
+}
+
+pub(super) fn collect_transforms<'ast>(
+    source: &str,
+    ast: &'ast SourceUnit<'ast>,
+) -> Vec<Transform> {
+    let mut visitor = BrutalizerVisitor::new(source);
+    let _ = visitor.visit_source_unit(ast);
+    visitor.transforms
 }

--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -27,10 +27,6 @@ use solar::{
     parse::Parser,
 };
 
-fn failed_to_parse(path: &Path) -> eyre::Report {
-    eyre!("failed to parse {}", path.display())
-}
-
 #[derive(Clone, Copy)]
 enum CacheKind<'a> {
     Mutants,
@@ -43,27 +39,6 @@ struct CachedMutationResults {
     mutant_count: usize,
     mutant_hash: u64,
     results: Vec<(Mutant, MutationResult)>,
-}
-
-fn mutant_set_hash(mutants: &[Mutant]) -> u64 {
-    let mut entries: Vec<_> = mutants
-        .iter()
-        .map(|mutant| {
-            (
-                mutant.span.lo().0,
-                mutant.span.hi().0,
-                mutant.mutation.to_string(),
-                mutant.original.clone(),
-            )
-        })
-        .collect();
-    entries.sort();
-
-    let mut hasher = DefaultHasher::new();
-    for entry in entries {
-        entry.hash(&mut hasher);
-    }
-    hasher.finish()
 }
 
 pub mod mutant;
@@ -607,6 +582,31 @@ impl MutationHandler {
 
         false
     }
+}
+
+fn failed_to_parse(path: &Path) -> eyre::Report {
+    eyre!("failed to parse {}", path.display())
+}
+
+fn mutant_set_hash(mutants: &[Mutant]) -> u64 {
+    let mut entries: Vec<_> = mutants
+        .iter()
+        .map(|mutant| {
+            (
+                mutant.span.lo().0,
+                mutant.span.hi().0,
+                mutant.mutation.to_string(),
+                mutant.original.clone(),
+            )
+        })
+        .collect();
+    entries.sort();
+
+    let mut hasher = DefaultHasher::new();
+    for entry in entries {
+        entry.hash(&mut hasher);
+    }
+    hasher.finish()
 }
 
 #[cfg(test)]

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -35,18 +35,10 @@ use std::{
 };
 use yansi::Paint;
 
-pub(crate) fn invariant_campaign_display_name(contract_name: &str) -> String {
-    format!("{contract_name} invariants")
-}
-
 const INVARIANT_CAMPAIGN_FALLBACK_NAME: &str = "Invariant campaign";
 const SYMBOLIC_RESULT_SCHEMA_VERSION: u32 = 1;
 pub const SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA: &str = "foundry:symbolic.counterexample@v1";
 pub const SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA_VERSION: u32 = 1;
-
-const fn symbolic_result_schema_version() -> u32 {
-    SYMBOLIC_RESULT_SCHEMA_VERSION
-}
 
 /// The aggregated result of a test run.
 #[derive(Clone, Debug)]
@@ -3089,4 +3081,12 @@ impl TestSetup {
     pub fn merge_coverages(&mut self, other_coverage: Option<HitMaps>) {
         HitMaps::merge_opt(&mut self.coverage, other_coverage);
     }
+}
+
+pub(crate) fn invariant_campaign_display_name(contract_name: &str) -> String {
+    format!("{contract_name} invariants")
+}
+
+const fn symbolic_result_schema_version() -> u32 {
+    SYMBOLIC_RESULT_SCHEMA_VERSION
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -90,103 +90,6 @@ use std::{
 use tokio::signal;
 use tracing::Span;
 
-fn should_symbolically_import_fuzz_corpus(config: &Config, func: &Function) -> bool {
-    config.symbolic.use_fuzz_corpus && func.test_function_kind().is_fuzz_test()
-}
-
-pub(crate) fn effective_test_function_kind(
-    kind: TestFunctionKind,
-    config: &Config,
-    func: &Function,
-) -> TestFunctionKind {
-    if should_symbolically_import_fuzz_corpus(config, func) {
-        TestFunctionKind::SymbolicTest
-    } else {
-        kind
-    }
-}
-
-fn symbolic_invariant_unsupported_domain_reason(
-    invariant_config: &InvariantConfig,
-    sender_filters: &SenderFilters,
-    targets: &FuzzRunIdentifiedContracts,
-    symbolic_targets: &[SymbolicInvariantTarget],
-) -> Option<String> {
-    if sender_filters.targeted.is_empty() {
-        return Some("symbolic invariant execution requires explicit target senders".to_string());
-    }
-    if invariant_config.has_delay() {
-        return Some("symbolic invariant execution does not model warp/roll delays".to_string());
-    }
-    if invariant_config.call_override {
-        return Some(
-            "symbolic invariant execution does not model call override targets".to_string(),
-        );
-    }
-    if targets.is_updatable {
-        return Some(
-            "symbolic invariant execution does not model dynamically updatable targets".to_string(),
-        );
-    }
-    if invariant_config.corpus.payable_value_weight > 0
-        && symbolic_targets
-            .iter()
-            .any(|target| target.function.state_mutability == StateMutability::Payable)
-    {
-        return Some("symbolic invariant execution does not model payable call values".to_string());
-    }
-    None
-}
-
-fn symbolic_artifact_handler_failure_matches(
-    failure: Option<&SymbolicInvariantArtifactFailure>,
-    site: Option<CheckSequenceFailureSite>,
-) -> bool {
-    matches!(
-        (failure, site),
-        (
-            Some(SymbolicInvariantArtifactFailure::Handler {
-                reverter,
-                selector,
-                fingerprint,
-                ..
-            }),
-            Some(CheckSequenceFailureSite::SequenceCall {
-                target,
-                selector: actual_selector,
-                fingerprint: actual_fingerprint,
-            })
-        ) if *reverter == target && *selector == actual_selector && *fingerprint == actual_fingerprint
-    )
-}
-
-const fn symbolic_invariant_failure_site(
-    site: CheckSequenceFailureSite,
-) -> SymbolicInvariantFailureSite {
-    match site {
-        CheckSequenceFailureSite::SequenceCall { target, selector, fingerprint } => {
-            SymbolicInvariantFailureSite::SequenceCall { target, selector, fingerprint }
-        }
-        CheckSequenceFailureSite::Invariant { target, selector, fingerprint } => {
-            SymbolicInvariantFailureSite::Invariant { target, selector, fingerprint }
-        }
-        CheckSequenceFailureSite::AfterInvariant { target, selector, fingerprint } => {
-            SymbolicInvariantFailureSite::AfterInvariant { target, selector, fingerprint }
-        }
-    }
-}
-
-fn symbolic_artifact_predicate_failure_matches(
-    failure: Option<&SymbolicInvariantArtifactFailure>,
-    outcome: &CheckSequenceOutcome,
-) -> bool {
-    let Some(SymbolicInvariantArtifactFailure::Predicate { site: Some(expected), .. }) = failure
-    else {
-        return false;
-    };
-    outcome.failure_site.is_some_and(|actual| symbolic_invariant_failure_site(actual) == *expected)
-}
-
 const FUZZ_BRANCH_FRONTIER_SCHEMA: &str = "foundry:fuzz.branch-frontiers@v1";
 const FUZZ_BRANCH_FRONTIER_FILE: &str = "branch-frontiers.json";
 
@@ -5883,4 +5786,101 @@ fn replay_persisted_handler_failures<FEN: FoundryEvmNetwork>(
         }
     }
     (replayed, replayed_storage)
+}
+
+fn should_symbolically_import_fuzz_corpus(config: &Config, func: &Function) -> bool {
+    config.symbolic.use_fuzz_corpus && func.test_function_kind().is_fuzz_test()
+}
+
+pub(crate) fn effective_test_function_kind(
+    kind: TestFunctionKind,
+    config: &Config,
+    func: &Function,
+) -> TestFunctionKind {
+    if should_symbolically_import_fuzz_corpus(config, func) {
+        TestFunctionKind::SymbolicTest
+    } else {
+        kind
+    }
+}
+
+fn symbolic_invariant_unsupported_domain_reason(
+    invariant_config: &InvariantConfig,
+    sender_filters: &SenderFilters,
+    targets: &FuzzRunIdentifiedContracts,
+    symbolic_targets: &[SymbolicInvariantTarget],
+) -> Option<String> {
+    if sender_filters.targeted.is_empty() {
+        return Some("symbolic invariant execution requires explicit target senders".to_string());
+    }
+    if invariant_config.has_delay() {
+        return Some("symbolic invariant execution does not model warp/roll delays".to_string());
+    }
+    if invariant_config.call_override {
+        return Some(
+            "symbolic invariant execution does not model call override targets".to_string(),
+        );
+    }
+    if targets.is_updatable {
+        return Some(
+            "symbolic invariant execution does not model dynamically updatable targets".to_string(),
+        );
+    }
+    if invariant_config.corpus.payable_value_weight > 0
+        && symbolic_targets
+            .iter()
+            .any(|target| target.function.state_mutability == StateMutability::Payable)
+    {
+        return Some("symbolic invariant execution does not model payable call values".to_string());
+    }
+    None
+}
+
+fn symbolic_artifact_handler_failure_matches(
+    failure: Option<&SymbolicInvariantArtifactFailure>,
+    site: Option<CheckSequenceFailureSite>,
+) -> bool {
+    matches!(
+        (failure, site),
+        (
+            Some(SymbolicInvariantArtifactFailure::Handler {
+                reverter,
+                selector,
+                fingerprint,
+                ..
+            }),
+            Some(CheckSequenceFailureSite::SequenceCall {
+                target,
+                selector: actual_selector,
+                fingerprint: actual_fingerprint,
+            })
+        ) if *reverter == target && *selector == actual_selector && *fingerprint == actual_fingerprint
+    )
+}
+
+const fn symbolic_invariant_failure_site(
+    site: CheckSequenceFailureSite,
+) -> SymbolicInvariantFailureSite {
+    match site {
+        CheckSequenceFailureSite::SequenceCall { target, selector, fingerprint } => {
+            SymbolicInvariantFailureSite::SequenceCall { target, selector, fingerprint }
+        }
+        CheckSequenceFailureSite::Invariant { target, selector, fingerprint } => {
+            SymbolicInvariantFailureSite::Invariant { target, selector, fingerprint }
+        }
+        CheckSequenceFailureSite::AfterInvariant { target, selector, fingerprint } => {
+            SymbolicInvariantFailureSite::AfterInvariant { target, selector, fingerprint }
+        }
+    }
+}
+
+fn symbolic_artifact_predicate_failure_matches(
+    failure: Option<&SymbolicInvariantArtifactFailure>,
+    outcome: &CheckSequenceOutcome,
+) -> bool {
+    let Some(SymbolicInvariantArtifactFailure::Predicate { site: Some(expected), .. }) = failure
+    else {
+        return false;
+    };
+    outcome.failure_site.is_some_and(|actual| symbolic_invariant_failure_site(actual) == *expected)
 }

--- a/crates/lint/src/sol/analysis/primitives.rs
+++ b/crates/lint/src/sol/analysis/primitives.rs
@@ -6,12 +6,6 @@ use solar::{
     sema::hir::{self, ElementaryType, Expr, ExprKind, Res, Stmt, StmtKind, TypeKind, VariableId},
 };
 
-/// True if `expr` references the named global builtin (`msg`, `tx`, `this`, ...).
-fn is_builtin(expr: &Expr<'_>, name: Symbol) -> bool {
-    matches!(&expr.peel_parens().kind, ExprKind::Ident(reses)
-        if reses.iter().any(|r| matches!(r, Res::Builtin(b) if b.name() == name)))
-}
-
 /// True if `vid` is typed as `address`/`address payable`.
 pub fn is_address_type(hir: &hir::Hir<'_>, vid: VariableId) -> bool {
     matches!(hir.variable(vid).ty.kind, TypeKind::Elementary(ElementaryType::Address(_)))
@@ -54,6 +48,12 @@ pub fn branch_always_exits(stmt: &Stmt<'_>) -> bool {
         StmtKind::If(_, t, Some(e)) => branch_always_exits(t) && branch_always_exits(e),
         _ => false,
     }
+}
+
+/// True if `expr` references the named global builtin (`msg`, `tx`, `this`, ...).
+fn is_builtin(expr: &Expr<'_>, name: Symbol) -> bool {
+    matches!(&expr.peel_parens().kind, ExprKind::Ident(reses)
+        if reses.iter().any(|r| matches!(r, Res::Builtin(b) if b.name() == name)))
 }
 
 fn is_exit_call(expr: &Expr<'_>) -> bool {

--- a/crates/lint/src/sol/low/payable_loop.rs
+++ b/crates/lint/src/sol/low/payable_loop.rs
@@ -16,91 +16,6 @@ use solar::{
 };
 use std::ops::ControlFlow;
 
-pub(super) fn visit_payable_loop_expressions<'ctx, 's, 'hir, 'cb>(
-    ctx: &'ctx LintContext<'s, 'ctx>,
-    gcx: Gcx<'hir>,
-    hir: &'hir Hir<'hir>,
-    func: &'hir Function<'hir>,
-    f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Expr<'hir>) + 'cb,
-) {
-    if !is_payable_entry_point(func) {
-        return;
-    }
-
-    visit_loop_statements_and_expressions_with_options(
-        ctx,
-        gcx,
-        hir,
-        func,
-        true,
-        true,
-        |_, _, _, _| {},
-        f,
-    );
-}
-
-pub(super) fn visit_loop_statements_and_expressions<'ctx, 's, 'hir, 'cb>(
-    ctx: &'ctx LintContext<'s, 'ctx>,
-    gcx: Gcx<'hir>,
-    hir: &'hir Hir<'hir>,
-    func: &'hir Function<'hir>,
-    mut stmt_f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Stmt<'hir>)
-    + 'cb,
-    mut expr_f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Expr<'hir>)
-    + 'cb,
-) {
-    visit_loop_statements_and_expressions_with_options(
-        ctx,
-        gcx,
-        hir,
-        func,
-        false,
-        false,
-        &mut stmt_f,
-        &mut expr_f,
-    );
-}
-
-#[allow(clippy::too_many_arguments)]
-fn visit_loop_statements_and_expressions_with_options<'ctx, 's, 'hir, 'cb>(
-    ctx: &'ctx LintContext<'s, 'ctx>,
-    gcx: Gcx<'hir>,
-    hir: &'hir Hir<'hir>,
-    func: &'hir Function<'hir>,
-    follow_calls_outside_loop: bool,
-    report_local_loops_in_internal_calls: bool,
-    mut stmt_f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Stmt<'hir>)
-    + 'cb,
-    mut expr_f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Expr<'hir>)
-    + 'cb,
-) {
-    let Some(body) = func.body else { return };
-
-    let mut checker = LoopContextChecker {
-        ctx,
-        hir,
-        gcx,
-        loop_depth: 0,
-        placeholder: None,
-        modifier_stack: Vec::new(),
-        call_stack: Vec::new(),
-        internal_call_loop_depths: Vec::new(),
-        dispatch_contract: func.contract,
-        current_contract: func.contract,
-        follow_calls_outside_loop,
-        report_local_loops_in_internal_calls,
-        stmt_f: &mut stmt_f,
-        expr_f: &mut expr_f,
-    };
-    checker.visit_modifier_chain(func.modifiers, 0, body, func.contract);
-}
-
-fn is_payable_entry_point(func: &Function<'_>) -> bool {
-    !matches!(func.kind, FunctionKind::Constructor | FunctionKind::Modifier)
-        && func.state_mutability == StateMutability::Payable
-        && matches!(func.visibility, Visibility::Public | Visibility::External)
-}
-
 type LoopExprCallback<'ctx, 's, 'hir, 'cb> =
     dyn FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Expr<'hir>) + 'cb;
 type LoopStmtCallback<'ctx, 's, 'hir, 'cb> =
@@ -748,4 +663,89 @@ fn variable_data_location(hir: &Hir<'_>, var_id: VariableId) -> Option<DataLocat
 
 pub(super) fn is_address_ty(ty: Ty<'_>) -> bool {
     matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::Address(_)))
+}
+
+pub(super) fn visit_payable_loop_expressions<'ctx, 's, 'hir, 'cb>(
+    ctx: &'ctx LintContext<'s, 'ctx>,
+    gcx: Gcx<'hir>,
+    hir: &'hir Hir<'hir>,
+    func: &'hir Function<'hir>,
+    f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Expr<'hir>) + 'cb,
+) {
+    if !is_payable_entry_point(func) {
+        return;
+    }
+
+    visit_loop_statements_and_expressions_with_options(
+        ctx,
+        gcx,
+        hir,
+        func,
+        true,
+        true,
+        |_, _, _, _| {},
+        f,
+    );
+}
+
+pub(super) fn visit_loop_statements_and_expressions<'ctx, 's, 'hir, 'cb>(
+    ctx: &'ctx LintContext<'s, 'ctx>,
+    gcx: Gcx<'hir>,
+    hir: &'hir Hir<'hir>,
+    func: &'hir Function<'hir>,
+    mut stmt_f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Stmt<'hir>)
+    + 'cb,
+    mut expr_f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Expr<'hir>)
+    + 'cb,
+) {
+    visit_loop_statements_and_expressions_with_options(
+        ctx,
+        gcx,
+        hir,
+        func,
+        false,
+        false,
+        &mut stmt_f,
+        &mut expr_f,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn visit_loop_statements_and_expressions_with_options<'ctx, 's, 'hir, 'cb>(
+    ctx: &'ctx LintContext<'s, 'ctx>,
+    gcx: Gcx<'hir>,
+    hir: &'hir Hir<'hir>,
+    func: &'hir Function<'hir>,
+    follow_calls_outside_loop: bool,
+    report_local_loops_in_internal_calls: bool,
+    mut stmt_f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Stmt<'hir>)
+    + 'cb,
+    mut expr_f: impl FnMut(&'ctx LintContext<'s, 'ctx>, Gcx<'hir>, &'hir Hir<'hir>, &'hir Expr<'hir>)
+    + 'cb,
+) {
+    let Some(body) = func.body else { return };
+
+    let mut checker = LoopContextChecker {
+        ctx,
+        hir,
+        gcx,
+        loop_depth: 0,
+        placeholder: None,
+        modifier_stack: Vec::new(),
+        call_stack: Vec::new(),
+        internal_call_loop_depths: Vec::new(),
+        dispatch_contract: func.contract,
+        current_contract: func.contract,
+        follow_calls_outside_loop,
+        report_local_loops_in_internal_calls,
+        stmt_f: &mut stmt_f,
+        expr_f: &mut expr_f,
+    };
+    checker.visit_modifier_chain(func.modifiers, 0, body, func.contract);
+}
+
+fn is_payable_entry_point(func: &Function<'_>) -> bool {
+    !matches!(func.kind, FunctionKind::Constructor | FunctionKind::Modifier)
+        && func.state_mutability == StateMutability::Payable
+        && matches!(func.visibility, Visibility::Public | Visibility::External)
 }

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -53,60 +53,6 @@ use revm_inspectors::tracing::types::CallKind;
 use tempo_alloy::{TempoNetwork, rpc::TempoTransactionRequest};
 use tempo_primitives::transaction::Call;
 
-pub async fn estimate_gas<N: Network, P: Provider<N>>(
-    tx: &mut N::TransactionRequest,
-    provider: &P,
-    estimate_multiplier: u64,
-    tempo_browser: bool,
-) -> Result<()>
-where
-    N::TransactionRequest: FoundryTransactionBuilder<N>,
-{
-    // if already set, some RPC endpoints might simply return the gas value that is already
-    // set in the request and omit the estimate altogether, so we remove it here
-    tx.reset_gas_limit();
-
-    let request =
-        if tempo_browser { tx.browser_wallet_gas_estimation_request() } else { tx.clone() };
-    tx.set_gas_limit(
-        provider.estimate_gas(request).await.wrap_err("Failed to estimate gas for tx")?
-            * estimate_multiplier
-            / 100,
-    );
-    Ok(())
-}
-
-/// Returns `caller`'s nonce at an already resolved fork block.
-pub(super) async fn next_nonce_resolved(
-    caller: Address,
-    evm_opts: &EvmOpts,
-    fork: &ResolvedFork,
-) -> eyre::Result<u64> {
-    evm_opts.transaction_count_at_resolved_fork(caller, fork).await
-}
-
-fn reject_access_key_create<N: Network>(
-    tx: &N::TransactionRequest,
-    uses_access_key: bool,
-) -> Result<()>
-where
-    N::TransactionRequest: FoundryTransactionBuilder<N>,
-{
-    if uses_access_key && tx.tempo_calls().iter().any(|(to, _)| to.is_create()) {
-        bail!("Tempo access-key transactions cannot use CREATE");
-    }
-    Ok(())
-}
-
-fn convert_tempo_aa_create<N: Network>(tx: &mut N::TransactionRequest)
-where
-    N::TransactionRequest: FoundryTransactionBuilder<N>,
-{
-    if tx.is_tempo_aa() {
-        tx.convert_create_to_call();
-    }
-}
-
 /// Represents how to send a single transaction.
 #[derive(Clone)]
 pub enum SendTransactionKind<'a, N: Network> {
@@ -1368,6 +1314,60 @@ async fn wait_for_batch_receipt<N: Network>(
         }
 
         tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+pub async fn estimate_gas<N: Network, P: Provider<N>>(
+    tx: &mut N::TransactionRequest,
+    provider: &P,
+    estimate_multiplier: u64,
+    tempo_browser: bool,
+) -> Result<()>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    // if already set, some RPC endpoints might simply return the gas value that is already
+    // set in the request and omit the estimate altogether, so we remove it here
+    tx.reset_gas_limit();
+
+    let request =
+        if tempo_browser { tx.browser_wallet_gas_estimation_request() } else { tx.clone() };
+    tx.set_gas_limit(
+        provider.estimate_gas(request).await.wrap_err("Failed to estimate gas for tx")?
+            * estimate_multiplier
+            / 100,
+    );
+    Ok(())
+}
+
+/// Returns `caller`'s nonce at an already resolved fork block.
+pub(super) async fn next_nonce_resolved(
+    caller: Address,
+    evm_opts: &EvmOpts,
+    fork: &ResolvedFork,
+) -> eyre::Result<u64> {
+    evm_opts.transaction_count_at_resolved_fork(caller, fork).await
+}
+
+fn reject_access_key_create<N: Network>(
+    tx: &N::TransactionRequest,
+    uses_access_key: bool,
+) -> Result<()>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    if uses_access_key && tx.tempo_calls().iter().any(|(to, _)| to.is_create()) {
+        bail!("Tempo access-key transactions cannot use CREATE");
+    }
+    Ok(())
+}
+
+fn convert_tempo_aa_create<N: Network>(tx: &mut N::TransactionRequest)
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    if tx.is_tempo_aa() {
+        tx.convert_create_to_call();
     }
 }
 

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -31,32 +31,6 @@ use foundry_linking::Linker;
 use foundry_wallets::{MultiWalletOpts, wallet_browser::signer::BrowserSigner};
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
-/// Returns whether every scoped signer needed for resume is already available.
-///
-/// `Wallets` only tracks signers collected from CLI options and script cheatcodes. A Tempo
-/// session signer lives in the Accounts store instead, so resume needs to treat the session
-/// root account as available only on the chain covered by the session.
-fn has_available_script_signers(
-    tempo: &TempoOpts,
-    wallets: &MultiWalletOpts,
-    script_wallets: &Wallets,
-    expected_sender: Option<Address>,
-    remaining: &[RemainingScriptTransaction],
-) -> Result<bool> {
-    let signers = script_wallets
-        .signers()
-        .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
-    if remaining.is_empty() {
-        return Ok(true);
-    }
-
-    let session_scope = tempo
-        .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
-        .map(|s| SignerScope::new(s.session.chain_id, s.access_key.account()));
-
-    Ok(remaining.iter().all(|tx| signers.contains(&tx.from) || session_scope == Some(tx.scope())))
-}
-
 /// Container for the compiled contracts.
 #[derive(Clone, Debug)]
 pub struct BuildData {
@@ -443,6 +417,32 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
             Ok(ScriptSequenceKind::Multi(sequence))
         }
     }
+}
+
+/// Returns whether every scoped signer needed for resume is already available.
+///
+/// `Wallets` only tracks signers collected from CLI options and script cheatcodes. A Tempo
+/// session signer lives in the Accounts store instead, so resume needs to treat the session
+/// root account as available only on the chain covered by the session.
+fn has_available_script_signers(
+    tempo: &TempoOpts,
+    wallets: &MultiWalletOpts,
+    script_wallets: &Wallets,
+    expected_sender: Option<Address>,
+    remaining: &[RemainingScriptTransaction],
+) -> Result<bool> {
+    let signers = script_wallets
+        .signers()
+        .map_err(|e| eyre::eyre!("Failed to get available signers: {}", e))?;
+    if remaining.is_empty() {
+        return Ok(true);
+    }
+
+    let session_scope = tempo
+        .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
+        .map(|s| SignerScope::new(s.session.chain_id, s.access_key.account()));
+
+    Ok(remaining.iter().all(|tx| signers.contains(&tx.from) || session_scope == Some(tx.scope())))
 }
 
 #[cfg(test)]

--- a/crates/script/src/sequence.rs
+++ b/crates/script/src/sequence.rs
@@ -12,48 +12,6 @@ use std::{
     path::Path,
 };
 
-/// Format transaction details for display
-fn format_transaction<N: Network>(
-    index: usize,
-    tx: &TransactionWithMetadata<N>,
-) -> Result<String, Error>
-where
-    N::TxEnvelope: UIfmt,
-    N::TransactionRequest: FoundryTransactionBuilder<N>,
-{
-    let mut output = String::new();
-    writeln!(output, "### Transaction {index} ###")?;
-    writeln!(output, "{}", tx.tx().pretty())?;
-
-    // Show contract name and address if available
-    if !tx.call_kind.is_any_create()
-        && let (Some(name), Some(addr)) = (&tx.contract_name, &tx.contract_address)
-    {
-        writeln!(output, "contract: {name}({addr})")?;
-    }
-
-    // Show decoded function if available
-    if let (Some(func), Some(args)) = (&tx.display_function, &tx.arguments) {
-        if args.is_empty() {
-            writeln!(output, "data (decoded): {func}()")?;
-        } else {
-            writeln!(output, "data (decoded): {func}(")?;
-            for (i, arg) in args.iter().enumerate() {
-                writeln!(&mut output, "  {}{}", arg, if i + 1 < args.len() { "," } else { "" })?;
-            }
-            writeln!(output, ")")?;
-        }
-    }
-
-    writeln!(output)?;
-    Ok(output)
-}
-
-/// Returns the commit hash of the project if it exists
-pub fn get_commit_hash(root: &Path) -> Option<String> {
-    Git::new(root).commit_hash(true, "HEAD").ok()
-}
-
 pub enum ScriptSequenceKind<N: Network>
 where
     N::TxEnvelope: for<'d> Deserialize<'d> + Serialize,
@@ -143,4 +101,46 @@ where
             error!(?err, "could not save deployment sequence");
         }
     }
+}
+
+/// Format transaction details for display
+fn format_transaction<N: Network>(
+    index: usize,
+    tx: &TransactionWithMetadata<N>,
+) -> Result<String, Error>
+where
+    N::TxEnvelope: UIfmt,
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+{
+    let mut output = String::new();
+    writeln!(output, "### Transaction {index} ###")?;
+    writeln!(output, "{}", tx.tx().pretty())?;
+
+    // Show contract name and address if available
+    if !tx.call_kind.is_any_create()
+        && let (Some(name), Some(addr)) = (&tx.contract_name, &tx.contract_address)
+    {
+        writeln!(output, "contract: {name}({addr})")?;
+    }
+
+    // Show decoded function if available
+    if let (Some(func), Some(args)) = (&tx.display_function, &tx.arguments) {
+        if args.is_empty() {
+            writeln!(output, "data (decoded): {func}()")?;
+        } else {
+            writeln!(output, "data (decoded): {func}(")?;
+            for (i, arg) in args.iter().enumerate() {
+                writeln!(&mut output, "  {}{}", arg, if i + 1 < args.len() { "," } else { "" })?;
+            }
+            writeln!(output, ")")?;
+        }
+    }
+
+    writeln!(output)?;
+    Ok(output)
+}
+
+/// Returns the commit hash of the project if it exists
+pub fn get_commit_hash(root: &Path) -> Option<String> {
+    Git::new(root).commit_hash(true, "HEAD").ok()
 }

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -26,13 +26,6 @@ use external::{ExternalResolver, MAX_PROVENANCE_ADDRESSES, MatchResult, match_ca
 
 const MAX_EXTERNAL_JOBS: usize = 32;
 
-fn same_endpoint(left: &str, right: &str) -> bool {
-    let (Ok(left), Ok(right)) = (reqwest::Url::parse(left), reqwest::Url::parse(right)) else {
-        return false;
-    };
-    left == right
-}
-
 /// State after we have broadcasted the script.
 /// It is assumed that at this point [BroadcastedState::sequence] contains receipts for all
 /// broadcasted transactions.
@@ -625,6 +618,13 @@ fn check_unverified<N: Network>(
             }
         }
     }
+}
+
+fn same_endpoint(left: &str, right: &str) -> bool {
+    let (Ok(left), Ok(right)) = (reqwest::Url::parse(left), reqwest::Url::parse(right)) else {
+        return false;
+    };
+    left == right
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is the Forge, script, and lint slice split from #16373. It moves incidental module helpers below their primary declarations. The patch only reorders existing items: signatures, bodies, attributes, comments, and behavior are unchanged, and every touched file retains the same line multiset.

Codex assisted with the repository scan and mechanical relocation of existing functions. No function logic was generated or changed. This is maintenance-only and has no release-note impact, so `L-ignore` applies.
