### PR TITLE
perf(forge): gate lock check behind --locked

### DIFF
--- a/.changelog/forge-lock-check.md
+++ b/.changelog/forge-lock-check.md
@@ -3,4 +3,4 @@ forge: minor
 foundry-cli: patch
 ---
 
-Added `forge build --locked` to fail before installation or compilation when `foundry.lock` diverges from direct Git dependency submodules.
+Added opt-in `forge build --locked` to fail before installation or compilation when `foundry.lock` diverges from direct Git dependency submodules.

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -94,7 +94,7 @@ impl BuildArgs {
         let mut config = self.load_config()?;
 
         if locked {
-            self.check_foundry_lock_consistency(&config, true)?;
+            self.check_foundry_lock_consistency(&config)?;
         }
 
         if install::install_missing_dependencies(&mut config).await && config.auto_detect_remappings
@@ -104,9 +104,6 @@ impl BuildArgs {
         }
 
         self.check_soldeer_lock_consistency(&config).await;
-        if !locked {
-            self.check_foundry_lock_consistency(&config, false)?;
-        }
 
         let project = config.project()?;
 
@@ -303,33 +300,19 @@ impl BuildArgs {
     }
 
     /// Checks foundry.lock file consistency with Git submodules.
-    fn check_foundry_lock_consistency(&self, config: &Config, locked: bool) -> Result<()> {
+    fn check_foundry_lock_consistency(&self, config: &Config) -> Result<()> {
         let git = Git::new(&config.root);
         let mut lockfile = Lockfile::new(&config.root).with_git(&git);
-        let mismatches = match lockfile.check() {
-            Ok(mismatches) => mismatches,
-            Err(err) if locked => return Err(err),
-            Err(err) => {
-                sh_warn!("Failed to check foundry.lock: {err}")?;
-                return Ok(());
-            }
-        };
+        let mismatches = lockfile.check()?;
         if mismatches.is_empty() {
             return Ok(());
         }
 
-        if locked {
-            let mut message = String::from("foundry.lock does not match installed dependencies:");
-            for mismatch in mismatches {
-                write!(message, "\n  {mismatch}")?;
-            }
-            return Err(eyre::eyre!(message));
-        }
-
+        let mut message = String::from("foundry.lock does not match installed dependencies:");
         for mismatch in mismatches {
-            sh_warn!("{mismatch}")?;
+            write!(message, "\n  {mismatch}")?;
         }
-        Ok(())
+        Err(eyre::eyre!(message))
     }
 }
 

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -899,50 +899,6 @@ forgetest_init!(build_no_warning_without_soldeer_lock, |prj, cmd| {
 "#]]);
 });
 
-// tests that malformed foundry.lock triggers a warning during build
-forgetest_init!(build_warns_on_malformed_foundry_lock, |prj, cmd| {
-    let foundry_lock = prj.root().join("foundry.lock");
-    fs::write(&foundry_lock, "this is not valid toml { [ }").unwrap();
-
-    cmd.args(["build"]).assert_success().stderr_eq(str![[r#"
-Warning: Failed to check foundry.lock: Failed to read foundry.lock; expected ident at line 1 column 2
-...
-"#]]);
-});
-
-// tests that build warns when dependencies are missing from foundry.lock
-forgetest_init!(build_warns_without_foundry_lock, |prj, cmd| {
-    let foundry_lock = prj.root().join("foundry.lock");
-    // Remove foundry.lock if it exists from template
-    let _ = fs::remove_file(&foundry_lock);
-
-    cmd.args(["build"]).assert_success().stderr_eq(str![[r#"
-Warning: lib/forge-std: missing from foundry.lock (found [..])
-
-"#]]);
-});
-
-// tests that build warns when foundry.lock revision differs from actual submodule revision
-forgetest_init!(build_warns_on_foundry_lock_revision_mismatch, |prj, cmd| {
-    let foundry_lock = prj.root().join("foundry.lock");
-
-    // Write a foundry.lock with a fake/old revision for forge-std that differs from the actual
-    let lockfile_content = r#"{
-  "lib/forge-std": {
-    "tag": {
-      "name": "v1.9.7",
-      "rev": "0000000000000000000000000000000000000000"
-    }
-  }
-}"#;
-    fs::write(&foundry_lock, lockfile_content).unwrap();
-
-    cmd.args(["build"]).assert_success().stderr_eq(str![[r#"
-Warning: lib/forge-std: expected 0000000000000000000000000000000000000000, found [..]
-
-"#]]);
-});
-
 forgetest_init!(build_locked_succeeds_when_dependencies_match, |_prj, cmd| {
     cmd.args(["build", "--locked"]).assert_success();
 });
@@ -1022,7 +978,7 @@ Context:
 "#]]);
 });
 
-forgetest_init!(build_locked_reports_revision_mismatch, |prj, cmd| {
+forgetest_init!(build_checks_foundry_lock_only_when_locked, |prj, cmd| {
     let foundry_lock = prj.root().join("foundry.lock");
     let lockfile = r#"{
   "lib/forge-std": {
@@ -1030,13 +986,18 @@ forgetest_init!(build_locked_reports_revision_mismatch, |prj, cmd| {
   }
 }"#;
     fs::write(&foundry_lock, lockfile).unwrap();
+
+    cmd.args(["build"]).assert_success().stderr_eq("");
+
     fs::write(prj.root().join("src/Broken.sol"), "this is not Solidity").unwrap();
 
-    cmd.args(["build", "--locked"]).assert_failure().stdout_eq("").stderr_eq(str![[r#"
+    cmd.forge_fuse().args(["build", "--locked"]).assert_failure().stdout_eq("").stderr_eq(str![[
+        r#"
 Error: foundry.lock does not match installed dependencies:
   lib/forge-std: expected 0000000000000000000000000000000000000000, found [..]
 
-"#]]);
+"#
+    ]]);
     assert_eq!(fs::read_to_string(foundry_lock).unwrap(), lockfile);
 });
 


### PR DESCRIPTION
Ordinary `forge build` currently checks `foundry.lock` consistency even when the user did not opt into `--locked`. That walks Git submodules on every cache-hit build and turns the new opt-in validation into default work.

This gates the check entirely behind `--locked`, keeps its early failure before dependency installation or compilation, and simplifies the helper now that it only has a strict path. The CLI coverage is consolidated into one test that proves ordinary builds ignore a mismatched lockfile while `forge build --locked` reports it before a deliberately broken Solidity source is compiled.

### Results

Measured with `dist` binaries on an 18-core Apple M5 Pro, using five runs of `FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build` after an untimed warm build. The baseline is tagged v1.8.0 before this change.

| Cached build | v1.8.0 | this PR | delta |
| --- | ---: | ---: | ---: |
| `ithacaxyz-account` | 0.467s | 0.083s | -82.2% |
| `vectorized-solady` | 0.116s | 0.103s | -11.6% |
| `uniswap-v4-core` | 0.273s | 0.055s | -79.7% |
| `sparkdotfi-spark-psm` | 0.345s | 0.061s | -82.2% |
| `aave-aave-v4` | 0.351s | 0.207s | -41.0% |

Validation covers the locked-build CLI suite, the watch argument unit test, formatting, diff checks, and `cargo clippy -p forge --lib -- -D warnings`.

Prepared with Codex.
