### PR TITLE
feat(cast): add --delegate to cast call

### DIFF
--- a/.changelog/cast-call-delegate.md
+++ b/.changelog/cast-call-delegate.md
@@ -1,0 +1,5 @@
+---
+cast: minor
+---
+
+`cast call --delegate` simulates the call as a `delegatecall` from the `--from` address, running the destination's code against the sender's storage.

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -115,8 +115,12 @@ pub struct CallArgs {
     ///
     /// The destination's runtime code is applied as a code override on the `--from` address and
     /// the call is then made to that address, so the destination's code runs in the caller's
-    /// storage context, exactly as an on-chain `delegatecall` would.
-    #[arg(long, requires = "from")]
+    /// storage context, like an on-chain `delegatecall`.
+    ///
+    /// Note that the executed code observes `msg.sender` (and `tx.origin`) equal to the `--from`
+    /// address itself, whereas in an on-chain `delegatecall` `msg.sender` is preserved from the
+    /// delegating contract's own caller.
+    #[arg(long, requires = "from", conflicts_with = "browser")]
     delegate: bool,
 
     /// Fetch the call trace from the node via `debug_traceCall` (callTracer) and render it,
@@ -395,33 +399,32 @@ impl CallArgs {
 
         // A `delegatecall` runs the destination's code against the caller's storage, which
         // `eth_call` cannot express. Overriding the caller's code with the destination's and
-        // then calling the caller reproduces exactly that context.
+        // then calling the caller reproduces that context. The retarget to the caller happens
+        // after the transaction is built, so calldata encoding and function resolution still
+        // see the destination.
         if delegate {
+            if command.is_some() {
+                eyre::bail!("`--delegate` cannot be combined with `--create`");
+            }
             let Some(target) = to else {
                 eyre::bail!("`--delegate` requires a destination address");
             };
             let target = target.resolve(&provider).await?;
+            let overrides = state_overrides.get_or_insert_with(Default::default);
+            if overrides.get(&from).is_some_and(|account| account.code.is_some()) {
+                eyre::bail!("`--delegate` conflicts with `--override-code` for the sender {from}");
+            }
             // A code override for the destination is the state this call runs against, so it
             // takes precedence over the deployed code.
-            let code = match state_overrides
-                .as_ref()
-                .and_then(|overrides| overrides.get(&target))
-                .and_then(|account| account.code.clone())
-            {
+            let code = match overrides.get(&target).and_then(|account| account.code.clone()) {
                 Some(code) => code,
                 None => provider.get_code_at(target).block_id(block.unwrap_or_default()).await?,
             };
             if code.is_empty() {
                 eyre::bail!("`--delegate` destination {target} has no code to delegate to");
             }
-
-            let account =
-                state_overrides.get_or_insert_with(Default::default).entry(from).or_default();
-            if account.code.is_some() {
-                eyre::bail!("`--delegate` conflicts with `--override-code` for the sender {from}");
-            }
-            account.code = Some(code);
-            to = Some(NameOrAddress::Address(from));
+            overrides.entry(from).or_default().code = Some(code);
+            to = Some(NameOrAddress::Address(target));
         }
 
         let code = if let Some(CallSubcommands::Create {
@@ -456,7 +459,13 @@ impl CallArgs {
         {
             return Ok(());
         }
-        let (tx, func) = builder.build(sender).await?;
+        let (mut tx, func) = builder.build(sender).await?;
+
+        // The delegate override put the destination's code on the sender, so the built call is
+        // aimed at the sender; the calldata above was still encoded against the destination.
+        if delegate {
+            tx.set_to(from);
+        }
 
         if debug_trace_call {
             let endpoint_identity = endpoint_identity
@@ -755,7 +764,10 @@ impl CallArgs {
             .call(&tx, func.as_ref(), block, state_overrides, block_overrides)
             .await?;
 
+        // With `--delegate` the call targets the sender, whose code comes from the override and
+        // was already checked to be non-empty, so the on-chain code lookup would be misleading.
         if response == "0x"
+            && !delegate
             && let Some(contract_address) = tx.to()
         {
             let code = provider.get_code_at(contract_address).await?;

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -84,6 +84,9 @@ use std::str::FromStr;
 ///   --override-state 0x123:0x1:0x1234
 ///   --override-state-diff 0x123:0x1:0x1234
 /// ```
+///
+/// `--delegate` builds on the same mechanism: it overrides the code of the `--from` address with
+/// the destination's code so the call runs as a `delegatecall`.
 #[derive(Debug, Parser)]
 pub struct CallArgs {
     /// The destination of the transaction.
@@ -107,6 +110,14 @@ pub struct CallArgs {
     /// Forks the remote rpc, executes the transaction locally and prints a trace
     #[arg(long, default_value_t = false)]
     trace: bool,
+
+    /// Simulate the call as a `delegatecall` from the `--from` address.
+    ///
+    /// The destination's runtime code is applied as a code override on the `--from` address and
+    /// the call is then made to that address, so the destination's code runs in the caller's
+    /// storage context, exactly as an on-chain `delegatecall` would.
+    #[arg(long, requires = "from")]
+    delegate: bool,
 
     /// Fetch the call trace from the node via `debug_traceCall` (callTracer) and render it,
     /// instead of re-executing the call locally like `--trace`.
@@ -229,6 +240,11 @@ impl CallArgs {
             if self.browser.browser {
                 eyre::bail!("--browser cannot be combined with --curl; use --from <ADDRESS>");
             }
+            if self.delegate {
+                // The code override that makes the call a `delegatecall` is read from the node,
+                // which `--curl` deliberately never contacts.
+                eyre::bail!("--delegate cannot be combined with --curl");
+            }
             return self.run_curl().await;
         }
 
@@ -336,13 +352,13 @@ impl CallArgs {
         <FEN::Network as Network>::TransactionRequest: FoundryTransactionBuilder<FEN::Network>,
     {
         config.networks = evm_opts.networks;
-        let state_overrides = self.get_state_overrides()?;
+        let mut state_overrides = self.get_state_overrides()?;
         let block_overrides = self.get_block_overrides()?;
         config.tracing = self.resolve_tracing(&config.tracing, shell::verbosity());
         let tracing = config.tracing.clone();
 
         let Self {
-            to,
+            mut to,
             mut sig,
             mut args,
             mut tx,
@@ -357,6 +373,7 @@ impl CallArgs {
             wallet,
             browser,
             force,
+            delegate,
             ..
         } = self;
 
@@ -375,6 +392,37 @@ impl CallArgs {
             SenderKind::from_wallet_opts(wallet).await?
         };
         let from = sender.address();
+
+        // A `delegatecall` runs the destination's code against the caller's storage, which
+        // `eth_call` cannot express. Overriding the caller's code with the destination's and
+        // then calling the caller reproduces exactly that context.
+        if delegate {
+            let Some(target) = to else {
+                eyre::bail!("`--delegate` requires a destination address");
+            };
+            let target = target.resolve(&provider).await?;
+            // A code override for the destination is the state this call runs against, so it
+            // takes precedence over the deployed code.
+            let code = match state_overrides
+                .as_ref()
+                .and_then(|overrides| overrides.get(&target))
+                .and_then(|account| account.code.clone())
+            {
+                Some(code) => code,
+                None => provider.get_code_at(target).block_id(block.unwrap_or_default()).await?,
+            };
+            if code.is_empty() {
+                eyre::bail!("`--delegate` destination {target} has no code to delegate to");
+            }
+
+            let account =
+                state_overrides.get_or_insert_with(Default::default).entry(from).or_default();
+            if account.code.is_some() {
+                eyre::bail!("`--delegate` conflicts with `--override-code` for the sender {from}");
+            }
+            account.code = Some(code);
+            to = Some(NameOrAddress::Address(from));
+        }
 
         let code = if let Some(CallSubcommands::Create {
             code,

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -7010,6 +7010,162 @@ Error: `--delegate` conflicts with `--override-code` for the sender 0x0000000000
 "#]]);
 });
 
+// The primary `--delegate` path reads the destination's runtime code from the node: no override
+// flags are involved, the delegated code and the sender's storage both come from chain state.
+casttest!(cast_call_delegate_fetches_code_from_node, async |_prj, cmd| {
+    let (api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let from = "0x00000000000000000000000000000000000000d4";
+    let to = "0x00000000000000000000000000000000000000d5";
+
+    // runtime: PUSH1 0 SLOAD PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+    api.anvil_set_code(to.parse().unwrap(), "0x60005460005260206000f3".parse().unwrap())
+        .await
+        .unwrap();
+    api.anvil_set_storage_at(from.parse().unwrap(), U256::ZERO, B256::from(U256::from(0x1234)))
+        .await
+        .unwrap();
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            to,
+            "number()(uint256)",
+            "--from",
+            from,
+            "--delegate",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+4660
+
+"#]]);
+
+    // A delegated call that returns no data must not trip the empty-code warning: the sender has
+    // no on-chain code, but the delegate override guarantees executable code.
+    let void = "0x00000000000000000000000000000000000000d6";
+    // runtime: STOP
+    api.anvil_set_code(void.parse().unwrap(), "0x00".parse().unwrap()).await.unwrap();
+    cmd.cast_fuse()
+        .args(["call", void, "--from", from, "--delegate", "--rpc-url", &handle.http_endpoint()])
+        .assert_success()
+        .stdout_eq(str![[r#"
+0x
+
+"#]])
+        .stderr_eq(str![""]);
+});
+
+// The motivating invocation in issue #11521 is `cast call --trace --from <safe> <to>`, so the
+// delegate override must reach the local tracing executor as well. The trace shows the call
+// executing at the sender address, which is where the delegated code runs.
+casttest!(cast_call_delegate_trace_uses_sender_storage, async |_prj, cmd| {
+    let (api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let from = "0x00000000000000000000000000000000000000d7";
+    let to = "0x00000000000000000000000000000000000000d8";
+
+    // runtime: PUSH1 0 SLOAD PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+    api.anvil_set_code(to.parse().unwrap(), "0x60005460005260206000f3".parse().unwrap())
+        .await
+        .unwrap();
+    api.anvil_set_storage_at(from.parse().unwrap(), U256::ZERO, B256::from(U256::from(0x1234)))
+        .await
+        .unwrap();
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            to,
+            "number()(uint256)",
+            "--from",
+            from,
+            "--delegate",
+            "--trace",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [..] 0x00000000000000000000000000000000000000d7::number()
+    └─ ← [Return] 0x0000000000000000000000000000000000000000000000000000000000001234
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+});
+
+// Documents the identity semantics: the delegated code observes the sender itself as
+// `msg.sender`, not the delegating contract's caller as an on-chain `delegatecall` would.
+casttest!(cast_call_delegate_msg_sender_is_from, async |_prj, cmd| {
+    let (api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let from = "0x00000000000000000000000000000000000000d9";
+    let to = "0x00000000000000000000000000000000000000da";
+
+    // runtime: CALLER PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+    api.anvil_set_code(to.parse().unwrap(), "0x3360005260206000f3".parse().unwrap()).await.unwrap();
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            to,
+            "sender()(address)",
+            "--from",
+            from,
+            "--delegate",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+0x00000000000000000000000000000000000000D9
+
+"#]]);
+});
+
+// `--delegate` needs runtime code at the destination; a codeless address is an explicit error.
+casttest!(cast_call_delegate_no_code_destination, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            "0x00000000000000000000000000000000000000db",
+            "number()(uint256)",
+            "--from",
+            "0x00000000000000000000000000000000000000dc",
+            "--delegate",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: `--delegate` destination 0x00000000000000000000000000000000000000db has no code to delegate to
+
+"#]]);
+});
+
+// `--curl` builds the request offline, but the delegate override needs the destination's code
+// from the node.
+casttest!(cast_call_delegate_rejects_curl, |_prj, cmd| {
+    cmd.args([
+        "call",
+        "0x00000000000000000000000000000000000000dd",
+        "--from",
+        "0x00000000000000000000000000000000000000de",
+        "--delegate",
+        "--curl",
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+Error: --delegate cannot be combined with --curl
+
+"#]]);
+});
+
 // `--debug-trace-call` must render a multi-node trace (a call that emits a log AND makes a
 // sub-call), exercising the log/sub-call interleaving and nesting through the real pipeline, not
 // just in the unit tests. The overridden runtime emits a LOG0 then STATICCALLs the identity

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -6932,6 +6932,84 @@ Transaction successfully executed.
 "#]]);
 });
 
+// https://github.com/foundry-rs/foundry/issues/11521
+// `--delegate` must run the destination's code against the sender's storage. The destination's
+// runtime returns slot 0, and only the sender holds a value there, so a plain call returns zero
+// and the delegated call returns the sender's value.
+casttest!(cast_call_delegate_uses_sender_storage, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let from = "0x00000000000000000000000000000000000000d0";
+    let to = "0x00000000000000000000000000000000000000d1";
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            to,
+            "number()(uint256)",
+            "--from",
+            from,
+            "--delegate",
+            // runtime: PUSH1 0 SLOAD PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+            "--override-code",
+            &format!("{to}:0x60005460005260206000f3"),
+            "--override-state",
+            &format!("{from}:0x0:0x1234"),
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+4660
+
+"#]]);
+
+    // Without `--delegate` the same call runs against the destination's own empty storage.
+    cmd.cast_fuse()
+        .args([
+            "call",
+            to,
+            "number()(uint256)",
+            "--from",
+            from,
+            "--override-code",
+            &format!("{to}:0x60005460005260206000f3"),
+            "--override-state",
+            &format!("{from}:0x0:0x1234"),
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+0
+
+"#]]);
+});
+
+// A code override on the sender is what `--delegate` installs, so the two cannot both win.
+casttest!(cast_call_delegate_rejects_sender_code_override, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let from = "0x00000000000000000000000000000000000000d2";
+    let to = "0x00000000000000000000000000000000000000d3";
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            to,
+            "--from",
+            from,
+            "--delegate",
+            "--override-code",
+            &format!("{to}:0x60005460005260206000f3,{from}:0x00"),
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: `--delegate` conflicts with `--override-code` for the sender 0x00000000000000000000000000000000000000D2
+
+"#]]);
+});
+
 // `--debug-trace-call` must render a multi-node trace (a call that emits a log AND makes a
 // sub-call), exercising the log/sub-call interleaving and nesting through the real pipeline, not
 // just in the unit tests. The overridden runtime emits a LOG0 then STATICCALLs the identity


### PR DESCRIPTION
`eth_call` has no way to express a `delegatecall`, so simulating one against a Safe (or any contract that delegates) currently means forking with anvil, copying the destination's code onto the caller with `anvil_setCode`, and calling the caller: the workaround written out in #11521. `--delegate` does that in-process: it reads the destination's runtime code, applies it as a code override on the `--from` address, and retargets the call at that address, so the destination's code runs against the caller's storage exactly as it would on-chain.

Because it is expressed as an ordinary state override, the flag reaches the three execution paths through a single injection point and behaves the same for a plain `eth_call`, for local `--trace` execution and for `--debug-trace-call`. It also composes with the existing override flags: a `--override-code` entry for the destination wins over its deployed code, since the overrides are the state the call runs against. The retarget happens only after the transaction is built, so calldata encoding and bare-name function lookups still resolve against the destination. A few combinations are rejected rather than silently resolved: a `--override-code` entry on the `--from` address, which is the slot `--delegate` writes into; `--curl`, which never contacts the node the code has to come from; `--browser`, whose wallet would silently replace the `--from` context; and `--create`, which has no destination to delegate to.

One caveat is inherent to the approach: the executed code observes `msg.sender` (and `tx.origin`) equal to the `--from` address itself, whereas in an on-chain `delegatecall` `msg.sender` is preserved from the delegating contract's own caller. The flag's help text documents this, and a test pins it.

The tests cover the semantics rather than the plumbing: the same call with and without `--delegate` returns the sender's storage in one case and the destination's empty slot in the other, the destination's code is taken both from the node and from an override, the local `--trace` path from the original issue report resolves the same storage, and the codeless-destination and rejected-combination errors are pinned.

Closes #11521
