### PR TITLE
fix(cli): remove project trust warnings

### DIFF
--- a/.changelog/remove-project-trust-warnings.md
+++ b/.changelog/remove-project-trust-warnings.md
@@ -1,0 +1,10 @@
+---
+forge: patch
+cast: patch
+anvil: patch
+chisel: patch
+foundry-cli: patch
+foundry-config: patch
+---
+
+Removed warnings when loading project dotenv files and running project-configured local compiler executables.

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -205,10 +205,7 @@ pub fn common_setup() {
     enable_paint();
 }
 
-/// Loads dotenv files from the cwd and project root after warning, ignoring parse failures.
-///
-/// The warning is written directly because dotenv may configure logging before the tracing
-/// subscriber is initialized.
+/// Loads dotenv files from the cwd and project root, ignoring parse failures.
 pub fn load_dotenv() {
     // we only want the .env file of the cwd and project root
     // `find_project_root` calls `current_dir` internally so both paths are either both `Ok` or
@@ -226,25 +223,6 @@ pub fn load_dotenv() {
                 paths.push(cwd_env);
             }
         }
-    }
-
-    if paths.is_empty() {
-        return;
-    }
-
-    {
-        use std::io::Write as _;
-
-        let mut stderr = std::io::stderr().lock();
-        let _ = writeln!(stderr, "Warning: loading project dotenv files:");
-        for path in &paths {
-            let _ = writeln!(stderr, "  {path:?}");
-        }
-        let _ = writeln!(
-            stderr,
-            "Project environment variables can affect executable and library loading. Only run \
-             commands in projects you trust."
-        );
     }
 
     for path in paths {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -47,11 +47,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::{
     borrow::Cow,
     collections::BTreeMap,
-    fs,
-    io::{self, Write as _},
+    fs, io,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::Mutex,
 };
 
 mod macros;
@@ -155,7 +153,6 @@ pub use semver;
 
 #[cfg(not(test))]
 static SELECTED_PROFILE: std::sync::OnceLock<Profile> = std::sync::OnceLock::new();
-static WARNED_LOCAL_COMPILERS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
 /// Foundry configuration
 ///
@@ -1506,7 +1503,6 @@ impl Config {
                     if !solc.is_file() {
                         return Err(SolcError::msg(format!("`solc` {solc:?} does not exist")));
                     }
-                    warn_local_compiler(solc);
                     Solc::new(solc)?
                 }
             };
@@ -1595,7 +1591,6 @@ impl Config {
             return Ok(None);
         }
         let vyper = if let Some(path) = &self.vyper.path {
-            warn_local_compiler(path);
             Some(Vyper::new(path)?)
         } else {
             Vyper::new("vyper").ok()
@@ -3119,10 +3114,7 @@ impl SolcReq {
     pub fn try_version(&self) -> Result<Version, SolcError> {
         match self {
             Self::Version(version) => Ok(version.clone()),
-            Self::Local(path) => {
-                warn_local_compiler(path);
-                Solc::new(path).map(|solc| solc.version)
-            }
+            Self::Local(path) => Solc::new(path).map(|solc| solc.version),
         }
     }
 }
@@ -3266,21 +3258,6 @@ pub(crate) mod from_str_lowercase {
     {
         String::deserialize(deserializer)?.to_lowercase().parse().map_err(serde::de::Error::custom)
     }
-}
-
-fn warn_local_compiler(path: &Path) {
-    let mut warned = WARNED_LOCAL_COMPILERS.lock().unwrap_or_else(|err| err.into_inner());
-    if warned.iter().any(|warned_path| warned_path == path) {
-        return;
-    }
-    warned.push(path.to_path_buf());
-
-    let mut stderr = io::stderr().lock();
-    let _ = writeln!(
-        stderr,
-        "Warning: this project is configured to use a local compiler executable:\n  {path:?}\n\
-         Running this executable may execute arbitrary code."
-    );
 }
 
 fn canonic(path: impl Into<PathBuf>) -> PathBuf {

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -34,7 +34,7 @@ fn add_local_submodule(root: &Path, path: &str) -> String {
 }
 
 #[cfg(unix)]
-forgetest!(local_compiler_warns_and_runs, |prj, cmd| {
+forgetest!(local_compiler_runs_without_warning, |prj, cmd| {
     let solc = prj.root().join("payload");
     let invoked = prj.root().join("payload.invoked");
     fs::write(
@@ -60,36 +60,18 @@ exit 1
 
     let output = cmd.arg("build").assert_failure();
     let stderr = output.get_output().stderr_lossy();
-    assert!(stderr.contains("configured to use a local compiler executable"), "{stderr}");
-    assert!(invoked.exists(), "local compiler did not run after warning");
+    assert!(!stderr.contains("configured to use a local compiler executable"), "{stderr}");
+    assert!(invoked.exists(), "local compiler did not run");
 });
 
-forgetest!(project_dotenv_loads_with_warning, |prj, cmd| {
+forgetest!(project_dotenv_loads_without_warning, |prj, cmd| {
     fs::write(prj.root().join(".env"), "FOUNDRY_SRC=dotenv-src").unwrap();
 
     let output = cmd.args(["config", "--json"]).assert_success();
     let stderr = output.get_output().stderr_lossy();
-    assert!(stderr.contains("Warning: loading project dotenv"), "{stderr}");
+    assert!(!stderr.contains("Warning: loading project dotenv"), "{stderr}");
     let config: serde_json::Value = serde_json::from_slice(&output.get_output().stdout).unwrap();
     assert_eq!(config["src"], "dotenv-src");
-});
-
-#[cfg(unix)]
-forgetest!(local_compiler_path_escapes_control_characters, |prj, cmd| {
-    let solc = prj.root().join("payload\n\u{1b}[2Jspoofed");
-    fs::write(&solc, "#!/bin/sh\nexit 1\n").unwrap();
-    let mut permissions = fs::metadata(&solc).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&solc, permissions).unwrap();
-    prj.add_source("Contract", "contract Contract {}");
-    prj.update_config(|config| {
-        config.solc = Some(foundry_config::SolcReq::Local(solc.clone()));
-    });
-
-    let output = cmd.arg("build").assert_failure();
-    let stderr = output.get_output().stderr_lossy();
-    assert!(stderr.contains(r"payload\n\u{1b}[2Jspoofed"), "{stderr:?}");
-    assert!(!stderr.contains("payload\n\u{1b}[2Jspoofed"), "{stderr:?}");
 });
 
 forgetest!(


### PR DESCRIPTION
Removes the non-blocking warnings printed before Foundry loads project dotenv files or invokes project-configured local Solc and Vyper executables. The underlying behavior is unchanged: dotenv files continue to load and configured compilers continue to execute normally.

This also removes the warning-only path escaping test and updates the integration coverage to assert that both features still work without emitting the warnings.

Closes #16421.

Implemented with Codex assistance and reviewed by me.
