### PR TITLE
fix(forge, anvil): accept method-not-supported node info replies

### DIFF
--- a/.changelog/accept-method-not-supported-node-info.md
+++ b/.changelog/accept-method-not-supported-node-info.md
@@ -1,0 +1,7 @@
+---
+anvil: patch
+forge: patch
+foundry-common: patch
+---
+
+Accepted EIP-1474 `-32004` method-not-supported responses to the optional `anvil_nodeInfo` probe as method unavailability, so endpoints such as Hardhat can be forked, and made anvil's fork detection use the same classification as forge's.

--- a/.changelog/node-info-probe-empty-params.md
+++ b/.changelog/node-info-probe-empty-params.md
@@ -1,0 +1,9 @@
+---
+anvil: patch
+cast: patch
+forge: patch
+foundry-common: patch
+foundry-evm-core: patch
+---
+
+Sent the `anvil_nodeInfo` and `anvil_metadata` requests with `[]` parameters instead of the invalid `"params": null`.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -39,7 +39,10 @@ use anvil_server::ServerConfig;
 use eyre::{Context, Result};
 use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING, REQUEST_TIMEOUT,
-    provider::{ProviderBuilder, RetryProvider, is_rpc_method_not_found, redact_url},
+    provider::{
+        ProviderBuilder, RetryProvider, is_rpc_method_not_found, is_rpc_method_unavailable,
+        redact_url,
+    },
 };
 use foundry_config::Config;
 use foundry_evm::{
@@ -121,7 +124,7 @@ impl AnvilNodeInfoProbe {
                 self.identified = true;
                 Ok(Some(node_info))
             }
-            Err(error) if !self.identified && is_rpc_method_not_found(&error) => Ok(None),
+            Err(error) if !self.identified && is_rpc_method_unavailable(&error) => Ok(None),
             Err(error) => {
                 Err(error).wrap_err("failed to determine network family from fork endpoint")
             }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -40,8 +40,8 @@ use eyre::{Context, Result};
 use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING, REQUEST_TIMEOUT,
     provider::{
-        ProviderBuilder, RetryProvider, is_rpc_method_not_found, is_rpc_method_unavailable,
-        redact_url,
+        NO_PARAMS, ProviderBuilder, RetryProvider, is_rpc_method_not_found,
+        is_rpc_method_unavailable, redact_url,
     },
 };
 use foundry_config::Config;
@@ -119,7 +119,7 @@ impl AnvilNodeInfoProbe {
     }
 
     async fn request(&mut self, provider: &RetryProvider) -> Result<Option<NodeInfo>> {
-        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), ()).await {
+        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), NO_PARAMS).await {
             Ok(node_info) => {
                 self.identified = true;
                 Ok(Some(node_info))
@@ -1566,7 +1566,7 @@ impl NodeConfig {
             instance_id,
             source_fork_block_number,
             source_fork_block_hash,
-        ) = match provider.raw_request::<_, Metadata>("anvil_metadata".into(), ()).await {
+        ) = match provider.raw_request::<_, Metadata>("anvil_metadata".into(), NO_PARAMS).await {
             Ok(metadata) => (
                 metadata.chain_id,
                 source_chain_id_override.unwrap_or_else(|| {

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -44,7 +44,8 @@ use foundry_evm_networks::NetworkConfigs;
 use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope};
 use foundry_test_utils::rpc::{
     self, next_http_rpc_endpoint, next_rpc_endpoint, spawn_rpc_proxy_erroring_method_after,
-    spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
+    spawn_rpc_proxy_internal_error_after, spawn_rpc_proxy_method_not_found_before,
+    spawn_rpc_proxy_rejecting_method_after,
 };
 use futures::StreamExt;
 use revm::{
@@ -95,11 +96,23 @@ pub fn fork_config() -> NodeConfig {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_fork_rejects_anvil_node_info_rpc_error() {
+async fn test_fork_accepts_node_info_method_not_supported() {
     let (_api, origin) =
         spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
     let fork_url =
         spawn_rpc_proxy_erroring_method_after(origin.http_endpoint(), "anvil_nodeInfo", 0).await;
+
+    let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
+
+    assert_eq!(api.chain_id(), NamedChain::Mainnet as u64);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_rejects_anvil_node_info_internal_error() {
+    let (_api, origin) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
+    let fork_url =
+        spawn_rpc_proxy_internal_error_after(origin.http_endpoint(), "anvil_nodeInfo", 0).await;
 
     let result = try_spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
     let Err(error) = result else { panic!("expected fork startup to fail") };

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -21,7 +21,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     FoundryTransactionBuilder,
-    provider::ProviderBuilder,
+    provider::{NO_PARAMS, ProviderBuilder},
     sh_warn, shell,
     tempo::{
         self, AccountsStoreView, KeyType, maybe_print_fee_token, read_tempo_accounts_store,
@@ -3831,7 +3831,7 @@ async fn anvil_tempo_hardfork_active<P>(
 where
     P: Provider<TempoNetwork>,
 {
-    let info = provider.raw_request::<_, AnvilNodeInfo>("anvil_nodeInfo".into(), ()).await?;
+    let info = provider.raw_request::<_, AnvilNodeInfo>("anvil_nodeInfo".into(), NO_PARAMS).await?;
     Ok(active_from_anvil_node_info(&info, hardfork))
 }
 

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -17,7 +17,7 @@ use alloy_provider::{
     fillers::{FillProvider, JoinFill, RecommendedFillers, WalletFiller},
     network::{AnyNetwork, EthereumWallet},
 };
-use alloy_rpc_client::ClientBuilder;
+use alloy_rpc_client::{ClientBuilder, NoParams};
 use alloy_transport::{
     TransportError, TransportFut, layers::RetryBackoffLayer, utils::guess_local_url,
 };
@@ -559,6 +559,12 @@ pub fn is_rpc_method_not_found(error: &TransportError) -> bool {
 pub fn is_rpc_method_unavailable(error: &TransportError) -> bool {
     matches!(rpc_error_code(error), Some(-32601 | -32600 | -32004))
 }
+
+/// Empty JSON-RPC parameters, serialized as `[]`.
+///
+/// Passing `()` to a raw request serializes to `"params": null`, which JSON-RPC 2.0 does not
+/// allow: `params` is a structured value that may be omitted.
+pub const NO_PARAMS: NoParams = [];
 
 /// Returns an RPC URL safe for display by retaining only its scheme, host, and port.
 pub fn redact_url(raw: &str) -> String {

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -552,10 +552,12 @@ pub fn is_rpc_method_not_found(error: &TransportError) -> bool {
 
 /// Returns whether an RPC transport error reports that an optional method is unavailable.
 ///
-/// Some RPC gateways return invalid-request instead of method-not-found for methods they do not
-/// expose.
+/// Endpoints disagree on how they report a method they do not expose: the JSON-RPC spec reserves
+/// `-32601` (method not found), some RPC gateways answer `-32600` (invalid request), and
+/// EIP-1474 defines `-32004` (method not supported). Authentication, internal, and transport
+/// errors remain visible to callers.
 pub fn is_rpc_method_unavailable(error: &TransportError) -> bool {
-    matches!(rpc_error_code(error), Some(-32601 | -32600))
+    matches!(rpc_error_code(error), Some(-32601 | -32600 | -32004))
 }
 
 /// Returns an RPC URL safe for display by retaining only its scheme, host, and port.
@@ -699,18 +701,34 @@ mod tests {
     }
 
     #[test]
-    fn method_unavailable_recognizes_invalid_request() {
-        let invalid_request = TransportError::ErrorResp(ErrorPayload::invalid_request());
-        let http_invalid_request = alloy_transport::TransportErrorKind::http_error(
-            400,
-            r#"{"jsonrpc":"2.0","error":{"code":-32600,"message":"Unsupported method"}}"#
-                .to_owned(),
-        );
-        let internal_error = TransportError::ErrorResp(ErrorPayload::internal_error());
+    fn method_unavailable_recognizes_unsupported_method_codes() {
+        for code in [-32601, -32600, -32004] {
+            let error_response = TransportError::ErrorResp(ErrorPayload {
+                code,
+                message: "method unavailable".into(),
+                data: None,
+            });
+            let http_error = alloy_transport::TransportErrorKind::http_error(
+                403,
+                format!(
+                    r#"{{"jsonrpc":"2.0","error":{{"code":{code},"message":"method unavailable"}}}}"#
+                ),
+            );
 
-        assert!(is_rpc_method_unavailable(&invalid_request));
-        assert!(is_rpc_method_unavailable(&http_invalid_request));
+            assert!(is_rpc_method_unavailable(&error_response), "{code}");
+            assert!(is_rpc_method_unavailable(&http_error), "{code}");
+        }
+
+        let internal_error = TransportError::ErrorResp(ErrorPayload::internal_error());
+        let http_internal_error = alloy_transport::TransportErrorKind::http_error(
+            500,
+            r#"{"jsonrpc":"2.0","error":{"code":-32603,"message":"internal error"}}"#.to_owned(),
+        );
+        let transport_error = alloy_transport::TransportErrorKind::backend_gone();
+
         assert!(!is_rpc_method_unavailable(&internal_error));
+        assert!(!is_rpc_method_unavailable(&http_internal_error));
+        assert!(!is_rpc_method_unavailable(&transport_error));
     }
 
     #[test]

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -1558,8 +1558,8 @@ mod tests {
     use alloy_rpc_types::TransactionRequest;
     use alloy_serde::WithOtherFields;
     use foundry_test_utils::rpc::{
-        spawn_rpc_proxy_invalid_request_before, spawn_rpc_proxy_method_not_found_before,
-        spawn_rpc_proxy_rejecting_method_after,
+        spawn_rpc_proxy_internal_error_after, spawn_rpc_proxy_invalid_request_before,
+        spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
     };
     #[cfg(feature = "optimism")]
     use op_revm::OpSpecId;
@@ -2248,8 +2248,7 @@ mod tests {
             anvil::spawn(anvil::NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64)))
                 .await;
         let fork_url =
-            spawn_rpc_proxy_rejecting_method_after(handle.http_endpoint(), "anvil_nodeInfo", 0)
-                .await;
+            spawn_rpc_proxy_internal_error_after(handle.http_endpoint(), "anvil_nodeInfo", 0).await;
         let mut evm_opts = EvmOpts { fork_url: Some(fork_url), ..Default::default() };
 
         let error = evm_opts.infer_network_from_fork().await.unwrap_err();
@@ -2258,6 +2257,22 @@ mod tests {
             error.to_string().contains("failed to determine network family from endpoint"),
             "{error}"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fork_node_info_method_not_supported_is_optional() {
+        let (_api, handle) =
+            anvil::spawn(anvil::NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64)))
+                .await;
+        let fork_url =
+            spawn_rpc_proxy_rejecting_method_after(handle.http_endpoint(), "anvil_nodeInfo", 0)
+                .await;
+        let mut evm_opts = EvmOpts { fork_url: Some(fork_url), ..Default::default() };
+
+        evm_opts.infer_network_from_fork().await.unwrap();
+
+        assert_eq!(evm_opts.networks, NetworkConfigs::default());
+        assert_eq!(evm_opts.env.chain_id, Some(NamedChain::Mainnet as u64));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -18,7 +18,7 @@ use alloy_rpc_types::{
 use eyre::{OptionExt, WrapErr};
 use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING,
-    provider::{ProviderBuilder, is_rpc_method_not_found, is_rpc_method_unavailable},
+    provider::{NO_PARAMS, ProviderBuilder, is_rpc_method_not_found, is_rpc_method_unavailable},
 };
 use foundry_config::{Chain, Config, ExecutionSpec, FoundryHardfork, GasLimit};
 use foundry_evm_hardforks::TempoHardfork;
@@ -183,7 +183,7 @@ impl AnvilNodeInfoProbe {
         &mut self,
         provider: &P,
     ) -> eyre::Result<Option<NodeInfo>> {
-        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), ()).await {
+        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), NO_PARAMS).await {
             Ok(node_info) => {
                 self.identified = true;
                 Ok(Some(node_info))
@@ -734,7 +734,10 @@ impl EvmOpts {
                     instance_id,
                     source_fork_block_number,
                     source_fork_block_hash,
-                ) = match provider.raw_request::<_, Metadata>("anvil_metadata".into(), ()).await {
+                ) = match provider
+                    .raw_request::<_, Metadata>("anvil_metadata".into(), NO_PARAMS)
+                    .await
+                {
                     Ok(metadata) => {
                         let forked_network = metadata.forked_network;
                         (

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -345,6 +345,24 @@ pub async fn spawn_rpc_proxy_invalid_request_before(
     .await
 }
 
+/// Spawns an RPC proxy that returns a JSON-RPC internal error for `method` after forwarding
+/// `successful_calls` requests.
+pub async fn spawn_rpc_proxy_internal_error_after(
+    endpoint: String,
+    method: &'static str,
+    successful_calls: usize,
+) -> String {
+    spawn_rpc_proxy_rejecting_method(
+        endpoint,
+        method,
+        RpcMethodRejection::After(successful_calls),
+        StatusCode::OK,
+        -32603,
+        "internal error",
+    )
+    .await
+}
+
 /// Spawns an RPC proxy that returns a vendor-specific JSON-RPC error for `method` after
 /// forwarding `successful_calls` requests.
 pub async fn spawn_rpc_proxy_erroring_method_after(


### PR DESCRIPTION
## Motivation

Forking a Hardhat node still fails after #16414, and there are two separate reasons.

Hardhat answers the `anvil_nodeInfo` probe with `-32004`, which EIP-1474 defines as "method not supported". The probe only accepts `-32601` and `-32600`, so with Hardhat 3:

```
$ forge test   # forge 1.8.0, fork url pointing at hardhat 3.15.0
[FAIL: vm.createSelectFork: could not instantiate forked environment with provider 127.0.0.1;
 failed to determine network family from endpoint; server returned an error response:
 error code -32004: Method anvil_nodeInfo is not supported] setUp()
```

And anvil has its own copy of the probe in `config.rs` that #16414 didn't touch, so `anvil --fork-url` can't fork a Hardhat node at all:

```
$ anvil --fork-url http://127.0.0.1:8551   # hardhat 2.29.1
Error: failed to determine network family from fork endpoint
- server returned an error response: error code -32600: Invalid request

$ anvil --fork-url http://127.0.0.1:8552   # hardhat 3.15.0
Error: failed to determine network family from fork endpoint
- server returned an error response: error code -32004: Method anvil_nodeInfo is not supported
```

There's a smaller bug underneath: the probe sends `"params": null`, because `raw_request(..., ())` serializes the unit type that way. That's not valid JSON-RPC 2.0, and it's the reason Hardhat 2 answers `-32600` (rejecting the request shape) instead of saying the method is missing. Alloy fixed the same thing on its side in alloy-rs/alloy#1193.

## Solution

Two commits, and the order matters. First accept `-32004` in `is_rpc_method_unavailable` and use that function for anvil's probe too. Then send `[]` instead of `null`. With valid params Hardhat 2 answers `-32004` instead of `-32600`, so the params fix alone would re-break it.

I kept the accepted set explicit rather than treating any error as "not Anvil": #16295 made auth, internal, and transport errors visible on purpose, and they stay fatal here. Same for errors after the endpoint has been identified as Anvil. The tests asserting both of those had used `-32004` as their stand-in error code, so they now use a new internal-error proxy helper (`-32603`), and the `-32004` case has its own tests.

Tested against Hardhat 2.28.6, 2.29.1 and 3.15.0. A locally built anvil forks the same two nodes shown failing above.

This PR was written with Claude Code assistance and reviewed by me.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
