### PR TITLE
refactor: reorder support module helpers

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -57,24 +57,6 @@ sol! {
     }
 }
 
-/// Creates a provider with a pre-resolved signer.
-pub(crate) fn build_provider_with_signer<N: Network + RecommendedFillers>(
-    tx_opts: &SendTxOpts,
-    signer: WalletSigner,
-) -> eyre::Result<RetryProviderWithSigner<N>>
-where
-    N::TxEnvelope: From<Signed<N::UnsignedTx>>,
-    N::UnsignedTx: SignableTransaction<Signature>,
-{
-    let config = tx_opts.eth.load_config()?;
-    let wallet = EthereumWallet::from(signer);
-    let provider = ProviderBuilder::<N>::from_config(&config)?.build_with_wallet(wallet)?;
-    if let Some(interval) = tx_opts.poll_interval {
-        provider.client().set_poll_interval(Duration::from_secs(interval))
-    }
-    Ok(provider)
-}
-
 /// Interact with ERC20 tokens.
 #[derive(Debug, Parser, Clone)]
 pub enum Erc20Subcommand {
@@ -775,6 +757,24 @@ impl Erc20Subcommand {
         };
         Ok(())
     }
+}
+
+/// Creates a provider with a pre-resolved signer.
+pub(crate) fn build_provider_with_signer<N: Network + RecommendedFillers>(
+    tx_opts: &SendTxOpts,
+    signer: WalletSigner,
+) -> eyre::Result<RetryProviderWithSigner<N>>
+where
+    N::TxEnvelope: From<Signed<N::UnsignedTx>>,
+    N::UnsignedTx: SignableTransaction<Signature>,
+{
+    let config = tx_opts.eth.load_config()?;
+    let wallet = EthereumWallet::from(signer);
+    let provider = ProviderBuilder::<N>::from_config(&config)?.build_with_wallet(wallet)?;
+    if let Some(interval) = tx_opts.poll_interval {
+        provider.client().set_poll_interval(Duration::from_secs(interval))
+    }
+    Ok(provider)
 }
 
 /// Fills from, chain_id, nonce, fees, and gas limit on a transaction request for sponsor/browser

--- a/crates/cheatcodes/src/base64.rs
+++ b/crates/cheatcodes/src/base64.rs
@@ -3,14 +3,6 @@ use alloy_sol_types::SolValue;
 use base64::prelude::*;
 use foundry_evm_core::evm::FoundryEvmNetwork;
 
-fn encode_base64(data: impl AsRef<[u8]>) -> Result {
-    Ok(BASE64_STANDARD.encode(data).abi_encode())
-}
-
-fn encode_base64_url(data: impl AsRef<[u8]>) -> Result {
-    Ok(BASE64_URL_SAFE.encode(data).abi_encode())
-}
-
 impl Cheatcode for toBase64_0Call {
     fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
         let Self { data } = self;
@@ -30,6 +22,14 @@ impl Cheatcode for toBase64URL_0Call {
         let Self { data } = self;
         encode_base64_url(data)
     }
+}
+
+fn encode_base64(data: impl AsRef<[u8]>) -> Result {
+    Ok(BASE64_STANDARD.encode(data).abi_encode())
+}
+
+fn encode_base64_url(data: impl AsRef<[u8]>) -> Result {
+    Ok(BASE64_URL_SAFE.encode(data).abi_encode())
 }
 
 impl Cheatcode for toBase64URL_1Call {

--- a/crates/cheatcodes/src/tempo.rs
+++ b/crates/cheatcodes/src/tempo.rs
@@ -13,16 +13,6 @@ use crate::{Cheatcode, CheatsCtxt, Error, Result};
 use foundry_config::ExecutionSpec;
 use foundry_evm_core::constants::MAGIC_ASSUME;
 
-/// Resolves the active Tempo hardfork from the cheatcode-visible spec, or `None` on non-Tempo
-/// networks. Goes through the spec's stable string name because the context is generic over
-/// the network type.
-fn active_tempo_hardfork<FEN: FoundryEvmNetwork>(
-    ccx: &CheatsCtxt<'_, '_, FEN>,
-) -> Option<TempoHardfork> {
-    let spec = ccx.ecx.cfg().spec();
-    TempoHardfork::from_str(&spec.evm_version_name()).ok()
-}
-
 impl Cheatcode for isImplicitlyApprovedCall {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { spender } = *self;
@@ -43,4 +33,14 @@ impl Cheatcode for assumeImplicitApprovalCall {
         };
         if approved { Ok(Default::default()) } else { Err(Error::from(MAGIC_ASSUME)) }
     }
+}
+
+/// Resolves the active Tempo hardfork from the cheatcode-visible spec, or `None` on non-Tempo
+/// networks. Goes through the spec's stable string name because the context is generic over
+/// the network type.
+fn active_tempo_hardfork<FEN: FoundryEvmNetwork>(
+    ccx: &CheatsCtxt<'_, '_, FEN>,
+) -> Option<TempoHardfork> {
+    let spec = ccx.ecx.cfg().spec();
+    TempoHardfork::from_str(&spec.evm_version_name()).ok()
 }

--- a/crates/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/cheatcodes/src/test/revert_handlers.rs
@@ -23,16 +23,6 @@ static DUMMY_CALL_OUTPUT: Bytes = Bytes::from_static(&[0u8; 8192]);
 /// Same reasoning as [DUMMY_CALL_OUTPUT], but for creates.
 const DUMMY_CREATE_ADDRESS: Address = address!("0x0000000000000000000000000000000000000001");
 
-fn stringify(data: &[u8]) -> String {
-    if let Ok(s) = String::abi_decode(data) {
-        return s;
-    }
-    if data.is_ascii() {
-        return std::str::from_utf8(data).unwrap().to_owned();
-    }
-    hex::encode_prefixed(data)
-}
-
 /// Common parameters for expected or assumed reverts. Allows for code reuse.
 pub(crate) trait RevertParameters {
     fn reverter(&self) -> Option<Address>;
@@ -286,6 +276,16 @@ pub(crate) fn handle_expect_revert(
         )?;
         Ok(success_return())
     }
+}
+
+fn stringify(data: &[u8]) -> String {
+    if let Ok(s) = String::abi_decode(data) {
+        return s;
+    }
+    if data.is_ascii() {
+        return std::str::from_utf8(data).unwrap().to_owned();
+    }
+    hex::encode_prefixed(data)
 }
 
 fn decode_revert(revert: Vec<u8>) -> Vec<u8> {

--- a/crates/cli/src/utils/abi.rs
+++ b/crates/cli/src/utils/abi.rs
@@ -9,24 +9,6 @@ use foundry_common::abi::{
 };
 use futures::future::join_all;
 
-async fn resolve_name_args<N: Network, P: Provider<N>>(
-    args: &[String],
-    provider: &P,
-) -> Vec<String> {
-    join_all(args.iter().map(|arg| async {
-        if arg.contains('.') {
-            let addr = NameOrAddress::Name(arg.clone()).resolve(provider).await;
-            match addr {
-                Ok(addr) => addr.to_string(),
-                Err(_) => arg.clone(),
-            }
-        } else {
-            arg.clone()
-        }
-    }))
-    .await
-}
-
 pub async fn parse_function_args<N: Network, P: Provider<N>>(
     sig: &str,
     args: Vec<String>,
@@ -70,4 +52,22 @@ pub async fn parse_function_args<N: Network, P: Provider<N>>(
     } else {
         Ok((encode_function_args(&func, &args)?, Some(func)))
     }
+}
+
+async fn resolve_name_args<N: Network, P: Provider<N>>(
+    args: &[String],
+    provider: &P,
+) -> Vec<String> {
+    join_all(args.iter().map(|arg| async {
+        if arg.contains('.') {
+            let addr = NameOrAddress::Name(arg.clone()).resolve(provider).await;
+            match addr {
+                Ok(addr) => addr.to_string(),
+                Err(_) => arg.clone(),
+            }
+        } else {
+            arg.clone()
+        }
+    }))
+    .await
 }

--- a/crates/config/src/filter.rs
+++ b/crates/config/src/filter.rs
@@ -9,20 +9,6 @@ use std::{
     str::FromStr,
 };
 
-/// Expand globs with a root path.
-pub fn expand_globs(
-    root: &Path,
-    patterns: impl IntoIterator<Item = impl AsRef<str>>,
-) -> eyre::Result<Vec<PathBuf>> {
-    let mut expanded = Vec::new();
-    for pattern in patterns {
-        for paths in glob::glob(&root.join(pattern.as_ref()).display().to_string())? {
-            expanded.push(paths?);
-        }
-    }
-    Ok(expanded)
-}
-
 /// A `globset::Glob` that creates its `globset::GlobMatcher` when its created, so it doesn't need
 /// to be compiled when the filter functions `TestFilter` functions are called.
 #[derive(Clone, Debug)]
@@ -195,6 +181,20 @@ impl FromStr for SkipBuildFilter {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self::new(s))
     }
+}
+
+/// Expand globs with a root path.
+pub fn expand_globs(
+    root: &Path,
+    patterns: impl IntoIterator<Item = impl AsRef<str>>,
+) -> eyre::Result<Vec<PathBuf>> {
+    let mut expanded = Vec::new();
+    for pattern in patterns {
+        for paths in glob::glob(&root.join(pattern.as_ref()).display().to_string())? {
+            expanded.push(paths?);
+        }
+    }
+    Ok(expanded)
 }
 
 #[cfg(test)]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -157,21 +157,6 @@ pub use semver;
 static SELECTED_PROFILE: std::sync::OnceLock<Profile> = std::sync::OnceLock::new();
 static WARNED_LOCAL_COMPILERS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
-fn warn_local_compiler(path: &Path) {
-    let mut warned = WARNED_LOCAL_COMPILERS.lock().unwrap_or_else(|err| err.into_inner());
-    if warned.iter().any(|warned_path| warned_path == path) {
-        return;
-    }
-    warned.push(path.to_path_buf());
-
-    let mut stderr = io::stderr().lock();
-    let _ = writeln!(
-        stderr,
-        "Warning: this project is configured to use a local compiler executable:\n  {path:?}\n\
-         Running this executable may execute arbitrary code."
-    );
-}
-
 /// Foundry configuration
 ///
 /// # Defaults
@@ -3276,6 +3261,21 @@ pub(crate) mod from_str_lowercase {
     {
         String::deserialize(deserializer)?.to_lowercase().parse().map_err(serde::de::Error::custom)
     }
+}
+
+fn warn_local_compiler(path: &Path) {
+    let mut warned = WARNED_LOCAL_COMPILERS.lock().unwrap_or_else(|err| err.into_inner());
+    if warned.iter().any(|warned_path| warned_path == path) {
+        return;
+    }
+    warned.push(path.to_path_buf());
+
+    let mut stderr = io::stderr().lock();
+    let _ = writeln!(
+        stderr,
+        "Warning: this project is configured to use a local compiler executable:\n  {path:?}\n\
+         Running this executable may execute arbitrary code."
+    );
 }
 
 fn canonic(path: impl Into<PathBuf>) -> PathBuf {

--- a/crates/debugger/src/dump.rs
+++ b/crates/debugger/src/dump.rs
@@ -10,12 +10,6 @@ use foundry_evm_traces::debug::{ArtifactData, ContractSources, SourceData};
 use serde::Serialize;
 use std::{collections::HashMap, path::Path};
 
-/// Dumps debugger data to a JSON file.
-pub(crate) fn dump(path: &Path, context: &DebuggerContext) -> eyre::Result<()> {
-    write_json_file(path, &DebuggerDump::new(context))?;
-    Ok(())
-}
-
 /// Holds info of debugger dump.
 #[derive(Serialize)]
 struct DebuggerDump<'a> {
@@ -145,4 +139,10 @@ impl<'a> ArtifactDataDump<'a> {
             file_id: v.file_id,
         }
     }
+}
+
+/// Dumps debugger data to a JSON file.
+pub(crate) fn dump(path: &Path, context: &DebuggerContext) -> eyre::Result<()> {
+    write_json_file(path, &DebuggerDump::new(context))?;
+    Ok(())
 }

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -26,141 +26,6 @@ use std::{
     sync::Arc,
 };
 
-// ── public entry point ───────────────────────────────────────────────────────
-
-/// Render a single Solidity source file as a list of `(relative_output_path, mdx_content)` pairs.
-#[allow(clippy::too_many_arguments)]
-pub fn source<'ast, 'gcx>(
-    ast: &'ast SourceUnit<'ast>,
-    file: &Arc<SourceFile>,
-    _sm: &SourceMap,
-    rel_sol_path: &Path,
-    abs_sol_path: &Path,
-    _root: &Path,
-    gcx: Gcx<'gcx>,
-    name_to_page: &NameToPage,
-    git_url: Option<&str>,
-    deployments: &HashMap<String, Vec<Deployment>>,
-) -> Vec<(PathBuf, String)> {
-    let out_dir = rel_sol_path.parent().unwrap_or(Path::new(""));
-    let stem = rel_sol_path.file_stem().and_then(|s| s.to_str()).unwrap_or("constants");
-
-    let src_text = file.src.as_str();
-    let src_start = file.start_pos.to_usize();
-    let ctx = Ctx { src_text, src_start };
-
-    let mut pages: Vec<(PathBuf, String)> = Vec::new();
-    let mut const_vars: Vec<(Span, &VariableDefinition<'_>, &DocComments<'_>)> = Vec::new();
-    let mut free_fns: std::collections::BTreeMap<
-        String,
-        Vec<(Span, &ItemFunction<'_>, &DocComments<'_>)>,
-    > = Default::default();
-
-    for item in ast.items.iter() {
-        let span = item.span;
-        match &item.kind {
-            ItemKind::Pragma(_) | ItemKind::Import(_) | ItemKind::Using(_) => (),
-            ItemKind::Contract(c) => {
-                let kind_str = contract_kind_str(c.kind);
-                let fname = format!("{kind_str}.{}.mdx", c.name.as_str());
-                let page_path = out_dir.join(&fname);
-                // Look up HIR contract id for inheritance/inheritdoc.
-                let hir_id = find_contract_id(gcx, c.name.as_str(), abs_sol_path);
-                // Deployments only apply to non-abstract, non-interface, non-library contracts.
-                let contract_deployments = if matches!(c.kind, ContractKind::Contract) {
-                    deployments.get(c.name.as_str()).map(Vec::as_slice).unwrap_or(&[])
-                } else {
-                    &[]
-                };
-                let content = render_contract(
-                    span,
-                    c,
-                    &item.docs,
-                    &ctx,
-                    gcx,
-                    hir_id,
-                    name_to_page,
-                    &page_path,
-                    git_url,
-                    contract_deployments,
-                );
-                pages.push((page_path, content));
-            }
-
-            ItemKind::Function(f) => {
-                let name = f.header.name.map(|n| n.as_str().to_string()).unwrap_or_default();
-                free_fns.entry(name).or_default().push((span, f, &item.docs));
-            }
-
-            ItemKind::Variable(v) => {
-                const_vars.push((span, v, &item.docs));
-            }
-
-            ItemKind::Struct(s) => {
-                let fname = format!("struct.{}.mdx", s.name.as_str());
-                let page_path = out_dir.join(&fname);
-                pages.push((
-                    page_path.clone(),
-                    render_struct(span, s, &item.docs, &ctx, name_to_page, &page_path, git_url),
-                ));
-            }
-
-            ItemKind::Enum(e) => {
-                let fname = format!("enum.{}.mdx", e.name.as_str());
-                let page_path = out_dir.join(&fname);
-                pages.push((
-                    page_path.clone(),
-                    render_enum(span, e, &item.docs, &ctx, name_to_page, &page_path, git_url),
-                ));
-            }
-
-            ItemKind::Udvt(u) => {
-                let fname = format!("type.{}.mdx", u.name.as_str());
-                let page_path = out_dir.join(&fname);
-                pages.push((
-                    page_path.clone(),
-                    render_udvt(span, u, &item.docs, &ctx, name_to_page, &page_path, git_url),
-                ));
-            }
-
-            ItemKind::Error(e) => {
-                let fname = format!("error.{}.mdx", e.name.as_str());
-                let page_path = out_dir.join(&fname);
-                pages.push((
-                    page_path.clone(),
-                    render_error(span, e, &item.docs, &ctx, name_to_page, &page_path, git_url),
-                ));
-            }
-
-            ItemKind::Event(e) => {
-                let fname = format!("event.{}.mdx", e.name.as_str());
-                let page_path = out_dir.join(&fname);
-                pages.push((
-                    page_path.clone(),
-                    render_event(span, e, &item.docs, &ctx, name_to_page, &page_path, git_url),
-                ));
-            }
-        }
-    }
-
-    for (name, overloads) in &free_fns {
-        let fname = format!("function.{name}.mdx");
-        let page_path = out_dir.join(&fname);
-        let content =
-            render_free_functions(name, overloads, &ctx, name_to_page, &page_path, git_url);
-        pages.push((page_path, content));
-    }
-
-    if !const_vars.is_empty() {
-        let fname = format!("constants.{stem}.mdx");
-        let page_path = out_dir.join(&fname);
-        let content = render_constants(stem, &const_vars, &ctx, name_to_page, &page_path, git_url);
-        pages.push((page_path, content));
-    }
-
-    pages
-}
-
 // ── rendering context ────────────────────────────────────────────────────────
 
 struct Ctx<'a> {
@@ -1370,6 +1235,141 @@ fn dedent(s: &str) -> String {
         .map(|l| if l.len() >= indent { &l[indent..] } else { l.trim() })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+// ── public entry point ───────────────────────────────────────────────────────
+
+/// Render a single Solidity source file as a list of `(relative_output_path, mdx_content)` pairs.
+#[allow(clippy::too_many_arguments)]
+pub fn source<'ast, 'gcx>(
+    ast: &'ast SourceUnit<'ast>,
+    file: &Arc<SourceFile>,
+    _sm: &SourceMap,
+    rel_sol_path: &Path,
+    abs_sol_path: &Path,
+    _root: &Path,
+    gcx: Gcx<'gcx>,
+    name_to_page: &NameToPage,
+    git_url: Option<&str>,
+    deployments: &HashMap<String, Vec<Deployment>>,
+) -> Vec<(PathBuf, String)> {
+    let out_dir = rel_sol_path.parent().unwrap_or(Path::new(""));
+    let stem = rel_sol_path.file_stem().and_then(|s| s.to_str()).unwrap_or("constants");
+
+    let src_text = file.src.as_str();
+    let src_start = file.start_pos.to_usize();
+    let ctx = Ctx { src_text, src_start };
+
+    let mut pages: Vec<(PathBuf, String)> = Vec::new();
+    let mut const_vars: Vec<(Span, &VariableDefinition<'_>, &DocComments<'_>)> = Vec::new();
+    let mut free_fns: std::collections::BTreeMap<
+        String,
+        Vec<(Span, &ItemFunction<'_>, &DocComments<'_>)>,
+    > = Default::default();
+
+    for item in ast.items.iter() {
+        let span = item.span;
+        match &item.kind {
+            ItemKind::Pragma(_) | ItemKind::Import(_) | ItemKind::Using(_) => (),
+            ItemKind::Contract(c) => {
+                let kind_str = contract_kind_str(c.kind);
+                let fname = format!("{kind_str}.{}.mdx", c.name.as_str());
+                let page_path = out_dir.join(&fname);
+                // Look up HIR contract id for inheritance/inheritdoc.
+                let hir_id = find_contract_id(gcx, c.name.as_str(), abs_sol_path);
+                // Deployments only apply to non-abstract, non-interface, non-library contracts.
+                let contract_deployments = if matches!(c.kind, ContractKind::Contract) {
+                    deployments.get(c.name.as_str()).map(Vec::as_slice).unwrap_or(&[])
+                } else {
+                    &[]
+                };
+                let content = render_contract(
+                    span,
+                    c,
+                    &item.docs,
+                    &ctx,
+                    gcx,
+                    hir_id,
+                    name_to_page,
+                    &page_path,
+                    git_url,
+                    contract_deployments,
+                );
+                pages.push((page_path, content));
+            }
+
+            ItemKind::Function(f) => {
+                let name = f.header.name.map(|n| n.as_str().to_string()).unwrap_or_default();
+                free_fns.entry(name).or_default().push((span, f, &item.docs));
+            }
+
+            ItemKind::Variable(v) => {
+                const_vars.push((span, v, &item.docs));
+            }
+
+            ItemKind::Struct(s) => {
+                let fname = format!("struct.{}.mdx", s.name.as_str());
+                let page_path = out_dir.join(&fname);
+                pages.push((
+                    page_path.clone(),
+                    render_struct(span, s, &item.docs, &ctx, name_to_page, &page_path, git_url),
+                ));
+            }
+
+            ItemKind::Enum(e) => {
+                let fname = format!("enum.{}.mdx", e.name.as_str());
+                let page_path = out_dir.join(&fname);
+                pages.push((
+                    page_path.clone(),
+                    render_enum(span, e, &item.docs, &ctx, name_to_page, &page_path, git_url),
+                ));
+            }
+
+            ItemKind::Udvt(u) => {
+                let fname = format!("type.{}.mdx", u.name.as_str());
+                let page_path = out_dir.join(&fname);
+                pages.push((
+                    page_path.clone(),
+                    render_udvt(span, u, &item.docs, &ctx, name_to_page, &page_path, git_url),
+                ));
+            }
+
+            ItemKind::Error(e) => {
+                let fname = format!("error.{}.mdx", e.name.as_str());
+                let page_path = out_dir.join(&fname);
+                pages.push((
+                    page_path.clone(),
+                    render_error(span, e, &item.docs, &ctx, name_to_page, &page_path, git_url),
+                ));
+            }
+
+            ItemKind::Event(e) => {
+                let fname = format!("event.{}.mdx", e.name.as_str());
+                let page_path = out_dir.join(&fname);
+                pages.push((
+                    page_path.clone(),
+                    render_event(span, e, &item.docs, &ctx, name_to_page, &page_path, git_url),
+                ));
+            }
+        }
+    }
+
+    for (name, overloads) in &free_fns {
+        let fname = format!("function.{name}.mdx");
+        let page_path = out_dir.join(&fname);
+        let content =
+            render_free_functions(name, overloads, &ctx, name_to_page, &page_path, git_url);
+        pages.push((page_path, content));
+    }
+
+    if !const_vars.is_empty() {
+        let fname = format!("constants.{stem}.mdx");
+        let page_path = out_dir.join(&fname);
+        let content = render_constants(stem, &const_vars, &ctx, name_to_page, &page_path, git_url);
+        pages.push((page_path, content));
+    }
+
+    pages
 }
 
 #[cfg(test)]

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -23,13 +23,6 @@ pub type CrosstermTerminal = Terminal<CrosstermBackend<Stdout>>;
 
 type PanicHandler = Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>;
 
-/// Runs a closure with the default Foundry terminal setup.
-pub fn with_terminal<T>(f: impl FnMut(&mut CrosstermTerminal) -> T) -> IoResult<T> {
-    let backend = CrosstermBackend::new(stdout());
-    let terminal = Terminal::new(backend)?;
-    Ok(TerminalGuard::with(terminal, f))
-}
-
 /// The resolved mode for a requested TUI run.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TuiMode {
@@ -207,6 +200,13 @@ impl<B: Backend + Write> Drop for TerminalGuard<B> {
     fn drop(&mut self) {
         self.restore();
     }
+}
+
+/// Runs a closure with the default Foundry terminal setup.
+pub fn with_terminal<T>(f: impl FnMut(&mut CrosstermTerminal) -> T) -> IoResult<T> {
+    let backend = CrosstermBackend::new(stdout());
+    let terminal = Terminal::new(backend)?;
+    Ok(TerminalGuard::with(terminal, f))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is the supporting-crate slice split from #16373, covering Cast, cheatcodes, shared CLI utilities, configuration, the debugger, documentation rendering, and TUI setup. It moves incidental module helpers below their primary declarations. The patch only reorders existing items: signatures, bodies, attributes, comments, and behavior are unchanged, and every touched file retains the same line multiset.

Codex assisted with the repository scan and mechanical relocation of existing functions. No function logic was generated or changed. This is maintenance-only and has no release-note impact, so `L-ignore` applies.
