### PR TITLE
perf(config): skip remapping auto-detection in Config::with_root

### DIFF
--- a/.changelog/config-skip-eager-remappings.md
+++ b/.changelog/config-skip-eager-remappings.md
@@ -1,0 +1,9 @@
+---
+forge: patch
+cast: patch
+anvil: patch
+chisel: patch
+foundry-config: patch
+---
+
+Sped up config resolution in projects with large `lib` trees by no longer auto-detecting remappings for a path layout that discards them.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2108,8 +2108,13 @@ impl Config {
     }
 
     fn _with_root(root: &Path) -> Self {
-        // autodetect paths
-        let paths = ProjectPathsConfig::builder().build_with_root::<()>(root);
+        // Autodetect the source, artifact and library directories from `root`.
+        let paths = ProjectPathsConfig::builder()
+            // The builder autodetects remappings too, which is a separate and far more expensive
+            // scan: it recursively walks every directory under every library path. Only the
+            // directories are read below, so opt out of it.
+            .remappings(Vec::new())
+            .build_with_root::<()>(root);
         let artifacts: PathBuf = paths.artifacts.file_name().unwrap().into();
         let mut config = Self::default();
         if config.uses_default_src() {


### PR DESCRIPTION
`ProjectPathsConfigBuilder::build_with_root` auto-detects remappings when none are configured:

```rust
remappings: self.remappings.unwrap_or_else(|| {
    libraries.iter().flat_map(|p| Remapping::find_many(p)).collect()
}),
```

`Remapping::find_many` recursively walks every directory under every library path. `Config::_with_root` calls the builder only to learn the source, artifact and library directory names — it never touches `paths.remappings` — so that entire scan is thrown away.

The waste compounds. `Config::with_root` runs once for the project root, then once more for every nested dependency config that `find_nested_foundry_remappings` loads, and afterwards `RemappingsProvider` performs the scan again for real. On ithacaxyz/account a wall-clock profile of the main thread showed `Config::_with_root` and `RemappingsProvider::data` each blocking for ~44% of the load — two full walks of the same 1631-directory tree, one of which was pure waste.

Passing an empty remapping list opts out of the eager scan. Nothing downstream changes, since the field was never read here.

### Results

`Config::load_with_root`, min of five 200-iteration rounds, `profiling` builds:

| Project | `lib` dirs | master | this PR | delta |
| --- | ---: | ---: | ---: | ---: |
| ithacaxyz/account | 1631 | 38.44 ms | 18.64 ms | -51.5% |
| aave-v4 | 24 | 3.44 ms | 3.26 ms | -5.3% |
| vectorized/solady | 6 | 1.43 ms | 1.45 ms | neutral |

`forge config` wall time, hyperfine, 25 runs:

| Project | master | this PR | delta |
| --- | ---: | ---: | ---: |
| ithacaxyz/account | 46.1 ms | 28.0 ms | **-39.3%** |
| aave-v4 | 11.9 ms | 11.8 ms | neutral |

System time on `account` halves, 287 ms to 147 ms, which is the one eliminated walk.

Projects with small `lib` trees see nothing; the win scales with dependency count, so monorepo-style projects benefit most. Independent of #16394, which speeds up the figment side of the same load.

> AI assistance: Claude profiled the config load path, found the discarded scan and ran the benchmarks.
