### PR TITLE
refactor(anvil): isolate Monad fork replay

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5030,21 +5030,20 @@ where
         let scheduled_hardfork =
             FoundryHardfork::from_chain_and_timestamp(source_chain_id, timestamp);
         #[cfg(feature = "monad")]
-        let explicit_monad_hardfork =
-            if self.is_monad() { self.node_config.read().await.hardfork } else { None };
-        // The target block's schedule can cross a hardfork boundary after the selected parent.
-        // Explicit Monad overrides still take precedence over timestamp inference.
+        let mut monad_replay = self
+            .prepare_monad_fork_replay(
+                source_chain_id,
+                execution_chain_id,
+                timestamp,
+                best_hash,
+                &transactions,
+            )
+            .await?;
         #[cfg(feature = "monad")]
-        let hardfork = if self.is_monad() {
-            explicit_monad_hardfork
-                .or_else(|| {
-                    monad_revm::MonadHardfork::from_chain_and_timestamp(source_chain_id, timestamp)
-                        .map(FoundryHardfork::Monad)
-                })
-                .unwrap_or_else(|| self.hardfork())
-        } else {
-            scheduled_hardfork.unwrap_or_else(|| self.hardfork())
-        };
+        let hardfork = monad_replay
+            .as_ref()
+            .map(monad::ForkReplay::hardfork)
+            .unwrap_or_else(|| scheduled_hardfork.unwrap_or_else(|| self.hardfork()));
         #[cfg(not(feature = "monad"))]
         let hardfork = scheduled_hardfork.unwrap_or_else(|| self.hardfork());
         if !self.is_optimism() && !self.is_tempo() {
@@ -5061,20 +5060,9 @@ where
         }
 
         #[cfg(feature = "monad")]
-        let monad_context = if self.is_monad() {
-            Some(self.monad_context_for_child_of_block_hash(best_hash).await?)
-        } else {
-            None
-        };
+        let monad_context = monad_replay.as_mut().and_then(monad::ForkReplay::take_context);
         #[cfg(not(feature = "monad"))]
         let monad_context = None;
-
-        #[cfg(feature = "monad")]
-        let monad_participants = self.is_monad().then(|| {
-            foundry_evm::core::evm::monad_block_participants(
-                &self.monad_historical_replay_tx_envs(&transactions),
-            )
-        });
 
         let (block_info, state_changes, block_hash) = {
             let db = self.db.read().await;
@@ -5136,14 +5124,8 @@ where
             storage.blocks.insert(block_hash, block);
             storage.hashes.insert(block_number, block_hash);
             #[cfg(feature = "monad")]
-            if let Some(participants) = monad_participants {
-                monad::store_block_metadata(
-                    &mut storage,
-                    block_hash,
-                    participants,
-                    execution_chain_id,
-                    hardfork,
-                );
+            if let Some(replay) = &mut monad_replay {
+                replay.store_metadata(&mut storage, block_hash);
             }
             for (info, receipt) in transactions.into_iter().zip(receipts) {
                 let mined_tx = MinedTransaction { info, receipt, block_hash, block_number };
@@ -5160,21 +5142,8 @@ where
         }
 
         #[cfg(feature = "monad")]
-        if self.is_monad() {
-            let spec_id = SpecId::from(hardfork);
-            evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec_id);
-            self.fees.set_execution_rules(spec_id, self.networks.base_fee_params(timestamp), None);
-            self.fees
-                .set_blob_params(foundry_evm::utils::get_blob_params(source_chain_id, timestamp));
-
-            // An inferred hardfork follows the replayed source block. Keep an explicit override
-            // fixed, even when the source schedule differs.
-            if explicit_monad_hardfork.is_none() {
-                *self.hardfork.write() = hardfork;
-                if let Some(fork) = self.fork.read().clone() {
-                    fork.config.write().hardfork = Some(hardfork);
-                }
-            }
+        if let Some(replay) = &monad_replay {
+            self.finalize_monad_fork_replay(replay, &mut evm_env);
         }
 
         evm_env.block_env.difficulty = U256::ZERO;

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -44,6 +44,7 @@ use foundry_evm::{
         },
     },
     hardfork::FoundryHardfork,
+    utils::get_blob_params,
 };
 use foundry_primitives::{FoundryReceiptEnvelope, FoundryTxEnvelope};
 use monad_revm::{MonadChainContext, MonadHardfork, instructions::monad_gas_params};
@@ -65,6 +66,40 @@ pub(super) struct PreparedExecution {
     pub(super) context: Option<MonadChainContext>,
     pub(super) kind: EnvelopeExecutionKind,
     pub(super) hardfork: MonadHardfork,
+}
+
+pub(super) struct ForkReplay {
+    hardfork: FoundryHardfork,
+    context: Option<MonadChainContext>,
+    participants: MonadBlockParticipants,
+    execution_chain_id: u64,
+    source_chain_id: u64,
+    timestamp: u64,
+    inferred_hardfork: bool,
+}
+
+impl ForkReplay {
+    pub(super) const fn hardfork(&self) -> FoundryHardfork {
+        self.hardfork
+    }
+
+    pub(super) fn take_context(&mut self) -> Option<MonadChainContext> {
+        self.context.take()
+    }
+
+    pub(super) fn store_metadata<N: Network>(
+        &mut self,
+        storage: &mut BlockchainStorage<N>,
+        block_hash: B256,
+    ) {
+        store_block_metadata(
+            storage,
+            block_hash,
+            std::mem::take(&mut self.participants),
+            self.execution_chain_id,
+            self.hardfork,
+        );
+    }
 }
 
 pub(super) fn normalize_access_list(
@@ -148,6 +183,62 @@ pub(super) fn rollback_transaction<DB: alloy_evm::Database>(
 }
 
 impl<N: Network> Backend<N> {
+    /// Prepares the Monad-specific inputs for replaying a historical transaction prefix.
+    pub(super) async fn prepare_monad_fork_replay(
+        &self,
+        source_chain_id: u64,
+        execution_chain_id: u64,
+        timestamp: u64,
+        parent_hash: B256,
+        transactions: &[HistoricalReplayTransaction],
+    ) -> Result<Option<ForkReplay>> {
+        if !self.is_monad() {
+            return Ok(None);
+        }
+
+        let explicit_hardfork = self.node_config.read().await.hardfork;
+        // The target block's schedule can cross a hardfork boundary after the selected parent.
+        // Explicit overrides still take precedence over timestamp inference.
+        let hardfork = explicit_hardfork
+            .or_else(|| {
+                MonadHardfork::from_chain_and_timestamp(source_chain_id, timestamp)
+                    .map(FoundryHardfork::Monad)
+            })
+            .unwrap_or_else(|| self.hardfork());
+        let context = self.monad_context_for_child_of_block_hash(parent_hash).await?;
+        let participants =
+            monad_block_participants(&self.monad_historical_replay_tx_envs(transactions));
+
+        Ok(Some(ForkReplay {
+            hardfork,
+            context: Some(context),
+            participants,
+            execution_chain_id,
+            source_chain_id,
+            timestamp,
+            inferred_hardfork: explicit_hardfork.is_none(),
+        }))
+    }
+
+    /// Applies the Monad execution rules selected for a completed fork replay.
+    pub(super) fn finalize_monad_fork_replay(&self, replay: &ForkReplay, evm_env: &mut EvmEnv) {
+        let spec_id = SpecId::from(replay.hardfork);
+        evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec_id);
+        self.fees.set_execution_rules(
+            spec_id,
+            self.networks.base_fee_params(replay.timestamp),
+            None,
+        );
+        self.fees.set_blob_params(get_blob_params(replay.source_chain_id, replay.timestamp));
+
+        if replay.inferred_hardfork {
+            *self.hardfork.write() = replay.hardfork;
+            if let Some(fork) = self.fork.read().clone() {
+                fork.config.write().hardfork = Some(replay.hardfork);
+            }
+        }
+    }
+
     /// Validates Monad-specific transaction type restrictions.
     pub(super) const fn validate_monad_transaction_type(
         &self,

--- a/crates/anvil/src/eth/backend/mem/monad.rs
+++ b/crates/anvil/src/eth/backend/mem/monad.rs
@@ -83,7 +83,7 @@ impl ForkReplay {
         self.hardfork
     }
 
-    pub(super) fn take_context(&mut self) -> Option<MonadChainContext> {
+    pub(super) const fn take_context(&mut self) -> Option<MonadChainContext> {
         self.context.take()
     }
 


### PR DESCRIPTION
Moves Monad-specific fork transaction replay preparation, metadata storage, and finalization from the generic in-memory backend into the Monad module. The refactor preserves execution ordering and move semantics while reducing feature-specific logic in the shared replay path.