### PR TITLE
chore(bench): update Aave v4 pin

### DIFF
--- a/benches/scripts/run-benchmark-suite.sh
+++ b/benches/scripts/run-benchmark-suite.sh
@@ -34,7 +34,7 @@ SYMBOLIC_REPOSITORIES=$(join_repositories \
   "SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5" \
   "farcasterxyz/contracts:3f37e21db8e9c6319b4a3d5f62b1c514ef01c36b")
 
-NIGHTLY_REPOSITORIES="aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35"
+NIGHTLY_REPOSITORIES="aave/aave-v4:1e8de8630dfeb26ad309d986eaec44c1ceb48a6d"
 
 SUITE_PROFILES=()
 SUITE_NAMES=()


### PR DESCRIPTION
The [latest benchmark comparison](https://github.com/foundry-rs/foundry/actions/runs/33055120820) emitted the same unknown `optimizer` configuration warning 204 times while exercising the pinned Aave v4 workload. The warning is correct: the old Aave `foundry.toml` places `optimizer` under `compilation_restrictions`, where the key is ignored.

This advances the Aave pin by two upstream commits to `1e8de8630dfeb26ad309d986eaec44c1ceb48a6d`, the earliest revision containing [Aave's cleanup](https://github.com/aave/aave-v4/pull/1308). The intervening changes do not modify contracts, tests, dependencies, or lockfiles, and the effective hub and spoke compiler settings remain unchanged.

This is CI-only repository maintenance, so no changelog entry is included; please apply `L-ignore`.

This PR was prepared with Codex, which audited the Actions logs, identified and verified the narrow upstream fix, and made the pin update.
