### PR TITLE
chore(deps): bump Solar to 4237b97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1450,7 +1450,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -1467,7 +1467,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -1487,7 +1487,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -1508,7 +1508,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "zeroize",
@@ -1526,7 +1526,7 @@ dependencies = [
  "ark-std 0.6.0",
  "digest 0.10.7",
  "educe",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "zeroize",
 ]
@@ -1577,7 +1577,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1589,7 +1589,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1602,7 +1602,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1615,7 +1615,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1649,7 +1649,7 @@ dependencies = [
  "ark-std 0.6.0",
  "educe",
  "itertools 0.14.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "tracing",
@@ -1689,7 +1689,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1701,7 +1701,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1713,7 +1713,7 @@ dependencies = [
  "ark-serialize-derive",
  "ark-std 0.6.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
  "serde_with",
 ]
 
@@ -2627,7 +2627,7 @@ dependencies = [
  "boa_macros",
  "boa_string",
  "indexmap 2.14.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "rustc-hash",
 ]
 
@@ -2661,7 +2661,7 @@ dependencies = [
  "indexmap 2.14.0",
  "intrusive-collections",
  "itertools 0.14.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "num_enum",
@@ -2737,7 +2737,7 @@ dependencies = [
  "boa_macros",
  "fast-float2",
  "icu_properties",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "regress",
  "rustc-hash",
@@ -2773,7 +2773,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2981,7 +2981,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "comfy-table 8.0.0",
+ "comfy-table",
  "dirs",
  "dunce",
  "evmole",
@@ -3267,7 +3267,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.20",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3426,7 +3426,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3437,16 +3437,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "comfy-table"
-version = "7.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
-dependencies = [
- "unicode-segmentation",
- "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3679,7 +3669,7 @@ dependencies = [
  "commonware-utils",
  "either",
  "futures",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-rational",
  "num-traits",
@@ -3839,7 +3829,7 @@ dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.3",
  "hashbrown 0.16.1",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-rational",
  "num-traits",
@@ -4670,7 +4660,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4977,7 +4967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5146,7 +5136,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5316,7 +5306,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clearscreen",
- "comfy-table 8.0.0",
+ "comfy-table",
  "ctrlc",
  "dialoguer",
  "dunce",
@@ -5759,7 +5749,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "clap",
- "comfy-table 8.0.0",
+ "comfy-table",
  "dunce",
  "eyre",
  "flate2",
@@ -5809,7 +5799,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-serde",
  "chrono",
- "comfy-table 8.0.0",
+ "comfy-table",
  "eyre",
  "foundry-macros",
  "op-alloy-consensus",
@@ -6591,8 +6581,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -7046,7 +7036,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7406,7 +7396,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8261,7 +8251,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8270,7 +8260,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -8287,6 +8277,16 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -8339,7 +8339,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -8500,7 +8500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -9536,7 +9536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9688,7 +9688,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10957,7 +10957,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -11064,7 +11064,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11123,7 +11123,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11806,7 +11806,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "thiserror 2.0.20",
  "time",
@@ -11888,7 +11888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11901,7 +11901,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11917,7 +11917,7 @@ dependencies = [
 [[package]]
 name = "solar-cli"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -11943,7 +11943,7 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -11962,7 +11962,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "alloy-primitives",
  "idna_adapter",
@@ -11980,7 +11980,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11992,7 +11992,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "bumpalo",
  "diff",
@@ -12007,7 +12007,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream",
@@ -12015,7 +12015,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -12035,7 +12035,7 @@ dependencies = [
 [[package]]
 name = "solar-lint"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "rayon",
  "solar-ast",
@@ -12046,7 +12046,7 @@ dependencies = [
 [[package]]
 name = "solar-lsp"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "async-lsp",
  "crop",
@@ -12060,7 +12060,7 @@ dependencies = [
  "solar-interface",
  "solar-parse",
  "solar-sema",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "toml_edit",
@@ -12071,7 +12071,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12081,14 +12081,14 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-rational",
  "num-traits",
  "ruint",
@@ -12102,17 +12102,17 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=a1568c0b841cf7ad7c4f397222db25843a856c67#a1568c0b841cf7ad7c4f397222db25843a856c67"
+source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "comfy-table 7.2.2",
+ "comfy-table",
  "derive_more",
  "either",
  "indexmap 2.14.0",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-traits",
  "once_map",
  "paste",
@@ -12560,7 +12560,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12788,7 +12788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13968,7 +13968,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14116,7 +14116,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -565,10 +565,10 @@ snapbox = { version = "1.2", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "a1568c0b841cf7ad7c4f397222db25843a856c67" }
-solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "a1568c0b841cf7ad7c4f397222db25843a856c67" }
-solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "a1568c0b841cf7ad7c4f397222db25843a856c67" }
-solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "a1568c0b841cf7ad7c4f397222db25843a856c67" }
+solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e9152721e4d2236d2304ae480fd18655c" }
+solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e9152721e4d2236d2304ae480fd18655c" }
+solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e9152721e4d2236d2304ae480fd18655c" }
+solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e9152721e4d2236d2304ae480fd18655c" }
 
 ## foundry-core
 foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "78e5b57f86986eabd969a5fdf238b8159f7086fd" }

--- a/crates/lint/src/sol/gas/cache_array_length.rs
+++ b/crates/lint/src/sol/gas/cache_array_length.rs
@@ -56,7 +56,9 @@ impl<'hir> LateLintPass<'hir> for CacheArrayLength {
         hir: &'hir hir::Hir<'hir>,
         stmt: &'hir hir::Stmt<'hir>,
     ) {
-        let StmtKind::Loop(block, LoopSource::For) = &stmt.kind else { return };
+        let StmtKind::Loop(block, LoopSource::For | LoopSource::ForWithUpdate) = &stmt.kind else {
+            return;
+        };
         let Some((condition, body)) = for_loop_parts(*block) else { return };
 
         let mut reads = Vec::new();

--- a/crates/lint/src/sol/high/enumerable_loop_removal.rs
+++ b/crates/lint/src/sol/high/enumerable_loop_removal.rs
@@ -78,11 +78,12 @@ impl<'hir> LoopFinder<'_, '_, '_, 'hir> {
         // which runs once, on the straight line entering the loop.
         if let StmtKind::Block(block) = &stmt.kind
             && let Some(last) = block.stmts.last()
-            && let StmtKind::Loop(body, LoopSource::For) = &last.kind
+            && let StmtKind::Loop(body, source @ (LoopSource::For | LoopSource::ForWithUpdate)) =
+                &last.kind
         {
             let init = &block.stmts[..block.stmts.len() - 1];
             self.walk_body(init);
-            self.enter_loop(init, body.stmts, LoopSource::For);
+            self.enter_loop(init, body.stmts, *source);
             return;
         }
         match &stmt.kind {
@@ -237,7 +238,7 @@ impl<'hir> LoopFinder<'_, '_, '_, 'hir> {
 /// that does not match the exact synthetic shape is returned unchanged.
 const fn real_body<'hir>(source: LoopSource, body: &'hir [Stmt<'hir>]) -> &'hir [Stmt<'hir>] {
     match source {
-        LoopSource::For | LoopSource::While => {
+        LoopSource::For | LoopSource::ForWithUpdate | LoopSource::While => {
             if let [only] = body
                 && let StmtKind::If(_, then, Some(else_)) = &only.kind
                 && matches!(else_.kind, StmtKind::Break)

--- a/crates/lint/src/sol/high/function_selector_collision.rs
+++ b/crates/lint/src/sol/high/function_selector_collision.rs
@@ -536,7 +536,7 @@ impl<'hir> DelegateTargetCollector<'hir> {
             }
 
             self.paths = std::mem::take(&mut pending);
-            let next = if source == hir::LoopSource::For
+            let next = if source == hir::LoopSource::ForWithUpdate
                 && let Some((next, for_exits)) = self.visit_for_iteration(block)
             {
                 Self::extend_unique(&mut exits, for_exits);

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -559,7 +559,7 @@ impl<'hir> Analyzer<'hir> {
         }) else {
             return;
         };
-        if matches!(source, LoopSource::For)
+        if matches!(source, LoopSource::ForWithUpdate)
             && let Some(next) = for_loop_next_expr(block)
         {
             self.add_expr_effects(next, &mut effects);


### PR DESCRIPTION
Updates Solar from `a1568c0b841cf7ad7c4f397222db25843a856c67` to `4237b97e9152721e4d2236d2304ae480fd18655c` and refreshes the lockfile. Solar now distinguishes `for` loops with non-empty update expressions through `LoopSource::ForWithUpdate`; the affected lint analyses are updated to preserve their existing control-flow behavior.

This dependency-maintenance change should use `L-ignore` rather than a release-note fragment.

This PR was written by Codex.

Prompted by: @DaniPopes
