### PR TITLE
fix(evm): enforce execution network family

### DIFF
--- a/.changelog/enforce-evm-network-family.md
+++ b/.changelog/enforce-evm-network-family.md
@@ -1,0 +1,9 @@
+---
+foundry-evm-networks: patch
+foundry-evm-core: patch
+foundry-evm: patch
+forge-script: patch
+---
+
+Rejected runtime network configurations that conflict with the selected EVM execution family and
+preserved that family when scripts switch RPC sources.

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -347,7 +347,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
             })
             .gas_limit(self.config.evm_opts.gas_limit())
             .legacy_assertions(self.config.foundry_config.legacy_assertions)
-            .build(evm_env, tx_env, backend, self.config.evm_opts.networks);
+            .build(evm_env, tx_env, backend, self.config.evm_opts.networks)?;
 
         Ok(ChiselRunner::new(executor, U256::MAX, Address::ZERO, self.config.calldata.clone()))
     }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -682,12 +682,27 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         fork: Option<CreateFork>,
     ) -> eyre::Result<Self> {
         trace!(target: "backend", forking_mode=?fork.is_some(), "creating executor backend");
+        let configured_networks =
+            fork.as_ref().map(|fork| fork.evm_opts.networks).unwrap_or_default();
+        configured_networks.validate().map_err(eyre::Report::msg)?;
+        let source_network_is_inferred = fork.as_ref().is_some_and(|fork| {
+            fork.evm_opts.fork_network_is_inferred || !configured_networks.has_network_selection()
+        });
+        let networks = if source_network_is_inferred
+            && configured_networks.execution_network() != FEN::EXECUTION_NETWORK
+        {
+            NetworkConfigs::default()
+        } else {
+            configured_networks
+        }
+        .normalize_for_execution_network(FEN::EXECUTION_NETWORK)
+        .map_err(eyre::Report::msg)?;
         // Note: this will take of registering the `fork`
         let persistent_accounts = HashSet::from(DEFAULT_PERSISTENT_ACCOUNTS);
         let inner = BackendInner { persistent_accounts, ..Default::default() };
 
         let mut backend = Self {
-            networks: NetworkConfigs::default(),
+            networks,
             forks,
             mem_db: CacheDB::new(Default::default()),
             fork_init_journaled_state: inner.new_journaled_state(),
@@ -698,7 +713,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
 
         if let Some(fork) = fork {
             let ForkResult { id: fork_id, backend: fork, resolved, .. } =
-                backend.forks.create_fork(fork)?;
+                backend.create_typed_fork(fork)?;
             let context = resolved.context();
             let block = resolved.block();
             let fork_db = ForkDB::new(fork);
@@ -718,6 +733,38 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         Ok(backend)
     }
 
+    fn create_typed_fork(
+        &self,
+        mut fork: CreateFork,
+    ) -> eyre::Result<ForkResult<AnyNetwork, SpecFor<FEN>, BlockEnvFor<FEN>>> {
+        let require_source_family_match = fork.evm_opts.fork_network_is_inferred
+            || !fork.evm_opts.networks.has_network_selection();
+        if !require_source_family_match {
+            fork.evm_opts
+                .networks
+                .normalize_for_execution_network(FEN::EXECUTION_NETWORK)
+                .map_err(eyre::Report::msg)?;
+        }
+
+        // The backend's typed EVM is already fixed. Use its profile as the fallback for endpoints
+        // without authoritative metadata, while retaining the original provenance for the check
+        // against the resolved source below.
+        fork.evm_opts.networks = self.networks;
+        fork.evm_opts.fork_network_is_inferred = false;
+        let result = self.forks.create_fork(fork)?;
+        let context = result.resolved.context();
+        if require_source_family_match
+            && !self.networks.supports_fork_source(&context.network_profile)
+        {
+            eyre::bail!(
+                "cannot create a `{}` fork with an EVM instantiated for `{}`",
+                context.network,
+                self.networks.execution_network()
+            );
+        }
+        Ok(result)
+    }
+
     /// Creates a new instance of `Backend` with fork added to the fork database and sets the fork
     /// as active
     pub(crate) fn new_with_fork(
@@ -726,8 +773,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         journaled_state: JournaledState,
         networks: NetworkConfigs,
     ) -> eyre::Result<Self> {
-        let mut backend = Self::spawn(None)?;
-        backend.networks = networks;
+        let mut backend = Self::spawn(None)?.with_networks(networks)?;
         fork.journaled_state = journaled_state;
         let fork_ids = backend.inner.insert_fork(id.clone(), fork);
         backend.inner.launched_with_fork = Some((id.clone(), fork_ids.0, fork_ids.1));
@@ -753,9 +799,16 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         self.networks
     }
 
-    /// Sets the active network configuration.
-    pub const fn set_networks(&mut self, networks: NetworkConfigs) {
-        self.networks = networks;
+    /// Sets the active network configuration before the backend is used for execution.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configuration conflicts with this backend's EVM family.
+    pub fn with_networks(mut self, networks: NetworkConfigs) -> eyre::Result<Self> {
+        self.networks = networks
+            .normalize_for_execution_network(FEN::EXECUTION_NETWORK)
+            .map_err(eyre::Report::msg)?;
+        Ok(self)
     }
 
     pub fn insert_account_info(&mut self, address: Address, account: AccountInfo) {
@@ -1924,7 +1977,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
     fn create_fork(&mut self, create_fork: CreateFork) -> eyre::Result<LocalForkId> {
         trace!("create fork");
         let ForkResult { id: fork_id, backend: fork, resolved, .. } =
-            self.forks.create_fork(create_fork)?;
+            self.create_typed_fork(create_fork)?;
         let context = resolved.context();
         let block = resolved.block();
         let fork_db = ForkDB::new(fork);
@@ -3257,7 +3310,7 @@ mod tests {
     };
     use crate::{
         backend::{Backend, DatabaseExt, ForkPosition},
-        evm::EthEvmNetwork,
+        evm::{EthEvmNetwork, TempoEvmNetwork},
         opts::EvmOpts,
     };
     use alloy_consensus::transaction::Recovered;
@@ -3301,6 +3354,61 @@ mod tests {
             journaled_state: JournalInner::new(),
             source_chain_id: 1,
             position: ForkPosition::AfterBlock { block: BlockNumHash::default() },
+        }
+    }
+
+    #[cfg(feature = "monad")]
+    #[test]
+    fn backend_networks_follow_the_evm_family() {
+        let monad = Backend::<crate::evm::MonadEvmNetwork>::spawn(None).unwrap();
+        assert!(monad.networks().is_monad());
+
+        let ethereum = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let error = ethereum.with_networks(NetworkConfigs::with_monad()).unwrap_err();
+        assert_eq!(error.to_string(), "network config `monad` conflicts with `ethereum` EVM");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn typed_backend_preserves_profiles_and_checks_inferred_fork_sources() {
+        fn fork(endpoint: String, networks: NetworkConfigs) -> crate::fork::CreateFork {
+            crate::fork::CreateFork {
+                url: endpoint.clone(),
+                enable_caching: false,
+                evm_opts: EvmOpts { fork_url: Some(endpoint), networks, ..Default::default() },
+                resolved: None,
+            }
+        }
+
+        let (_api, handle) = spawn(NodeConfig::test()).await;
+        let endpoint = handle.http_endpoint();
+
+        let celo = Backend::<EthEvmNetwork>::spawn(Some(fork(
+            endpoint.clone(),
+            NetworkConfigs::with_celo(),
+        )))
+        .unwrap();
+        assert!(celo.networks().is_celo());
+
+        let tempo = Backend::<TempoEvmNetwork>::spawn(Some(fork(
+            endpoint.clone(),
+            NetworkConfigs::default(),
+        )))
+        .unwrap();
+        assert!(tempo.networks().is_tempo());
+
+        #[cfg(feature = "monad")]
+        {
+            let error = Backend::<crate::evm::MonadEvmNetwork>::spawn(Some(fork(
+                endpoint,
+                NetworkConfigs::default(),
+            )))
+            .unwrap_err();
+            assert!(
+                error.to_string().contains(
+                    "cannot create a `ethereum` fork with an EVM instantiated for `monad`"
+                ),
+                "{error}"
+            );
         }
     }
 

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -14,6 +14,7 @@ use alloy_primitives::{Address, Signature, U256};
 use alloy_rlp::Decodable;
 use foundry_common::{FoundryReceiptResponse, FoundryTransactionBuilder, fmt::UIfmt};
 use foundry_config::ExecutionSpec;
+use foundry_evm_networks::NetworkVariant;
 use foundry_fork_db::{DatabaseError, ForkBlockEnv};
 use revm::{
     Database,
@@ -52,6 +53,9 @@ pub use tempo::*;
 
 /// Foundry's compatibility trait associating a [`Network`] with a [`FoundryEvmFactory`].
 pub trait FoundryEvmNetwork: Copy + Debug + Default + 'static {
+    /// The execution family implemented by this network's EVM factory.
+    const EXECUTION_NETWORK: NetworkVariant;
+
     type Network: Network<
             TxEnvelope: Decodable
                             + SignerRecoverable
@@ -71,6 +75,8 @@ pub trait FoundryEvmNetwork: Copy + Debug + Default + 'static {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct EthEvmNetwork;
 impl FoundryEvmNetwork for EthEvmNetwork {
+    const EXECUTION_NETWORK: NetworkVariant = NetworkVariant::Ethereum;
+
     type Network = Ethereum;
     type EvmFactory = EthEvmFactory;
 }
@@ -78,6 +84,8 @@ impl FoundryEvmNetwork for EthEvmNetwork {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct TempoEvmNetwork;
 impl FoundryEvmNetwork for TempoEvmNetwork {
+    const EXECUTION_NETWORK: NetworkVariant = NetworkVariant::Tempo;
+
     type Network = TempoNetwork;
     type EvmFactory = TempoEvmFactory;
 }
@@ -87,6 +95,8 @@ impl FoundryEvmNetwork for TempoEvmNetwork {
 pub struct MonadEvmNetwork;
 #[cfg(feature = "monad")]
 impl FoundryEvmNetwork for MonadEvmNetwork {
+    const EXECUTION_NETWORK: NetworkVariant = NetworkVariant::Monad;
+
     type Network = Ethereum;
     type EvmFactory = alloy_monad_evm::MonadEvmFactory;
 }

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -1,5 +1,6 @@
 use alloy_evm::{Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use alloy_op_evm::{OpEvm, OpEvmContext, OpEvmFactory, OpTx};
+use foundry_evm_networks::NetworkVariant;
 use foundry_fork_db::DatabaseError;
 use op_alloy_network::Optimism;
 use op_revm::{
@@ -29,6 +30,8 @@ impl FoundryChain<OpTx> for L1BlockInfo {}
 #[derive(Clone, Copy, Debug, Default)]
 pub struct OpEvmNetwork;
 impl FoundryEvmNetwork for OpEvmNetwork {
+    const EXECUTION_NETWORK: NetworkVariant = NetworkVariant::Optimism;
+
     type Network = Optimism;
     type EvmFactory = OpEvmFactory;
 }

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -78,6 +78,10 @@ impl<FEN: FoundryEvmNetwork> ExecutorBuilder<FEN> {
     }
 
     /// Builds the executor as configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the network configuration conflicts with `FEN`'s execution family.
     #[inline]
     pub fn build(
         self,
@@ -85,8 +89,10 @@ impl<FEN: FoundryEvmNetwork> ExecutorBuilder<FEN> {
         tx_env: TxEnvFor<FEN>,
         db: Backend<FEN>,
         networks: NetworkConfigs,
-    ) -> Executor<FEN> {
+    ) -> eyre::Result<Executor<FEN>> {
         let Self { mut stack, gas_limit, spec, legacy_assertions, .. } = self;
+        let db = db.with_networks(networks)?;
+        let networks = db.networks();
         stack.networks = networks;
         if stack.block.is_none() {
             stack.block = Some(evm_env.block_env.clone());
@@ -98,6 +104,6 @@ impl<FEN: FoundryEvmNetwork> ExecutorBuilder<FEN> {
         if let Some(spec) = spec {
             evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec);
         }
-        Executor::new(db, evm_env, tx_env, stack.build(), networks, gas_limit, legacy_assertions)
+        Ok(Executor::new(db, evm_env, tx_env, stack.build(), gas_limit, legacy_assertions))
     }
 }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1919,12 +1919,15 @@ mod tests {
     }
 
     fn sync_test_executor(corpus_root: PathBuf, target: Address) -> Executor<EthEvmNetwork> {
-        let mut executor = ExecutorBuilder::<EthEvmNetwork>::default().gas_limit(1 << 24).build(
-            EvmEnvFor::<EthEvmNetwork>::default(),
-            TxEnvFor::<EthEvmNetwork>::default(),
-            Backend::spawn(None).unwrap(),
-            Default::default(),
-        );
+        let mut executor = ExecutorBuilder::<EthEvmNetwork>::default()
+            .gas_limit(1 << 24)
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                Backend::spawn(None).unwrap(),
+                Default::default(),
+            )
+            .unwrap();
         executor.inspector_mut().collect_edge_coverage_with_config(&corpus_config(corpus_root));
         // CALLDATALOAD(4); PUSH1 8; JUMPI; STOP; JUMPDEST; STOP.
         executor

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -2331,7 +2331,8 @@ mod tests {
                 TxEnvFor::<EthEvmNetwork>::default(),
                 backend,
                 Default::default(),
-            );
+            )
+            .unwrap();
         let target = Address::repeat_byte(0x11);
         let mut code = vec![0x6e]; // PUSH15.
         code.extend_from_slice(MAGIC_ASSUME);
@@ -2725,12 +2726,15 @@ mod tests {
         let invariant_address = Address::repeat_byte(0x11);
         let handler_address = Address::repeat_byte(0x22);
         let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
-        let mut executor = ExecutorBuilder::default().gas_limit(GAS_LIMIT).build(
-            EvmEnvFor::<EthEvmNetwork>::default(),
-            TxEnvFor::<EthEvmNetwork>::default(),
-            backend,
-            Default::default(),
-        );
+        let mut executor = ExecutorBuilder::default()
+            .gas_limit(GAS_LIMIT)
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                backend,
+                Default::default(),
+            )
+            .unwrap();
         // Return ABI-encoded `true` for the invariant predicate.
         executor
             .set_code(

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -511,7 +511,8 @@ mod tests {
                 TxEnvFor::<EthEvmNetwork>::default(),
                 backend,
                 Default::default(),
-            );
+            )
+            .unwrap();
         let invariant_address = Address::repeat_byte(0x11);
         executor
             .set_code(

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -42,7 +42,6 @@ use foundry_evm_core::{
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::ObservedCall;
-use foundry_evm_networks::NetworkConfigs;
 use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     bytecode::Bytecode,
@@ -145,17 +144,15 @@ pub struct Executor<FEN: FoundryEvmNetwork> {
 impl<FEN: FoundryEvmNetwork> Executor<FEN> {
     /// Creates a new `Executor` with the given arguments.
     #[inline]
-    pub fn new(
+    pub(crate) fn new(
         mut backend: Backend<FEN>,
         evm_env: EvmEnvFor<FEN>,
         tx_env: TxEnvFor<FEN>,
-        mut inspector: InspectorStack<FEN>,
-        networks: NetworkConfigs,
+        inspector: InspectorStack<FEN>,
         gas_limit: u64,
         legacy_assertions: bool,
     ) -> Self {
-        inspector.networks(networks);
-        backend.set_networks(networks);
+        let networks = backend.networks();
         let extra_cheatcode_addresses = networks.extra_cheatcode_addresses();
         backend.extend_persistent_accounts(extra_cheatcode_addresses.iter().copied());
 
@@ -1802,7 +1799,8 @@ mod tests {
         Vm::{blobhashesCall, mockCallRevert_1Call, revertToStateCall, snapshotStateCall},
     };
     use foundry_config::Config;
-    use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
+    use foundry_evm_core::{constants::MAGIC_SKIP, evm::TempoEvmNetwork, opts::EvmOpts};
+    use foundry_evm_networks::NetworkConfigs;
     use foundry_evm_traces::InternalTraceMode;
     use revm::context::TxEnv;
     use std::{sync::mpsc, thread};
@@ -1848,12 +1846,14 @@ mod tests {
     #[cfg(feature = "monad")]
     #[test]
     fn executor_networks_follow_explicit_configuration() {
-        let ethereum = ExecutorBuilder::<EthEvmNetwork>::default().build(
-            EvmEnvFor::<EthEvmNetwork>::default(),
-            TxEnvFor::<EthEvmNetwork>::default(),
-            Backend::spawn(None).unwrap(),
-            NetworkConfigs::default(),
-        );
+        let ethereum = ExecutorBuilder::<EthEvmNetwork>::default()
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                Backend::spawn(None).unwrap(),
+                NetworkConfigs::default(),
+            )
+            .unwrap();
         assert!(!ethereum.backend().networks().is_monad());
         assert!(
             !ethereum
@@ -1868,12 +1868,52 @@ mod tests {
                 TxEnvFor::<foundry_evm_core::evm::MonadEvmNetwork>::default(),
                 Backend::spawn(None).unwrap(),
                 NetworkConfigs::with_monad(),
-            );
+            )
+            .unwrap();
         assert!(monad.inspector().networks.is_monad());
         assert!(monad.backend().networks().is_monad());
         assert!(
             monad.backend().is_persistent(&foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS)
         );
+    }
+
+    #[cfg(feature = "monad")]
+    #[test]
+    fn executor_networks_normalize_defaults_and_reject_conflicts() {
+        let monad = ExecutorBuilder::<foundry_evm_core::evm::MonadEvmNetwork>::default()
+            .build(
+                EvmEnvFor::<foundry_evm_core::evm::MonadEvmNetwork>::default(),
+                TxEnvFor::<foundry_evm_core::evm::MonadEvmNetwork>::default(),
+                Backend::spawn(None).unwrap(),
+                NetworkConfigs::default(),
+            )
+            .unwrap();
+        assert!(monad.backend().networks().is_monad());
+
+        let error = ExecutorBuilder::<EthEvmNetwork>::default()
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                Backend::spawn(None).unwrap(),
+                NetworkConfigs::with_monad(),
+            )
+            .unwrap_err();
+        assert_eq!(error.to_string(), "network config `monad` conflicts with `ethereum` EVM");
+    }
+
+    #[test]
+    fn executor_normalizes_networks_before_building_inspectors() {
+        let tempo = ExecutorBuilder::<TempoEvmNetwork>::default()
+            .build(
+                EvmEnvFor::<TempoEvmNetwork>::default(),
+                TxEnvFor::<TempoEvmNetwork>::default(),
+                Backend::spawn(None).unwrap(),
+                NetworkConfigs::default(),
+            )
+            .unwrap();
+
+        assert!(tempo.inspector().networks.is_tempo());
+        assert!(tempo.inspector().inner.tempo_labels.is_some());
     }
 
     #[test]
@@ -1964,12 +2004,14 @@ mod tests {
     #[test]
     fn set_spec_id_updates_spec_dependent_cfg_state() {
         let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
-        let mut executor = ExecutorBuilder::default().build(
-            EvmEnvFor::<EthEvmNetwork>::default(),
-            TxEnvFor::<EthEvmNetwork>::default(),
-            backend,
-            NetworkConfigs::default(),
-        );
+        let mut executor = ExecutorBuilder::default()
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                backend,
+                NetworkConfigs::default(),
+            )
+            .unwrap();
 
         executor.evm_env_mut().cfg_env.set_spec_and_mainnet_gas_params(SpecId::HOMESTEAD);
         assert_eq!(
@@ -2020,7 +2062,8 @@ mod tests {
             .inspectors(|stack| stack.cheatcodes(cheats_config))
             .spec_id(SpecId::AMSTERDAM)
             .gas_limit(1_000_000)
-            .build(EvmEnv::default(), TxEnv::default(), backend, NetworkConfigs::default());
+            .build(EvmEnv::default(), TxEnv::default(), backend, NetworkConfigs::default())
+            .unwrap();
 
         let target = Address::repeat_byte(0x11);
         // PUSH0; PUSH0; PUSH0; CREATE; POP; STOP.
@@ -2052,7 +2095,8 @@ mod tests {
             .inspectors(|stack| stack.cheatcodes(cheats_config))
             .spec_id(SpecId::AMSTERDAM)
             .gas_limit(1_000_000)
-            .build(EvmEnv::default(), TxEnv::default(), backend, NetworkConfigs::default());
+            .build(EvmEnv::default(), TxEnv::default(), backend, NetworkConfigs::default())
+            .unwrap();
 
         let target = Address::repeat_byte(0x11);
         let mocked = Address::repeat_byte(0x22);
@@ -2094,12 +2138,15 @@ mod tests {
     #[test]
     fn set_trace_requirements_replaces_trace_mode_between_transactions() {
         let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
-        let mut executor = ExecutorBuilder::default().gas_limit(1 << 20).build(
-            EvmEnvFor::<EthEvmNetwork>::default(),
-            TxEnvFor::<EthEvmNetwork>::default(),
-            backend,
-            NetworkConfigs::default(),
-        );
+        let mut executor = ExecutorBuilder::default()
+            .gas_limit(1 << 20)
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                backend,
+                NetworkConfigs::default(),
+            )
+            .unwrap();
         executor.evm_env_mut().cfg_env.disable_nonce_check = true;
         let target = Address::repeat_byte(0x11);
         // PUSH1 4; JUMP; STOP; JUMPDEST; PUSH1 1; PUSH1 0; SSTORE; STOP.
@@ -2138,12 +2185,15 @@ mod tests {
     fn early_exit_interrupts_active_evm_execution() {
         const GAS_LIMIT: u64 = 1 << 24;
         let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
-        let mut executor = ExecutorBuilder::default().gas_limit(GAS_LIMIT).build(
-            EvmEnvFor::<EthEvmNetwork>::default(),
-            TxEnvFor::<EthEvmNetwork>::default(),
-            backend,
-            NetworkConfigs::default(),
-        );
+        let mut executor = ExecutorBuilder::default()
+            .gas_limit(GAS_LIMIT)
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                backend,
+                NetworkConfigs::default(),
+            )
+            .unwrap();
         let early_exit = EarlyExit::new(false);
         executor.inspector_mut().set_early_exit(early_exit.clone());
 
@@ -2178,12 +2228,15 @@ mod tests {
     #[test]
     fn completed_execution_is_not_retroactively_cancelled() {
         let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
-        let mut executor = ExecutorBuilder::default().gas_limit(1 << 24).build(
-            EvmEnvFor::<EthEvmNetwork>::default(),
-            TxEnvFor::<EthEvmNetwork>::default(),
-            backend,
-            NetworkConfigs::default(),
-        );
+        let mut executor = ExecutorBuilder::default()
+            .gas_limit(1 << 24)
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                backend,
+                NetworkConfigs::default(),
+            )
+            .unwrap();
         let early_exit = EarlyExit::new(false);
         executor.inspector_mut().set_early_exit(early_exit.clone());
 
@@ -2200,12 +2253,15 @@ mod tests {
     fn campaign_deadline_interrupts_active_evm_execution() {
         const GAS_LIMIT: u64 = 1 << 24;
         let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
-        let mut executor = ExecutorBuilder::default().gas_limit(GAS_LIMIT).build(
-            EvmEnvFor::<EthEvmNetwork>::default(),
-            TxEnvFor::<EthEvmNetwork>::default(),
-            backend,
-            NetworkConfigs::default(),
-        );
+        let mut executor = ExecutorBuilder::default()
+            .gas_limit(GAS_LIMIT)
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                backend,
+                NetworkConfigs::default(),
+            )
+            .unwrap();
         let cancellation = EvmExecutionCancellation::campaign(
             EarlyExit::new(false),
             Arc::new(AtomicBool::new(false)),
@@ -2228,12 +2284,15 @@ mod tests {
     #[test]
     fn beacon_root_system_call_does_not_persist_system_address() {
         let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
-        let mut executor = ExecutorBuilder::default().spec_id(SpecId::CANCUN).build(
-            EvmEnvFor::<EthEvmNetwork>::default(),
-            TxEnvFor::<EthEvmNetwork>::default(),
-            backend,
-            NetworkConfigs::default(),
-        );
+        let mut executor = ExecutorBuilder::default()
+            .spec_id(SpecId::CANCUN)
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                backend,
+                NetworkConfigs::default(),
+            )
+            .unwrap();
         let before = executor.backend().basic_ref(SYSTEM_ADDRESS).unwrap();
 
         executor.apply_beacon_root(B256::repeat_byte(0x11)).unwrap();
@@ -2268,7 +2327,8 @@ mod tests {
         let mut executor = ExecutorBuilder::default()
             .inspectors(|stack| stack.cheatcodes(cheats_config))
             .spec_id(SpecId::CANCUN)
-            .build(EvmEnv::default(), TxEnv::default(), backend, NetworkConfigs::default());
+            .build(EvmEnv::default(), TxEnv::default(), backend, NetworkConfigs::default())
+            .unwrap();
 
         let original: Vec<B256> = vec![B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
         executor.tx_env_mut().set_blob_hashes(original.clone());

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -39,7 +39,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
                 stack.trace_requirements(trace_requirements).create2_deployer(create2_deployer)
             })
             .spec_id_opt(version.map(evm_spec_id::<SpecFor<FEN>>))
-            .build(env.0, env.1, db, networks);
+            .build(env.0, env.1, db, networks)?;
 
         // Apply the state overrides.
         if let Some(state_overrides) = state_overrides {

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -513,6 +513,34 @@ impl NetworkConfigs {
         if let Some(network) = self.resolved_network() { network } else { NetworkVariant::Ethereum }
     }
 
+    /// Resolves this configuration for an instantiated EVM's execution family.
+    ///
+    /// An unspecified family inherits a non-Ethereum EVM family and remains unresolved for an
+    /// Ethereum EVM so later RPC profile inference still works. An explicit selection must agree
+    /// with the EVM family; compatible profiles such as Celo remain unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configuration is invalid or its explicit family conflicts with
+    /// `expected`.
+    pub fn normalize_for_execution_network(self, expected: NetworkVariant) -> Result<Self, String> {
+        self.validate()?;
+        if !self.has_network_selection() {
+            return Ok(if expected.is_ethereum() {
+                self
+            } else {
+                self.with_execution_profile(expected.into())
+            });
+        }
+        if self.execution_network() != expected {
+            return Err(format!(
+                "network config `{}` conflicts with `{expected}` EVM",
+                self.execution_profile_name()
+            ));
+        }
+        Ok(self)
+    }
+
     /// Returns whether both configurations can use the same instantiated EVM backend.
     pub fn has_same_execution_profile(&self, other: &Self) -> bool {
         self.celo == other.celo
@@ -1280,6 +1308,33 @@ mod tests {
         );
         assert_eq!(NetworkConfigs::with_celo().execution_family_name(), "ethereum");
         assert_eq!(NetworkConfigs::with_celo().execution_profile_name(), "celo");
+    }
+
+    #[test]
+    fn execution_network_normalization_preserves_compatible_configuration() {
+        let ethereum = NetworkConfigs::default()
+            .normalize_for_execution_network(NetworkVariant::Ethereum)
+            .unwrap();
+        assert!(!ethereum.has_network_selection());
+
+        let default = NetworkConfigs { bypass_prevrandao: true, ..Default::default() }
+            .normalize_for_execution_network(NetworkVariant::Tempo)
+            .unwrap();
+        assert!(default.is_tempo());
+        assert!(default.bypass_prevrandao(NamedChain::Mainnet as u64));
+
+        let celo = NetworkConfigs::with_celo()
+            .normalize_for_execution_network(NetworkVariant::Ethereum)
+            .unwrap();
+        assert!(celo.is_celo());
+    }
+
+    #[test]
+    fn execution_network_normalization_rejects_explicit_conflicts() {
+        let error = NetworkConfigs::with_tempo()
+            .normalize_for_execution_network(NetworkVariant::Ethereum)
+            .unwrap_err();
+        assert_eq!(error, "network config `tempo` conflicts with `ethereum` EVM");
     }
 
     #[test]

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -375,12 +375,10 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
 
         debug!("start executing all tests in contract");
 
-        let executor = self.tcfg.executor(
-            self.known_contracts.clone(),
-            self.analysis.clone(),
-            artifact_id,
-            db.clone(),
-        );
+        let executor = self
+            .tcfg
+            .executor(self.known_contracts.clone(), self.analysis.clone(), artifact_id, db.clone())
+            .expect("test runner network configuration matches its EVM");
         let runner = ContractRunner::new(&identifier, contract, executor, span, self, context);
         let r = runner.run_tests(filter);
 
@@ -611,7 +609,7 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
         analysis: Arc<solar::sema::Compiler>,
         artifact_id: &ArtifactId,
         db: Backend<FEN>,
-    ) -> Executor<FEN> {
+    ) -> eyre::Result<Executor<FEN>> {
         let mut cheats_config = CheatsConfig::new(
             &self.config,
             self.evm_opts.clone(),

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -862,6 +862,8 @@ struct JsonResult<'a, N: Network> {
 pub struct ScriptConfig<FEN: FoundryEvmNetwork> {
     pub config: Config,
     pub evm_opts: EvmOpts,
+    /// Whether the execution family was inferred from the initial fork endpoint.
+    execution_network_is_inferred: bool,
     /// Exact network hardfork selected for script execution.
     pub hardfork: Option<FoundryHardfork>,
     /// Source chain used for trace decoding and external identifiers.
@@ -881,6 +883,7 @@ async fn resolve_script_fork(
     config: &mut Config,
     evm_opts: &mut EvmOpts,
     active_networks: Option<NetworkConfigs>,
+    execution_network_is_inferred: bool,
 ) -> Result<Option<ResolvedFork>> {
     if evm_opts.fork_url.is_none() {
         return Ok(None);
@@ -888,13 +891,24 @@ async fn resolve_script_fork(
     if evm_opts.fork_endpoint.is_none() {
         evm_opts.infer_network_from_fork().await?;
     }
-    if let Some(active_networks) = active_networks
-        && !active_networks.supports_fork_source(&evm_opts.networks)
-    {
-        eyre::bail!(
-            "fork network `{}` is incompatible with the active EVM",
-            evm_opts.networks.execution_network()
-        );
+    if let Some(active_networks) = active_networks {
+        let source_networks = evm_opts
+            .fork_endpoint
+            .as_ref()
+            .map(|identity| identity.network_profile)
+            .unwrap_or(evm_opts.networks);
+        let require_source_family_match =
+            execution_network_is_inferred || !active_networks.has_network_selection();
+        if require_source_family_match && !active_networks.supports_fork_source(&source_networks) {
+            eyre::bail!(
+                "fork network `{}` is incompatible with the active EVM",
+                source_networks.execution_network()
+            );
+        }
+        // Typed dispatch has already fixed the execution family. Preserve the endpoint profile in
+        // the resolved fork context without letting it replace the active execution configuration.
+        evm_opts.networks = active_networks;
+        evm_opts.fork_network_is_inferred = false;
     }
     config.networks = evm_opts.networks;
     if let Some(identity) = evm_opts.fork_endpoint.clone() {
@@ -914,7 +928,8 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
     ) -> Result<Self> {
         // Linking happens before runner construction, so resolve the fork context now and reuse it
         // for all preflight reads and environment construction.
-        let resolved_fork = resolve_script_fork(&mut config, &mut evm_opts, None).await?;
+        let resolved_fork = resolve_script_fork(&mut config, &mut evm_opts, None, false).await?;
+        let execution_network_is_inferred = evm_opts.fork_network_is_inferred;
         let sender_nonce = if let Some(sender_nonce) = sender_nonce_override {
             sender_nonce
         } else if evm_opts.fork_url.is_some() {
@@ -928,6 +943,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         Ok(Self {
             config,
             evm_opts,
+            execution_network_is_inferred,
             hardfork: None,
             source_chain_id: None,
             sender_nonce,
@@ -989,8 +1005,13 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
             self.evm_opts.invalidate_fork_endpoint_if_source_changed(fork);
         }
 
-        let fork =
-            resolve_script_fork(&mut self.config, &mut self.evm_opts, active_networks).await?;
+        let fork = resolve_script_fork(
+            &mut self.config,
+            &mut self.evm_opts,
+            active_networks,
+            self.execution_network_is_inferred,
+        )
+        .await?;
         self.resolved_fork = fork.clone();
         Ok(fork)
     }
@@ -1095,7 +1116,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         tx_env.set_fee_token(self.tempo.fee_token);
 
         let mut runner = ScriptRunner::new(
-            builder.build(evm_env, tx_env, db, self.evm_opts.networks),
+            builder.build(evm_env, tx_env, db, self.evm_opts.networks)?,
             self.evm_opts.clone(),
         )
         .with_debug_bytecodes(debug);
@@ -1257,6 +1278,91 @@ mod tests {
         assert_eq!(second.number(), 3);
         assert_eq!(second.context().network_profile, NetworkConfigs::with_monad());
         assert_eq!(config.evm_opts.networks, NetworkConfigs::with_ethereum());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn script_inferred_tempo_execution_is_preserved_for_an_ethereum_rpc() {
+        let (tempo_api, tempo_handle) = spawn(NodeConfig::test_tempo()).await;
+        let (ethereum_api, ethereum_handle) = spawn(NodeConfig::test()).await;
+        tempo_api.anvil_mine(Some(U256::from(1)), None).await.unwrap();
+        ethereum_api.anvil_mine(Some(U256::from(2)), None).await.unwrap();
+
+        let evm_opts = EvmOpts {
+            fork_url: Some(tempo_handle.http_endpoint()),
+            sender: tempo_handle.dev_accounts().next().unwrap(),
+            ..Default::default()
+        };
+        let mut config = ScriptConfig::<TempoEvmNetwork>::new(
+            Config::default(),
+            evm_opts,
+            false,
+            TempoOpts::default(),
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(config.evm_opts.networks.is_tempo());
+        assert!(config.evm_opts.fork_network_is_inferred);
+        config._get_runner(None, false, false).await.unwrap();
+
+        config.set_fork_url(ethereum_handle.http_endpoint());
+        let second = config.ensure_resolved_fork().await.unwrap().unwrap();
+
+        assert_eq!(second.number(), 2);
+        assert_eq!(second.context().network_profile, NetworkConfigs::default());
+        assert!(config.evm_opts.networks.is_tempo());
+        assert!(!config.evm_opts.fork_network_is_inferred);
+        config._get_runner(None, false, false).await.unwrap();
+    }
+
+    #[cfg(feature = "monad")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn script_inferred_execution_rejects_later_incompatible_rpc() {
+        let (_tempo_api, tempo_handle) = spawn(NodeConfig::test_tempo()).await;
+        let (_ethereum_api, ethereum_handle) = spawn(NodeConfig::test()).await;
+        let (_monad_api, monad_handle) = spawn(NodeConfig::test_monad()).await;
+
+        let evm_opts = EvmOpts {
+            fork_url: Some(tempo_handle.http_endpoint()),
+            sender: tempo_handle.dev_accounts().next().unwrap(),
+            ..Default::default()
+        };
+        let mut config = ScriptConfig::<TempoEvmNetwork>::new(
+            Config::default(),
+            evm_opts,
+            false,
+            TempoOpts::default(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        config.set_fork_url(ethereum_handle.http_endpoint());
+        config.ensure_resolved_fork().await.unwrap();
+        config.set_fork_url(monad_handle.http_endpoint());
+
+        let error = config.ensure_resolved_fork().await.unwrap_err();
+        assert_eq!(error.to_string(), "fork network `monad` is incompatible with the active EVM");
+    }
+
+    #[cfg(feature = "monad")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn script_unselected_execution_rejects_later_incompatible_rpc() {
+        let (_monad_api, monad_handle) = spawn(NodeConfig::test_monad()).await;
+        let mut config = ScriptConfig::<EthEvmNetwork>::new(
+            Config::default(),
+            EvmOpts::default(),
+            false,
+            TempoOpts::default(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        config.set_fork_url(monad_handle.http_endpoint());
+
+        let error = config.ensure_resolved_fork().await.unwrap_err();
+        assert_eq!(error.to_string(), "fork network `monad` is incompatible with the active EVM");
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Ensures runtime network configuration matches the EVM factory selected by the typed execution path. Backends and executors now normalize compatible defaults and reject conflicting execution families before state is executed.

Script RPC switching now keeps the selected execution family separate from the RPC state source. Compatible switches remain supported, intentional explicit overrides are preserved, and inferred switches across incompatible EVM boundaries fail clearly.