### PR TITLE
fix(ci): stop losing nightly regression reports to a missing label

### DIFF
--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -199,6 +199,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          LABEL: T-perf
         run: |
           DATE=$(date -u +%Y-%m-%d)
           BODY="$(cat results/regression.md)
@@ -210,8 +211,8 @@ jobs:
           **Repo benchmarked**: \`aave/aave-v4\` (pinned commit)
           **Threshold**: Per-benchmark calibrated thresholds from \`.github/benchmark-regression-thresholds.json\`"
 
-          gh issue create \
-            --title "[Nightly Regression] ${DATE}" \
-            --body "$BODY" \
-            --label "regression" \
-            --repo "$GH_REPO"
+          # `gh issue create` resolves labels before it creates anything, so a label that does not
+          # exist fails the whole step and the regression goes unreported. That silently dropped
+          # four consecutive nightly alerts, so fall back to filing the issue without the label.
+          ARGS=(--title "[Nightly Regression] ${DATE}" --body "$BODY" --repo "$GH_REPO")
+          gh issue create "${ARGS[@]}" --label "$LABEL" || gh issue create "${ARGS[@]}"


### PR DESCRIPTION
The nightly benchmark's `Report Regression` job files its report with `gh issue create --label "regression"`. That label does not exist in this repository — the closest thing is `T-perf` — and `gh` resolves labels before it creates anything, so the command fails with

```
could not add label: 'regression' not found
##[error]Process completed with exit code 1
```

without opening an issue, and takes the job down with it.

The job only runs when `has_regression == 'true'`, so the failure mode is the worst one available: every night a regression is detected, the report is generated, uploaded as an artifact, and then discarded. `benchmarks-nightly` has failed for four consecutive nights (last success 2026-08-22), and no `[Nightly Regression]` issue has ever been filed in this repository.

The reports it was trying to file are not noise. From the `bench-results` artifacts of those runs:

| Date | `forge_test/aave-v4` | `forge_fuzz_test/aave-v4` |
| --- | ---: | ---: |
| 2026-08-24 | +26.28% | +35.64% |
| 2026-08-25 | +27.17% | +25.10% |
| 2026-08-26 | +23.00% | +22.24% |

That is the regression #16367 is fixing. #16312 merged on 2026-08-21, the 2026-08-22 nightly was still clean, and the alert started the following night once the published nightly binary picked it up — consistent with it being specific to `dist` builds. So the detector worked correctly and tried to report it four times; the missing label swallowed every attempt, which is why it took a manual investigation to find.

Two changes here:

- file under the existing `T-perf` label instead of the non-existent `regression`
- fall back to filing the issue unlabeled if labeling fails, so a label problem can never discard a regression report again

I verified both paths against a stubbed `gh` under `bash -e`: with the label present it files once and exits 0; with the label missing the first call fails, the fallback files the issue, and the step still exits 0. Since `gh` resolves labels before creating, the fallback cannot produce a duplicate — confirmed by there being no `[Nightly Regression]` issues despite four failed attempts.

If you would rather keep a dedicated label, creating `regression` in repo settings and reverting the `LABEL` value works too; the fallback is worth keeping either way.

This is a CI-only change, so it has no changelog entry and needs the `L-ignore` label.

> AI assistance: Claude found the failing step while investigating why bench results were not being reported, and prepared this fix.
