### PR TITLE
refactor(traces): unify decoder hardfork state

### DIFF
--- a/.changelog/anvil-decoder-executed-hardfork.md
+++ b/.changelog/anvil-decoder-executed-hardfork.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed anvil trace decoding to follow the executed network hardfork when a cross-namespace hardfork override is configured.

--- a/.changelog/unified-trace-decoder-hardfork.md
+++ b/.changelog/unified-trace-decoder-hardfork.md
@@ -1,0 +1,10 @@
+---
+anvil: patch
+cast: patch
+chisel: patch
+forge: patch
+forge-script: patch
+foundry-evm-traces: patch
+---
+
+Unified trace decoder hardfork configuration across supported networks.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1422,7 +1422,7 @@ impl NodeConfig {
             .unwrap_or_else(|| self.get_hardfork());
         let mut decoder_builder = CallTraceDecoderBuilder::new()
             .with_networks(self.networks)
-            .with_hardfork(Some(active_hardfork));
+            .with_hardfork(Some(self.networks.executed_hardfork(active_hardfork)));
         if self.print_traces {
             // if traces should get printed we configure the decoder with the signatures cache
             if let Ok(identifier) = SignaturesIdentifier::new(false) {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1420,18 +1420,9 @@ impl NodeConfig {
             .as_ref()
             .and_then(|fork| fork.config.read().hardfork)
             .unwrap_or_else(|| self.get_hardfork());
-        let mut decoder_builder =
-            CallTraceDecoderBuilder::new().with_networks(self.networks).with_tempo_hardfork(
-                self.networks.is_tempo().then(|| TempoHardfork::from(active_hardfork)),
-            );
-        #[cfg(feature = "monad")]
-        {
-            decoder_builder = decoder_builder.with_monad_hardfork(
-                self.networks
-                    .is_monad()
-                    .then(|| foundry_evm::hardfork::MonadHardfork::from(active_hardfork)),
-            );
-        }
+        let mut decoder_builder = CallTraceDecoderBuilder::new()
+            .with_networks(self.networks)
+            .with_hardfork(Some(active_hardfork));
         if self.print_traces {
             // if traces should get printed we configure the decoder with the signatures cache
             if let Ok(identifier) = SignaturesIdentifier::new(false) {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1490,7 +1490,7 @@ impl<N: Network> Backend<N> {
 
     /// Returns a trace decoder configured for the currently resolved hardfork.
     fn call_trace_decoder(&self) -> Arc<CallTraceDecoder> {
-        let hardfork = Some(self.hardfork());
+        let hardfork = Some(self.networks.executed_hardfork(self.hardfork()));
         let decoder = self.call_trace_decoder.read();
         if decoder.hardfork() == hardfork {
             return Arc::clone(&decoder);
@@ -9881,6 +9881,20 @@ mod tests {
 
         let outcome = target_api.backend.mine_block(vec![]).await.unwrap();
         assert_eq!(outcome.block_number, original_best_number + 1);
+    }
+
+    #[tokio::test]
+    async fn trace_decoder_follows_executed_hardfork_for_cross_namespace_override() {
+        let (api, _) = spawn(
+            NodeConfig::test_tempo()
+                .with_hardfork(Some(FoundryHardfork::Ethereum(EthereumHardfork::Prague))),
+        )
+        .await;
+
+        let decoder = api.backend.call_trace_decoder();
+        assert_eq!(decoder.hardfork(), Some(FoundryHardfork::Tempo(api.backend.tempo_hardfork())));
+        // The refresh compares the same coerced value, so repeated calls stay stable.
+        assert!(Arc::ptr_eq(&decoder, &api.backend.call_trace_decoder()));
     }
 
     #[cfg(feature = "monad")]

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1490,23 +1490,16 @@ impl<N: Network> Backend<N> {
 
     /// Returns a trace decoder configured for the currently resolved hardfork.
     fn call_trace_decoder(&self) -> Arc<CallTraceDecoder> {
-        let tempo_hardfork = self.is_tempo().then(|| self.tempo_hardfork());
-        #[cfg(feature = "monad")]
-        let monad_hardfork = self.is_monad().then(|| self.monad_hardfork());
+        let hardfork = Some(self.hardfork());
         let decoder = self.call_trace_decoder.read();
-        let is_current = decoder.tempo_hardfork() == tempo_hardfork;
-        #[cfg(feature = "monad")]
-        let is_current = is_current && decoder.monad_hardfork() == monad_hardfork;
-        if is_current {
+        if decoder.hardfork() == hardfork {
             return Arc::clone(&decoder);
         }
         drop(decoder);
 
         let mut decoder = self.call_trace_decoder.write();
         let mut updated = decoder.as_ref().clone();
-        updated.set_tempo_hardfork(tempo_hardfork);
-        #[cfg(feature = "monad")]
-        updated.set_monad_hardfork(monad_hardfork);
+        updated.set_hardfork(hardfork);
         *decoder = Arc::new(updated);
         Arc::clone(&decoder)
     }
@@ -9899,14 +9892,14 @@ mod tests {
         )
         .await;
         let stale_monad_nine = foundry_evm::traces::CallTraceDecoderBuilder::new()
-            .with_monad_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine))
+            .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into()))
             .build();
         *monad_eight.backend.call_trace_decoder.write() = Arc::new(stale_monad_nine);
 
         let decoder = monad_eight.backend.call_trace_decoder();
         assert_eq!(
-            decoder.monad_hardfork(),
-            Some(foundry_evm::hardfork::MonadHardfork::MonadEight)
+            decoder.hardfork(),
+            Some(foundry_evm::hardfork::MonadHardfork::MonadEight.into())
         );
         assert!(
             !decoder
@@ -9920,12 +9913,15 @@ mod tests {
         )
         .await;
         let stale_monad_eight = foundry_evm::traces::CallTraceDecoderBuilder::new()
-            .with_monad_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadEight))
+            .with_hardfork(Some(foundry_evm::hardfork::MonadHardfork::MonadEight.into()))
             .build();
         *monad_nine.backend.call_trace_decoder.write() = Arc::new(stale_monad_eight);
 
         let decoder = monad_nine.backend.call_trace_decoder();
-        assert_eq!(decoder.monad_hardfork(), Some(foundry_evm::hardfork::MonadHardfork::MonadNine));
+        assert_eq!(
+            decoder.hardfork(),
+            Some(foundry_evm::hardfork::MonadHardfork::MonadNine.into())
+        );
         assert_eq!(
             decoder
                 .labels

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -8,7 +8,7 @@ use foundry_compilers::artifacts::output_selection::ContractOutputSelection;
 use foundry_config::{Config, FoundryHardfork, TracingConfig};
 use foundry_debugger::Debugger;
 use foundry_evm::{
-    hardforks::{ExecutionSpec, TempoHardfork},
+    hardforks::TempoHardfork,
     opts::ForkEndpointIdentity,
     traces::{
         CallTraceDecoderBuilder, DebugTraceIdentifier,
@@ -81,29 +81,24 @@ pub(crate) async fn handle_traces(
         (None, ContractSources::default())
     };
 
-    let resolved_hardfork = hardfork.or(config.hardfork);
     let execution_network = networks.execution_network();
-    let tempo_hardfork = resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork);
-    let is_tempo = execution_network.is_tempo();
+    let mut resolved_hardfork = hardfork
+        .or(config.hardfork)
+        .filter(|hardfork| hardfork.namespace() == execution_network.hardfork_namespace());
+    if resolved_hardfork.is_none() && execution_network.is_tempo() {
+        resolved_hardfork = Some(config.evm_spec_id::<TempoHardfork>().into());
+    }
     #[cfg(feature = "monad")]
-    let is_monad = execution_network.is_monad();
-    #[cfg(feature = "monad")]
-    let monad_hardfork =
-        resolved_hardfork.and_then(foundry_evm::hardforks::MonadHardfork::from_foundry_hardfork);
+    if resolved_hardfork.is_none() && execution_network.is_monad() {
+        resolved_hardfork =
+            Some(config.evm_spec_id::<foundry_evm::hardforks::MonadHardfork>().into());
+    }
     let mut builder = CallTraceDecoderBuilder::new()
         .with_tracing_config(tracing)
         .with_signature_identifier(SignaturesIdentifier::from_config(config)?)
         .with_networks(networks)
         .with_chain_id(Some(chain.id()))
-        .with_tempo_hardfork(
-            tempo_hardfork.or_else(|| is_tempo.then(|| config.evm_spec_id::<TempoHardfork>())),
-        );
-    #[cfg(feature = "monad")]
-    {
-        builder = builder.with_monad_hardfork(monad_hardfork.or_else(|| {
-            is_monad.then(|| config.evm_spec_id::<foundry_evm::hardforks::MonadHardfork>())
-        }));
-    }
+        .with_hardfork(resolved_hardfork);
     let mut identifier = TraceIdentifiers::new().with_external(config, Some(chain))?;
     if let Some(contracts) = &known_contracts {
         builder = builder.with_known_contracts(contracts);

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -16,7 +16,6 @@ use foundry_config::{Chain, Config, RpcEndpointUrl};
 use foundry_evm::{
     core::evm::FoundryEvmNetwork,
     decode::decode_console_logs,
-    hardforks::{ExecutionSpec, TempoHardfork},
     traces::{
         CallTraceDecoder, CallTraceDecoderBuilder, TraceKind, decode_trace_arena,
         identifier::{SignaturesIdentifier, TraceIdentifiers},
@@ -177,22 +176,14 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         let chain_id = session_config.source_chain_id.map(Chain::from);
         let resolved_hardfork = session_config.resolved_hardfork;
 
-        #[cfg_attr(not(feature = "monad"), allow(unused_mut))]
-        let mut builder = CallTraceDecoderBuilder::new()
+        let builder = CallTraceDecoderBuilder::new()
             .with_labels(result.labeled_addresses.clone())
             .with_signature_identifier(SignaturesIdentifier::from_config(
                 &session_config.foundry_config,
             )?)
             .with_networks(session_config.foundry_config.networks)
             .with_chain_id(chain_id.map(|c| c.id()))
-            .with_tempo_hardfork(resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork));
-        #[cfg(feature = "monad")]
-        {
-            builder = builder.with_monad_hardfork(
-                resolved_hardfork
-                    .and_then(foundry_evm::hardforks::MonadHardfork::from_foundry_hardfork),
-            );
-        }
+            .with_hardfork(resolved_hardfork);
         let mut decoder = builder.build();
 
         let mut identifier =

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -461,6 +461,23 @@ impl NetworkConfigs {
         false
     }
 
+    /// Coerces `hardfork` into this network's family.
+    ///
+    /// Execution and fee rules apply the same lossy `From` conversions, so a cross-namespace
+    /// override such as `--hardfork prague` on a Tempo node runs as a Tempo hardfork. Callers that
+    /// need to describe what actually executed, like trace decoding, go through here rather than
+    /// carrying the configured value.
+    pub fn executed_hardfork(&self, hardfork: FoundryHardfork) -> FoundryHardfork {
+        if self.is_tempo() {
+            return TempoHardfork::from(hardfork).into();
+        }
+        #[cfg(feature = "monad")]
+        if self.is_monad() {
+            return MonadHardfork::from(hardfork).into();
+        }
+        hardfork
+    }
+
     /// Returns additional cheatcode contract addresses for the active network.
     pub const fn extra_cheatcode_addresses(&self) -> &'static [Address] {
         #[cfg(feature = "monad")]
@@ -1788,5 +1805,17 @@ mod tests {
             let cfg_optimism: NetworkConfigs = serde_json::from_str(json_optimism).unwrap();
             assert!(cfg_optimism.is_optimism());
         }
+    }
+
+    #[test]
+    fn executed_hardfork_follows_the_network_family() {
+        // A cross-namespace override runs as the configured network's hardfork, so the value used
+        // to describe execution has to be coerced the same way.
+        let prague = FoundryHardfork::Ethereum(EthereumHardfork::Prague);
+        assert_eq!(NetworkConfigs::default().executed_hardfork(prague), prague);
+        assert_eq!(
+            NetworkConfigs::with_tempo().executed_hardfork(prague),
+            FoundryHardfork::Tempo(TempoHardfork::from(prague))
+        );
     }
 }

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -29,7 +29,7 @@ use foundry_evm_core::{
 };
 #[cfg(feature = "monad")]
 type MonadHardfork = foundry_evm_hardforks::MonadHardfork;
-use foundry_evm_hardforks::TempoHardfork;
+use foundry_evm_hardforks::{ExecutionSpec, FoundryHardfork, TempoHardfork};
 use foundry_evm_networks::{NetworkConfigs, NetworkVariant, celo::transfer::CELO_TRANSFER_LABEL};
 use itertools::Itertools;
 use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
@@ -53,8 +53,6 @@ use tempo_precompiles::{
 mod monad;
 pub(crate) mod precompiles;
 
-#[cfg(not(feature = "monad"))]
-type MonadHardfork = ();
 type AddressEvents = HashMap<Address, BTreeMap<(B256, usize), Vec<Event>>>;
 type AddressAnonymousEvents = HashMap<Address, BTreeMap<usize, Vec<Event>>>;
 
@@ -182,18 +180,10 @@ impl CallTraceDecoderBuilder {
         self
     }
 
-    /// Sets the Tempo hardfork for hardfork-specific precompile detection.
+    /// Sets the hardfork used for network-specific metadata and precompile detection.
     #[inline]
-    pub const fn with_tempo_hardfork(mut self, hardfork: Option<TempoHardfork>) -> Self {
-        self.decoder.tempo_hardfork = hardfork;
-        self
-    }
-
-    /// Sets the Monad hardfork used to register address-scoped metadata when built.
-    #[cfg(feature = "monad")]
-    #[inline]
-    pub const fn with_monad_hardfork(mut self, hardfork: Option<MonadHardfork>) -> Self {
-        self.decoder.monad_hardfork = hardfork;
+    pub const fn with_hardfork(mut self, hardfork: Option<FoundryHardfork>) -> Self {
+        self.decoder.hardfork = hardfork;
         self
     }
 
@@ -288,11 +278,8 @@ pub struct CallTraceDecoder {
     /// Detailed opcodes for analysis.
     pub opcodes: Vec<OpCode>,
 
-    /// The Tempo hardfork, used to determine hardfork-specific precompiles.
-    pub tempo_hardfork: Option<TempoHardfork>,
-
-    /// The Monad hardfork, used to determine network- and hardfork-specific metadata.
-    monad_hardfork: Option<MonadHardfork>,
+    /// The hardfork used to determine network-specific metadata and precompiles.
+    hardfork: Option<FoundryHardfork>,
 
     /// Hide addresses when a label is available, showing only the label.
     pub compact_labels: bool,
@@ -304,8 +291,7 @@ impl CallTraceDecoder {
             CELO_TRANSFER,
             self.networks,
             self.chain_id,
-            self.tempo_hardfork,
-            self.monad_hardfork,
+            self.hardfork,
         ) {
             self.labels.entry(CELO_TRANSFER).or_insert_with(|| CELO_TRANSFER_LABEL.to_string());
         }
@@ -315,12 +301,13 @@ impl CallTraceDecoder {
         if self.networks.is_some_and(|networks| !networks.is_tempo()) {
             return;
         }
-        if self.tempo_hardfork.is_some_and(|hardfork| hardfork.is_t5()) {
+        let hardfork = self.hardfork.and_then(TempoHardfork::from_foundry_hardfork);
+        if hardfork.is_some_and(|hardfork| hardfork.is_t5()) {
             self.labels
                 .entry(TIP20_CHANNEL_RESERVE_ADDRESS)
                 .or_insert_with(|| "TIP20ChannelReserve".to_string());
         }
-        if self.tempo_hardfork.is_some_and(|hardfork| hardfork.is_t6()) {
+        if hardfork.is_some_and(|hardfork| hardfork.is_t6()) {
             self.labels
                 .entry(RECEIVE_POLICY_GUARD_ADDRESS)
                 .or_insert_with(|| "ReceivePolicyGuard".to_string());
@@ -338,36 +325,20 @@ impl CallTraceDecoder {
         INIT.get_or_init(Self::init)
     }
 
-    /// Returns the Monad hardfork used for address-scoped metadata.
-    #[cfg(feature = "monad")]
-    pub const fn monad_hardfork(&self) -> Option<MonadHardfork> {
-        self.monad_hardfork
+    /// Returns the hardfork used for network-specific metadata.
+    pub const fn hardfork(&self) -> Option<FoundryHardfork> {
+        self.hardfork
     }
 
-    /// Returns the Tempo hardfork used for address-scoped metadata.
-    pub const fn tempo_hardfork(&self) -> Option<TempoHardfork> {
-        self.tempo_hardfork
-    }
-
-    /// Rebuilds address-scoped metadata for a new Tempo hardfork.
-    pub fn set_tempo_hardfork(&mut self, hardfork: Option<TempoHardfork>) {
-        if self.tempo_hardfork == hardfork {
-            return;
-        }
-        self.tempo_hardfork = hardfork;
-        self.clear_addresses();
-    }
-
-    /// Rebuilds address-scoped metadata for a new Monad hardfork.
+    /// Rebuilds address-scoped metadata for a new hardfork.
     ///
     /// Hardfork changes invalidate previously identified addresses because the set of active
     /// precompiles can change. Global ABI and signature metadata is preserved.
-    #[cfg(feature = "monad")]
-    pub fn set_monad_hardfork(&mut self, hardfork: Option<MonadHardfork>) {
-        if self.monad_hardfork == hardfork {
+    pub fn set_hardfork(&mut self, hardfork: Option<FoundryHardfork>) {
+        if self.hardfork == hardfork {
             return;
         }
-        self.monad_hardfork = hardfork;
+        self.hardfork = hardfork;
         self.clear_addresses();
     }
 
@@ -502,9 +473,7 @@ impl CallTraceDecoder {
 
             opcodes: Vec::new(),
 
-            tempo_hardfork: None,
-
-            monad_hardfork: None,
+            hardfork: None,
             compact_labels: false,
         }
     }
@@ -543,8 +512,7 @@ impl CallTraceDecoder {
                     **address,
                     self.networks,
                     self.chain_id,
-                    self.tempo_hardfork,
-                    self.monad_hardfork,
+                    self.hardfork,
                 )
             })
             .map(|(address, label)| (*address, label.clone()))
@@ -584,8 +552,7 @@ impl CallTraceDecoder {
                     &node.trace,
                     self.networks,
                     self.chain_id,
-                    self.tempo_hardfork,
-                    self.monad_hardfork,
+                    self.hardfork,
                 )
             {
                 return false;
@@ -695,7 +662,9 @@ impl CallTraceDecoder {
         if self.networks.is_some_and(|networks| !networks.is_monad()) {
             return;
         }
-        let Some(hardfork) = self.monad_hardfork else { return };
+        let Some(hardfork) = self.hardfork.and_then(MonadHardfork::from_foundry_hardfork) else {
+            return;
+        };
 
         self.labels
             .entry(foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS)
@@ -738,13 +707,15 @@ impl CallTraceDecoder {
 
     fn is_current_committee_active(&self, address: Address) -> bool {
         address == CURRENT_COMMITTEE_ADDRESS
-            && self.tempo_hardfork.is_some_and(|hardfork| hardfork.is_t8())
+            && self
+                .hardfork
+                .and_then(TempoHardfork::from_foundry_hardfork)
+                .is_some_and(|hardfork| hardfork.is_t8())
             && precompiles::is_known_precompile(
                 address,
                 self.networks,
                 self.chain_id,
-                self.tempo_hardfork,
-                self.monad_hardfork,
+                self.hardfork,
             )
     }
 
@@ -943,13 +914,8 @@ impl CallTraceDecoder {
             };
         }
 
-        if let Some(trace) = precompiles::decode(
-            trace,
-            self.networks,
-            self.chain_id,
-            self.tempo_hardfork,
-            self.monad_hardfork,
-        ) {
+        if let Some(trace) = precompiles::decode(trace, self.networks, self.chain_id, self.hardfork)
+        {
             return trace;
         }
 
@@ -1576,8 +1542,7 @@ impl CallTraceDecoder {
                         &n.trace,
                         self.networks,
                         self.chain_id,
-                        self.tempo_hardfork,
-                        self.monad_hardfork,
+                        self.hardfork,
                     )
                 {
                     return false;
@@ -1803,7 +1768,7 @@ mod tests {
         CallTraceDecoderBuilder::new()
             .with_execution_network(NetworkVariant::Monad)
             .with_chain_id(Some(143))
-            .with_monad_hardfork(Some(hardfork))
+            .with_hardfork(Some(hardfork.into()))
             .build()
     }
 
@@ -3280,8 +3245,8 @@ mod tests {
         };
         let mut decoder = monad_decoder(MonadHardfork::MonadEight);
 
-        decoder.set_monad_hardfork(Some(MonadHardfork::MonadNine));
-        assert_eq!(decoder.monad_hardfork(), Some(MonadHardfork::MonadNine));
+        decoder.set_hardfork(Some(MonadHardfork::MonadNine.into()));
+        assert_eq!(decoder.hardfork(), Some(MonadHardfork::MonadNine.into()));
         assert_eq!(
             decoder
                 .labels
@@ -3295,8 +3260,8 @@ mod tests {
             Some("dippedIntoReserve()")
         );
 
-        decoder.set_monad_hardfork(Some(MonadHardfork::MonadEight));
-        assert_eq!(decoder.monad_hardfork(), Some(MonadHardfork::MonadEight));
+        decoder.set_hardfork(Some(MonadHardfork::MonadEight.into()));
+        assert_eq!(decoder.hardfork(), Some(MonadHardfork::MonadEight.into()));
         assert!(
             !decoder
                 .labels
@@ -3494,7 +3459,7 @@ mod tests {
         // Decoder with Tempo chain ID (4217).
         let decoder = CallTraceDecoderBuilder::new()
             .with_chain_id(Some(4217))
-            .with_tempo_hardfork(Some(TempoHardfork::T5))
+            .with_hardfork(Some(TempoHardfork::T5.into()))
             .build();
 
         assert_eq!(
@@ -3529,9 +3494,9 @@ mod tests {
 
     #[test]
     fn test_precompile_labels_follow_tempo_hardfork_activation_boundaries() {
-        let labels_for_hardfork = |hardfork| {
+        let labels_for_hardfork = |hardfork: TempoHardfork| {
             CallTraceDecoderBuilder::new()
-                .with_tempo_hardfork(Some(hardfork))
+                .with_hardfork(Some(hardfork.into()))
                 .build()
                 .precompile_labels()
         };
@@ -3572,7 +3537,7 @@ mod tests {
         let ethereum_labels = CallTraceDecoderBuilder::new()
             .with_execution_network(NetworkVariant::Ethereum)
             .with_chain_id(Some(4217))
-            .with_tempo_hardfork(Some(TempoHardfork::T7))
+            .with_hardfork(Some(TempoHardfork::T7.into()))
             .build()
             .precompile_labels();
         assert!(!ethereum_labels.contains_key(&TIP20_CHANNEL_RESERVE_ADDRESS));
@@ -3629,7 +3594,7 @@ mod tests {
 
         let mut decoder = CallTraceDecoderBuilder::new()
             .with_chain_id(Some(4217))
-            .with_tempo_hardfork(Some(TempoHardfork::T8))
+            .with_hardfork(Some(TempoHardfork::T8.into()))
             .build();
         decoder.clear_addresses();
         let decoded = decoder.decode_function(&trace).await;
@@ -3643,11 +3608,11 @@ mod tests {
         for decoder in [
             CallTraceDecoderBuilder::new()
                 .with_chain_id(Some(4217))
-                .with_tempo_hardfork(Some(TempoHardfork::T7))
+                .with_hardfork(Some(TempoHardfork::T7.into()))
                 .build(),
             CallTraceDecoderBuilder::new()
                 .with_chain_id(Some(1))
-                .with_tempo_hardfork(Some(TempoHardfork::T8))
+                .with_hardfork(Some(TempoHardfork::T8.into()))
                 .build(),
         ] {
             let decoded = decoder.decode_function(&trace).await;
@@ -3668,7 +3633,7 @@ mod tests {
         };
         let decoder = CallTraceDecoderBuilder::new()
             .with_chain_id(Some(4217))
-            .with_tempo_hardfork(Some(TempoHardfork::T8))
+            .with_hardfork(Some(TempoHardfork::T8.into()))
             .build();
         assert_eq!(
             decoder.decode_function(&trace).await.return_data.as_deref(),
@@ -3684,7 +3649,7 @@ mod tests {
     fn test_precompile_labels_skip_tempo_precompiles_on_other_chains() {
         let decoder = CallTraceDecoderBuilder::new()
             .with_chain_id(Some(1))
-            .with_tempo_hardfork(Some(TempoHardfork::T6))
+            .with_hardfork(Some(TempoHardfork::T6.into()))
             .build();
 
         let labels = decoder.precompile_labels();
@@ -3702,7 +3667,7 @@ mod tests {
                 (TIP20_CHANNEL_RESERVE_ADDRESS, reserve_label.clone()),
                 (RECEIVE_POLICY_GUARD_ADDRESS, guard_label.clone()),
             ])
-            .with_tempo_hardfork(Some(TempoHardfork::T6))
+            .with_hardfork(Some(TempoHardfork::T6.into()))
             .build();
 
         assert_eq!(decoder.labels.get(&TIP20_CHANNEL_RESERVE_ADDRESS), Some(&reserve_label));
@@ -3716,7 +3681,7 @@ mod tests {
         let mut decoder = CallTraceDecoderBuilder::new()
             .with_execution_network(NetworkVariant::Tempo)
             .with_labels([(user_address, user_label.clone())])
-            .with_tempo_hardfork(Some(TempoHardfork::T4))
+            .with_hardfork(Some(TempoHardfork::T4.into()))
             .build();
 
         let labels = decoder.precompile_labels();
@@ -3724,21 +3689,21 @@ mod tests {
         assert!(!labels.contains_key(&TIP20_CHANNEL_RESERVE_ADDRESS));
         assert!(!labels.contains_key(&RECEIVE_POLICY_GUARD_ADDRESS));
 
-        decoder.set_tempo_hardfork(Some(TempoHardfork::T6));
+        decoder.set_hardfork(Some(TempoHardfork::T6.into()));
         let labels = decoder.precompile_labels();
         assert!(labels.contains_key(&TIP_FEE_MANAGER_ADDRESS));
         assert!(labels.contains_key(&TIP20_CHANNEL_RESERVE_ADDRESS));
         assert!(labels.contains_key(&RECEIVE_POLICY_GUARD_ADDRESS));
         assert_eq!(decoder.labels.get(&user_address), Some(&user_label));
 
-        decoder.set_tempo_hardfork(Some(TempoHardfork::T4));
+        decoder.set_hardfork(Some(TempoHardfork::T4.into()));
         let labels = decoder.precompile_labels();
         assert!(labels.contains_key(&TIP_FEE_MANAGER_ADDRESS));
         assert!(!labels.contains_key(&TIP20_CHANNEL_RESERVE_ADDRESS));
         assert!(!labels.contains_key(&RECEIVE_POLICY_GUARD_ADDRESS));
         assert_eq!(decoder.labels.get(&user_address), Some(&user_label));
 
-        decoder.set_tempo_hardfork(None);
+        decoder.set_hardfork(None);
         assert_eq!(decoder.labels.get(&user_address), Some(&user_label));
     }
 
@@ -3749,7 +3714,7 @@ mod tests {
         let reserve_label = "UserReserve".to_string();
         let decoder = CallTraceDecoderBuilder::new()
             .with_labels([(TIP20_CHANNEL_RESERVE_ADDRESS, reserve_label.clone())])
-            .with_tempo_hardfork(None)
+            .with_hardfork(None)
             .build();
 
         assert_eq!(decoder.labels.get(&TIP20_CHANNEL_RESERVE_ADDRESS), Some(&reserve_label));
@@ -3773,7 +3738,7 @@ mod tests {
 
         let decoder = CallTraceDecoderBuilder::new()
             .with_chain_id(Some(4217))
-            .with_tempo_hardfork(Some(TempoHardfork::T6))
+            .with_hardfork(Some(TempoHardfork::T6.into()))
             .build();
         let decoded = decoder.decode_function(&trace).await;
 
@@ -3785,7 +3750,7 @@ mod tests {
     async fn test_t6_receive_policy_calls_decode() {
         let decoder = CallTraceDecoderBuilder::new()
             .with_chain_id(Some(4217))
-            .with_tempo_hardfork(Some(TempoHardfork::T6))
+            .with_hardfork(Some(TempoHardfork::T6.into()))
             .build();
 
         let set_policy = ITIP403Registry::setReceivePolicyCall {
@@ -3829,7 +3794,7 @@ mod tests {
     async fn test_t6_admin_key_calls_decode() {
         let decoder = CallTraceDecoderBuilder::new()
             .with_chain_id(Some(4217))
-            .with_tempo_hardfork(Some(TempoHardfork::T6))
+            .with_hardfork(Some(TempoHardfork::T6.into()))
             .build();
         let account = address!("0x0000000000000000000000000000000000000abc");
         let key = address!("0x0000000000000000000000000000000000000def");
@@ -4031,7 +3996,7 @@ mod tests {
 
         let decoder = CallTraceDecoderBuilder::new()
             .with_chain_id(Some(4217))
-            .with_tempo_hardfork(Some(TempoHardfork::T4))
+            .with_hardfork(Some(TempoHardfork::T4.into()))
             .build();
 
         let mut arena = CallTraceArena::default();
@@ -4172,8 +4137,7 @@ mod tests {
             monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS,
             Some(NetworkVariant::Ethereum.into()),
             Some(143),
-            None,
-            Some(MonadHardfork::MonadNine),
+            Some(MonadHardfork::MonadNine.into()),
         ));
     }
 }

--- a/crates/evm/traces/src/decoder/precompiles.rs
+++ b/crates/evm/traces/src/decoder/precompiles.rs
@@ -1,4 +1,3 @@
-use super::MonadHardfork;
 use crate::{CallTrace, DecodedCallData};
 use alloy_primitives::{Address, B256, U256, hex};
 use alloy_sol_types::{SolCall, abi, sol};
@@ -11,7 +10,7 @@ use foundry_evm_core::{
     },
     tempo::{TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, active_tempo_precompile_addresses},
 };
-use foundry_evm_hardforks::TempoHardfork;
+use foundry_evm_hardforks::{ExecutionSpec, FoundryHardfork, TempoHardfork};
 use foundry_evm_networks::NetworkConfigs;
 use itertools::Itertools;
 use revm_inspectors::tracing::types::DecodedCallTrace;
@@ -476,11 +475,9 @@ pub(crate) fn is_known_precompile(
     address: Address,
     networks: Option<NetworkConfigs>,
     chain_id: Option<u64>,
-    tempo_hardfork: Option<TempoHardfork>,
-    monad_hardfork: Option<MonadHardfork>,
+    hardfork: Option<FoundryHardfork>,
 ) -> bool {
-    #[cfg(not(feature = "monad"))]
-    let _ = monad_hardfork;
+    let tempo_hardfork = hardfork.and_then(TempoHardfork::from_foundry_hardfork);
 
     // Standard EVM precompiles (all chains).
     // An 18-byte zero prefix, as `P256_VERIFY` (0x..0100) occupies the two lowest bytes.
@@ -528,6 +525,8 @@ pub(crate) fn is_known_precompile(
     // Monad precompiles (only on a Monad chain or in an explicitly configured Monad context).
     #[cfg(feature = "monad")]
     {
+        let monad_hardfork =
+            hardfork.and_then(foundry_evm_hardforks::MonadHardfork::from_foundry_hardfork);
         let is_monad_context = networks.map_or_else(
             || {
                 chain_id.is_some_and(|id| {
@@ -571,15 +570,14 @@ pub(crate) fn is_known_precompile_call(
     trace: &CallTrace,
     networks: Option<NetworkConfigs>,
     chain_id: Option<u64>,
-    tempo_hardfork: Option<TempoHardfork>,
-    monad_hardfork: Option<MonadHardfork>,
+    hardfork: Option<FoundryHardfork>,
 ) -> bool {
     // Unlike the long-established low addresses, P256 is hardfork-dependent. Traces without an
     // execution classification, such as RPC callTracer frames, cannot safely infer it by address.
     if trace.address == P256_VERIFY && trace.maybe_precompile != Some(true) {
         return false;
     }
-    is_known_precompile(trace.address, networks, chain_id, tempo_hardfork, monad_hardfork)
+    is_known_precompile(trace.address, networks, chain_id, hardfork)
 }
 
 /// Tries to decode a precompile call. Returns `Some` if successful.
@@ -587,10 +585,9 @@ pub(super) fn decode(
     trace: &CallTrace,
     networks: Option<NetworkConfigs>,
     chain_id: Option<u64>,
-    tempo_hardfork: Option<TempoHardfork>,
-    monad_hardfork: Option<MonadHardfork>,
+    hardfork: Option<FoundryHardfork>,
 ) -> Option<DecodedCallTrace> {
-    if !is_known_precompile_call(trace, networks, chain_id, tempo_hardfork, monad_hardfork) {
+    if !is_known_precompile_call(trace, networks, chain_id, hardfork) {
         return None;
     }
 
@@ -629,17 +626,15 @@ mod tests {
 
     #[test]
     fn known_precompile_boundaries() {
-        assert!(is_known_precompile(P256_VERIFY, None, None, None, None));
+        assert!(is_known_precompile(P256_VERIFY, None, None, None));
         assert!(!is_known_precompile(
             address!("0x0000000000000000000000000000000000000101"),
-            None,
             None,
             None,
             None
         ));
         assert!(!is_known_precompile(
             address!("0x0000000000000000000000000000000000000012"),
-            None,
             None,
             None,
             None
@@ -650,19 +645,19 @@ mod tests {
     fn decodes_only_confirmed_p256_precompile_calls() {
         for maybe_precompile in [None, Some(false)] {
             let trace = CallTrace { address: P256_VERIFY, maybe_precompile, ..Default::default() };
-            assert!(decode(&trace, None, None, None, None).is_none());
+            assert!(decode(&trace, None, None, None).is_none());
         }
 
         let trace =
             CallTrace { address: P256_VERIFY, maybe_precompile: Some(true), ..Default::default() };
-        assert!(decode(&trace, None, None, None, None).is_some());
+        assert!(decode(&trace, None, None, None).is_some());
     }
 
     #[test]
     fn decodes_established_precompile_despite_negative_execution_classification() {
         let trace =
             CallTrace { address: SHA_256, maybe_precompile: Some(false), ..Default::default() };
-        assert!(decode(&trace, None, None, None, None).is_some());
+        assert!(decode(&trace, None, None, None).is_some());
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -68,7 +68,6 @@ use foundry_evm::{
     executors::ShowmapDomain,
     fork::ResolvedFork,
     fuzz::{BaseCounterExample, BasicTxDetails, CounterExample},
-    hardforks::{ExecutionSpec, TempoHardfork},
     opts::EvmOpts,
     traces::{
         backtrace::BacktraceBuilder, identifier::TraceIdentifiers, prune_trace_depth,
@@ -2997,14 +2996,7 @@ impl TestArgs {
             .with_known_contracts(&known_contracts)
             .with_networks(networks)
             .with_chain_id(remote_chain.map(|c| c.id()))
-            .with_tempo_hardfork(resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork));
-        #[cfg(feature = "monad")]
-        {
-            builder = builder.with_monad_hardfork(
-                resolved_hardfork
-                    .and_then(foundry_evm::hardforks::MonadHardfork::from_foundry_hardfork),
-            );
-        }
+            .with_hardfork(resolved_hardfork);
         // Signatures are of no value for gas reports.
         if !self.gas_report {
             builder =

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -26,7 +26,6 @@ use foundry_debugger::Debugger;
 use foundry_evm::{
     core::evm::FoundryEvmNetwork,
     decode::decode_console_logs,
-    hardforks::{ExecutionSpec, TempoHardfork},
     inspectors::cheatcodes::BroadcastableTransactions,
     traces::{
         CallTraceDecoder, CallTraceDecoderBuilder, DebugTraceIdentifier, TraceKind,
@@ -453,21 +452,13 @@ pub(crate) fn build_trace_decoder_for_context<FEN: FoundryEvmNetwork>(
     let mut tracing = script_config.config.tracing.clone();
     tracing.labels.extend(execution_result.labeled_addresses.clone());
 
-    #[cfg_attr(not(feature = "monad"), allow(unused_mut))]
-    let mut builder = CallTraceDecoderBuilder::new()
+    let builder = CallTraceDecoderBuilder::new()
         .with_tracing_config(&tracing)
         .with_known_contracts(known_contracts)
         .with_signature_identifier(SignaturesIdentifier::from_config(&script_config.config)?)
         .with_networks(script_config.config.networks)
         .with_chain_id(chain_id.map(|chain| chain.id()))
-        .with_tempo_hardfork(resolved_hardfork.and_then(TempoHardfork::from_foundry_hardfork));
-    #[cfg(feature = "monad")]
-    {
-        builder = builder.with_monad_hardfork(
-            resolved_hardfork
-                .and_then(foundry_evm::hardforks::MonadHardfork::from_foundry_hardfork),
-        );
-    }
+        .with_hardfork(resolved_hardfork);
     let mut decoder = builder.build();
 
     if tracing.decode_internal {

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -463,7 +463,7 @@ mod tests {
         assert_eq!(monad_eight_runner.evm_opts.networks, NetworkConfigs::with_monad());
         assert!(!monad_eight_runner.evm_opts.fork_network_is_inferred);
         assert_eq!(monad_eight.decoder.chain_id, Some(NamedChain::Monad as u64));
-        assert_eq!(monad_eight.decoder.monad_hardfork(), Some(MonadHardfork::MonadEight));
+        assert_eq!(monad_eight.decoder.hardfork(), Some(MonadHardfork::MonadEight.into()));
         assert!(!monad_eight.decoder.precompile_labels().contains_key(&RESERVE_BALANCE_ADDRESS));
 
         let monad_nine = context_for_rpc(&contexts, &monad_nine_rpc);
@@ -475,7 +475,7 @@ mod tests {
         assert_eq!(monad_nine_runner.evm_opts.networks, NetworkConfigs::with_monad());
         assert!(!monad_nine_runner.evm_opts.fork_network_is_inferred);
         assert_eq!(monad_nine.decoder.chain_id, Some(NamedChain::Monad as u64));
-        assert_eq!(monad_nine.decoder.monad_hardfork(), Some(MonadHardfork::MonadNine));
+        assert_eq!(monad_nine.decoder.hardfork(), Some(MonadHardfork::MonadNine.into()));
         assert_eq!(
             monad_nine.decoder.precompile_labels().get(&RESERVE_BALANCE_ADDRESS),
             Some(&"ReserveBalance".to_string())
@@ -545,11 +545,11 @@ mod tests {
         .collect::<HashMap<_, _>>();
 
         let monad_eight = decoders.get(&monad_eight_rpc).unwrap();
-        assert_eq!(monad_eight.monad_hardfork(), Some(MonadHardfork::MonadEight));
+        assert_eq!(monad_eight.hardfork(), Some(MonadHardfork::MonadEight.into()));
         assert!(!monad_eight.precompile_labels().contains_key(&RESERVE_BALANCE_ADDRESS));
 
         let monad_nine = decoders.get(&monad_nine_rpc).unwrap();
-        assert_eq!(monad_nine.monad_hardfork(), Some(MonadHardfork::MonadNine));
+        assert_eq!(monad_nine.hardfork(), Some(MonadHardfork::MonadNine.into()));
         assert_eq!(
             monad_nine.precompile_labels().get(&RESERVE_BALANCE_ADDRESS),
             Some(&"ReserveBalance".to_string())

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -203,7 +203,7 @@ mod tests {
         CallTraceDecoderBuilder::new()
             .with_networks(NetworkConfigs::with_monad())
             .with_chain_id(Some(143))
-            .with_monad_hardfork(Some(hardfork))
+            .with_hardfork(Some(hardfork.into()))
             .build()
     }
 


### PR DESCRIPTION
`CallTraceDecoder` currently stores network-specific hardforks separately even though execution resolves a single `FoundryHardfork`. This requires callers to decompose that value when configuring and updating the decoder.

Store the resolved `FoundryHardfork` directly and let network-specific metadata extract its relevant variant internally. This simplifies decoder configuration, precompile detection, and runtime refreshes. It also lets Base use the same builder, state, and update APIs instead of adding a parallel Base upgrade field and feature-gated call-site plumbing.