### PR TITLE
chore(bench): update v1.8.0 results

### DIFF
--- a/benches/LATEST.md
+++ b/benches/LATEST.md
@@ -1,6 +1,6 @@
 # 📊 Foundry Benchmark Results
 
-**Generated at**: 2026-08-03 10:48:07 UTC
+**Generated at**: 2026-08-26 18:51:58 UTC
 
 ## Forge Test
 
@@ -15,25 +15,25 @@
 ### Foundry Versions
 
 - **v1.7.1**: forge Version: 1.7.1 (4072e48 2026-05-08)
-- **v1.8.0**: forge Version: 1.8.0-dev (c8993b3 2026-08-03)
+- **v1.8.0**: forge Version: 1.8.0 (61ae26a 2026-08-26)
 
 | Repository | v1.7.1 | v1.8.0 |
 |------------|----------|----------|
-| ithacaxyz-account | 1.41 s | 1.46 s |
-| vectorized-solady | 1.40 s | 1.29 s |
-| uniswap-v4-core | 2.66 s | 2.70 s |
-| sparkdotfi-spark-psm | 25.74 s | 13.45 s |
-| aave-aave-v4 | 3m 40.9s | 2m 44.9s |
+| ithacaxyz-account | 0.984 s | 1.03 s |
+| vectorized-solady | 0.904 s | 0.764 s |
+| uniswap-v4-core | 2.33 s | 2.18 s |
+| sparkdotfi-spark-psm | 17.07 s | 14.42 s |
+| aave-aave-v4 | 3m 1.5s | 2m 27.0s |
 
 ## Forge Fuzz Test
 
 | Repository | v1.7.1 | v1.8.0 |
 |------------|----------|----------|
-| ithacaxyz-account | 1.46 s | 1.42 s |
-| vectorized-solady | 1.36 s | 1.19 s |
-| uniswap-v4-core | 2.43 s | 2.50 s |
-| sparkdotfi-spark-psm | 1.87 s | 1.74 s |
-| aave-aave-v4 | 3m 18.3s | 2m 47.0s |
+| ithacaxyz-account | 1.07 s | 0.955 s |
+| vectorized-solady | 0.853 s | 0.699 s |
+| uniswap-v4-core | 2.26 s | 2.00 s |
+| sparkdotfi-spark-psm | 1.75 s | 1.54 s |
+| aave-aave-v4 | 3m 2.8s | 2m 27.4s |
 
 ## Forge Test (Isolated)
 
@@ -48,15 +48,15 @@
 ### Foundry Versions
 
 - **v1.7.1**: forge Version: 1.7.1 (4072e48 2026-05-08)
-- **v1.8.0**: forge Version: 1.8.0-dev (c8993b3 2026-08-03)
+- **v1.8.0**: forge Version: 1.8.0 (61ae26a 2026-08-26)
 
 | Repository | v1.7.1 | v1.8.0 |
 |------------|----------|----------|
-| ithacaxyz-account | 1.65 s | 1.45 s |
-| vectorized-solady | 1.37 s | 1.25 s |
-| uniswap-v4-core | 3.34 s | 2.67 s |
-| sparkdotfi-spark-psm | 26.15 s | 12.90 s |
-| aave-aave-v4 | 3m 51.1s | 3m 50.2s |
+| ithacaxyz-account | 1.06 s | 1.05 s |
+| vectorized-solady | 0.955 s | 0.879 s |
+| uniswap-v4-core | 2.37 s | 2.17 s |
+| sparkdotfi-spark-psm | 18.00 s | 14.45 s |
+| aave-aave-v4 | 3m 34.7s | 2m 55.8s |
 
 ## Forge Build
 
@@ -71,27 +71,27 @@
 ### Foundry Versions
 
 - **v1.7.1**: forge Version: 1.7.1 (4072e48 2026-05-08)
-- **v1.8.0**: forge Version: 1.8.0-dev (c8993b3 2026-08-03)
+- **v1.8.0**: forge Version: 1.8.0 (61ae26a 2026-08-26)
 
 ### No Cache
 
 | Repository | v1.7.1 | v1.8.0 |
 |------------|----------|----------|
-| ithacaxyz-account | 22.74 s | 23.40 s |
-| vectorized-solady | 13.35 s | 13.68 s |
-| uniswap-v4-core | 1m 50.4s | 1m 47.7s |
-| sparkdotfi-spark-psm | 12.33 s | 11.71 s |
-| aave-aave-v4 | 3m 20.1s | 3m 13.5s |
+| ithacaxyz-account | 23.43 s | 23.84 s |
+| vectorized-solady | 12.28 s | 12.30 s |
+| uniswap-v4-core | 1m 48.1s | 1m 48.8s |
+| sparkdotfi-spark-psm | 13.08 s | 13.33 s |
+| aave-aave-v4 | 3m 14.3s | 3m 14.1s |
 
 ### With Cache
 
 | Repository | v1.7.1 | v1.8.0 |
 |------------|----------|----------|
-| ithacaxyz-account | 0.224 s | 0.149 s |
-| vectorized-solady | 0.104 s | 0.103 s |
-| uniswap-v4-core | 0.156 s | 0.057 s |
-| sparkdotfi-spark-psm | 0.175 s | 0.065 s |
-| aave-aave-v4 | 0.308 s | 0.265 s |
+| ithacaxyz-account | 0.214 s | 0.083 s |
+| vectorized-solady | 0.107 s | 0.103 s |
+| uniswap-v4-core | 0.138 s | 0.055 s |
+| sparkdotfi-spark-psm | 0.147 s | 0.061 s |
+| aave-aave-v4 | 0.290 s | 0.207 s |
 
 ## Forge Coverage
 
@@ -105,17 +105,17 @@
 ### Foundry Versions
 
 - **v1.7.1**: forge Version: 1.7.1 (4072e48 2026-05-08)
-- **v1.8.0**: forge Version: 1.8.0-dev (c8993b3 2026-08-03)
+- **v1.8.0**: forge Version: 1.8.0 (61ae26a 2026-08-26)
 
 | Repository | v1.7.1 | v1.8.0 |
 |------------|----------|----------|
-| ithacaxyz-account | 1m 29.2s | 1m 15.9s |
-| uniswap-v4-core | 1m 2.6s | 1m 1.3s |
-| sparkdotfi-spark-psm | 2m 9.1s | 1m 40.6s |
-| aave-aave-v4 | 14m 12.1s | 13m 57.1s |
+| ithacaxyz-account | 17.70 s | 17.83 s |
+| uniswap-v4-core | 57.41 s | 58.64 s |
+| sparkdotfi-spark-psm | 2m 9.5s | 2m 0.2s |
+| aave-aave-v4 | 10m 28.4s | 8m 50.0s |
 
 ## System Information
 
 - **OS**: macos
-- **CPU**: 12
-- **Rustc**: rustc 1.97.1 (8bab26f4f 2026-07-14)
+- **CPU**: 18
+- **Rustc**: rustc 1.97.0 (2d8144b78 2026-07-07)


### PR DESCRIPTION
Updates the benchmark-page source data from the August v1.8.0-dev snapshot to the final v1.8.0 release.
