### PR TITLE
perf(forge): speed up named selector listing

### DIFF
--- a/.changelog/forge-targeted-selector-list.md
+++ b/.changelog/forge-targeted-selector-list.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Sped up listing selectors for a named contract by compiling only its source graph.

--- a/crates/forge/src/cmd/selectors.rs
+++ b/crates/forge/src/cmd/selectors.rs
@@ -241,6 +241,15 @@ impl SelectorsSubcommands {
             Self::List { contract, project_paths, no_group } => {
                 sh_status!("Listing selectors for contracts in the project...")?;
                 let (mut project, compiler) = project_from_paths(project_paths)?;
+                let target_path = contract
+                    .as_ref()
+                    .filter(|_| project.no_artifacts)
+                    .and_then(|contract| project.find_contract_path(contract).ok());
+                let compiler = if let Some(target_path) = target_path {
+                    compiler.files([target_path])
+                } else {
+                    compiler
+                };
                 let outcome = compile_abi_project(&mut project, compiler.quiet(true))?;
                 let artifacts = if let Some(contract) = contract {
                     let found_artifact = outcome.find_first(&contract);

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -5495,6 +5495,7 @@ contract Counter {
 }
    ",
     );
+    prj.add_source("Broken.sol", "contract Broken { function broken() public { missing(); } }");
 
     let artifact = prj.paths().artifacts.join("Counter.sol/Counter.json");
     let output = cmd.args(["selectors", "list", "Counter"]).assert_success();


### PR DESCRIPTION
## Summary

`forge selectors list <CONTRACT>` now ABI-compiles only the uniquely named contract's source graph when artifacts are disabled, avoiding compilation of unrelated project sources. Build-info runs and unresolved, missing, or ambiguous contract names retain the existing full-project path. The existing no-artifacts regression now includes an unrelated semantic compiler error, ensuring named listings stay target-only. This PR was written with Codex, including implementation, testing, benchmarking, and the PR description.

## Benchmarks

Measurements use exact `d88f52a3c` profiling binaries and five interleaved samples per project, with `forge clean` before every sample.

| Project / target | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Aave v4 / `AaveOracle` | 18.336 ± 5.587 s | 357.7 ± 121.4 ms | 51.3×; 17.978 s saved |
| Solady / `ERC20` | 2.688 ± 0.032 s | 97.8 ± 21.9 ms | 27.5×; 2.590 s saved |
