### PR TITLE
refactor(evm): share nested frame execution

### DIFF
--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -4,24 +4,19 @@ use alloy_evm::{
 use foundry_fork_db::DatabaseError;
 use revm::{
     context::{
-        BlockEnv, ContextTr, Evm as RevmEvm, Journal, LocalContextTr, TxEnv,
+        BlockEnv, Evm as RevmEvm, Journal, TxEnv,
         result::{EVMError, ResultAndState},
     },
-    handler::{
-        EthFrame, EvmTr, FrameResult, Handler, MainnetHandler, instructions::EthInstructions,
-    },
+    handler::{EthFrame, EvmTr, FrameResult, MainnetHandler, instructions::EthInstructions},
     inspector::InspectorHandler,
-    interpreter::{
-        FrameInput, GasTracker, SharedMemory, interpreter::EthInterpreter,
-        interpreter_action::FrameInit,
-    },
+    interpreter::{FrameInput, interpreter::EthInterpreter},
     primitives::hardfork::SpecId,
 };
 
 use crate::{
     FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
-    evm::{FoundryEvmFactory, NestedEvm, NestedEvmFor},
+    evm::{FoundryEvmFactory, NestedEvm, NestedEvmFor, run_inspected_frame},
 };
 
 type EthEvmHandler<'db, I> = MainnetHandler<EthRevmEvm<'db, I>, EVMError<DatabaseError>, EthFrame>;
@@ -107,24 +102,7 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = EthEvmHandler::<I>::default();
-        // Create first frame
-        let memory =
-            SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
-        let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
-
-        // Run execution loop
-        let mut frame_result = handler.inspect_run_exec_loop(self, first_frame_input)?;
-
-        // Handle last frame result
-        let mut parent_gas = GasTracker::new(
-            frame_result.gas().limit(),
-            frame_result.gas().remaining(),
-            frame_result.gas().reservoir(),
-        );
-        handler.last_frame_result(self, &mut frame_result, &mut parent_gas)?;
-
-        Ok(frame_result)
+        run_inspected_frame(self, EthEvmHandler::<I>::default(), frame)
     }
 
     fn transact_raw(&mut self, tx: Self::Tx) -> eyre::Result<ResultAndState> {

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -18,13 +18,15 @@ use foundry_fork_db::{DatabaseError, ForkBlockEnv};
 use revm::{
     Database,
     context::{
-        ContextTr, JournalTr,
+        ContextTr, JournalTr, LocalContextTr,
         result::{EVMError, HaltReason, ResultAndState},
     },
-    handler::FrameResult,
-    inspector::NoOpInspector,
+    handler::{EvmTr, FrameResult},
+    inspector::{InspectorEvmTr, InspectorHandler, NoOpInspector},
     interpreter::{
-        CallInput, CallInputs, CallScheme, CallValue, CreateInputs, FrameInput, InstructionResult,
+        CallInput, CallInputs, CallScheme, CallValue, CreateInputs, FrameInput, GasTracker,
+        InstructionResult, SharedMemory, interpreter::EthInterpreter,
+        interpreter_action::FrameInit,
     },
     primitives::hardfork::SpecId,
 };
@@ -258,6 +260,29 @@ pub type NestedEvmClosure<'a, F> = &'a mut dyn for<'j> FnMut(
 
 /// Nested EVM closure for a Foundry EVM network.
 pub type NestedEvmClosureFor<'a, FEN> = NestedEvmClosure<'a, EvmFactoryFor<FEN>>;
+
+/// Runs a nested frame with inspection and settles its gas into the parent frame.
+pub(crate) fn run_inspected_frame<H>(
+    evm: &mut H::Evm,
+    mut handler: H,
+    frame_input: FrameInput,
+) -> Result<FrameResult, H::Error>
+where
+    H: InspectorHandler<IT = EthInterpreter>,
+    H::Evm: InspectorEvmTr,
+{
+    let memory =
+        SharedMemory::new_with_buffer(evm.ctx_ref().local().shared_memory_buffer().clone());
+    let first_frame_input = FrameInit { depth: 0, memory, frame_input };
+    let mut frame_result = handler.inspect_run_exec_loop(evm, first_frame_input)?;
+    let mut parent_gas = GasTracker::new(
+        frame_result.gas().limit(),
+        frame_result.gas().remaining(),
+        frame_result.gas().reservoir(),
+    );
+    handler.last_frame_result(evm, &mut frame_result, &mut parent_gas)?;
+    Ok(frame_result)
+}
 
 /// Clones the current context (env + journal), passes the database, cloned env,
 /// and cloned journal inner to the callback. The callback builds whatever EVM it

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -22,21 +22,21 @@ use monad_revm::{
 };
 use revm::{
     context::{
-        BlockEnv, ContextTr, LocalContextTr, Transaction, TransactionType, TxEnv,
+        BlockEnv, ContextTr, Transaction, TransactionType, TxEnv,
         journaled_state::account::JournaledAccountTr,
         result::{EVMError, ResultAndState},
     },
     context_interface::{Cfg, ContextSetters, transaction::AuthorizationTr},
-    handler::{EthFrame, EvmTr, FrameResult, Handler},
+    handler::{EthFrame, EvmTr, FrameResult},
     inspector::{InspectSystemCallEvm, Inspector, InspectorHandler},
-    interpreter::{FrameInput, GasTracker, SharedMemory, interpreter_action::FrameInit},
+    interpreter::FrameInput,
     primitives::{Address, Bytes, HashSet, U256},
 };
 
 use crate::{
     FoundryChain, FoundryContextExt, FoundryInspectorExt, FoundryJournal,
     backend::{DatabaseExt, JournaledState},
-    evm::{FoundryEvmFactory, NestedEvm, NestedEvmFor},
+    evm::{FoundryEvmFactory, NestedEvm, NestedEvmFor, run_inspected_frame},
 };
 
 impl FoundryChain<TxEnv> for MonadChainContext {
@@ -452,22 +452,7 @@ impl<'db, I: FoundryInspectorExt<MonadContext<&'db mut dyn DatabaseExt<MonadEvmF
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = MonadEvmHandler::<I>::new();
-
-        let memory =
-            SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
-        let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
-
-        let mut frame_result = handler.inspect_run_exec_loop(self, first_frame_input)?;
-
-        let mut parent_gas = GasTracker::new(
-            frame_result.gas().limit(),
-            frame_result.gas().remaining(),
-            frame_result.gas().reservoir(),
-        );
-        handler.last_frame_result(self, &mut frame_result, &mut parent_gas)?;
-
-        Ok(frame_result)
+        run_inspected_frame(self, MonadEvmHandler::<I>::new(), frame)
     }
 
     fn transact_raw(&mut self, tx: Self::Tx) -> eyre::Result<ResultAndState> {

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -7,21 +7,21 @@ use op_revm::{
 };
 use revm::{
     context::{
-        BlockEnv, ContextTr, Journal, LocalContextTr,
+        BlockEnv, Journal,
         result::{EVMError, HaltReason, ResultAndState},
     },
-    handler::{EthFrame, EvmTr, FrameResult, Handler, instructions::EthInstructions},
+    handler::{EthFrame, EvmTr, FrameResult, instructions::EthInstructions},
     inspector::InspectorHandler,
-    interpreter::{
-        FrameInput, GasTracker, InstructionResult, SharedMemory, interpreter::EthInterpreter,
-        interpreter_action::FrameInit,
-    },
+    interpreter::{FrameInput, InstructionResult, interpreter::EthInterpreter},
 };
 
 use crate::{
     FoundryChain, FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
-    evm::{FoundryEvmFactory, FoundryEvmNetwork, IntoInstructionResult, NestedEvm, NestedEvmFor},
+    evm::{
+        FoundryEvmFactory, FoundryEvmNetwork, IntoInstructionResult, NestedEvm, NestedEvmFor,
+        run_inspected_frame,
+    },
 };
 
 impl FoundryChain<OpTx> for L1BlockInfo {}
@@ -135,24 +135,7 @@ impl<'db, I: FoundryInspectorExt<OpEvmContext<&'db mut dyn DatabaseExt<OpEvmFact
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = OpEvmHandler::<I>::new();
-        let memory =
-            SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
-        let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
-
-        let mut frame_result =
-            handler.inspect_run_exec_loop(self, first_frame_input).map_err(map_op_error)?;
-
-        let mut parent_gas = GasTracker::new(
-            frame_result.gas().limit(),
-            frame_result.gas().remaining(),
-            frame_result.gas().reservoir(),
-        );
-        handler
-            .last_frame_result(self, &mut frame_result, &mut parent_gas)
-            .map_err(map_op_error)?;
-
-        Ok(frame_result)
+        run_inspected_frame(self, OpEvmHandler::<I>::new(), frame).map_err(map_op_error)
     }
 
     fn transact_raw(&mut self, tx: Self::Tx) -> eyre::Result<ResultAndState<HaltReason>> {

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -4,12 +4,12 @@ use foundry_evm_hardforks::TempoHardfork;
 use foundry_fork_db::DatabaseError;
 use revm::{
     context::{
-        ContextTr, Journal, LocalContextTr,
+        Journal,
         result::{EVMError, HaltReason, ResultAndState},
     },
-    handler::{EvmTr, FrameResult, Handler},
+    handler::{EvmTr, FrameResult},
     inspector::InspectorHandler,
-    interpreter::{FrameInput, GasTracker, SharedMemory, interpreter_action::FrameInit},
+    interpreter::FrameInput,
     state::Bytecode,
 };
 use tempo_evm::{TempoBlockEnv, TempoEvmFactory, TempoHaltReason, evm::TempoEvm};
@@ -26,7 +26,7 @@ use crate::{
     FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
     constants::{CALLER, SYSTEM_PRECOMPILE_STUB, TEST_CONTRACT_ADDRESS},
-    evm::{FoundryEvmFactory, NestedEvm, NestedEvmFor},
+    evm::{FoundryEvmFactory, NestedEvm, NestedEvmFor, run_inspected_frame},
     tempo::{TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, initialize_tempo_test_genesis_inner},
 };
 
@@ -140,24 +140,7 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
     }
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
-        let mut handler = TempoEvmHandler::new();
-        let memory =
-            SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
-        let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
-
-        let mut frame_result =
-            handler.inspect_run_exec_loop(self, first_frame_input).map_err(map_tempo_error)?;
-
-        let mut parent_gas = GasTracker::new(
-            frame_result.gas().limit(),
-            frame_result.gas().remaining(),
-            frame_result.gas().reservoir(),
-        );
-        handler
-            .last_frame_result(self, &mut frame_result, &mut parent_gas)
-            .map_err(map_tempo_error)?;
-
-        Ok(frame_result)
+        run_inspected_frame(self, TempoEvmHandler::new(), frame).map_err(map_tempo_error)
     }
 
     fn transact_raw(&mut self, tx: Self::Tx) -> eyre::Result<ResultAndState> {


### PR DESCRIPTION
Ethereum, Optimism, Tempo, and Monad duplicate the mechanics for running an inspected nested frame: initializing shared memory, executing the frame loop, tracking parent gas, and settling the final result.

This centralizes that sequence while keeping network-specific handlers and error mapping in each adapter. It removes existing duplication and allows integrations such as Base to reuse the same execution path instead of adding another copy.