### PR TITLE
perf(config): resolve foundry.toml without re-parsing per section

### DIFF
--- a/.changelog/config-load-provider-caching.md
+++ b/.changelog/config-load-provider-caching.md
@@ -1,0 +1,9 @@
+---
+forge: patch
+cast: patch
+anvil: patch
+chisel: patch
+foundry-config: patch
+---
+
+Sped up `foundry.toml` resolution by parsing and transforming the file once per load instead of once per merged section.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2666,7 +2666,8 @@ impl Config {
         // Apply key fixes before selecting profiles, while standalone sections and profile names
         // are still distinguishable.
         let provider = ForcedSnakeCaseData(toml_provider).strict_select(profiles);
-        let provider = &BackwardsCompatTomlProvider(provider);
+        let provider = CachedProvider::new(BackwardsCompatTomlProvider(provider));
+        let provider = &provider;
 
         // merge the default profile as a base
         if profile != Self::DEFAULT_PROFILE {
@@ -2674,17 +2675,27 @@ impl Config {
         }
         // merge special keys into config
         for standalone_key in Self::STANDALONE_SECTIONS {
-            if let Some((_, fallback)) =
-                STANDALONE_FALLBACK_SECTIONS.iter().find(|(key, _)| standalone_key == key)
+            let fallback = STANDALONE_FALLBACK_SECTIONS
+                .iter()
+                .find(|(key, _)| standalone_key == key)
+                .map(|(_, fallback)| *fallback);
+
+            // Merging a section the file does not define contributes nothing, but still walks and
+            // clones the whole parsed file, so skip it.
+            if !provider.contains_profile(standalone_key)
+                && !fallback.is_some_and(|fallback| provider.contains_profile(fallback))
             {
-                figment = figment.merge(
+                continue;
+            }
+
+            figment = match fallback {
+                Some(fallback) => figment.merge(
                     provider
                         .fallback(standalone_key, fallback)
                         .wrap(profile.clone(), standalone_key),
-                );
-            } else {
-                figment = figment.merge(provider.wrap(profile.clone(), standalone_key));
-            }
+                ),
+                None => figment.merge(provider.wrap(profile.clone(), standalone_key)),
+            };
         }
         // merge the profile
         figment = figment.merge(provider);

--- a/crates/config/src/providers/ext.rs
+++ b/crates/config/src/providers/ext.rs
@@ -482,6 +482,42 @@ impl<P: Provider> Provider for BackwardsCompatTomlProvider<P> {
     }
 }
 
+/// A provider that serves an already-materialized [`Provider::data`] result.
+///
+/// The TOML chain is merged once per standalone section and once more per profile, and every one of
+/// those merges re-runs the snake-case and backwards-compat passes over the whole file. Wrapping
+/// the chain in this runs them once instead.
+pub(crate) struct CachedProvider {
+    metadata: Metadata,
+    profile: Option<Profile>,
+    data: Result<Map<Profile, Dict>, Error>,
+}
+
+impl CachedProvider {
+    pub(crate) fn new(provider: impl Provider) -> Self {
+        Self { metadata: provider.metadata(), profile: provider.profile(), data: provider.data() }
+    }
+
+    /// Whether the materialized data contains the given profile.
+    pub(crate) fn contains_profile(&self, profile: &str) -> bool {
+        self.data.as_ref().is_ok_and(|data| data.contains_key(&Profile::new(profile)))
+    }
+}
+
+impl Provider for CachedProvider {
+    fn metadata(&self) -> Metadata {
+        self.metadata.clone()
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, Error> {
+        self.data.clone()
+    }
+
+    fn profile(&self) -> Option<Profile> {
+        self.profile.clone()
+    }
+}
+
 /// Adapts deprecated labels from arbitrary external providers.
 pub(crate) struct LegacyLabelsProvider<P>(pub(crate) P);
 

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -4,7 +4,20 @@ use figment::{
     value::{Dict, Map, Value},
 };
 use heck::ToSnakeCase;
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::LazyLock,
+};
+
+/// The serialized default [`Config`], used to decide which keys a `foundry.toml` may contain.
+///
+/// Only key names are read from this, and those are fixed by the struct definitions, so it is built
+/// once instead of once per config load. Serializing a default `Config` is not cheap: it walks
+/// every field of the struct and of all its nested section configs.
+static DEFAULT_CONFIG_DICT: LazyLock<Option<Dict>> = LazyLock::new(|| {
+    let data = figment::providers::Serialized::defaults(&Config::default()).data().ok()?;
+    data.get(&Config::DEFAULT_PROFILE).cloned()
+});
 
 /// Allowed keys for CompilationRestrictions.
 const COMPILATION_RESTRICTIONS_KEYS: &[&str] = &[
@@ -152,11 +165,15 @@ impl<P: Provider> WarningsProvider<P> {
 
         let mut out = self.old_warnings.clone()?;
 
+        // Resolving the source rebuilds the underlying provider's metadata, so do it once here
+        // rather than per warning site.
+        let source = self.provider.metadata().source.map(|source| source.to_string());
+
         // Add warning for unknown sections.
         out.extend(data.keys().filter(|k| !Config::is_standalone_section(k.as_str())).map(
-            |unknown_section| {
-                let source = self.provider.metadata().source.map(|s| s.to_string());
-                Warning::UnknownSection { unknown_section: unknown_section.clone(), source }
+            |unknown_section| Warning::UnknownSection {
+                unknown_section: unknown_section.clone(),
+                source: source.clone(),
             },
         ));
 
@@ -184,9 +201,7 @@ impl<P: Provider> WarningsProvider<P> {
         self.collect_deprecated_label_warnings(&data, profiles.clone(), &mut out);
 
         // Add warning for unknown keys within profiles (root keys only here).
-        if let Ok(default_map) = figment::providers::Serialized::defaults(&Config::default()).data()
-            && let Some(default_dict) = default_map.get(&Config::DEFAULT_PROFILE)
-        {
+        if let Some(default_dict) = DEFAULT_CONFIG_DICT.as_ref() {
             let allowed_keys: BTreeSet<String> = default_dict.keys().cloned().collect();
             for profile_map in profiles.clone() {
                 for (profile, value) in profile_map {
@@ -194,12 +209,7 @@ impl<P: Provider> WarningsProvider<P> {
                         continue;
                     };
 
-                    let source = self
-                        .provider
-                        .metadata()
-                        .source
-                        .map(|s| s.to_string())
-                        .unwrap_or(Config::FILE_NAME.to_string());
+                    let source = source.clone().unwrap_or_else(|| Config::FILE_NAME.to_string());
                     for key in profile_dict.keys() {
                         let is_not_deprecated = !Self::is_deprecated_profile_key(key);
                         let is_not_allowed = !allowed_keys.contains(key)
@@ -233,7 +243,12 @@ impl<P: Provider> WarningsProvider<P> {
             }
 
             // Add warning for unknown keys in standalone sections.
-            self.collect_standalone_section_warnings(&data, default_dict, &mut out);
+            self.collect_standalone_section_warnings(
+                &data,
+                default_dict,
+                source.as_deref(),
+                &mut out,
+            );
         }
 
         Ok(out)
@@ -244,14 +259,10 @@ impl<P: Provider> WarningsProvider<P> {
         &self,
         data: &Map<Profile, Dict>,
         default_dict: &Dict,
+        source: Option<&str>,
         out: &mut Vec<Warning>,
     ) {
-        let source = self
-            .provider
-            .metadata()
-            .source
-            .map(|s| s.to_string())
-            .unwrap_or(Config::FILE_NAME.to_string());
+        let source = source.unwrap_or(Config::FILE_NAME).to_string();
 
         for section_name in Config::STANDALONE_SECTIONS {
             // Get the section from the parsed data


### PR DESCRIPTION
`Config::merge_toml_provider` merges the TOML provider once per standalone section, once for the default profile and once for the selected profile. Every one of those merges re-ran the whole provider chain — the snake-case pass and the backwards-compat pass over the entire parsed file, on top of a full clone of it. With sixteen standalone sections that is eighteen passes over the file per config load, and fourteen of them typically produce nothing at all because the file does not define the section.

This materializes the transformed data once behind a small `CachedProvider` and skips the merge outright for sections the file does not define. `WarningsProvider` also serialized a default `Config` on every load just to read its key names; those are fixed by the struct definitions, so it moves behind a `LazyLock`, and the provider metadata lookups move out of the per-profile loops.

Config resolution runs on every `forge`, `cast`, `anvil` and `chisel` invocation, so this is startup cost paid by every command.

### Results

`Config::load_with_root`, min of six 400-iteration rounds, `profiling` builds:

| Project | master | this PR | delta |
| --- | ---: | ---: | ---: |
| aave-v4 | 3.09 ms | 2.03 ms | -34.4% |
| vectorized/solady | 1.26 ms | 0.70 ms | -44.1% |
| ithacaxyz/account | 41.37 ms | 38.93 ms | -5.9% |

`forge config` wall time, hyperfine, against a 7.2 ms process floor:

| Project | master | this PR | delta |
| --- | ---: | ---: | ---: |
| aave-v4 | 11.2 ms | 10.2 ms | -9.5% |
| ithacaxyz/account | 50.6 ms | 48.0 ms | -5.1% |

`account` moves least because its config load is dominated by something else: 87% of it is `find_remapping_candidates` walking the 1631 directories under `lib/` for remappings auto-detection. That lives in `foundry-compilers` and is untouched here.

> AI assistance: Claude profiled the config load path, implemented the change and ran the benchmarks.
