### PR TITLE
feat(cli): add runtime hardfork override

### DIFF
--- a/.changelog/runtime-hardfork-cli-override.md
+++ b/.changelog/runtime-hardfork-cli-override.md
@@ -1,0 +1,7 @@
+---
+chisel: minor
+forge: minor
+foundry-cli: minor
+---
+
+Added a shared `--hardfork` override for selecting the runtime EVM hardfork in Forge and Chisel commands.

--- a/crates/cli/src/opts/evm.rs
+++ b/crates/cli/src/opts/evm.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::{Address, B256, U256};
 use clap::Parser;
 use foundry_config::{
-    Chain, Config,
+    Chain, Config, FoundryHardfork,
     figment::{
         self, Metadata, Profile, Provider,
         error::Kind::InvalidType,
@@ -124,6 +124,13 @@ pub struct EvmArgs {
     #[arg(long, conflicts_with = "isolate")]
     #[serde(skip)]
     pub no_isolate: bool,
+
+    /// The runtime EVM hardfork to use.
+    ///
+    /// Network-specific hardforks must be namespaced, for example `tempo:T5`.
+    #[arg(long, value_name = "HARDFORK")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hardfork: Option<FoundryHardfork>,
 
     /// Network selection.
     #[command(flatten)]
@@ -357,6 +364,17 @@ mod tests {
 
         let env = EnvArgs::parse_from(["foundry-cli", "--chain-id", "goerli"]);
         assert_eq!(env.chain, Some(NamedChain::Goerli.into()));
+    }
+
+    #[test]
+    fn hardfork_arg_selects_network() {
+        let args = EvmArgs::parse_from(["foundry-cli", "--hardfork", "tempo:T5"]);
+        let hardfork = "tempo:T5".parse::<FoundryHardfork>().unwrap();
+        assert_eq!(args.hardfork, Some(hardfork));
+
+        let config = Config::from_provider(Config::figment().merge(args)).unwrap();
+        assert_eq!(config.hardfork, Some(hardfork));
+        assert!(config.networks.is_tempo());
     }
 
     #[test]


### PR DESCRIPTION
Foundry already supports selecting the runtime EVM hardfork through configuration, but shared EVM CLI arguments have no equivalent per-invocation override. This adds `--hardfork` to Forge and Chisel commands, including namespaced values such as `tempo:T5`, without requiring users to edit `foundry.toml` between runs.

Keeping this network-agnostic option in shared CLI infrastructure also means future network integrations only need to add their hardfork values, rather than introducing a feature-gated CLI option themselves.