### PR TITLE
chore: bump version to 1.8.1

### DIFF
--- a/.changelog/bump-version-1.8.1.md
+++ b/.changelog/bump-version-1.8.1.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Prepared the workspace for the Foundry 1.8.1 release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-core"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-rpc"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-server"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anvil-rpc",
  "axum",
@@ -2952,7 +2952,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cast"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "chisel"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -5286,7 +5286,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "forge"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5377,7 +5377,7 @@ dependencies = [
 
 [[package]]
 name = "forge-doc"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "forge-fmt"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "foundry-common",
  "foundry-config",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "forge-lint"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script-sequence"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -5490,7 +5490,7 @@ dependencies = [
 
 [[package]]
 name = "forge-sol-macro-gen"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "forge-verify"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-bench"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "chrono",
  "clap",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5648,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes-spec"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli-markdown"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "clap",
  "pretty_assertions",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common-fmt"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-config"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5951,7 +5951,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-debugger"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-abi"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-core"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6083,7 +6083,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-coverage"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -6099,7 +6099,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-fuzz"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-hardforks"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -6140,7 +6140,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-networks"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -6158,11 +6158,11 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-sancov"
-version = "1.8.0"
+version = "1.8.1"
 
 [[package]]
 name = "foundry-evm-symbolic"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-traces"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -6249,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-linking"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "foundry-compilers",
@@ -6260,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-macros"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -6270,7 +6270,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-primitives"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-test-utils"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6326,7 +6326,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-tui"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -11893,7 +11893,7 @@ dependencies = [
 
 [[package]]
 name = "solar"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "solar-cli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.0"
+version = "1.8.1"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Foundry Contributors"]


### PR DESCRIPTION
Bumps the workspace version and lockfile entries to 1.8.1 and adds the release-preparation changelog fragment.

This PR was written by Codex.

Prompted by: @grandizzy
