### PR TITLE
fix(fork): relax node info probing

### DIFF
--- a/.changelog/handle-invalid-request-node-info.md
+++ b/.changelog/handle-invalid-request-node-info.md
@@ -1,7 +1,0 @@
----
-forge: patch
-foundry-common: patch
-foundry-evm-core: patch
----
-
-Allowed fork endpoint detection to continue when an RPC gateway rejects the optional `anvil_nodeInfo` probe with an invalid-request response.

--- a/.changelog/preserve-anvil-node-info-errors.md
+++ b/.changelog/preserve-anvil-node-info-errors.md
@@ -1,8 +1,0 @@
----
-anvil: patch
-cast: patch
-chisel: patch
-forge: patch
----
-
-Preserved non-method-not-found `anvil_nodeInfo` errors during fork endpoint detection.

--- a/.changelog/relax-anvil-node-info-probe.md
+++ b/.changelog/relax-anvil-node-info-probe.md
@@ -1,0 +1,11 @@
+---
+anvil: patch
+cast: patch
+forge: patch
+foundry-common: patch
+foundry-evm-core: patch
+---
+
+Treated failed `anvil_nodeInfo` calls as an unavailable optional capability until an endpoint is
+identified as Anvil, kept later validation strict across resets, and sent valid empty parameter
+arrays for Anvil metadata requests.

--- a/.changelog/relax-anvil-node-info-probe.md
+++ b/.changelog/relax-anvil-node-info-probe.md
@@ -8,6 +8,5 @@ foundry-evm-core: patch
 ---
 
 Treated `anvil_nodeInfo` as optional until an endpoint returns valid node info, while keeping later
-Anvil identity checks strict. Zero-parameter `anvil_nodeInfo` and `anvil_metadata` calls now send
-empty parameter arrays, allowing non-Anvil endpoints with vendor-specific rejection codes to be
-forked.
+Anvil identity checks strict across discovery and resets. This allows non-Anvil fork endpoints with
+vendor-specific rejection codes to proceed through standard RPC discovery.

--- a/.changelog/relax-anvil-node-info-probe.md
+++ b/.changelog/relax-anvil-node-info-probe.md
@@ -1,11 +1,13 @@
 ---
 anvil: patch
 cast: patch
+chisel: patch
 forge: patch
 foundry-common: patch
 foundry-evm-core: patch
 ---
 
-Treated failed `anvil_nodeInfo` calls as an unavailable optional capability until an endpoint is
-identified as Anvil, kept later validation strict across resets, and sent valid empty parameter
-arrays for Anvil metadata requests.
+Treated `anvil_nodeInfo` as optional until an endpoint returns valid node info, while keeping later
+Anvil identity checks strict. Zero-parameter `anvil_nodeInfo` and `anvil_metadata` calls now send
+empty parameter arrays, allowing non-Anvil endpoints with vendor-specific rejection codes to be
+forked.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -39,7 +39,7 @@ use anvil_server::ServerConfig;
 use eyre::{Context, Result};
 use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING, REQUEST_TIMEOUT,
-    provider::{ProviderBuilder, RetryProvider, is_rpc_method_not_found, redact_url},
+    provider::{NO_PARAMS, ProviderBuilder, RetryProvider, is_rpc_method_not_found, redact_url},
 };
 use foundry_config::Config;
 use foundry_evm::{
@@ -104,7 +104,12 @@ struct StableForkSnapshot {
     gas_price: u128,
 }
 
-/// Tracks whether `anvil_nodeInfo` has positively identified the endpoint as Anvil.
+/// Best-effort Anvil detection that becomes strict after positive identification.
+///
+/// Before the first successful `anvil_nodeInfo` response, any probe failure means that the
+/// optional capability is unavailable. Mandatory standard RPC reads still expose endpoint-wide
+/// failures. Once a response or cached endpoint identity identifies Anvil, every later probe
+/// failure is returned so it cannot hide an endpoint reset or execution-profile change.
 #[derive(Clone, Copy, Debug, Default)]
 struct AnvilNodeInfoProbe {
     identified: bool,
@@ -116,12 +121,12 @@ impl AnvilNodeInfoProbe {
     }
 
     async fn request(&mut self, provider: &RetryProvider) -> Result<Option<NodeInfo>> {
-        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), ()).await {
+        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), NO_PARAMS).await {
             Ok(node_info) => {
                 self.identified = true;
                 Ok(Some(node_info))
             }
-            Err(error) if !self.identified && is_rpc_method_not_found(&error) => Ok(None),
+            Err(_) if !self.identified => Ok(None),
             Err(error) => {
                 Err(error).wrap_err("failed to determine network family from fork endpoint")
             }
@@ -216,6 +221,8 @@ pub struct NodeConfig {
     pub fork_source_chain_id: Option<u64>,
     /// Chain ID exposed by the active fork endpoint.
     pub fork_execution_chain_id: Option<u64>,
+    /// Whether the active fork endpoint has positively identified itself as Anvil.
+    pub(crate) fork_endpoint_is_anvil: bool,
     /// Network family most recently inferred from a fork endpoint.
     inferred_fork_network: Option<NetworkVariant>,
     /// Network configuration replaced by chain-ID inference, if any.
@@ -606,6 +613,7 @@ impl Default for NodeConfig {
             fork_chain_id: None,
             fork_source_chain_id: None,
             fork_execution_chain_id: None,
+            fork_endpoint_is_anvil: false,
             inferred_fork_network: None,
             chain_id_network_base: None,
             fork_overrides: None,
@@ -1010,7 +1018,11 @@ impl NodeConfig {
     #[must_use]
     pub fn with_eth_rpc_url<U: Into<String>>(mut self, eth_rpc_url: Option<U>) -> Self {
         if let Some(url) = eth_rpc_url {
-            self.fork_urls = vec![url.into()];
+            let fork_urls = vec![url.into()];
+            if self.fork_urls != fork_urls {
+                self.fork_endpoint_is_anvil = false;
+            }
+            self.fork_urls = fork_urls;
         }
         self
     }
@@ -1018,6 +1030,9 @@ impl NodeConfig {
     /// Sets the fork URLs for load-balanced multi-endpoint forking.
     #[must_use]
     pub fn with_fork_urls(mut self, fork_urls: Vec<String>) -> Self {
+        if self.fork_urls != fork_urls {
+            self.fork_endpoint_is_anvil = false;
+        }
         self.fork_urls = fork_urls;
         self
     }
@@ -1563,7 +1578,7 @@ impl NodeConfig {
             instance_id,
             source_fork_block_number,
             source_fork_block_hash,
-        ) = match provider.raw_request::<_, Metadata>("anvil_metadata".into(), ()).await {
+        ) = match provider.raw_request::<_, Metadata>("anvil_metadata".into(), NO_PARAMS).await {
             Ok(metadata) => (
                 metadata.chain_id,
                 source_chain_id_override.unwrap_or_else(|| {
@@ -1681,7 +1696,7 @@ impl NodeConfig {
         provider: &Arc<RetryProvider>,
         fork_overrides: ForkOverrides,
     ) -> Result<StableForkSnapshot> {
-        let mut node_info_probe = AnvilNodeInfoProbe::default();
+        let mut node_info_probe = AnvilNodeInfoProbe::new(self.fork_endpoint_is_anvil);
         for _ in 0..3 {
             let before =
                 self.resolved_fork_endpoint_identity(provider, &mut node_info_probe).await?;
@@ -1847,6 +1862,7 @@ impl NodeConfig {
             block,
             gas_price,
         } = self.stable_fork_snapshot(&provider, fork_overrides).await?;
+        self.fork_endpoint_is_anvil = fork_identity.is_authoritative();
 
         let target_network = fork_identity.network.unwrap_or(NetworkVariant::Ethereum);
         let target_profile = fork_identity.network_profile.unwrap_or_default();

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -39,7 +39,7 @@ use anvil_server::ServerConfig;
 use eyre::{Context, Result};
 use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING, REQUEST_TIMEOUT,
-    provider::{NO_PARAMS, ProviderBuilder, RetryProvider, is_rpc_method_not_found, redact_url},
+    provider::{ProviderBuilder, RetryProvider, is_rpc_method_not_found, redact_url},
 };
 use foundry_config::Config;
 use foundry_evm::{
@@ -121,7 +121,7 @@ impl AnvilNodeInfoProbe {
     }
 
     async fn request(&mut self, provider: &RetryProvider) -> Result<Option<NodeInfo>> {
-        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), NO_PARAMS).await {
+        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), ()).await {
             Ok(node_info) => {
                 self.identified = true;
                 Ok(Some(node_info))
@@ -1578,7 +1578,7 @@ impl NodeConfig {
             instance_id,
             source_fork_block_number,
             source_fork_block_hash,
-        ) = match provider.raw_request::<_, Metadata>("anvil_metadata".into(), NO_PARAMS).await {
+        ) = match provider.raw_request::<_, Metadata>("anvil_metadata".into(), ()).await {
             Ok(metadata) => (
                 metadata.chain_id,
                 source_chain_id_override.unwrap_or_else(|| {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -634,6 +634,7 @@ impl<N: Network> EthApi<N> {
             config.fork_urls = vec![url.clone()];
             config.fork_chain_id = None;
             config.endpoint_identity = endpoint_identity;
+            node_config.fork_endpoint_is_anvil = endpoint_identity.is_authoritative();
         }
         // Keep node_config in sync so a subsequent URL-less fork reset uses the updated endpoint.
         node_config.fork_urls = vec![url];

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -77,10 +77,9 @@ impl ForkEndpointIdentity {
     }
 }
 
-/// Ensures the discovered upstream source network can be executed by Anvil's EVM backend.
+/// Ensures Anvil's EVM backend can execute the resolved upstream source chain.
 ///
-/// This validates the source identity after discovery; a local chain-ID override does not change
-/// which bytecode format the remote fork state contains.
+/// Anvil's execution chain-ID override does not change the bytecode format in remote fork state.
 pub(crate) fn ensure_fork_network_supported(chain_id: u64) -> Result<(), BlockchainError> {
     if matches!(NamedChain::try_from(chain_id), Ok(NamedChain::ZkSync | NamedChain::ZkSyncTestnet))
     {

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -77,7 +77,10 @@ impl ForkEndpointIdentity {
     }
 }
 
-/// Ensures the fork network can be executed by Anvil's EVM backend.
+/// Ensures the discovered upstream source network can be executed by Anvil's EVM backend.
+///
+/// This validates the source identity after discovery; a local chain-ID override does not change
+/// which bytecode format the remote fork state contains.
 pub(crate) fn ensure_fork_network_supported(chain_id: u64) -> Result<(), BlockchainError> {
     if matches!(NamedChain::try_from(chain_id), Ok(NamedChain::ZkSync | NamedChain::ZkSyncTestnet))
     {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4303,6 +4303,13 @@ impl<N: Network> Backend<N> {
         if rpc_url_was_provided {
             staged_config.fork_chain_id = None;
         }
+        let configured_endpoint_is_anvil = staged_config.fork_endpoint_is_anvil
+            && staged_config.fork_urls.contains(target_rpc_url);
+        let cached_endpoint_is_anvil = previous_source.as_ref().is_some_and(|source| {
+            source.rpc_url == *target_rpc_url && source.endpoint_identity.is_authoritative()
+        });
+        staged_config.fork_endpoint_is_anvil =
+            configured_endpoint_is_anvil || cached_endpoint_is_anvil;
         staged_config.fork_urls = target_rpc_urls.to_vec();
         staged_config.fork_choice = block_number.map(|number| ForkChoice::Block(number as i128));
         let mut staged_env = self.evm_env.read().clone();
@@ -4535,6 +4542,7 @@ impl<N: Network> Backend<N> {
         let mut staged_config = self.node_config.read().await.clone();
         staged_config.fork_source_chain_id = None;
         staged_config.fork_execution_chain_id = None;
+        staged_config.fork_endpoint_is_anvil = false;
         staged_config.restore_fork_overrides();
         let local_chain_id = staged_config.get_chain_id();
         staged_config.update_wallet_chain_id(local_chain_id);

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -150,6 +150,7 @@ async fn test_fork_reset_keeps_cached_anvil_node_info_probe_strict() {
         spawn_rpc_proxy_rejecting_method_when_enabled(origin.http_endpoint(), "anvil_nodeInfo")
             .await;
     let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url.clone()))).await;
+    api.anvil_reset(None).await.unwrap();
     reject_node_info.store(true, Ordering::SeqCst);
 
     let error = api
@@ -161,6 +162,23 @@ async fn test_fork_reset_keeps_cached_anvil_node_info_probe_strict() {
         error.to_string().contains("failed to determine network family from fork endpoint"),
         "{error}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_does_not_carry_anvil_identity_to_new_endpoint() {
+    let (_initial_api, initial_origin) = spawn(NodeConfig::test()).await;
+    let (api, handle) =
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(initial_origin.http_endpoint()))).await;
+    let (_target_api, target_origin) = spawn(NodeConfig::test().with_chain_id(Some(56u64))).await;
+    let target_url =
+        spawn_rpc_proxy_rejecting_method_after(target_origin.http_endpoint(), "anvil_nodeInfo", 0)
+            .await;
+
+    api.anvil_reset(Some(Forking { json_rpc_url: Some(target_url), block_number: None }))
+        .await
+        .unwrap();
+
+    assert_eq!(handle.http_provider().get_chain_id().await.unwrap(), 56);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -43,8 +43,9 @@ use foundry_config::Config;
 use foundry_evm_networks::NetworkConfigs;
 use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope};
 use foundry_test_utils::rpc::{
-    self, next_http_rpc_endpoint, next_rpc_endpoint, spawn_rpc_proxy_erroring_method_after,
+    self, next_http_rpc_endpoint, next_rpc_endpoint, spawn_rpc_proxy_internal_error_after,
     spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
+    spawn_rpc_proxy_rejecting_method_when_enabled,
 };
 use futures::StreamExt;
 use revm::{
@@ -53,7 +54,7 @@ use revm::{
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::Arc,
+    sync::{Arc, atomic::Ordering},
     time::Duration,
 };
 
@@ -95,19 +96,15 @@ pub fn fork_config() -> NodeConfig {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_fork_rejects_anvil_node_info_rpc_error() {
+async fn test_fork_ignores_initial_anvil_node_info_rpc_error() {
     let (_api, origin) =
         spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
     let fork_url =
-        spawn_rpc_proxy_erroring_method_after(origin.http_endpoint(), "anvil_nodeInfo", 0).await;
+        spawn_rpc_proxy_internal_error_after(origin.http_endpoint(), "anvil_nodeInfo", 0).await;
 
-    let result = try_spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
-    let Err(error) = result else { panic!("expected fork startup to fail") };
+    let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
 
-    assert!(
-        error.to_string().contains("failed to determine network family from fork endpoint"),
-        "{error}"
-    );
+    assert_eq!(api.chain_id(), NamedChain::Mainnet as u64);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -137,6 +134,71 @@ async fn test_fork_reset_keeps_node_info_probe_strict_after_identification_durin
 
     let error = api
         .anvil_reset(Some(Forking { json_rpc_url: Some(fork_url), block_number: None }))
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("failed to determine network family from fork endpoint"),
+        "{error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_keeps_cached_anvil_node_info_probe_strict() {
+    let (_origin_api, origin) = spawn(NodeConfig::test()).await;
+    let (fork_url, reject_node_info) =
+        spawn_rpc_proxy_rejecting_method_when_enabled(origin.http_endpoint(), "anvil_nodeInfo")
+            .await;
+    let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url.clone()))).await;
+    reject_node_info.store(true, Ordering::SeqCst);
+
+    let error = api
+        .anvil_reset(Some(Forking { json_rpc_url: Some(fork_url), block_number: None }))
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("failed to determine network family from fork endpoint"),
+        "{error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_keeps_set_rpc_url_anvil_node_info_probe_strict() {
+    let (_initial_api, initial_origin) = spawn(NodeConfig::test()).await;
+    let (api, _handle) =
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(initial_origin.http_endpoint()))).await;
+    let (replacement_url, reject_node_info) = spawn_rpc_proxy_rejecting_method_when_enabled(
+        initial_origin.http_endpoint(),
+        "anvil_nodeInfo",
+    )
+    .await;
+    api.anvil_set_rpc_url(replacement_url).await.unwrap();
+    reject_node_info.store(true, Ordering::SeqCst);
+
+    let error = api
+        .anvil_reset(Some(Forking { json_rpc_url: None, block_number: None }))
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("failed to determine network family from fork endpoint"),
+        "{error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_keeps_validated_mirror_anvil_node_info_probe_strict() {
+    let (_origin_api, origin) = spawn(NodeConfig::test()).await;
+    let primary_url = origin.http_endpoint();
+    let (mirror_url, reject_node_info) =
+        spawn_rpc_proxy_rejecting_method_when_enabled(primary_url.clone(), "anvil_nodeInfo").await;
+    let (api, _handle) =
+        spawn(NodeConfig::test().with_fork_urls(vec![primary_url, mirror_url.clone()])).await;
+    reject_node_info.store(true, Ordering::SeqCst);
+
+    let error = api
+        .anvil_reset(Some(Forking { json_rpc_url: Some(mirror_url), block_number: None }))
         .await
         .unwrap_err();
 

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -21,7 +21,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     FoundryTransactionBuilder,
-    provider::{NO_PARAMS, ProviderBuilder, is_rpc_method_not_found},
+    provider::{ProviderBuilder, is_rpc_method_not_found},
     sh_warn, shell,
     tempo::{
         self, AccountsStoreView, KeyType, maybe_print_fee_token, read_tempo_accounts_store,
@@ -3831,7 +3831,7 @@ async fn anvil_tempo_hardfork_active<P>(
 where
     P: Provider<TempoNetwork>,
 {
-    let info = provider.raw_request::<_, AnvilNodeInfo>("anvil_nodeInfo".into(), NO_PARAMS).await?;
+    let info = provider.raw_request::<_, AnvilNodeInfo>("anvil_nodeInfo".into(), ()).await?;
     Ok(active_from_anvil_node_info(&info, hardfork))
 }
 

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -21,7 +21,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     FoundryTransactionBuilder,
-    provider::{NO_PARAMS, ProviderBuilder},
+    provider::{NO_PARAMS, ProviderBuilder, is_rpc_method_not_found},
     sh_warn, shell,
     tempo::{
         self, AccountsStoreView, KeyType, maybe_print_fee_token, read_tempo_accounts_store,
@@ -3844,10 +3844,6 @@ fn active_from_anvil_node_info(info: &AnvilNodeInfo, hardfork: TempoHardfork) ->
     })
 }
 
-fn is_rpc_method_not_found(err: &TransportError) -> bool {
-    err.as_error_resp().is_some_and(|payload| payload.code == -32601)
-}
-
 fn resolve_key_metadata(
     key_address: Address,
     root_account: Option<Address>,
@@ -4293,7 +4289,6 @@ fn decoded_entry_key_authorization(entry: &tempo::KeyEntry) -> Option<SignedKeyA
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_json_rpc::ErrorPayload;
     use std::str::FromStr;
 
     #[test]
@@ -5272,19 +5267,5 @@ mod tests {
 
         assert!(sanitized.contains("private-key://<redacted>"));
         assert!(!sanitized.contains("super-secret"));
-    }
-
-    #[test]
-    fn test_rpc_method_not_found_detection() {
-        let method_missing: TransportError =
-            TransportError::ErrorResp(ErrorPayload::method_not_found());
-        assert!(is_rpc_method_not_found(&method_missing));
-
-        let internal_error: TransportError =
-            TransportError::ErrorResp(ErrorPayload::internal_error());
-        assert!(!is_rpc_method_not_found(&internal_error));
-
-        let transport_error = alloy_transport::TransportErrorKind::backend_gone();
-        assert!(!is_rpc_method_not_found(&transport_error));
     }
 }

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -21,7 +21,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     FoundryTransactionBuilder,
-    provider::ProviderBuilder,
+    provider::{NO_PARAMS, ProviderBuilder},
     sh_warn, shell,
     tempo::{
         self, AccountsStoreView, KeyType, maybe_print_fee_token, read_tempo_accounts_store,
@@ -3831,7 +3831,7 @@ async fn anvil_tempo_hardfork_active<P>(
 where
     P: Provider<TempoNetwork>,
 {
-    let info = provider.raw_request::<_, AnvilNodeInfo>("anvil_nodeInfo".into(), ()).await?;
+    let info = provider.raw_request::<_, AnvilNodeInfo>("anvil_nodeInfo".into(), NO_PARAMS).await?;
     Ok(active_from_anvil_node_info(&info, hardfork))
 }
 

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -17,7 +17,7 @@ use alloy_provider::{
     fillers::{FillProvider, JoinFill, RecommendedFillers, WalletFiller},
     network::{AnyNetwork, EthereumWallet},
 };
-use alloy_rpc_client::ClientBuilder;
+use alloy_rpc_client::{ClientBuilder, NoParams};
 use alloy_transport::{
     TransportError, TransportFut, layers::RetryBackoffLayer, utils::guess_local_url,
 };
@@ -558,6 +558,12 @@ pub fn is_rpc_method_unavailable(error: &TransportError) -> bool {
     matches!(rpc_error_code(error), Some(-32601 | -32600))
 }
 
+/// Empty JSON-RPC parameters, serialized as `[]`.
+///
+/// Passing `()` to a raw request serializes to `"params": null`, but JSON-RPC parameters must be
+/// an array or object when present.
+pub const NO_PARAMS: NoParams = [];
+
 /// Returns an RPC URL safe for display by retaining only its scheme, host, and port.
 pub fn redact_url(raw: &str) -> String {
     let Ok(mut redacted) = Url::parse(raw) else {
@@ -711,6 +717,11 @@ mod tests {
         assert!(is_rpc_method_unavailable(&invalid_request));
         assert!(is_rpc_method_unavailable(&http_invalid_request));
         assert!(!is_rpc_method_unavailable(&internal_error));
+    }
+
+    #[test]
+    fn no_params_serializes_as_empty_array() {
+        assert_eq!(serde_json::to_value(NO_PARAMS).unwrap(), serde_json::json!([]));
     }
 
     #[test]

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -17,7 +17,7 @@ use alloy_provider::{
     fillers::{FillProvider, JoinFill, RecommendedFillers, WalletFiller},
     network::{AnyNetwork, EthereumWallet},
 };
-use alloy_rpc_client::{ClientBuilder, NoParams};
+use alloy_rpc_client::ClientBuilder;
 use alloy_transport::{
     TransportError, TransportFut, layers::RetryBackoffLayer, utils::guess_local_url,
 };
@@ -550,12 +550,6 @@ pub fn is_rpc_method_not_found(error: &TransportError) -> bool {
     rpc_error_code(error) == Some(-32601)
 }
 
-/// Empty JSON-RPC parameters, serialized as `[]`.
-///
-/// Passing `()` to a raw request serializes to `"params": null`, but JSON-RPC parameters must be
-/// an array or object when present.
-pub const NO_PARAMS: NoParams = [];
-
 /// Returns an RPC URL safe for display by retaining only its scheme, host, and port.
 pub fn redact_url(raw: &str) -> String {
     let Ok(mut redacted) = Url::parse(raw) else {
@@ -694,11 +688,6 @@ mod tests {
         assert!(!is_rpc_method_not_found(&internal_error));
         assert!(!is_rpc_method_not_found(&http_internal_error));
         assert!(!is_rpc_method_not_found(&transport_error));
-    }
-
-    #[test]
-    fn no_params_serializes_as_empty_array() {
-        assert_eq!(serde_json::to_value(NO_PARAMS).unwrap(), serde_json::json!([]));
     }
 
     #[test]

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -550,14 +550,6 @@ pub fn is_rpc_method_not_found(error: &TransportError) -> bool {
     rpc_error_code(error) == Some(-32601)
 }
 
-/// Returns whether an RPC transport error reports that an optional method is unavailable.
-///
-/// Some RPC gateways return invalid-request instead of method-not-found for methods they do not
-/// expose.
-pub fn is_rpc_method_unavailable(error: &TransportError) -> bool {
-    matches!(rpc_error_code(error), Some(-32601 | -32600))
-}
-
 /// Empty JSON-RPC parameters, serialized as `[]`.
 ///
 /// Passing `()` to a raw request serializes to `"params": null`, but JSON-RPC parameters must be
@@ -702,21 +694,6 @@ mod tests {
         assert!(!is_rpc_method_not_found(&internal_error));
         assert!(!is_rpc_method_not_found(&http_internal_error));
         assert!(!is_rpc_method_not_found(&transport_error));
-    }
-
-    #[test]
-    fn method_unavailable_recognizes_invalid_request() {
-        let invalid_request = TransportError::ErrorResp(ErrorPayload::invalid_request());
-        let http_invalid_request = alloy_transport::TransportErrorKind::http_error(
-            400,
-            r#"{"jsonrpc":"2.0","error":{"code":-32600,"message":"Unsupported method"}}"#
-                .to_owned(),
-        );
-        let internal_error = TransportError::ErrorResp(ErrorPayload::internal_error());
-
-        assert!(is_rpc_method_unavailable(&invalid_request));
-        assert!(is_rpc_method_unavailable(&http_invalid_request));
-        assert!(!is_rpc_method_unavailable(&internal_error));
     }
 
     #[test]

--- a/crates/evm/core/src/fork/resolved.rs
+++ b/crates/evm/core/src/fork/resolved.rs
@@ -3,11 +3,13 @@ use alloy_eips::{BlockId, BlockNumHash};
 use alloy_primitives::{B256, BlockNumber, keccak256};
 use std::fmt;
 
-/// A fork selector and block identity resolved from a configured RPC source.
+/// An exact fork snapshot resolved from a configured RPC source.
 ///
-/// This context binds exact preflight reads and EVM environment reconstruction to the source,
-/// selector, and block that were resolved together. The fork database uses the resolved hash for
-/// state reads and block ancestry.
+/// The snapshot binds three layers that must travel together: the authenticated source (URL,
+/// headers, and JWT), the configured selector (`latest` or a block number), and the observed exact
+/// block (number and hash) plus endpoint context. `latest` is retained as the configured selector,
+/// while `block` is always exact. Reusing this value keeps preflight reads, environment
+/// reconstruction, cache identity, and backend construction on the same remote state.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ResolvedFork {
     source: ForkSource,

--- a/crates/evm/core/src/fork/resolved.rs
+++ b/crates/evm/core/src/fork/resolved.rs
@@ -3,13 +3,13 @@ use alloy_eips::{BlockId, BlockNumHash};
 use alloy_primitives::{B256, BlockNumber, keccak256};
 use std::fmt;
 
-/// An exact fork snapshot resolved from a configured RPC source.
+/// An exact fork snapshot resolved from a fully configured RPC source.
 ///
-/// The snapshot binds three layers that must travel together: the authenticated source (URL,
-/// headers, and JWT), the configured selector (`latest` or a block number), and the observed exact
-/// block (number and hash) plus endpoint context. `latest` is retained as the configured selector,
-/// while `block` is always exact. Reusing this value keeps preflight reads, environment
-/// reconstruction, cache identity, and backend construction on the same remote state.
+/// The snapshot binds three layers that must travel together: the source URL, request headers, and
+/// JWT; the configured selector (`latest` or a block number); and the observed exact block (number
+/// and hash) plus endpoint context. `latest` is retained as the configured selector, while `block`
+/// is always exact. Reusing this value keeps preflight reads, environment reconstruction, cache
+/// identity, and backend construction on the same remote state.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ResolvedFork {
     source: ForkSource,
@@ -106,7 +106,7 @@ impl ResolvedFork {
         resolved
     }
 
-    /// Returns an opaque identity for the complete authenticated RPC source.
+    /// Returns an opaque identity for the complete configured RPC source.
     pub(crate) fn source_id(&self) -> B256 {
         let mut encoded = Vec::new();
         encoded.extend_from_slice(b"foundry-resolved-fork-source-v1");
@@ -216,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn authenticated_source_identity_is_unambiguous() {
+    fn configured_source_identity_is_unambiguous() {
         let block = BlockNumHash::new(1, B256::with_last_byte(1));
         let context = context(1);
         let plain = ResolvedFork::new("http://localhost:8545", None, None, None, block, context);

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -18,7 +18,7 @@ use alloy_rpc_types::{
 use eyre::{OptionExt, WrapErr};
 use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING,
-    provider::{NO_PARAMS, ProviderBuilder, is_rpc_method_not_found},
+    provider::{ProviderBuilder, is_rpc_method_not_found},
 };
 use foundry_config::{Chain, Config, ExecutionSpec, FoundryHardfork, GasLimit};
 use foundry_evm_hardforks::TempoHardfork;
@@ -207,7 +207,7 @@ impl AnvilNodeInfoProbe {
         &mut self,
         provider: &P,
     ) -> eyre::Result<Option<NodeInfo>> {
-        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), NO_PARAMS).await {
+        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), ()).await {
             Ok(node_info) => {
                 self.identified = true;
                 Ok(Some(node_info))
@@ -785,10 +785,7 @@ impl EvmOpts {
                     instance_id,
                     source_fork_block_number,
                     source_fork_block_hash,
-                ) = match provider
-                    .raw_request::<_, Metadata>("anvil_metadata".into(), NO_PARAMS)
-                    .await
-                {
+                ) = match provider.raw_request::<_, Metadata>("anvil_metadata".into(), ()).await {
                     Ok(metadata) => {
                         let forked_network = metadata.forked_network;
                         (

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -30,14 +30,10 @@ use url::Url;
 
 /// EVM execution options, including the configured remote fork.
 ///
-/// Fork setup has two separate phases:
-///
-/// 1. [`Self::infer_network_from_fork`] uses [`Self::discover_fork_endpoint`] to identify the
-///    endpoint's execution family before selecting a concrete EVM implementation. This caches the
-///    endpoint identity but does not select a fork block.
-/// 2. [`Self::resolve_fork`] or [`Self::env_resolved`] resolves the configured block selector to an
-///    exact number and hash while the endpoint identity is stable. Callers reuse the returned
-///    [`ResolvedFork`] for preflight reads, environment reconstruction, and backend construction.
+/// Fork handling separates two responsibilities. Endpoint discovery identifies and caches the
+/// execution family without selecting a block. Exact resolution binds the configured source and
+/// selector to a block number, hash, and endpoint context. Forge normally performs discovery
+/// before resolution, while callers that already know the network can resolve directly.
 ///
 /// An implicit `latest` selector remains unchanged in these options; only the returned
 /// [`ResolvedFork`] is pinned to the exact block observed during resolution.
@@ -154,13 +150,14 @@ pub struct EvmOpts {
 ///
 /// This identity is independent of the block selector Forge resolves. In particular,
 /// `source_fork_block_*` describes the upstream block from which an Anvil endpoint was itself
-/// forked; the target block selected for local execution belongs to [`ResolvedFork`]. Equality is
-/// used to detect endpoint resets and execution-profile changes between related RPC reads.
+/// forked; the target block selected for local execution belongs to [`ResolvedFork`]. Equality
+/// detects observable endpoint identity changes, including Anvil instance resets, and
+/// execution-profile changes between related RPC reads.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ForkEndpointIdentity {
     /// RPC URL from which this identity was discovered.
     ///
-    /// Authentication headers and JWT credentials are bound separately by [`ResolvedFork`].
+    /// Request headers and JWT credentials are bound separately by [`ResolvedFork`].
     pub endpoint: String,
     /// Chain ID exposed through `eth_chainId`.
     pub execution_chain_id: ChainId,
@@ -243,7 +240,7 @@ fn endpoint_hardfork(
 
 /// Endpoint identity paired with the remote block number backing a fork.
 ///
-/// [`ResolvedFork`] adds the exact block hash and authenticated RPC source. The remote
+/// [`ResolvedFork`] adds the exact block hash and configured RPC source. The remote
 /// `block_number` may differ from a remapped EVM block number on L2s, and the source chain ID
 /// remains distinct from a configured `CHAINID` opcode override.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize)]
@@ -475,7 +472,7 @@ impl EvmOpts {
     /// `self`.
     ///
     /// Endpoint identity is read before and after the target block and the operation is retried if
-    /// it changes. The result binds the authenticated RPC source, configured selector, exact block
+    /// it changes. The result binds the configured RPC source, configured selector, exact block
     /// number and hash, and [`ForkContext`]. When the selector is implicit `latest`, only the
     /// returned [`ResolvedFork`] is pinned.
     pub async fn resolve_fork(&self) -> eyre::Result<Option<ResolvedFork>> {
@@ -677,8 +674,9 @@ impl EvmOpts {
     ///
     /// Each attempt reads `eth_chainId` and the optional Anvil identity methods before and after,
     /// and returns only when both snapshots agree. Before Anvil is positively identified, a failed
-    /// `anvil_nodeInfo` probe is treated as a normal non-Anvil endpoint. Later probe failures are
-    /// strict. This method does not mutate or cache the returned identity in `self`.
+    /// `anvil_nodeInfo` probe is treated as absence of optional Anvil identity information for that
+    /// snapshot. Later probe failures are strict. This method does not mutate or cache the returned
+    /// identity in `self`.
     pub async fn discover_fork_endpoint(&self) -> eyre::Result<ForkEndpointIdentity> {
         let fork_url = self.fork_url.as_deref().ok_or_eyre("fork URL is not configured")?;
         let provider = self.fork_provider_with_url::<AnyNetwork>(fork_url)?;
@@ -1618,8 +1616,8 @@ mod tests {
     use alloy_rpc_types::TransactionRequest;
     use alloy_serde::WithOtherFields;
     use foundry_test_utils::rpc::{
-        spawn_rpc_proxy_internal_error_after, spawn_rpc_proxy_invalid_request_before,
-        spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
+        spawn_rpc_proxy_internal_error_after, spawn_rpc_proxy_method_not_found_before,
+        spawn_rpc_proxy_rejecting_method_after,
     };
     #[cfg(feature = "optimism")]
     use op_revm::OpSpecId;
@@ -2309,22 +2307,6 @@ mod tests {
                 .await;
         let fork_url =
             spawn_rpc_proxy_internal_error_after(handle.http_endpoint(), "anvil_nodeInfo", 0).await;
-        let mut evm_opts = EvmOpts { fork_url: Some(fork_url), ..Default::default() };
-
-        evm_opts.infer_network_from_fork().await.unwrap();
-
-        assert_eq!(evm_opts.networks, NetworkConfigs::default());
-        assert_eq!(evm_opts.env.chain_id, Some(NamedChain::Mainnet as u64));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn fork_node_info_invalid_request_is_optional() {
-        let (_api, handle) =
-            anvil::spawn(anvil::NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64)))
-                .await;
-        let fork_url =
-            spawn_rpc_proxy_invalid_request_before(handle.http_endpoint(), "anvil_nodeInfo", 1)
-                .await;
         let mut evm_opts = EvmOpts { fork_url: Some(fork_url), ..Default::default() };
 
         evm_opts.infer_network_from_fork().await.unwrap();

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -18,7 +18,7 @@ use alloy_rpc_types::{
 use eyre::{OptionExt, WrapErr};
 use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING,
-    provider::{ProviderBuilder, is_rpc_method_not_found, is_rpc_method_unavailable},
+    provider::{NO_PARAMS, ProviderBuilder, is_rpc_method_not_found},
 };
 use foundry_config::{Chain, Config, ExecutionSpec, FoundryHardfork, GasLimit};
 use foundry_evm_hardforks::TempoHardfork;
@@ -28,6 +28,19 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Write;
 use url::Url;
 
+/// EVM execution options, including the configured remote fork.
+///
+/// Fork setup has two separate phases:
+///
+/// 1. [`Self::infer_network_from_fork`] uses [`Self::discover_fork_endpoint`] to identify the
+///    endpoint's execution family before selecting a concrete EVM implementation. This caches the
+///    endpoint identity but does not select a fork block.
+/// 2. [`Self::resolve_fork`] or [`Self::env_resolved`] resolves the configured block selector to an
+///    exact number and hash while the endpoint identity is stable. Callers reuse the returned
+///    [`ResolvedFork`] for preflight reads, environment reconstruction, and backend construction.
+///
+/// An implicit `latest` selector remains unchanged in these options; only the returned
+/// [`ResolvedFork`] is pinned to the exact block observed during resolution.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EvmOpts {
     /// The EVM environment configuration.
@@ -116,11 +129,11 @@ pub struct EvmOpts {
     /// The CREATE2 deployer's address.
     pub create2_deployer: Address,
 
-    /// Identity discovered from the configured fork endpoint.
+    /// Most recently discovered endpoint identity, cached for network dispatch and revalidation.
     #[serde(skip)]
     pub fork_endpoint: Option<ForkEndpointIdentity>,
 
-    /// Endpoint identity that must remain stable while constructing local execution state.
+    /// Endpoint identity promoted to an invariant that later discovery must match.
     #[serde(skip)]
     pub expected_fork_endpoint: Option<ForkEndpointIdentity>,
 
@@ -137,10 +150,17 @@ pub struct EvmOpts {
     pub fork_block_number_is_inferred: bool,
 }
 
-/// Execution and source identity exposed by a fork endpoint.
+/// A snapshot of the execution and upstream-source identity exposed by an RPC endpoint.
+///
+/// This identity is independent of the block selector Forge resolves. In particular,
+/// `source_fork_block_*` describes the upstream block from which an Anvil endpoint was itself
+/// forked; the target block selected for local execution belongs to [`ResolvedFork`]. Equality is
+/// used to detect endpoint resets and execution-profile changes between related RPC reads.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ForkEndpointIdentity {
     /// RPC URL from which this identity was discovered.
+    ///
+    /// Authentication headers and JWT credentials are bound separately by [`ResolvedFork`].
     pub endpoint: String,
     /// Chain ID exposed through `eth_chainId`.
     pub execution_chain_id: ChainId,
@@ -164,11 +184,18 @@ pub struct ForkEndpointIdentity {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum EndpointHardforkPolicy {
+    /// Permit an unrecognized hardfork during early network-family discovery.
     Optional,
+    /// Require a recognized hardfork before constructing an execution environment.
     Required,
 }
 
-/// Tracks whether `anvil_nodeInfo` has positively identified the endpoint as Anvil.
+/// Best-effort Anvil detection that becomes strict after positive identification.
+///
+/// Before the first successful `anvil_nodeInfo` response, any probe failure means that the
+/// optional capability is unavailable. Mandatory standard RPC reads still expose endpoint-wide
+/// failures. Once a response or cached endpoint identity identifies Anvil, every later probe
+/// failure is returned so it cannot hide an endpoint reset or execution-profile change.
 #[derive(Clone, Copy, Debug, Default)]
 struct AnvilNodeInfoProbe {
     identified: bool,
@@ -183,12 +210,12 @@ impl AnvilNodeInfoProbe {
         &mut self,
         provider: &P,
     ) -> eyre::Result<Option<NodeInfo>> {
-        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), ()).await {
+        match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), NO_PARAMS).await {
             Ok(node_info) => {
                 self.identified = true;
                 Ok(Some(node_info))
             }
-            Err(error) if !self.identified && is_rpc_method_unavailable(&error) => Ok(None),
+            Err(_) if !self.identified => Ok(None),
             Err(error) => Err(error).wrap_err("failed to determine network family from endpoint"),
         }
     }
@@ -214,9 +241,11 @@ fn endpoint_hardfork(
     }
 }
 
-/// Identity and block context of the remote chain backing a fork.
+/// Endpoint identity paired with the remote block number backing a fork.
 ///
-/// The source chain ID remains distinct from the configured `CHAINID` opcode override.
+/// [`ResolvedFork`] adds the exact block hash and authenticated RPC source. The remote
+/// `block_number` may differ from a remapped EVM block number on L2s, and the source chain ID
+/// remains distinct from a configured `CHAINID` opcode override.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize)]
 pub struct ForkContext {
     /// Chain ID exposed through `eth_chainId`.
@@ -424,7 +453,12 @@ impl EvmOpts {
         )
     }
 
-    /// Resolves and pins an unpinned fork to the current latest block.
+    /// Converts an implicit `latest` selector into a block-number selector in place.
+    ///
+    /// This only reads the endpoint's current block number; it does not resolve a block hash or
+    /// endpoint identity and is therefore not a reorg-safe fork snapshot. Use
+    /// [`Self::resolve_fork`] when later reads and backend construction must share an exact
+    /// identity.
     pub async fn pin_fork_block(&mut self) -> eyre::Result<Option<BlockNumber>> {
         if self.fork_block_number.is_none()
             && let Some(fork_url) = &self.fork_url
@@ -437,7 +471,13 @@ impl EvmOpts {
         Ok(self.fork_block_number)
     }
 
-    /// Resolves the configured fork selector without changing it.
+    /// Resolves the configured fork source and selector to an exact snapshot without changing
+    /// `self`.
+    ///
+    /// Endpoint identity is read before and after the target block and the operation is retried if
+    /// it changes. The result binds the authenticated RPC source, configured selector, exact block
+    /// number and hash, and [`ForkContext`]. When the selector is implicit `latest`, only the
+    /// returned [`ResolvedFork`] is pinned.
     pub async fn resolve_fork(&self) -> eyre::Result<Option<ResolvedFork>> {
         let Some(fork_url) = &self.fork_url else { return Ok(None) };
         let provider = self.fork_provider_with_url::<AnyNetwork>(fork_url)?;
@@ -576,10 +616,12 @@ impl EvmOpts {
         builder.build()
     }
 
-    /// Infers the network configuration and exact endpoint identity for a fork.
+    /// Discovers and caches the network configuration and endpoint identity for a fork.
     ///
-    /// Explicit network selections are preserved, while endpoint identity is still cached so
-    /// downstream execution can honor an Anvil endpoint's exact hardfork.
+    /// This is the dispatch phase of fork setup: explicit network selections are preserved, while
+    /// inferred chain and network settings are applied when no override exists. The method does not
+    /// resolve or pin a fork block; block resolution happens later through [`Self::resolve_fork`]
+    /// or [`Self::env_resolved`].
     pub async fn infer_network_from_fork(&mut self) -> eyre::Result<()> {
         let previous_identity = self.fork_endpoint.clone();
         let Some(fork_url) = self.fork_url.clone() else {
@@ -631,7 +673,12 @@ impl EvmOpts {
         Ok(())
     }
 
-    /// Discovers the complete identity exposed by the configured fork endpoint.
+    /// Discovers a stable identity snapshot without selecting a fork block.
+    ///
+    /// Each attempt reads `eth_chainId` and the optional Anvil identity methods before and after,
+    /// and returns only when both snapshots agree. Before Anvil is positively identified, a failed
+    /// `anvil_nodeInfo` probe is treated as a normal non-Anvil endpoint. Later probe failures are
+    /// strict. This method does not mutate or cache the returned identity in `self`.
     pub async fn discover_fork_endpoint(&self) -> eyre::Result<ForkEndpointIdentity> {
         let fork_url = self.fork_url.as_deref().ok_or_eyre("fork URL is not configured")?;
         let provider = self.fork_provider_with_url::<AnyNetwork>(fork_url)?;
@@ -676,8 +723,11 @@ impl EvmOpts {
         );
     }
 
-    /// Resolves one endpoint identity snapshot, using Anvil's authoritative node metadata when it
-    /// is already known to be available.
+    /// Reads one endpoint identity snapshot without performing a stability check.
+    ///
+    /// The shared node-info probe starts permissive for endpoints that do not expose Anvil methods
+    /// and becomes strict after Anvil is identified. Callers either bracket mutable remote reads
+    /// with two snapshots or use this helper to revalidate an already resolved fork.
     async fn resolve_fork_endpoint_once<N: Network, P: Provider<N>>(
         &self,
         provider: &P,
@@ -719,6 +769,9 @@ impl EvmOpts {
         Ok((identity.execution_chain_id, identity.network))
     }
 
+    /// Builds an identity from one observed chain ID and optional Anvil node-info response.
+    ///
+    /// Anvil metadata is consulted only after node info has positively identified the endpoint.
     async fn resolve_fork_endpoint_identity<N: Network, P: Provider<N>>(
         provider: &P,
         endpoint: &str,
@@ -734,7 +787,10 @@ impl EvmOpts {
                     instance_id,
                     source_fork_block_number,
                     source_fork_block_hash,
-                ) = match provider.raw_request::<_, Metadata>("anvil_metadata".into(), ()).await {
+                ) = match provider
+                    .raw_request::<_, Metadata>("anvil_metadata".into(), NO_PARAMS)
+                    .await
+                {
                     Ok(metadata) => {
                         let forked_network = metadata.forked_network;
                         (
@@ -828,7 +884,11 @@ impl EvmOpts {
         Ok((evm_env, tx, fork.as_ref().map(ResolvedFork::number)))
     }
 
-    /// Returns the EVM and transaction environments with their resolved fork context.
+    /// Returns the EVM and transaction environments with an exact resolved fork snapshot.
+    ///
+    /// Resolution brackets block and gas-price reads with endpoint identity checks and retries if
+    /// the endpoint changes. Downstream preflight reads and backend construction should reuse the
+    /// returned [`ResolvedFork`] instead of carrying only its block number.
     pub async fn env_resolved<
         SPEC: Into<SpecId> + Default + Copy,
         BLOCK: FoundryBlock + Default,
@@ -1558,8 +1618,8 @@ mod tests {
     use alloy_rpc_types::TransactionRequest;
     use alloy_serde::WithOtherFields;
     use foundry_test_utils::rpc::{
-        spawn_rpc_proxy_invalid_request_before, spawn_rpc_proxy_method_not_found_before,
-        spawn_rpc_proxy_rejecting_method_after,
+        spawn_rpc_proxy_internal_error_after, spawn_rpc_proxy_invalid_request_before,
+        spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
     };
     #[cfg(feature = "optimism")]
     use op_revm::OpSpecId;
@@ -2243,21 +2303,18 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn fork_non_anvil_node_info_rpc_error_is_visible() {
+    async fn fork_non_anvil_node_info_rpc_error_is_optional() {
         let (_api, handle) =
             anvil::spawn(anvil::NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64)))
                 .await;
         let fork_url =
-            spawn_rpc_proxy_rejecting_method_after(handle.http_endpoint(), "anvil_nodeInfo", 0)
-                .await;
+            spawn_rpc_proxy_internal_error_after(handle.http_endpoint(), "anvil_nodeInfo", 0).await;
         let mut evm_opts = EvmOpts { fork_url: Some(fork_url), ..Default::default() };
 
-        let error = evm_opts.infer_network_from_fork().await.unwrap_err();
+        evm_opts.infer_network_from_fork().await.unwrap();
 
-        assert!(
-            error.to_string().contains("failed to determine network family from endpoint"),
-            "{error}"
-        );
+        assert_eq!(evm_opts.networks, NetworkConfigs::default());
+        assert_eq!(evm_opts.env.chain_id, Some(NamedChain::Mainnet as u64));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -1266,6 +1266,29 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/16413>
+forgetest_async!(fork_endpoint_without_anvil_node_info, |prj, cmd| {
+    let (api, handle) = spawn(NodeConfig::test().with_chain_id(Some(1u64))).await;
+    api.anvil_mine(Some(U256::ONE), None).await.unwrap();
+    let endpoint =
+        rpc::spawn_rpc_proxy_rejecting_method_after(handle.http_endpoint(), "anvil_nodeInfo", 0)
+            .await;
+
+    prj.add_test(
+        "NonAnvilFork.t.sol",
+        r#"
+contract NonAnvilForkTest {
+    function testFork() external view {
+        require(block.chainid == 1, "wrong chain");
+        require(block.number == 1, "wrong block");
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--fork-url", &endpoint, "--match-test", "testFork"]).assert_success();
+});
+
 // <https://github.com/foundry-rs/foundry/issues/7574>
 forgetest_async!(failed_fork_test_reports_block_number, |prj, cmd| {
     let (api, handle) = spawn(NodeConfig::test()).await;

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -13,8 +13,8 @@ use serde_json::{Value, json};
 use std::{
     env,
     sync::{
-        LazyLock,
-        atomic::{AtomicUsize, Ordering},
+        Arc, LazyLock,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -309,6 +309,24 @@ pub async fn spawn_rpc_proxy_rejecting_method_before(
     .await
 }
 
+/// Spawns an RPC proxy whose rejection of `method` can be enabled after startup.
+pub async fn spawn_rpc_proxy_rejecting_method_when_enabled(
+    endpoint: String,
+    method: &'static str,
+) -> (String, Arc<AtomicBool>) {
+    let enabled = Arc::new(AtomicBool::new(false));
+    let proxy = spawn_rpc_proxy_rejecting_method(
+        endpoint,
+        method,
+        RpcMethodRejection::Enabled(enabled.clone()),
+        StatusCode::FORBIDDEN,
+        -32004,
+        "method is not allowed",
+    )
+    .await;
+    (proxy, enabled)
+}
+
 /// Spawns an RPC proxy that returns method-not-found for the first `unavailable_calls` requests to
 /// `method`.
 pub async fn spawn_rpc_proxy_method_not_found_before(
@@ -345,6 +363,24 @@ pub async fn spawn_rpc_proxy_invalid_request_before(
     .await
 }
 
+/// Spawns an RPC proxy that returns a JSON-RPC internal error for `method` after forwarding
+/// `successful_calls` requests.
+pub async fn spawn_rpc_proxy_internal_error_after(
+    endpoint: String,
+    method: &'static str,
+    successful_calls: usize,
+) -> String {
+    spawn_rpc_proxy_rejecting_method(
+        endpoint,
+        method,
+        RpcMethodRejection::After(successful_calls),
+        StatusCode::OK,
+        -32603,
+        "internal error",
+    )
+    .await
+}
+
 /// Spawns an RPC proxy that returns a vendor-specific JSON-RPC error for `method` after
 /// forwarding `successful_calls` requests.
 pub async fn spawn_rpc_proxy_erroring_method_after(
@@ -363,17 +399,19 @@ pub async fn spawn_rpc_proxy_erroring_method_after(
     .await
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 enum RpcMethodRejection {
     Before(usize),
     After(usize),
+    Enabled(Arc<AtomicBool>),
 }
 
 impl RpcMethodRejection {
-    const fn rejects(self, call: usize) -> bool {
+    fn rejects(&self, call: usize) -> bool {
         match self {
-            Self::Before(rejected_calls) => call < rejected_calls,
-            Self::After(successful_calls) => call >= successful_calls,
+            Self::Before(rejected_calls) => call < *rejected_calls,
+            Self::After(successful_calls) => call >= *successful_calls,
+            Self::Enabled(enabled) => enabled.load(Ordering::SeqCst),
         }
     }
 }
@@ -394,6 +432,7 @@ async fn spawn_rpc_proxy_rejecting_method(
             let client = client.clone();
             let endpoint = endpoint.clone();
             let calls = calls.clone();
+            let rejection = rejection.clone();
             async move {
                 if request.get("method").and_then(Value::as_str) == Some(method)
                     && rejection.rejects(calls.fetch_add(1, Ordering::Relaxed))

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -292,23 +292,6 @@ pub async fn spawn_rpc_proxy_rejecting_method_after(
     .await
 }
 
-/// Spawns an RPC proxy that rejects the first `rejected_calls` requests to `method`.
-pub async fn spawn_rpc_proxy_rejecting_method_before(
-    endpoint: String,
-    method: &'static str,
-    rejected_calls: usize,
-) -> String {
-    spawn_rpc_proxy_rejecting_method(
-        endpoint,
-        method,
-        RpcMethodRejection::Before(rejected_calls),
-        StatusCode::FORBIDDEN,
-        -32004,
-        "method is not allowed",
-    )
-    .await
-}
-
 /// Spawns an RPC proxy whose rejection of `method` can be enabled after startup.
 pub async fn spawn_rpc_proxy_rejecting_method_when_enabled(
     endpoint: String,
@@ -345,24 +328,6 @@ pub async fn spawn_rpc_proxy_method_not_found_before(
     .await
 }
 
-/// Spawns an RPC proxy that returns invalid-request for the first `unavailable_calls` requests to
-/// `method`.
-pub async fn spawn_rpc_proxy_invalid_request_before(
-    endpoint: String,
-    method: &'static str,
-    unavailable_calls: usize,
-) -> String {
-    spawn_rpc_proxy_rejecting_method(
-        endpoint,
-        method,
-        RpcMethodRejection::Before(unavailable_calls),
-        StatusCode::BAD_REQUEST,
-        -32600,
-        "invalid request",
-    )
-    .await
-}
-
 /// Spawns an RPC proxy that returns a JSON-RPC internal error for `method` after forwarding
 /// `successful_calls` requests.
 pub async fn spawn_rpc_proxy_internal_error_after(
@@ -377,24 +342,6 @@ pub async fn spawn_rpc_proxy_internal_error_after(
         StatusCode::OK,
         -32603,
         "internal error",
-    )
-    .await
-}
-
-/// Spawns an RPC proxy that returns a vendor-specific JSON-RPC error for `method` after
-/// forwarding `successful_calls` requests.
-pub async fn spawn_rpc_proxy_erroring_method_after(
-    endpoint: String,
-    method: &'static str,
-    successful_calls: usize,
-) -> String {
-    spawn_rpc_proxy_rejecting_method(
-        endpoint,
-        method,
-        RpcMethodRejection::After(successful_calls),
-        StatusCode::OK,
-        -32004,
-        "method is not allowed",
     )
     .await
 }


### PR DESCRIPTION
`anvil_nodeInfo` is a capability probe, but fork setup had started treating only a small allowlist of JSON-RPC error codes as absence. That made standard RPC endpoints fail before their mandatory chain and block methods were used, and every new gateway or client response code required another exception. This restores capability semantics: before an endpoint has returned valid node info, a failed probe falls back to standard chain-ID discovery; once Anvil is positively identified, later failures remain strict across discovery, resets, RPC URL replacement, and validated mirror promotion.

The fork lifecycle docs distinguish endpoint discovery, which selects and caches the execution family without choosing a block, from exact resolution, which binds the configured RPC source, selector, exact block number and hash, and endpoint context for downstream reads and backend construction. A Forge CLI regression exercises the complete `forge test --fork-url` path through a proxy that rejects every `anvil_nodeInfo` request.

This supersedes the narrow `-32600`/`-32601` node-info allowlist introduced by #16414 and proposed for extension in #16418. The exact method-not-found parser remains for RPC fallbacks that genuinely require `-32601`, while the obsolete broad classifier and policy-specific test helpers are removed. The overlapping #16295 and #16414 changelog fragments are consolidated into one release note.

Fixes #16413.

AI assistance was used to investigate the fork lifecycle, implement the code and documentation changes, add regression coverage, and review the result.
