### PR TITLE
fix(forge): reload LSP workspace config

### DIFF
--- a/.changelog/forge-lsp-config-reload.md
+++ b/.changelog/forge-lsp-config-reload.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `forge lsp` to reload host-resolved workspace settings after `foundry.toml` changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2773,7 +2773,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3267,7 +3267,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.20",
  "which",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3426,7 +3426,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4660,7 +4660,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4967,7 +4967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5136,7 +5136,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6581,8 +6581,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -7036,7 +7036,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7396,7 +7396,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8251,7 +8251,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8500,7 +8500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -9536,7 +9536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9688,7 +9688,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11064,7 +11064,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11123,7 +11123,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11888,7 +11888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11901,7 +11901,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11917,10 +11917,12 @@ dependencies = [
 [[package]]
 name = "solar-cli"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
+ "anstream",
+ "anstyle",
  "bitflags 2.13.1",
  "cfg-if",
  "clap",
@@ -11943,7 +11945,7 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -11962,7 +11964,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "alloy-primitives",
  "idna_adapter",
@@ -11980,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11992,7 +11994,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "bumpalo",
  "diff",
@@ -12007,7 +12009,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream",
@@ -12015,7 +12017,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -12027,7 +12029,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.20",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -12035,7 +12037,7 @@ dependencies = [
 [[package]]
 name = "solar-lint"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "rayon",
  "solar-ast",
@@ -12046,7 +12048,7 @@ dependencies = [
 [[package]]
 name = "solar-lsp"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "async-lsp",
  "crop",
@@ -12060,7 +12062,7 @@ dependencies = [
  "solar-interface",
  "solar-parse",
  "solar-sema",
- "thiserror 2.0.20",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "toml_edit",
@@ -12071,7 +12073,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12081,12 +12083,12 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint 0.5.1",
  "num-rational",
@@ -12102,7 +12104,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=4237b97e9152721e4d2236d2304ae480fd18655c#4237b97e9152721e4d2236d2304ae480fd18655c"
+source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -12421,7 +12423,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror 1.0.69",
  "url",
  "zip 8.6.0",
 ]
@@ -12560,7 +12562,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12788,7 +12790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13968,7 +13970,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14116,7 +14118,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2773,7 +2773,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3267,7 +3267,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.20",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3426,7 +3426,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4660,7 +4660,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4967,7 +4967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5136,7 +5136,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6581,8 +6581,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -7036,7 +7036,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7396,7 +7396,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8251,7 +8251,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8500,7 +8500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -9536,7 +9536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9688,7 +9688,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11064,7 +11064,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11123,7 +11123,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11888,7 +11888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11901,7 +11901,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11917,7 +11917,7 @@ dependencies = [
 [[package]]
 name = "solar-cli"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -11945,7 +11945,7 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -11964,7 +11964,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "alloy-primitives",
  "idna_adapter",
@@ -11982,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11994,7 +11994,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "bumpalo",
  "diff",
@@ -12009,7 +12009,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream",
@@ -12017,7 +12017,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -12029,7 +12029,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -12037,7 +12037,7 @@ dependencies = [
 [[package]]
 name = "solar-lint"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "rayon",
  "solar-ast",
@@ -12048,7 +12048,7 @@ dependencies = [
 [[package]]
 name = "solar-lsp"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "async-lsp",
  "crop",
@@ -12062,7 +12062,7 @@ dependencies = [
  "solar-interface",
  "solar-parse",
  "solar-sema",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "toml_edit",
@@ -12073,7 +12073,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12083,12 +12083,12 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint 0.5.1",
  "num-rational",
@@ -12104,7 +12104,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=e13b02c7f1f0791ebf6b5362abec7f566c6269e7#e13b02c7f1f0791ebf6b5362abec7f566c6269e7"
+source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -12423,7 +12423,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "url",
  "zip 8.6.0",
 ]
@@ -12562,7 +12562,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12790,7 +12790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13970,7 +13970,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14118,7 +14118,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11901,7 +11901,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11917,7 +11917,7 @@ dependencies = [
 [[package]]
 name = "solar-cli"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -11945,7 +11945,7 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -11964,7 +11964,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "alloy-primitives",
  "idna_adapter",
@@ -11982,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11994,7 +11994,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "bumpalo",
  "diff",
@@ -12009,7 +12009,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream",
@@ -12037,7 +12037,7 @@ dependencies = [
 [[package]]
 name = "solar-lint"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "rayon",
  "solar-ast",
@@ -12048,7 +12048,7 @@ dependencies = [
 [[package]]
 name = "solar-lsp"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "async-lsp",
  "crop",
@@ -12073,7 +12073,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12083,7 +12083,7 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
@@ -12104,7 +12104,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=c66e752321441cabca30f40d15de3d97e029ddc8#c66e752321441cabca30f40d15de3d97e029ddc8"
+source = "git+https://github.com/paradigmxyz/solar?rev=0b8a4f83b3831e8a82bc7008788f85bc7bb80062#0b8a4f83b3831e8a82bc7008788f85bc7bb80062"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -565,10 +565,10 @@ snapbox = { version = "1.2", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "c66e752321441cabca30f40d15de3d97e029ddc8" }
-solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "c66e752321441cabca30f40d15de3d97e029ddc8" }
-solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "c66e752321441cabca30f40d15de3d97e029ddc8" }
-solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "c66e752321441cabca30f40d15de3d97e029ddc8" }
+solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "0b8a4f83b3831e8a82bc7008788f85bc7bb80062" }
+solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "0b8a4f83b3831e8a82bc7008788f85bc7bb80062" }
+solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "0b8a4f83b3831e8a82bc7008788f85bc7bb80062" }
+solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "0b8a4f83b3831e8a82bc7008788f85bc7bb80062" }
 
 ## foundry-core
 foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "78e5b57f86986eabd969a5fdf238b8159f7086fd" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -565,10 +565,10 @@ snapbox = { version = "1.2", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e9152721e4d2236d2304ae480fd18655c" }
-solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e9152721e4d2236d2304ae480fd18655c" }
-solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e9152721e4d2236d2304ae480fd18655c" }
-solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e9152721e4d2236d2304ae480fd18655c" }
+solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "e13b02c7f1f0791ebf6b5362abec7f566c6269e7" }
+solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "e13b02c7f1f0791ebf6b5362abec7f566c6269e7" }
+solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "e13b02c7f1f0791ebf6b5362abec7f566c6269e7" }
+solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "e13b02c7f1f0791ebf6b5362abec7f566c6269e7" }
 
 ## foundry-core
 foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "78e5b57f86986eabd969a5fdf238b8159f7086fd" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -565,10 +565,10 @@ snapbox = { version = "1.2", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "e13b02c7f1f0791ebf6b5362abec7f566c6269e7" }
-solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "e13b02c7f1f0791ebf6b5362abec7f566c6269e7" }
-solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "e13b02c7f1f0791ebf6b5362abec7f566c6269e7" }
-solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "e13b02c7f1f0791ebf6b5362abec7f566c6269e7" }
+solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "c66e752321441cabca30f40d15de3d97e029ddc8" }
+solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "c66e752321441cabca30f40d15de3d97e029ddc8" }
+solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "c66e752321441cabca30f40d15de3d97e029ddc8" }
+solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "c66e752321441cabca30f40d15de3d97e029ddc8" }
 
 ## foundry-core
 foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "78e5b57f86986eabd969a5fdf238b8159f7086fd" }

--- a/crates/forge/src/cmd/lsp.rs
+++ b/crates/forge/src/cmd/lsp.rs
@@ -3,6 +3,7 @@ use foundry_compilers::compilers::multi::MultiCompilerLanguage;
 use foundry_config::{Config, load_config_with_root};
 use solar::config::ImportRemapping;
 use solar_lsp::FoundryWorkspaceConfig;
+use std::path::{MAIN_SEPARATOR, Path, PathBuf};
 
 pub use solar::config::LspArgs;
 
@@ -11,22 +12,53 @@ pub async fn run(args: LspArgs) -> Result<()> {
         .with_default_forge_path(std::env::current_exe()?)
         .with_selected_profile(Config::selected_profile().to_string())
         .with_foundry_workspace_config_loader(|root| {
-            foundry_workspace_config(load_config_with_root(Some(root))?)
+            foundry_workspace_config(root, load_config_with_root(Some(root))?)
         });
     solar_lsp::launch(config).await?;
     Ok(())
 }
 
-fn foundry_workspace_config(config: Config) -> Result<FoundryWorkspaceConfig> {
+fn foundry_workspace_config(root: &Path, config: Config) -> Result<FoundryWorkspaceConfig> {
     let paths = config.project_paths::<MultiCompilerLanguage>();
-    Ok(FoundryWorkspaceConfig::new(paths.root)
-        .with_source_roots([paths.sources.clone()])
-        .with_flycheck_source_roots([paths.sources, paths.tests, paths.scripts])
-        .with_include_paths(paths.libraries.into_iter().chain(paths.include_paths))
+    let resolved_root = paths.root;
+    let sources = rebase_workspace_path(&resolved_root, root, paths.sources);
+    let tests = rebase_workspace_path(&resolved_root, root, paths.tests);
+    let scripts = rebase_workspace_path(&resolved_root, root, paths.scripts);
+
+    Ok(FoundryWorkspaceConfig::new(root)
+        .with_source_roots([sources.clone()])
+        .with_flycheck_source_roots([sources, tests, scripts])
+        .with_include_paths(
+            paths
+                .libraries
+                .into_iter()
+                .chain(paths.include_paths)
+                .map(|path| rebase_workspace_path(&resolved_root, root, path)),
+        )
         .with_import_remappings(paths.remappings.into_iter().map(|remapping| ImportRemapping {
-            context: remapping.context.unwrap_or_default(),
+            context: rebase_remapping_path(
+                &resolved_root,
+                root,
+                remapping.context.unwrap_or_default(),
+            ),
             prefix: remapping.name,
-            path: remapping.path,
+            path: rebase_remapping_path(&resolved_root, root, remapping.path),
         }))
         .with_evm_version(config.evm_version.to_string().parse()?))
+}
+
+fn rebase_workspace_path(resolved_root: &Path, root: &Path, path: PathBuf) -> PathBuf {
+    let Ok(relative) = path.strip_prefix(resolved_root) else { return path };
+    root.join(relative)
+}
+
+fn rebase_remapping_path(resolved_root: &Path, root: &Path, path: impl Into<String>) -> String {
+    let path = path.into();
+    let has_directory_boundary = path.ends_with(['/', '\\']);
+    let mut rebased =
+        rebase_workspace_path(resolved_root, root, PathBuf::from(path)).display().to_string();
+    if has_directory_boundary && !rebased.ends_with(['/', '\\']) {
+        rebased.push(MAIN_SEPARATOR);
+    }
+    rebased
 }

--- a/crates/forge/src/cmd/lsp.rs
+++ b/crates/forge/src/cmd/lsp.rs
@@ -1,17 +1,15 @@
 use eyre::Result;
 use foundry_compilers::compilers::multi::MultiCompilerLanguage;
-use foundry_config::{Config, load_config, load_config_with_root};
+use foundry_config::{Config, load_config_with_root};
 use solar::config::ImportRemapping;
 use solar_lsp::FoundryWorkspaceConfig;
 
 pub use solar::config::LspArgs;
 
 pub async fn run(args: LspArgs) -> Result<()> {
-    let workspace_config = foundry_workspace_config(load_config()?)?;
     let config = solar_lsp::LaunchConfig::from(args)
         .with_default_forge_path(std::env::current_exe()?)
         .with_selected_profile(Config::selected_profile().to_string())
-        .with_foundry_workspace_config(workspace_config)
         .with_foundry_workspace_config_loader(|root| {
             foundry_workspace_config(load_config_with_root(Some(root))?)
         });

--- a/crates/forge/src/cmd/lsp.rs
+++ b/crates/forge/src/cmd/lsp.rs
@@ -1,15 +1,27 @@
 use eyre::Result;
 use foundry_compilers::compilers::multi::MultiCompilerLanguage;
-use foundry_config::{Config, load_config};
+use foundry_config::{Config, load_config, load_config_with_root};
 use solar::config::ImportRemapping;
 use solar_lsp::FoundryWorkspaceConfig;
 
 pub use solar::config::LspArgs;
 
 pub async fn run(args: LspArgs) -> Result<()> {
-    let config = load_config()?;
+    let workspace_config = foundry_workspace_config(load_config()?)?;
+    let config = solar_lsp::LaunchConfig::from(args)
+        .with_default_forge_path(std::env::current_exe()?)
+        .with_selected_profile(Config::selected_profile().to_string())
+        .with_foundry_workspace_config(workspace_config)
+        .with_foundry_workspace_config_loader(|root| {
+            foundry_workspace_config(load_config_with_root(Some(root))?)
+        });
+    solar_lsp::launch(config).await?;
+    Ok(())
+}
+
+fn foundry_workspace_config(config: Config) -> Result<FoundryWorkspaceConfig> {
     let paths = config.project_paths::<MultiCompilerLanguage>();
-    let workspace_config = FoundryWorkspaceConfig::new(paths.root)
+    Ok(FoundryWorkspaceConfig::new(paths.root)
         .with_source_roots([paths.sources.clone()])
         .with_flycheck_source_roots([paths.sources, paths.tests, paths.scripts])
         .with_include_paths(paths.libraries.into_iter().chain(paths.include_paths))
@@ -18,11 +30,5 @@ pub async fn run(args: LspArgs) -> Result<()> {
             prefix: remapping.name,
             path: remapping.path,
         }))
-        .with_evm_version(config.evm_version.to_string().parse()?);
-    let config = solar_lsp::LaunchConfig::from(args)
-        .with_default_forge_path(std::env::current_exe()?)
-        .with_selected_profile(Config::selected_profile().to_string())
-        .with_foundry_workspace_config(workspace_config);
-    solar_lsp::launch(config).await?;
-    Ok(())
+        .with_evm_version(config.evm_version.to_string().parse()?))
 }

--- a/crates/forge/tests/cli/lsp.rs
+++ b/crates/forge/tests/cli/lsp.rs
@@ -1,8 +1,9 @@
 use async_lsp::{
     LanguageServer,
     lsp_types::{
-        ClientCapabilities, InitializeParams, InitializedParams, Url, WorkspaceFolder,
-        WorkspaceSymbolParams, WorkspaceSymbolResponse,
+        ClientCapabilities, DidChangeWatchedFilesParams, FileChangeType, FileEvent,
+        InitializeParams, InitializedParams, Url, WorkspaceFolder, WorkspaceSymbolParams,
+        WorkspaceSymbolResponse,
     },
 };
 use std::{
@@ -13,6 +14,39 @@ use std::{
 use super::lsp_client::{LspClient, request};
 
 const SYMBOL_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn wait_for_workspace_symbols(client: &mut LspClient, expected: &str, unexpected: &str) {
+    let deadline = Instant::now() + SYMBOL_TIMEOUT;
+    let mut last_names = Vec::new();
+    while Instant::now() < deadline {
+        let response = request(
+            &client.runtime,
+            client.server.symbol(WorkspaceSymbolParams {
+                query: String::new(),
+                ..WorkspaceSymbolParams::default()
+            }),
+        );
+        last_names = match response {
+            None => Vec::new(),
+            Some(WorkspaceSymbolResponse::Flat(symbols)) => {
+                symbols.into_iter().map(|symbol| symbol.name).collect()
+            }
+            Some(WorkspaceSymbolResponse::Nested(symbols)) => {
+                symbols.into_iter().map(|symbol| symbol.name).collect()
+            }
+        };
+        if last_names.iter().any(|name| name == expected)
+            && last_names.iter().all(|name| name != unexpected)
+        {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+
+    panic!(
+        "expected workspace symbol `{expected}` without `{unexpected}`; observed: {last_names:?}"
+    );
+}
 
 #[test]
 fn lsp_profile_selects_workspace_sources() {
@@ -51,35 +85,51 @@ fn lsp_profile_selects_workspace_sources() {
     client.server.initialized(InitializedParams {}).unwrap();
     client.wait_for_log_message();
 
-    let deadline = Instant::now() + SYMBOL_TIMEOUT;
-    let mut last_names = Vec::new();
-    while Instant::now() < deadline {
-        let response = request(
-            &client.runtime,
-            client.server.symbol(WorkspaceSymbolParams {
-                query: String::new(),
-                ..WorkspaceSymbolParams::default()
-            }),
-        );
-        last_names = match response {
-            None => Vec::new(),
-            Some(WorkspaceSymbolResponse::Flat(symbols)) => {
-                symbols.into_iter().map(|symbol| symbol.name).collect()
-            }
-            Some(WorkspaceSymbolResponse::Nested(symbols)) => {
-                symbols.into_iter().map(|symbol| symbol.name).collect()
-            }
-        };
-        if last_names.iter().any(|name| name == "CustomContract")
-            && last_names.iter().all(|name| name != "DefaultContract")
-        {
-            client.shutdown();
-            return;
-        }
-        thread::sleep(Duration::from_millis(20));
-    }
+    wait_for_workspace_symbols(&mut client, "CustomContract", "DefaultContract");
+    client.shutdown();
+}
 
-    panic!("custom profile was not used for workspace indexing; observed symbols: {last_names:?}");
+#[test]
+fn lsp_reloads_host_resolved_config_after_manifest_change() {
+    let project = tempfile::tempdir().unwrap();
+    let project_root = dunce::canonicalize(project.path()).unwrap();
+    let manifest = project_root.join("foundry.toml");
+    fs::write(&manifest, "[profile.default]\nsrc = \"old-src\"\n").unwrap();
+    fs::create_dir_all(project_root.join("old-src")).unwrap();
+    fs::create_dir_all(project_root.join("new-src")).unwrap();
+    fs::write(project_root.join("old-src/Old.sol"), "contract OldContract {}\n").unwrap();
+    fs::write(project_root.join("new-src/New.sol"), "contract NewContract {}\n").unwrap();
+
+    let empty_path = tempfile::tempdir().unwrap();
+    let mut client = LspClient::spawn(&project_root, empty_path.path(), &["lsp", "--stdio"]);
+    let initialize = request(
+        &client.runtime,
+        client.server.initialize(InitializeParams {
+            capabilities: ClientCapabilities::default(),
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: Url::from_directory_path(&project_root).unwrap(),
+                name: "fixture".into(),
+            }]),
+            ..InitializeParams::default()
+        }),
+    );
+    assert!(initialize.capabilities.workspace_symbol_provider.is_some());
+    client.server.initialized(InitializedParams {}).unwrap();
+    client.wait_for_log_message();
+    wait_for_workspace_symbols(&mut client, "OldContract", "NewContract");
+
+    fs::write(&manifest, "[profile.default]\nsrc = \"new-src\"\n").unwrap();
+    client
+        .server
+        .did_change_watched_files(DidChangeWatchedFilesParams {
+            changes: vec![FileEvent {
+                uri: Url::from_file_path(&manifest).unwrap(),
+                typ: FileChangeType::CHANGED,
+            }],
+        })
+        .unwrap();
+    wait_for_workspace_symbols(&mut client, "NewContract", "OldContract");
+    client.shutdown();
 }
 
 #[test]

--- a/crates/forge/tests/cli/lsp.rs
+++ b/crates/forge/tests/cli/lsp.rs
@@ -11,6 +11,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
 use super::lsp_client::{LspClient, request};
 
 const SYMBOL_TIMEOUT: Duration = Duration::from_secs(10);
@@ -129,6 +132,40 @@ fn lsp_reloads_host_resolved_config_after_manifest_change() {
         })
         .unwrap();
     wait_for_workspace_symbols(&mut client, "NewContract", "OldContract");
+    client.shutdown();
+}
+
+#[cfg(unix)]
+#[test]
+fn lsp_preserves_aliased_workspace_root() {
+    let project = tempfile::tempdir().unwrap();
+    let project_root = dunce::canonicalize(project.path()).unwrap();
+    fs::write(project_root.join("foundry.toml"), "[profile.default]\nsrc = \"src\"\n").unwrap();
+    fs::create_dir_all(project_root.join("src")).unwrap();
+    fs::write(project_root.join("src/Alias.sol"), "contract AliasContract {}\n").unwrap();
+
+    let alias_parent = tempfile::tempdir().unwrap();
+    let alias_root = alias_parent.path().join("project-alias");
+    symlink(&project_root, &alias_root).unwrap();
+
+    let empty_path = tempfile::tempdir().unwrap();
+    let mut client = LspClient::spawn(&alias_root, empty_path.path(), &["lsp", "--stdio"]);
+    let initialize = request(
+        &client.runtime,
+        client.server.initialize(InitializeParams {
+            capabilities: ClientCapabilities::default(),
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: Url::from_directory_path(&alias_root).unwrap(),
+                name: "fixture".into(),
+            }]),
+            ..InitializeParams::default()
+        }),
+    );
+    assert!(initialize.capabilities.workspace_symbol_provider.is_some());
+    client.server.initialized(InitializedParams {}).unwrap();
+    client.wait_for_log_message();
+
+    wait_for_workspace_symbols(&mut client, "AliasContract", "MissingContract");
     client.shutdown();
 }
 


### PR DESCRIPTION
Fixes #16397.

`forge lsp` previously passed Solar one host-resolved Foundry workspace snapshot at launch. Solar could rediscover a workspace after `foundry.toml` changed, but the snapshot left source roots, libraries, remappings, inherited profiles, and the EVM version stale until restart.

Forge now registers its resolver as Solar's single Foundry configuration source. Solar invokes it once for every project root encountered in each discovery pass, which refreshes changed workspaces, applies the same host semantics to newly discovered nested projects, and avoids resolving the initial root twice. Because Foundry canonicalizes loaded configuration paths, Forge rebases project-local sources, libraries, include paths, and remappings into the exact workspace namespace supplied by the editor so symlinked and platform-aliased roots remain indexable. The integration coverage verifies both live source-root changes and end-to-end symbol indexing through an aliased root.

This depends on [paradigmxyz/solar#1320](https://github.com/paradigmxyz/solar/pull/1320), which adds the per-discovered-root host loader while preserving static snapshots for other embedders. This change was developed with assistance from OpenAI Codex.
