### PR TITLE
feat(cast): decode events with local artifacts

### DIFF
--- a/.changelog/cast-events-local-artifacts.md
+++ b/.changelog/cast-events-local-artifacts.md
@@ -1,0 +1,5 @@
+---
+cast: minor
+---
+
+Added `cast events --with-local-artifacts` for decoding transaction events from matching local project artifacts.

--- a/.changelog/cast-events-local-artifacts.md
+++ b/.changelog/cast-events-local-artifacts.md
@@ -1,5 +1,6 @@
 ---
 cast: minor
+foundry-common: minor
 ---
 
 Added `cast events --with-local-artifacts` for decoding transaction events from matching local project artifacts.

--- a/crates/cast/src/cmd/events.rs
+++ b/crates/cast/src/cmd/events.rs
@@ -7,21 +7,28 @@ use crate::{
     },
 };
 use alloy_dyn_abi::DynSolValue;
+use alloy_json_abi::JsonAbi;
+use alloy_network::Network;
 use alloy_primitives::{Address, B256, Bytes, TxHash};
 use alloy_provider::Provider;
-use alloy_rpc_types::Log;
+use alloy_rpc_types::{BlockId, Log};
 use clap::{ArgGroup, Parser};
 use eyre::Result;
 use foundry_cli::{
     json::print_json_object,
     opts::{EtherscanOpts, RpcOpts},
-    utils::{self, LoadConfig},
+    utils::{self, LoadConfig, load_config_from_provider},
 };
-use foundry_common::{fmt::serialize_value_as_json, shell};
+use foundry_common::{
+    ContractsByArtifact, compile::ProjectCompiler, fmt::serialize_value_as_json, shell,
+};
 use foundry_config::{Chain, Config};
 use futures::StreamExt;
 use serde::{Serialize, Serializer};
-use std::{collections::BTreeSet, fmt::Write as _};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write as _,
+};
 
 foundry_config::impl_figment_convert!(EventsArgs, etherscan, rpc);
 
@@ -58,13 +65,25 @@ pub struct EventsArgs {
 
     #[command(flatten)]
     rpc: RpcOpts,
+
+    /// Use current project artifacts for event decoding.
+    ///
+    /// Only supported when querying by transaction hash.
+    #[arg(long, visible_alias = "la")]
+    with_local_artifacts: bool,
 }
 
 impl EventsArgs {
     pub async fn run(self) -> Result<()> {
+        let project_config = self.with_local_artifacts.then(|| {
+            load_config_from_provider(self.rpc.clone().into_figment(true).merge(&self.etherscan))
+        });
         let mut config = self.load_config()?;
-        let Self { tx_hash, mut query, etherscan: _, rpc: _ } = self;
+        let Self { tx_hash, mut query, etherscan: _, rpc: _, with_local_artifacts } = self;
         let tx_hash = tx_hash.or_else(|| query.take_transaction_hash());
+        if with_local_artifacts && tx_hash.is_none() {
+            eyre::bail!("--with-local-artifacts is only supported with a transaction hash");
+        }
         let provider = utils::get_provider(&config)?;
         let chain_id = provider.get_chain_id().await?;
         let (rpc_chain, explorer_chain) = resolve_chains(config.chain, Chain::from(chain_id));
@@ -81,7 +100,12 @@ impl EventsArgs {
             }
         };
 
-        let events = decode_logs(logs, &config, explorer_chain).await?;
+        let local_abis = if with_local_artifacts {
+            local_event_abis(&provider, &logs, &project_config.unwrap()?).await?
+        } else {
+            BTreeMap::new()
+        };
+        let events = decode_logs(logs, &config, explorer_chain, local_abis).await?;
         if shell::is_json() {
             print_json_object(events)?;
         } else {
@@ -99,10 +123,50 @@ fn resolve_chains(configured_chain: Option<Chain>, rpc_chain: Chain) -> (Chain, 
     (rpc_chain, configured_chain.unwrap_or(rpc_chain))
 }
 
+async fn local_event_abis<N: Network, P: Provider<N>>(
+    provider: &P,
+    logs: &[Log],
+    config: &Config,
+) -> Result<BTreeMap<Address, JsonAbi>> {
+    let addresses = logs.iter().map(Log::address).collect::<BTreeSet<_>>();
+    let Some(block_number) = logs.first().and_then(|log| log.block_number) else {
+        return Ok(BTreeMap::new());
+    };
+
+    let mut bytecodes = BTreeMap::new();
+    let mut requests = futures::stream::iter(addresses.iter().copied())
+        .map(|address| async move {
+            (address, provider.get_code_at(address).block_id(BlockId::number(block_number)).await)
+        })
+        .buffer_unordered(MAX_CONCURRENT_RPC_REQUESTS);
+    while let Some((address, code)) = requests.next().await {
+        match code {
+            Ok(code) if !code.is_empty() => {
+                bytecodes.insert(address, code);
+            }
+            Ok(_) => {}
+            Err(err) => sh_warn!("Failed to fetch code for {address}: {err}")?,
+        }
+    }
+
+    let project = config.project()?;
+    let output = ProjectCompiler::new().quiet(true).compile(&project)?;
+    let contracts = ContractsByArtifact::from(output);
+    Ok(addresses
+        .iter()
+        .filter_map(|&address| {
+            let code = bytecodes.get(&address)?;
+            let (_, contract) = contracts.find_by_deployed_code_exact_unique(code)?;
+            Some((address, contract.abi.clone()))
+        })
+        .collect())
+}
+
 async fn decode_logs(
     logs: Vec<Log>,
     config: &Config,
     explorer_chain: Chain,
+    local_abis: BTreeMap<Address, JsonAbi>,
 ) -> Result<Vec<EventOutput>> {
     let signature_identifier = SignaturesIdentifier::from_config(config)?;
     let mut builder = CallTraceDecoderBuilder::new()
@@ -110,12 +174,14 @@ async fn decode_logs(
         .with_networks(config.networks)
         .with_chain_id(config.chain.map(|chain| chain.id()));
 
+    let mut externally_resolved = BTreeSet::new();
     if let Some(mut identifier) = ExternalIdentifier::new(config, Some(explorer_chain))? {
         let addresses =
             logs.iter().map(Log::address).collect::<BTreeSet<_>>().into_iter().collect::<Vec<_>>();
         for (address, result) in identifier.get_abis(&addresses).await {
             match result {
                 Ok((abis, complete)) => {
+                    externally_resolved.insert(address);
                     if !complete {
                         sh_warn!("Only partially resolved proxy ABI chain for {address}")?;
                     }
@@ -125,6 +191,12 @@ async fn decode_logs(
                 }
                 Err(err) => sh_warn!("Failed to fetch ABI for {address}: {err}")?,
             }
+        }
+    }
+
+    for (address, abi) in local_abis {
+        if !externally_resolved.contains(&address) {
+            builder = builder.with_address_events(address, &abi);
         }
     }
 

--- a/crates/cast/src/cmd/events.rs
+++ b/crates/cast/src/cmd/events.rs
@@ -17,7 +17,7 @@ use eyre::Result;
 use foundry_cli::{
     json::print_json_object,
     opts::{EtherscanOpts, RpcOpts},
-    utils::{self, LoadConfig, load_config_from_provider},
+    utils::{self, load_config_from_provider},
 };
 use foundry_common::{
     ContractsByArtifact, compile::ProjectCompiler, fmt::serialize_value_as_json, shell,
@@ -75,10 +75,9 @@ pub struct EventsArgs {
 
 impl EventsArgs {
     pub async fn run(self) -> Result<()> {
-        let project_config = self.with_local_artifacts.then(|| {
-            load_config_from_provider(self.rpc.clone().into_figment(true).merge(&self.etherscan))
-        });
-        let mut config = self.load_config()?;
+        let figment =
+            self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self.etherscan);
+        let mut config = load_config_from_provider(figment)?;
         let Self { tx_hash, mut query, etherscan: _, rpc: _, with_local_artifacts } = self;
         let tx_hash = tx_hash.or_else(|| query.take_transaction_hash());
         if with_local_artifacts && tx_hash.is_none() {
@@ -101,7 +100,7 @@ impl EventsArgs {
         };
 
         let local_abis = if with_local_artifacts {
-            local_event_abis(&provider, &logs, &project_config.unwrap()?).await?
+            local_event_abis(&provider, &logs, &config).await?
         } else {
             BTreeMap::new()
         };

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3493,6 +3493,10 @@ forgetest_async!(events_quiet_preserves_output, |prj, cmd| {
     let endpoint = handle.http_endpoint();
     let private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
     cmd.set_current_dir(prj.root());
+    prj.update_config(|config| {
+        config.cbor_metadata = false;
+        config.bytecode_hash = "none".parse().unwrap();
+    });
 
     prj.add_source(
         "EventEmitter",
@@ -3593,6 +3597,28 @@ contract EventEmitter {
         .assert_success()
         .stdout_eq(str![[r#"
 [block 2, tx 0x[..], log 0] 0x5FbDB2315678afecb367f032d93F642f64180aa3::Transfer(address,address,uint256) { from: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, to: 0x5FbDB2315678afecb367f032d93F642f64180aa3, value: 42 }
+
+"#]]);
+
+    prj.add_source(
+        "AmbiguousEventEmitter",
+        r#"
+import {EventEmitter} from "./EventEmitter.sol";
+
+contract AmbiguousEventEmitter is EventEmitter {
+    event Ambiguous(uint256 value);
+}
+"#,
+    );
+    cmd.cast_fuse()
+        .args(["--quiet", "events", tx_hash, "--with-local-artifacts", "--rpc-url", &endpoint])
+        .assert_success()
+        .stdout_eq(str![[r#"
+[block 2, tx 0x[..], log 0] 0x5FbDB2315678afecb367f032d93F642f64180aa3
+  topic 0: 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
+  topic 1: 0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266
+  topic 2: 0x0000000000000000000000005fbdb2315678afecb367f032d93f642f64180aa3
+  data: 0x000000000000000000000000000000000000000000000000000000000000002a
 
 "#]]);
 });

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3492,12 +3492,18 @@ forgetest_async!(events_quiet_preserves_output, |prj, cmd| {
     let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
     let endpoint = handle.http_endpoint();
     let private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    cmd.set_current_dir(prj.root());
 
     prj.add_source(
         "EventEmitter",
         r#"
 contract EventEmitter {
+    event Constructed(address indexed owner, uint256 value);
     event Transfer(address indexed from, address indexed to, uint256 value);
+
+    constructor() {
+        emit Constructed(msg.sender, 42);
+    }
 
     function emitTransfer() external {
         emit Transfer(msg.sender, address(this), 42);
@@ -3528,6 +3534,22 @@ contract EventEmitter {
         .stdout_lossy();
     let deployment: serde_json::Value = serde_json::from_str(&deployment).unwrap();
     let address = deployment["contractAddress"].as_str().unwrap();
+    let deployment_tx_hash = deployment["transactionHash"].as_str().unwrap();
+
+    cmd.cast_fuse()
+        .args([
+            "--quiet",
+            "events",
+            deployment_tx_hash,
+            "--with-local-artifacts",
+            "--rpc-url",
+            &endpoint,
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+[block 1, tx 0x[..], log 0] 0x5FbDB2315678afecb367f032d93F642f64180aa3::Constructed(address,uint256) { owner: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, value: 42 }
+
+"#]]);
 
     let receipt = cmd
         .cast_fuse()
@@ -3556,6 +3578,21 @@ contract EventEmitter {
   topic 1: 0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266
   topic 2: 0x0000000000000000000000005fbdb2315678afecb367f032d93f642f64180aa3
   data: 0x000000000000000000000000000000000000000000000000000000000000002a
+
+"#]]);
+
+    cmd.cast_fuse()
+        .args([
+            "--quiet",
+            "events",
+            tx_hash,
+            "--with-local-artifacts",
+            "--rpc-url",
+            &endpoint,
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+[block 2, tx 0x[..], log 0] 0x5FbDB2315678afecb367f032d93F642f64180aa3::Transfer(address,address,uint256) { from: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, to: 0x5FbDB2315678afecb367f032d93F642f64180aa3, value: 42 }
 
 "#]]);
 });

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -251,135 +251,167 @@ impl ContractsByArtifact {
     /// Finds a contract which deployed bytecode exactly matches the given code. Accounts for link
     /// references and immutables.
     pub fn find_by_deployed_code_exact(&self, code: &[u8]) -> Option<ArtifactWithContractRef<'_>> {
+        self.find_by_deployed_code_exact_inner(code, false)
+    }
+
+    /// Finds the only contract whose deployed bytecode exactly matches the given code.
+    pub fn find_by_deployed_code_exact_unique(
+        &self,
+        code: &[u8],
+    ) -> Option<ArtifactWithContractRef<'_>> {
+        self.find_by_deployed_code_exact_inner(code, true)
+    }
+
+    fn find_by_deployed_code_exact_inner(
+        &self,
+        code: &[u8],
+        unique: bool,
+    ) -> Option<ArtifactWithContractRef<'_>> {
         // Immediately return None if the code is empty.
         if code.is_empty() {
             return None;
         }
 
         let mut partial_match = None;
-        self.iter()
-            .find(|(id, contract)| {
-                let Some(deployed_bytecode) = &contract.deployed_bytecode else {
-                    return false;
-                };
-                let Some(deployed_code) = &deployed_bytecode.object else {
-                    return false;
-                };
+        let mut unique_match = None;
+        let matched = self.iter().find(|(id, contract)| {
+            let Some(deployed_bytecode) = &contract.deployed_bytecode else {
+                return false;
+            };
+            let Some(deployed_code) = &deployed_bytecode.object else {
+                return false;
+            };
 
-                let len = match deployed_code {
-                    BytecodeObject::Bytecode(bytes) => bytes.len(),
-                    BytecodeObject::Unlinked(bytes) => bytes.len() / 2,
-                };
+            let len = match deployed_code {
+                BytecodeObject::Bytecode(bytes) => bytes.len(),
+                BytecodeObject::Unlinked(bytes) => bytes.len() / 2,
+            };
 
-                if len != code.len() {
-                    return false;
+            if len != code.len() {
+                return false;
+            }
+
+            // Collect ignored offsets by chaining link and immutable references.
+            let mut ignored = deployed_bytecode
+                .immutable_references
+                .values()
+                .chain(deployed_bytecode.link_references.values().flat_map(|v| v.values()))
+                .flatten()
+                .cloned()
+                .collect::<Vec<_>>();
+
+            // For libraries solidity adds a call protection prefix to the bytecode. We need to
+            // ignore it as it includes library address determined at runtime.
+            // See https://docs.soliditylang.org/en/latest/contracts.html#call-protection-for-libraries and
+            // https://github.com/NomicFoundation/hardhat/blob/af7807cf38842a4f56e7f4b966b806e39631568a/packages/hardhat-verify/src/internal/solc/bytecode.ts#L172
+            let has_call_protection = match deployed_code {
+                BytecodeObject::Bytecode(bytes) => {
+                    bytes.starts_with(&CALL_PROTECTION_BYTECODE_PREFIX)
                 }
-
-                // Collect ignored offsets by chaining link and immutable references.
-                let mut ignored = deployed_bytecode
-                    .immutable_references
-                    .values()
-                    .chain(deployed_bytecode.link_references.values().flat_map(|v| v.values()))
-                    .flatten()
-                    .cloned()
-                    .collect::<Vec<_>>();
-
-                // For libraries solidity adds a call protection prefix to the bytecode. We need to
-                // ignore it as it includes library address determined at runtime.
-                // See https://docs.soliditylang.org/en/latest/contracts.html#call-protection-for-libraries and
-                // https://github.com/NomicFoundation/hardhat/blob/af7807cf38842a4f56e7f4b966b806e39631568a/packages/hardhat-verify/src/internal/solc/bytecode.ts#L172
-                let has_call_protection = match deployed_code {
-                    BytecodeObject::Bytecode(bytes) => {
+                BytecodeObject::Unlinked(bytes) => {
+                    if let Ok(bytes) =
+                        Bytes::from_str(&bytes[..CALL_PROTECTION_BYTECODE_PREFIX.len() * 2])
+                    {
                         bytes.starts_with(&CALL_PROTECTION_BYTECODE_PREFIX)
+                    } else {
+                        false
                     }
+                }
+            };
+
+            if has_call_protection {
+                ignored.push(Offsets { start: 1, length: 20 });
+            }
+
+            let metadata_start = find_metadata_start(code);
+
+            if let Some(metadata) = metadata_start {
+                ignored.push(Offsets {
+                    start: metadata as u32,
+                    length: (code.len() - metadata) as u32,
+                });
+            }
+
+            ignored.sort_by_key(|o| o.start);
+
+            let mut left = 0;
+            for offset in ignored {
+                let right = offset.start as usize;
+
+                let matched = match deployed_code {
+                    BytecodeObject::Bytecode(bytes) => bytes[left..right] == code[left..right],
                     BytecodeObject::Unlinked(bytes) => {
-                        if let Ok(bytes) =
-                            Bytes::from_str(&bytes[..CALL_PROTECTION_BYTECODE_PREFIX.len() * 2])
-                        {
-                            bytes.starts_with(&CALL_PROTECTION_BYTECODE_PREFIX)
+                        if let Ok(bytes) = Bytes::from_str(&bytes[left * 2..right * 2]) {
+                            bytes == code[left..right]
                         } else {
                             false
                         }
                     }
                 };
 
-                if has_call_protection {
-                    ignored.push(Offsets { start: 1, length: 20 });
-                }
-
-                let metadata_start = find_metadata_start(code);
-
-                if let Some(metadata) = metadata_start {
-                    ignored.push(Offsets {
-                        start: metadata as u32,
-                        length: (code.len() - metadata) as u32,
-                    });
-                }
-
-                ignored.sort_by_key(|o| o.start);
-
-                let mut left = 0;
-                for offset in ignored {
-                    let right = offset.start as usize;
-
-                    let matched = match deployed_code {
-                        BytecodeObject::Bytecode(bytes) => bytes[left..right] == code[left..right],
-                        BytecodeObject::Unlinked(bytes) => {
-                            if let Ok(bytes) = Bytes::from_str(&bytes[left * 2..right * 2]) {
-                                bytes == code[left..right]
-                            } else {
-                                false
-                            }
-                        }
-                    };
-
-                    if !matched {
-                        return false;
-                    }
-
-                    left = right + offset.length as usize;
-                }
-
-                let is_partial = if left < code.len() {
-                    match deployed_code {
-                        BytecodeObject::Bytecode(bytes) => bytes[left..] == code[left..],
-                        BytecodeObject::Unlinked(bytes) => {
-                            if let Ok(bytes) = Bytes::from_str(&bytes[left * 2..]) {
-                                bytes == code[left..]
-                            } else {
-                                false
-                            }
-                        }
-                    }
-                } else {
-                    true
-                };
-
-                if !is_partial {
+                if !matched {
                     return false;
                 }
 
-                let Some(metadata) = metadata_start else { return true };
+                left = right + offset.length as usize;
+            }
 
-                let exact_match = match deployed_code {
-                    BytecodeObject::Bytecode(bytes) => bytes[metadata..] == code[metadata..],
+            let is_partial = if left < code.len() {
+                match deployed_code {
+                    BytecodeObject::Bytecode(bytes) => bytes[left..] == code[left..],
                     BytecodeObject::Unlinked(bytes) => {
-                        if let Ok(bytes) = Bytes::from_str(&bytes[metadata * 2..]) {
-                            bytes == code[metadata..]
+                        if let Ok(bytes) = Bytes::from_str(&bytes[left * 2..]) {
+                            bytes == code[left..]
                         } else {
                             false
                         }
                     }
-                };
-
-                if exact_match {
-                    true
-                } else {
-                    partial_match = Some((*id, *contract));
-                    false
                 }
-            })
-            .or(partial_match)
+            } else {
+                true
+            };
+
+            if !is_partial {
+                return false;
+            }
+
+            let Some(metadata) = metadata_start else {
+                if unique && unique_match.is_none() {
+                    unique_match = Some((*id, *contract));
+                    return false;
+                }
+                return true;
+            };
+
+            let exact_match = match deployed_code {
+                BytecodeObject::Bytecode(bytes) => bytes[metadata..] == code[metadata..],
+                BytecodeObject::Unlinked(bytes) => {
+                    if let Ok(bytes) = Bytes::from_str(&bytes[metadata * 2..]) {
+                        bytes == code[metadata..]
+                    } else {
+                        false
+                    }
+                }
+            };
+
+            if exact_match {
+                if unique && unique_match.is_none() {
+                    unique_match = Some((*id, *contract));
+                    false
+                } else {
+                    true
+                }
+            } else {
+                partial_match = Some((*id, *contract));
+                false
+            }
+        });
+
+        if unique {
+            matched.is_none().then_some(unique_match).flatten()
+        } else {
+            matched.or(partial_match)
+        }
     }
 
     /// Finds a contract which has the same contract name or identifier as `id`. If more than one is
@@ -658,6 +690,32 @@ mod tests {
     use super::*;
     use alloy_dyn_abi::DynSolValue;
     use alloy_primitives::U256;
+    use semver::Version;
+
+    fn deployed_artifact(name: &str, code: Bytes) -> (ArtifactId, CompactContractBytecode) {
+        (
+            ArtifactId {
+                path: format!("out/{name}.json").into(),
+                name: name.to_owned(),
+                source: format!("src/{name}.sol").into(),
+                version: Version::new(0, 8, 30),
+                build_id: String::new(),
+                profile: "default".to_owned(),
+            },
+            CompactContractBytecode {
+                abi: Some(Default::default()),
+                bytecode: None,
+                deployed_bytecode: Some(CompactDeployedBytecode {
+                    bytecode: Some(CompactBytecode {
+                        object: BytecodeObject::Bytecode(code),
+                        source_map: None,
+                        link_references: Default::default(),
+                    }),
+                    immutable_references: Default::default(),
+                }),
+            },
+        )
+    }
 
     #[test]
     fn exact_creation_match_requires_canonical_constructor_suffix() {
@@ -708,5 +766,29 @@ mod tests {
         let contracts = ContractsByArtifact::new(vec![]);
 
         assert!(contracts.find_by_deployed_code_exact(&[]).is_none());
+    }
+
+    #[test]
+    fn find_by_deployed_code_exact_unique_rejects_ambiguity() {
+        let code = Bytes::from_static(&[0x60, 0x00]);
+        let contracts = ContractsByArtifact::new([
+            deployed_artifact("A", code.clone()),
+            deployed_artifact("B", code.clone()),
+        ]);
+
+        assert!(contracts.find_by_deployed_code_exact_unique(&code).is_none());
+
+        let contracts = ContractsByArtifact::new([deployed_artifact("A", code.clone())]);
+        assert_eq!(contracts.find_by_deployed_code_exact_unique(&code).unwrap().0.name, "A");
+    }
+
+    #[test]
+    fn find_by_deployed_code_exact_unique_rejects_partial_metadata_match() {
+        let artifact_code = Bytes::from_static(&[0x60, 0x00, 0xa0, 0x00, 0x01]);
+        let deployed_code = Bytes::from_static(&[0x60, 0x00, 0xf6, 0x00, 0x01]);
+        let contracts = ContractsByArtifact::new([deployed_artifact("A", artifact_code)]);
+
+        assert!(contracts.find_by_deployed_code_exact(&deployed_code).is_some());
+        assert!(contracts.find_by_deployed_code_exact_unique(&deployed_code).is_none());
     }
 }


### PR DESCRIPTION
Adds an opt-in `cast events --with-local-artifacts` mode for transaction queries. It matches emitting-address runtime bytecode at the receipt block against exactly one local artifact, then registers that ABI as address-scoped metadata. This preserves explorer precedence and the existing ambiguity-safe raw fallback while supporting local unverified deployments.

Closes #16396.