### PR TITLE
refactor(evm): share precompile sentinel

### DIFF
--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -47,6 +47,13 @@ pub const DEFAULT_CREATE2_DEPLOYER_DEPLOYER: Address =
 /// The default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER: Address =
     address!("0x4e59b44847b379578588920ca78fbf26c0b4956c");
+
+/// Sentinel bytecode for network-native precompiles that have no deployed code.
+///
+/// The EIP-3541-reserved `0xEF` prefix makes `extcodesize` treat the account as non-empty while
+/// execution remains handled by the precompile.
+pub const SYSTEM_PRECOMPILE_STUB: &[u8] = &[0xEF];
+
 /// The initcode of the default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER_CODE: &[u8] = &hex!(
     "604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -25,7 +25,7 @@ use tempo_revm::{
 use crate::{
     FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
-    constants::{CALLER, TEST_CONTRACT_ADDRESS},
+    constants::{CALLER, SYSTEM_PRECOMPILE_STUB, TEST_CONTRACT_ADDRESS},
     evm::{FoundryEvmFactory, NestedEvm, NestedEvmFor},
     tempo::{TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, initialize_tempo_test_genesis_inner},
 };
@@ -205,7 +205,7 @@ pub(crate) fn initialize_tempo_evm<
             if is_forked {
                 // In fork mode, warm up precompile accounts to avoid repeated RPC fetches.
                 let mut sctx = StorageCtx;
-                let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
+                let sentinel = Bytecode::new_legacy(Bytes::from_static(SYSTEM_PRECOMPILE_STUB));
                 for addr in TEMPO_PRECOMPILE_ADDRESSES
                     .iter()
                     .copied()

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -21,6 +21,8 @@ use tempo_precompiles::{
     validator_config,
 };
 
+use crate::constants::SYSTEM_PRECOMPILE_STUB;
+
 pub use foundry_common::tempo::{
     ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
 };
@@ -122,7 +124,7 @@ fn initialize_tempo_genesis_inner_with_precompiles(
     let mut ctx = StorageCtx;
 
     // Set sentinel bytecode for precompile addresses
-    let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
+    let sentinel = Bytecode::new_legacy(Bytes::from_static(SYSTEM_PRECOMPILE_STUB));
     for precompile in precompiles {
         ctx.set_code(precompile, sentinel.clone())?;
     }


### PR DESCRIPTION
Tempo currently hardcodes the same `0xEF` sentinel in its genesis and fork initialization paths, while Base requires identical behavior for its native precompiles. This centralizes the protocol-sensitive value as `SYSTEM_PRECOMPILE_STUB` and reuses it across Tempo. Base support can then consume the existing shared definition instead of introducing a feature-gated duplicate.