### PR TITLE
fix(forge): resolve lint imports with --root

### DIFF
--- a/.changelog/root-lint-import-resolution.md
+++ b/.changelog/root-lint-import-resolution.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed post-build lint import resolution when using `forge build --root` from outside the project directory.

--- a/crates/cli/src/opts/build/utils.rs
+++ b/crates/cli/src/opts/build/utils.rs
@@ -319,8 +319,9 @@ fn configure_pcx_from_solc_cli(
     project_paths: &ProjectPathsConfig,
     cli_settings: &foundry_compilers::solc::CliSettings,
 ) {
-    pcx.file_resolver
-        .set_current_dir(cli_settings.base_path.as_ref().unwrap_or(&project_paths.root));
+    let base_path = cli_settings.base_path.as_ref().unwrap_or(&project_paths.root);
+    pcx.file_resolver.set_base_path(base_path);
+    pcx.file_resolver.set_current_dir(base_path);
     for remapping in &project_paths.remappings {
         let context = remapping.context.clone().unwrap_or_default();
         // Solar compares the context directly with the parent source path. Match the slash form

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -897,6 +897,32 @@ note[mixed-case-variable]: mutable variables should use mixedCase
 "#]]);
 });
 
+forgetest!(build_lint_resolves_imports_with_explicit_root, |prj, cmd| {
+    prj.add_source("Imported", "contract Imported {}");
+    prj.add_source(
+        "RelativeImporter",
+        r#"
+import {Imported} from "./Imported.sol";
+
+contract RelativeImporter is Imported {}
+"#,
+    );
+    prj.add_source(
+        "Importer",
+        r#"
+import {RelativeImporter} from "src/RelativeImporter.sol";
+
+contract Importer is RelativeImporter {}
+"#,
+    );
+
+    let root = prj.root();
+    cmd.current_dir(root.parent().unwrap())
+        .args(["build", "--force", "--no-cache", "--root"])
+        .arg(root.file_name().unwrap())
+        .assert_success();
+});
+
 forgetest!(build_no_lint_flag_skips_lint, |prj, cmd| {
     prj.add_source("ContractWithLints", CONTRACT);
 


### PR DESCRIPTION
Solar tracks its compiler base path separately from its filesystem current directory. Foundry configured only the latter, so `forge lint` and post-build lint resolved source-unit and relative imports against the process cwd when `--root` selected a nested project. Configure both resolver paths from the effective Solc/project base and add regression coverage for `src/...` and `./...` imports.

This fixes the v1.8 regression reproduced in [Gear's bridge CI](https://github.com/gear-tech/gear-bridges/actions/runs/33145788504/job/98766407181), where compilation succeeded but post-build lint failed to resolve imports such as OpenZeppelin's `./IERC20.sol`.

This PR was written with Codex assistance, including diagnosis, implementation, and test coverage.
