### PR TITLE
fix(forge): accept invalid node info response

### DIFF
--- a/.changelog/handle-invalid-request-node-info.md
+++ b/.changelog/handle-invalid-request-node-info.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Allowed fork endpoint detection to continue when an RPC gateway rejects the optional `anvil_nodeInfo` probe with an invalid-request response.

--- a/.changelog/handle-invalid-request-node-info.md
+++ b/.changelog/handle-invalid-request-node-info.md
@@ -1,5 +1,7 @@
 ---
 forge: patch
+foundry-common: patch
+foundry-evm-core: patch
 ---
 
 Allowed fork endpoint detection to continue when an RPC gateway rejects the optional `anvil_nodeInfo` probe with an invalid-request response.

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -547,14 +547,15 @@ impl<N: Network> ProviderBuilder<N> {
 /// normal JSON-RPC response. Only the exact `-32601` code is treated as method unavailability;
 /// authentication, internal, and transport errors must remain visible to callers.
 pub fn is_rpc_method_not_found(error: &TransportError) -> bool {
-    if error.as_error_resp().is_some_and(|response| response.code == -32601) {
-        return true;
-    }
-    let TransportError::Transport(error) = error else { return false };
-    error
-        .as_http_error()
-        .and_then(|error| rpc_error_code(&error.body))
-        .is_some_and(|code| code == -32601)
+    rpc_error_code(error) == Some(-32601)
+}
+
+/// Returns whether an RPC transport error reports that an optional method is unavailable.
+///
+/// Some RPC gateways return invalid-request instead of method-not-found for methods they do not
+/// expose.
+pub fn is_rpc_method_unavailable(error: &TransportError) -> bool {
+    matches!(rpc_error_code(error), Some(-32601 | -32600))
 }
 
 /// Returns an RPC URL safe for display by retaining only its scheme, host, and port.
@@ -570,12 +571,21 @@ pub fn redact_url(raw: &str) -> String {
     redacted.to_string()
 }
 
-fn rpc_error_code(body: &str) -> Option<i64> {
+fn rpc_error_code(error: &TransportError) -> Option<i64> {
+    if let Some(response) = error.as_error_resp() {
+        return Some(response.code);
+    }
+    let TransportError::Transport(error) = error else { return None };
+    error.as_http_error().and_then(|error| rpc_error_code_from_body(&error.body))
+}
+
+fn rpc_error_code_from_body(body: &str) -> Option<i64> {
     // HTTP transports may append human-readable diagnostics after the JSON-RPC body. Parse the
     // first complete JSON value instead of requiring the entire body to be JSON.
     let value =
         serde_json::Deserializer::from_str(body).into_iter::<serde_json::Value>().next()?.ok()?;
-    value.get("error").unwrap_or(&value).get("code")?.as_i64()
+    let error = value.get("error").unwrap_or(&value);
+    error.get("code")?.as_i64()
 }
 
 /// Constructs a provider with a 100 millisecond interval poll if it's a localhost URL (most likely
@@ -686,6 +696,21 @@ mod tests {
         assert!(!is_rpc_method_not_found(&internal_error));
         assert!(!is_rpc_method_not_found(&http_internal_error));
         assert!(!is_rpc_method_not_found(&transport_error));
+    }
+
+    #[test]
+    fn method_unavailable_recognizes_invalid_request() {
+        let invalid_request = TransportError::ErrorResp(ErrorPayload::invalid_request());
+        let http_invalid_request = alloy_transport::TransportErrorKind::http_error(
+            400,
+            r#"{"jsonrpc":"2.0","error":{"code":-32600,"message":"Unsupported method"}}"#
+                .to_owned(),
+        );
+        let internal_error = TransportError::ErrorResp(ErrorPayload::internal_error());
+
+        assert!(is_rpc_method_unavailable(&invalid_request));
+        assert!(is_rpc_method_unavailable(&http_invalid_request));
+        assert!(!is_rpc_method_unavailable(&internal_error));
     }
 
     #[test]

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -18,7 +18,7 @@ use alloy_rpc_types::{
 use eyre::{OptionExt, WrapErr};
 use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING,
-    provider::{ProviderBuilder, is_rpc_method_not_found},
+    provider::{ProviderBuilder, is_rpc_method_not_found, is_rpc_method_unavailable},
 };
 use foundry_config::{Chain, Config, ExecutionSpec, FoundryHardfork, GasLimit};
 use foundry_evm_hardforks::TempoHardfork;
@@ -188,7 +188,7 @@ impl AnvilNodeInfoProbe {
                 self.identified = true;
                 Ok(Some(node_info))
             }
-            Err(error) if !self.identified && is_rpc_method_not_found(&error) => Ok(None),
+            Err(error) if !self.identified && is_rpc_method_unavailable(&error) => Ok(None),
             Err(error) => Err(error).wrap_err("failed to determine network family from endpoint"),
         }
     }
@@ -1558,7 +1558,8 @@ mod tests {
     use alloy_rpc_types::TransactionRequest;
     use alloy_serde::WithOtherFields;
     use foundry_test_utils::rpc::{
-        spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
+        spawn_rpc_proxy_invalid_request_before, spawn_rpc_proxy_method_not_found_before,
+        spawn_rpc_proxy_rejecting_method_after,
     };
     #[cfg(feature = "optimism")]
     use op_revm::OpSpecId;
@@ -2257,6 +2258,22 @@ mod tests {
             error.to_string().contains("failed to determine network family from endpoint"),
             "{error}"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fork_node_info_invalid_request_is_optional() {
+        let (_api, handle) =
+            anvil::spawn(anvil::NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64)))
+                .await;
+        let fork_url =
+            spawn_rpc_proxy_invalid_request_before(handle.http_endpoint(), "anvil_nodeInfo", 1)
+                .await;
+        let mut evm_opts = EvmOpts { fork_url: Some(fork_url), ..Default::default() };
+
+        evm_opts.infer_network_from_fork().await.unwrap();
+
+        assert_eq!(evm_opts.networks, NetworkConfigs::default());
+        assert_eq!(evm_opts.env.chain_id, Some(NamedChain::Mainnet as u64));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -327,6 +327,24 @@ pub async fn spawn_rpc_proxy_method_not_found_before(
     .await
 }
 
+/// Spawns an RPC proxy that returns invalid-request for the first `unavailable_calls` requests to
+/// `method`.
+pub async fn spawn_rpc_proxy_invalid_request_before(
+    endpoint: String,
+    method: &'static str,
+    unavailable_calls: usize,
+) -> String {
+    spawn_rpc_proxy_rejecting_method(
+        endpoint,
+        method,
+        RpcMethodRejection::Before(unavailable_calls),
+        StatusCode::BAD_REQUEST,
+        -32600,
+        "invalid request",
+    )
+    .await
+}
+
 /// Spawns an RPC proxy that returns a vendor-specific JSON-RPC error for `method` after
 /// forwarding `successful_calls` requests.
 pub async fn spawn_rpc_proxy_erroring_method_after(


### PR DESCRIPTION
## Motivation

The initial `anvil_nodeInfo` request is an optional capability probe. Some RPC gateways reject unsupported custom methods with `-32600` (`Invalid Request`) instead of `-32601` (`Method not found`), causing otherwise valid fork endpoints to fail before standard network detection can proceed.

Fixes #16413

## Solution

Treat both `-32600` and `-32601` as method unavailability during the initial optional probe. Once an endpoint has been identified as Anvil, node-info errors remain strict. Authentication, transport, internal, and other RPC errors remain visible.

This adds coverage for normal and HTTP-wrapped invalid-request responses, as well as fork detection through a proxy that rejects the initial probe.

This PR was written with Codex assistance, including implementation and tests, and manually reviewed by me.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
