### PR TITLE
perf(forge): speed up path-filtered test listing

### DIFF
--- a/.changelog/forge-targeted-test-list.md
+++ b/.changelog/forge-targeted-test-list.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Sped up path-filtered test listing by compiling only matching test source graphs.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1811,10 +1811,23 @@ impl TestArgs {
         let quiet = shell::is_json() || self.junit;
 
         if self.list {
-            let output = compile_abi_project(
-                &mut project,
-                ProjectCompiler::new().dynamic_test_linking(dynamic_test_linking).quiet(quiet),
-            )?;
+            let compiler =
+                ProjectCompiler::new().dynamic_test_linking(dynamic_test_linking).quiet(quiet);
+            let compiler = if filter.args().path_pattern.is_some()
+                && config.extra_output.is_empty()
+                && config.extra_output_files.is_empty()
+                && !config.build_info
+            {
+                let files = project
+                    .paths
+                    .input_files_iter()
+                    .filter(|path| filter.matches_path(path))
+                    .collect::<Vec<_>>();
+                if files.is_empty() { compiler } else { compiler.files(files) }
+            } else {
+                compiler
+            };
+            let output = compile_abi_project(&mut project, compiler)?;
             let inline_config = Arc::new(InlineConfig::new_parsed(&output, &config)?);
             return Ok(CompiledTestProject {
                 project_root,

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -217,8 +217,11 @@ test/ListTests.t.sol
 
 "#]]);
 
+    // Path-filtered listing should not compile unrelated sources.
+    prj.add_test("Broken.t.sol", "contract");
     cmd.forge_fuse()
         .args(["test", "--list", "--match-test", "test_alpha", "--json"])
+        .arg("test/ListTests.t.sol")
         .assert_success()
         .stdout_eq("{\"test/ListTests.t.sol\":{\"ListTests\":[\"test_alpha\"]}}\n");
 });


### PR DESCRIPTION
Path-filtered `forge test --list` now passes only matching project roots to the existing ABI-only `ProjectCompiler`, leaving transitive imports to the compiler graph instead of compiling every configured source and filtering afterward. Empty matches and explicit `extra_output`, `extra_output_files`, or `build_info` requests retain full-project compilation, and the regression uses an invalid unrelated source to pin the target-only behavior. Developed with OpenAI Codex assistance.

### Results

Profiling builds from exact master `be4fa5bee`, with `forge clean` before every sample:

| Workload | Master | This PR | Speedup |
| --- | ---: | ---: | ---: |
| Solady, `MinHeapLib.t.sol` (10 runs) | 1.303s ± 0.021s | 140.7ms ± 5.1ms | 9.26× |
| Aave v4, `PercentageMath.t.sol` (5 runs) | 4.919s ± 0.084s | 348.9ms ± 9.7ms | 14.10× |

Solady compiler inputs fell from 208 files to 10, while the selected-test JSON matched master.
