### PR TITLE
feat(cheatcodes): expose state gas

### DIFF
--- a/.changelog/cheatcode-state-gas.md
+++ b/.changelog/cheatcode-state-gas.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added `gasStateUsed` to the `Vm.Gas` values returned by `lastCallGas` and `lastFrameGas`.

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -524,7 +524,7 @@
         {
           "name": "gasTotalUsed",
           "ty": "uint64",
-          "description": "The total gas used."
+          "description": "The total regular gas used."
         },
         {
           "name": "gasMemoryUsed",
@@ -540,6 +540,11 @@
           "name": "gasRemaining",
           "ty": "uint64",
           "description": "The amount of gas remaining."
+        },
+        {
+          "name": "gasStateUsed",
+          "ty": "int64",
+          "description": "The amount of state gas used. May be negative within a nested frame when state gas is refunded."
         }
       ]
     },

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -544,7 +544,7 @@
         {
           "name": "gasStateUsed",
           "ty": "int64",
-          "description": "The amount of state gas used. May be negative within a nested frame when state gas is refunded."
+          "description": "The net state gas used. Zero for reverted or halted frames; may be negative within a nested frame when state gas is refunded."
         }
       ]
     },

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -100,7 +100,7 @@ interface Vm {
     struct Gas {
         /// The gas limit of the call.
         uint64 gasLimit;
-        /// The total gas used.
+        /// The total regular gas used.
         uint64 gasTotalUsed;
         /// DEPRECATED: The amount of gas used for memory expansion. Ref: <https://github.com/foundry-rs/foundry/pull/7934#pullrequestreview-2069236939>
         uint64 gasMemoryUsed;
@@ -108,6 +108,8 @@ interface Vm {
         int64 gasRefunded;
         /// The amount of gas remaining.
         uint64 gasRemaining;
+        /// The amount of state gas used. May be negative within a nested frame when state gas is refunded.
+        int64 gasStateUsed;
     }
 
     /// An RPC URL and its alias. Returned by `rpcUrlStructs`.

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -108,7 +108,7 @@ interface Vm {
         int64 gasRefunded;
         /// The amount of gas remaining.
         uint64 gasRemaining;
-        /// The amount of state gas used. May be negative within a nested frame when state gas is refunded.
+        /// The net state gas used. Zero for reverted or halted frames; may be negative within a nested frame when state gas is refunded.
         int64 gasStateUsed;
     }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2103,14 +2103,14 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
     }
 }
 
-const fn frame_gas(gas: &Gas) -> Vm::Gas {
+const fn frame_gas(gas: &Gas, success: bool) -> Vm::Gas {
     Vm::Gas {
         gasLimit: gas.limit(),
-        gasTotalUsed: gas.total_gas_spent(),
+        gasTotalUsed: gas.total_gas_spent().saturating_sub(gas.state_gas_spilled()),
         gasMemoryUsed: 0,
         gasRefunded: gas.refunded(),
         gasRemaining: gas.remaining(),
-        gasStateUsed: gas.state_gas_spent(),
+        gasStateUsed: if success { gas.state_gas_spent() } else { 0 },
     }
 }
 
@@ -2560,7 +2560,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
 
         // Record the gas usage of the call, this allows the `lastFrameGas` cheatcode to
         // retrieve the gas usage of the last call or create.
-        let frame_gas = frame_gas(&outcome.result.gas);
+        let frame_gas = frame_gas(&outcome.result.gas, outcome.result.is_ok());
         self.gas_metering.last_call_gas = Some(frame_gas.clone());
         self.gas_metering.last_frame_gas = Some(frame_gas);
 
@@ -3063,7 +3063,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         if curr_depth > 0 {
             // Record the gas usage of the create frame, this allows the `lastFrameGas` cheatcode to
             // retrieve the gas usage of the last call or create.
-            self.gas_metering.last_frame_gas = Some(frame_gas(&outcome.result.gas));
+            self.gas_metering.last_frame_gas =
+                Some(frame_gas(&outcome.result.gas, outcome.result.is_ok()));
         }
 
         // If `startStateDiffRecording` has been called, update the `reverted` status of the
@@ -4269,15 +4270,21 @@ mod tests {
     }
 
     #[test]
-    fn frame_gas_includes_state_gas() {
-        let mut gas = Gas::new_with_regular_gas_and_reservoir(100_000, 50_000);
-        assert!(gas.record_regular_cost(1_000));
-        assert!(gas.record_state_cost(20_000));
+    fn frame_gas_splits_regular_and_state_gas() {
+        for mut gas in [Gas::new(100_000), Gas::new_with_regular_gas_and_reservoir(100_000, 50_000)]
+        {
+            assert!(gas.record_regular_cost(1_000));
+            assert!(gas.record_state_cost(20_000));
 
-        let frame_gas = frame_gas(&gas);
-        assert_eq!(frame_gas.gasTotalUsed, 1_000);
-        assert_eq!(frame_gas.gasStateUsed, 20_000);
-        assert_eq!(frame_gas.gasRemaining, 99_000);
+            let reported = frame_gas(&gas, true);
+            assert_eq!(reported.gasTotalUsed, 1_000);
+            assert_eq!(reported.gasStateUsed, 20_000);
+            assert_eq!(frame_gas(&gas, false).gasStateUsed, 0);
+        }
+
+        let mut gas = Gas::new(100_000);
+        gas.refill_reservoir(20_000);
+        assert_eq!(frame_gas(&gas, true).gasStateUsed, -20_000);
     }
 
     #[test]

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2103,14 +2103,21 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
     }
 }
 
-const fn frame_gas(gas: &Gas, success: bool) -> Vm::Gas {
+const fn frame_gas(result: &InterpreterResult) -> Vm::Gas {
+    let gas = &result.gas;
+    // A halt consumes the regular gas restored while rolling back state gas.
+    let regular_gas_spent = if result.is_halt() {
+        gas.total_gas_spent()
+    } else {
+        gas.total_gas_spent().saturating_sub(gas.state_gas_spilled())
+    };
     Vm::Gas {
         gasLimit: gas.limit(),
-        gasTotalUsed: gas.total_gas_spent().saturating_sub(gas.state_gas_spilled()),
+        gasTotalUsed: regular_gas_spent,
         gasMemoryUsed: 0,
         gasRefunded: gas.refunded(),
         gasRemaining: gas.remaining(),
-        gasStateUsed: if success { gas.state_gas_spent() } else { 0 },
+        gasStateUsed: if result.is_ok() { gas.state_gas_spent() } else { 0 },
     }
 }
 
@@ -2560,7 +2567,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
 
         // Record the gas usage of the call, this allows the `lastFrameGas` cheatcode to
         // retrieve the gas usage of the last call or create.
-        let frame_gas = frame_gas(&outcome.result.gas, outcome.result.is_ok());
+        let frame_gas = frame_gas(&outcome.result);
         self.gas_metering.last_call_gas = Some(frame_gas.clone());
         self.gas_metering.last_frame_gas = Some(frame_gas);
 
@@ -3063,8 +3070,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         if curr_depth > 0 {
             // Record the gas usage of the create frame, this allows the `lastFrameGas` cheatcode to
             // retrieve the gas usage of the last call or create.
-            self.gas_metering.last_frame_gas =
-                Some(frame_gas(&outcome.result.gas, outcome.result.is_ok()));
+            self.gas_metering.last_frame_gas = Some(frame_gas(&outcome.result));
         }
 
         // If `startStateDiffRecording` has been called, update the `reverted` status of the
@@ -4270,21 +4276,33 @@ mod tests {
     }
 
     #[test]
-    fn frame_gas_splits_regular_and_state_gas() {
+    fn frame_gas_reports_settled_components() {
         for mut gas in [Gas::new(100_000), Gas::new_with_regular_gas_and_reservoir(100_000, 50_000)]
         {
             assert!(gas.record_regular_cost(1_000));
             assert!(gas.record_state_cost(20_000));
 
-            let reported = frame_gas(&gas, true);
+            let mut result = InterpreterResult::new(InstructionResult::Stop, Bytes::new(), gas);
+            let reported = frame_gas(&result);
             assert_eq!(reported.gasTotalUsed, 1_000);
             assert_eq!(reported.gasStateUsed, 20_000);
-            assert_eq!(frame_gas(&gas, false).gasStateUsed, 0);
+
+            result.result = InstructionResult::Revert;
+            assert_eq!(frame_gas(&result).gasStateUsed, 0);
         }
 
         let mut gas = Gas::new(100_000);
         gas.refill_reservoir(20_000);
-        assert_eq!(frame_gas(&gas, true).gasStateUsed, -20_000);
+        let result = InterpreterResult::new(InstructionResult::Stop, Bytes::new(), gas);
+        assert_eq!(frame_gas(&result).gasStateUsed, -20_000);
+
+        let mut gas = Gas::new(100_000);
+        assert!(gas.record_state_cost(20_000));
+        gas.spend_all();
+        let result = InterpreterResult::new(InstructionResult::OutOfGas, Bytes::new(), gas);
+        let reported = frame_gas(&result);
+        assert_eq!(reported.gasTotalUsed, 100_000);
+        assert_eq!(reported.gasStateUsed, 0);
     }
 
     #[test]

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2103,6 +2103,17 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
     }
 }
 
+fn frame_gas(gas: &Gas) -> Vm::Gas {
+    Vm::Gas {
+        gasLimit: gas.limit(),
+        gasTotalUsed: gas.total_gas_spent(),
+        gasMemoryUsed: 0,
+        gasRefunded: gas.refunded(),
+        gasRemaining: gas.remaining(),
+        gasStateUsed: gas.state_gas_spent(),
+    }
+}
+
 impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcodes<FEN> {
     fn initialize_interp(
         &mut self,
@@ -2549,14 +2560,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
 
         // Record the gas usage of the call, this allows the `lastFrameGas` cheatcode to
         // retrieve the gas usage of the last call or create.
-        let gas = outcome.result.gas;
-        let frame_gas = crate::Vm::Gas {
-            gasLimit: gas.limit(),
-            gasTotalUsed: gas.total_gas_spent(),
-            gasMemoryUsed: 0,
-            gasRefunded: gas.refunded(),
-            gasRemaining: gas.remaining(),
-        };
+        let frame_gas = frame_gas(&outcome.result.gas);
         self.gas_metering.last_call_gas = Some(frame_gas.clone());
         self.gas_metering.last_frame_gas = Some(frame_gas);
 
@@ -3059,14 +3063,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         if curr_depth > 0 {
             // Record the gas usage of the create frame, this allows the `lastFrameGas` cheatcode to
             // retrieve the gas usage of the last call or create.
-            let gas = outcome.result.gas;
-            self.gas_metering.last_frame_gas = Some(crate::Vm::Gas {
-                gasLimit: gas.limit(),
-                gasTotalUsed: gas.total_gas_spent(),
-                gasMemoryUsed: 0,
-                gasRefunded: gas.refunded(),
-                gasRemaining: gas.remaining(),
-            });
+            self.gas_metering.last_frame_gas = Some(frame_gas(&outcome.result.gas));
         }
 
         // If `startStateDiffRecording` has been called, update the `reverted` status of the
@@ -4269,6 +4266,18 @@ mod tests {
             Default::default(),
         ));
         assert!(cheats.has_log_hooks());
+    }
+
+    #[test]
+    fn frame_gas_includes_state_gas() {
+        let mut gas = Gas::new_with_regular_gas_and_reservoir(100_000, 50_000);
+        assert!(gas.record_regular_cost(1_000));
+        assert!(gas.record_state_cost(20_000));
+
+        let frame_gas = frame_gas(&gas);
+        assert_eq!(frame_gas.gasTotalUsed, 1_000);
+        assert_eq!(frame_gas.gasStateUsed, 20_000);
+        assert_eq!(frame_gas.gasRemaining, 99_000);
     }
 
     #[test]

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2103,7 +2103,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
     }
 }
 
-fn frame_gas(gas: &Gas) -> Vm::Gas {
+const fn frame_gas(gas: &Gas) -> Vm::Gas {
     Vm::Gas {
         gasLimit: gas.limit(),
         gasTotalUsed: gas.total_gas_spent(),

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1118,6 +1118,11 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
             return (result, None, was_precompile_called);
         };
 
+        gas.set_state_gas_spent(
+            i64::try_from(res.result.gas().state_gas_spent_final())
+                .expect("transaction state gas originates from a signed gas tracker"),
+        );
+
         let rolled_back = !res.result.is_success();
 
         for (addr, mut acc) in res.state {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1118,14 +1118,13 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
             return (result, None, was_precompile_called);
         };
 
-        let result_gas = res.result.gas();
-        let state_gas_used = result_gas.state_gas_spent_final();
-        let regular_gas_used = result_gas.tx_gas_used().saturating_sub(state_gas_used);
+        let transaction_gas = res.result.gas();
+        let state_gas_used = transaction_gas.block_state_gas_used();
         gas.set_state_gas_spent(
             i64::try_from(state_gas_used)
                 .expect("transaction state gas originates from a signed gas tracker"),
         );
-        let _ = gas.record_regular_cost(regular_gas_used);
+        let _ = gas.record_regular_cost(transaction_gas.block_regular_gas_used());
 
         let rolled_back = !res.result.is_success();
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1118,10 +1118,14 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
             return (result, None, was_precompile_called);
         };
 
+        let result_gas = res.result.gas();
+        let state_gas_used = result_gas.state_gas_spent_final();
+        let regular_gas_used = result_gas.tx_gas_used().saturating_sub(state_gas_used);
         gas.set_state_gas_spent(
-            i64::try_from(res.result.gas().state_gas_spent_final())
+            i64::try_from(state_gas_used)
                 .expect("transaction state gas originates from a signed gas tracker"),
         );
+        let _ = gas.record_regular_cost(regular_gas_used);
 
         let rolled_back = !res.result.is_success();
 
@@ -1159,21 +1163,16 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         let (result, address, output) = match res.result {
             ExecutionResult::Success { reason, gas: result_gas, logs: _, output } => {
                 gas.set_refund(result_gas.final_refunded() as i64);
-                let _ = gas.record_regular_cost(result_gas.tx_gas_used());
                 let address = match output {
                     Output::Create(_, address) => address,
                     Output::Call(_) => None,
                 };
                 (reason.into(), address, output.into_data())
             }
-            ExecutionResult::Halt { reason, gas: result_gas, .. } => {
-                let _ = gas.record_regular_cost(result_gas.tx_gas_used());
+            ExecutionResult::Halt { reason, .. } => {
                 (InstructionResult::from(reason), None, Bytes::new())
             }
-            ExecutionResult::Revert { gas: result_gas, output, .. } => {
-                let _ = gas.record_regular_cost(result_gas.tx_gas_used());
-                (InstructionResult::Revert, None, output)
-            }
+            ExecutionResult::Revert { output, .. } => (InstructionResult::Revert, None, output),
         };
         if rolled_back {
             refresh_chain_journal(ecx);

--- a/crates/forge/tests/cli/svm.rs
+++ b/crates/forge/tests/cli/svm.rs
@@ -116,29 +116,49 @@ contract StateGasTarget {
         value = 1;
         revert();
     }
+
+    function setValueWithData(bytes calldata) external {
+        value = 1;
+    }
 }
 
 contract StateGasTest is Test {
     uint64 constant STORAGE_SET_STATE_GAS = 64 * 1530;
-    VmGas constant vmGas = VmGas(address(uint160(uint256(keccak256("hevm cheat code")))));
+    uint256 constant CALLDATA_SIZE = 20_000;
+    uint256 constant CALL_FLOOR_BASE_GAS = 15_000;
+    uint256 constant CALLDATA_FLOOR_GAS_PER_BYTE = 64;
+    VmGas constant VM_GAS = VmGas(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    function testLastFrameGasReportsStateGas() public {
+    function testReportsStateGas() public {
         StateGasTarget target = new StateGasTarget();
         target.setValue();
 
-        assertGasSplit(vmGas.lastCallGas());
-        assertGasSplit(vmGas.lastFrameGas());
+        assertStorageWriteGas(VM_GAS.lastCallGas());
+        assertStorageWriteGas(VM_GAS.lastFrameGas());
 
         StateGasTarget revertingTarget = new StateGasTarget();
         (bool success,) = address(revertingTarget).call(
             abi.encodeCall(revertingTarget.setValueAndRevert, ())
         );
         assertFalse(success, "state gas call should revert");
-        assertEq(vmGas.lastCallGas().gasStateUsed, 0, "reverted call used state gas");
-        assertEq(vmGas.lastFrameGas().gasStateUsed, 0, "reverted frame used state gas");
+        assertEq(VM_GAS.lastFrameGas().gasStateUsed, 0, "reverted frame used state gas");
     }
 
-    function assertGasSplit(VmGas.Gas memory gas) internal pure {
+    /// forge-config: default.isolate = true
+    function testCalldataFloorPreservesRegularGas() public {
+        bytes memory data = new bytes(CALLDATA_SIZE);
+        StateGasTarget target = new StateGasTarget();
+        bytes memory callData = abi.encodeCall(target.setValueWithData, (data));
+        uint256 floorGas = CALL_FLOOR_BASE_GAS + callData.length * CALLDATA_FLOOR_GAS_PER_BYTE;
+        (bool success,) = address(target).call(callData);
+        assertTrue(success, "state gas call failed");
+
+        VmGas.Gas memory gas = VM_GAS.lastFrameGas();
+        assertEq(gas.gasTotalUsed, floorGas, "wrong calldata floor gas");
+        assertEq(gas.gasStateUsed, int64(STORAGE_SET_STATE_GAS), "wrong state gas");
+    }
+
+    function assertStorageWriteGas(VmGas.Gas memory gas) internal pure {
         assertGt(gas.gasTotalUsed, 0, "regular gas was not recorded");
         assertLt(gas.gasTotalUsed, STORAGE_SET_STATE_GAS, "state gas counted as regular gas");
         assertEq(gas.gasStateUsed, int64(STORAGE_SET_STATE_GAS), "wrong state gas");

--- a/crates/forge/tests/cli/svm.rs
+++ b/crates/forge/tests/cli/svm.rs
@@ -84,6 +84,48 @@ Ran 2 test suites [ELAPSED]: 3 tests passed, 0 failed, 0 skipped (3 total tests)
 
 forgetest_init!(can_test_with_solc_0_8_36_amsterdam, |prj, cmd| {
     prj.initialize_default_contracts();
+    prj.add_test(
+        "StateGas.t.sol",
+        r#"
+pragma solidity =0.8.36;
+
+import "forge-std/Test.sol";
+
+interface VmGas {
+    struct Gas {
+        uint64 gasLimit;
+        uint64 gasTotalUsed;
+        uint64 gasMemoryUsed;
+        int64 gasRefunded;
+        uint64 gasRemaining;
+        int64 gasStateUsed;
+    }
+
+    function lastFrameGas() external view returns (Gas memory gas);
+}
+
+contract StateGasTarget {
+    uint256 value;
+
+    function setValue() external {
+        value = 1;
+    }
+}
+
+contract StateGasTest is Test {
+    VmGas constant vmGas = VmGas(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function testLastFrameGasReportsStateGas() public {
+        StateGasTarget target = new StateGasTarget();
+        target.setValue();
+
+        VmGas.Gas memory gas = vmGas.lastFrameGas();
+        assertGt(gas.gasTotalUsed, 0, "regular gas was not recorded");
+        assertTrue(gas.gasStateUsed > 0, "state gas was not recorded");
+    }
+}
+"#,
+    );
 
     // Amsterdam is an experimental EVM version in solc 0.8.36.
     cmd.args(["test", "--use", "0.8.36", "--evm-version", "amsterdam", "--experimental"])

--- a/crates/forge/tests/cli/svm.rs
+++ b/crates/forge/tests/cli/svm.rs
@@ -101,6 +101,7 @@ interface VmGas {
         int64 gasStateUsed;
     }
 
+    function lastCallGas() external view returns (Gas memory gas);
     function lastFrameGas() external view returns (Gas memory gas);
 }
 
@@ -110,24 +111,45 @@ contract StateGasTarget {
     function setValue() external {
         value = 1;
     }
+
+    function setValueAndRevert() external {
+        value = 1;
+        revert();
+    }
 }
 
 contract StateGasTest is Test {
+    uint64 constant STORAGE_SET_STATE_GAS = 64 * 1530;
     VmGas constant vmGas = VmGas(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     function testLastFrameGasReportsStateGas() public {
         StateGasTarget target = new StateGasTarget();
         target.setValue();
 
-        VmGas.Gas memory gas = vmGas.lastFrameGas();
+        assertGasSplit(vmGas.lastCallGas());
+        assertGasSplit(vmGas.lastFrameGas());
+
+        StateGasTarget revertingTarget = new StateGasTarget();
+        (bool success,) = address(revertingTarget).call(
+            abi.encodeCall(revertingTarget.setValueAndRevert, ())
+        );
+        assertFalse(success, "state gas call should revert");
+        assertEq(vmGas.lastCallGas().gasStateUsed, 0, "reverted call used state gas");
+        assertEq(vmGas.lastFrameGas().gasStateUsed, 0, "reverted frame used state gas");
+    }
+
+    function assertGasSplit(VmGas.Gas memory gas) internal pure {
         assertGt(gas.gasTotalUsed, 0, "regular gas was not recorded");
-        assertTrue(gas.gasStateUsed > 0, "state gas was not recorded");
+        assertLt(gas.gasTotalUsed, STORAGE_SET_STATE_GAS, "state gas counted as regular gas");
+        assertEq(gas.gasStateUsed, int64(STORAGE_SET_STATE_GAS), "wrong state gas");
     }
 }
 "#,
     );
 
     // Amsterdam is an experimental EVM version in solc 0.8.36.
-    cmd.args(["test", "--use", "0.8.36", "--evm-version", "amsterdam", "--experimental"])
-        .assert_success();
+    let args = ["test", "--use", "0.8.36", "--evm-version", "amsterdam", "--experimental"];
+    cmd.args(args).assert_success();
+    cmd.forge_fuse().args(args).arg("--enable-tx-gas-limit").assert_success();
+    cmd.forge_fuse().args(args).arg("--isolate").assert_success();
 });

--- a/testdata/paris/cheats/LastCallGas.t.sol
+++ b/testdata/paris/cheats/LastCallGas.t.sol
@@ -275,7 +275,7 @@ contract LastCallGasIsolatedTest is LastCallGasFixture {
     function testRecordGasRefund() public {
         _setup();
         _performRefund();
-        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 21380, gasMemoryUsed: 0, gasRefunded: 4800}));
+        _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 26180, gasMemoryUsed: 0, gasRefunded: 4800}));
     }
 
     function testStateDiffRecordingDoesNotWarmStorageReads() public {

--- a/testdata/paris/cheats/LastCallGas.t.sol
+++ b/testdata/paris/cheats/LastCallGas.t.sol
@@ -160,6 +160,7 @@ abstract contract LastCallGasFixture is Test {
         assertEq(lhs.gasTotalUsed, rhs.gasTotalUsed);
         assertEq(lhs.gasMemoryUsed, rhs.gasMemoryUsed);
         assertEq(lhs.gasRefunded, rhs.gasRefunded);
+        assertEq(lhs.gasStateUsed, 0);
     }
 
     function _assertGasRecorded(Vm.Gas memory gas) internal {
@@ -167,6 +168,7 @@ abstract contract LastCallGasFixture is Test {
         assertGt(gas.gasRemaining, 0);
         assertGt(gas.gasTotalUsed, 0);
         assertEq(gas.gasMemoryUsed, 0);
+        assertEq(gas.gasStateUsed, 0);
     }
 }
 

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -21,7 +21,7 @@ interface Vm {
     struct Chain { string name; uint256 chainId; string chainAlias; string rpcUrl; }
     struct AccountAccess { ChainInfo chainInfo; AccountAccessKind kind; address account; address accessor; bool initialized; uint256 oldBalance; uint256 newBalance; bytes deployedCode; uint256 value; bytes data; bool reverted; StorageAccess[] storageAccesses; uint64 depth; uint64 oldNonce; uint64 newNonce; }
     struct StorageAccess { address account; bytes32 slot; bool isWrite; bytes32 previousValue; bytes32 newValue; bool reverted; }
-    struct Gas { uint64 gasLimit; uint64 gasTotalUsed; uint64 gasMemoryUsed; int64 gasRefunded; uint64 gasRemaining; }
+    struct Gas { uint64 gasLimit; uint64 gasTotalUsed; uint64 gasMemoryUsed; int64 gasRefunded; uint64 gasRemaining; int64 gasStateUsed; }
     struct DebugStep { uint256[] stack; bytes memoryInput; uint8 opcode; uint64 depth; bool isOutOfGas; address contractAddr; }
     struct BroadcastTxSummary { bytes32 txHash; BroadcastTxType txType; address contractAddress; uint64 blockNumber; bool success; }
     struct SignedDelegation { uint8 v; bytes32 r; bytes32 s; uint64 nonce; address implementation; }


### PR DESCRIPTION
Amsterdam splits regular and state gas, but `vm.lastCallGas()` and `vm.lastFrameGas()` currently expose only the regular component. This makes it difficult to measure EIP-8037 costs from Forge tests.

This appends a signed `gasStateUsed` field to `Vm.Gas` while keeping the existing five ABI words in place. The field is signed because a nested frame can return more state gas than it consumes. State gas is also preserved when Forge reconstructs isolated call results.

The coverage checks pre-Amsterdam zero behavior and an Amsterdam storage write with nonzero regular and state gas.

Addresses the follow-up requested in #16357.
