### PR TITLE
fix(cheatcodes): match exact revert data

### DIFF
--- a/.changelog/expect-revert-exact-match.md
+++ b/.changelog/expect-revert-exact-match.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `vm.expectRevert(bytes)` accepting revert payloads with trailing ABI data.

--- a/.changelog/expect-revert-exact-match.md
+++ b/.changelog/expect-revert-exact-match.md
@@ -1,5 +1,6 @@
 ---
 forge: patch
+foundry-cheatcodes: patch
 ---
 
 Fixed `vm.expectRevert(bytes)` accepting revert payloads with trailing ABI data.

--- a/crates/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/cheatcodes/src/test/revert_handlers.rs
@@ -1,8 +1,7 @@
 use crate::{Error, Result};
-use alloy_dyn_abi::{DynSolValue, ErrorExt};
 use alloy_primitives::{Address, Bytes, address, hex};
 use alloy_sol_types::{SolError, SolValue};
-use foundry_common::{ContractsByArtifact, abi::get_error};
+use foundry_common::ContractsByArtifact;
 use foundry_evm_core::decode::RevertDecoder;
 use revm::interpreter::{InstructionResult, return_ok};
 use spec::Vm;
@@ -84,6 +83,11 @@ fn handle_revert(
         return Ok(());
     }
 
+    // Compare raw data before decoding, which may ignore trailing ABI data.
+    if actual_revert == expected_reason {
+        return Ok(());
+    }
+
     // Try decoding as known errors.
     actual_revert = decode_revert(actual_revert);
 
@@ -93,29 +97,20 @@ fn handle_revert(
         return Ok(());
     }
 
-    // If expected reason is `Error(string)` then decode and compare with actual revert.
-    // See <https://github.com/foundry-rs/foundry/issues/12511>
-    if expected_reason.len() >= 4
-        && let Ok(e) = get_error("Error(string)")
-        && let Ok(dec) = e.decode_error(expected_reason)
-        && let Some(DynSolValue::String(revert_str)) = dec.body.first()
-        && revert_str.as_str() == String::from_utf8_lossy(&actual_revert)
-    {
-        return Ok(());
-    }
-
-    let (actual, expected) = if let Some(contracts) = known_contracts {
+    let (mut actual, mut expected) = if let Some(contracts) = known_contracts {
         let decoder = RevertDecoder::new().with_abis(contracts.values().map(|c| &c.abi));
         (
-            &decoder.decode(actual_revert.as_slice(), Some(status)),
-            &decoder.decode(expected_reason, Some(status)),
+            decoder.decode(actual_revert.as_slice(), Some(status)),
+            decoder.decode(expected_reason, Some(status)),
         )
     } else {
-        (&stringify(&actual_revert), &stringify(expected_reason))
+        (stringify(&actual_revert), stringify(expected_reason))
     };
 
+    // Fall back to raw data if lossy decoding rendered distinct payloads identically.
     if expected == actual {
-        return Ok(());
+        actual = hex::encode_prefixed(retdata);
+        expected = hex::encode_prefixed(expected_reason);
     }
 
     Err(fmt_err!("Error != expected error: {} != {}", actual, expected))

--- a/crates/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/cheatcodes/src/test/revert_handlers.rs
@@ -69,7 +69,7 @@ fn handle_revert(
         return Ok(());
     };
 
-    let mut actual_revert = if retdata.is_empty() && !expected_reason.is_empty() {
+    let actual_revert = if retdata.is_empty() && !expected_reason.is_empty() {
         if status == InstructionResult::Revert {
             bail!("call reverted as expected, but without data");
         }
@@ -83,34 +83,37 @@ fn handle_revert(
         return Ok(());
     }
 
-    // Compare raw data before decoding, which may ignore trailing ABI data.
+    // Compare complete payloads before decoding, which may ignore trailing ABI data.
     if actual_revert == expected_reason {
         return Ok(());
     }
 
-    // Try decoding as known errors.
-    actual_revert = decode_revert(actual_revert);
+    // Unwrap string errors for legacy raw-message matching.
+    let actual_reason = decode_revert(actual_revert);
 
-    if actual_revert == expected_reason
-        || (is_cheatcode && memchr::memmem::find(&actual_revert, expected_reason).is_some())
+    if actual_reason == expected_reason
+        || (is_cheatcode && memchr::memmem::find(&actual_reason, expected_reason).is_some())
     {
         return Ok(());
     }
 
-    let (mut actual, mut expected) = if let Some(contracts) = known_contracts {
+    let (actual, expected) = if let Some(contracts) = known_contracts {
         let decoder = RevertDecoder::new().with_abis(contracts.values().map(|c| &c.abi));
         (
-            decoder.decode(actual_revert.as_slice(), Some(status)),
-            decoder.decode(expected_reason, Some(status)),
+            &decoder.decode(actual_reason.as_slice(), Some(status)),
+            &decoder.decode(expected_reason, Some(status)),
         )
     } else {
-        (stringify(&actual_revert), stringify(expected_reason))
+        (&stringify(&actual_reason), &stringify(expected_reason))
     };
 
     // Fall back to raw data if lossy decoding rendered distinct payloads identically.
     if expected == actual {
-        actual = hex::encode_prefixed(retdata);
-        expected = hex::encode_prefixed(expected_reason);
+        return Err(fmt_err!(
+            "Error != expected error: {} != {}",
+            hex::encode_prefixed(retdata),
+            hex::encode_prefixed(expected_reason)
+        ));
     }
 
     Err(fmt_err!("Error != expected error: {} != {}", actual, expected))

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -3098,6 +3098,14 @@ contract Counter {
         }
         number = newNumber;
     }
+    function revertWithMessage(string memory message) public pure {
+        revert(message);
+    }
+    function revertWithData(bytes memory data) public pure {
+        assembly ("memory-safe") {
+            revert(add(data, 0x20), mload(data))
+        }
+    }
 }
 contract CounterTest is Test {
     Counter public counter;
@@ -3113,14 +3121,39 @@ contract CounterTest is Test {
         vm.expectRevert(abi.encodePacked(Counter.NumberNotEven.selector, uint(2)));
         counter.setNumber(1);
     }
+    // https://github.com/foundry-rs/foundry/issues/16424
+    function test_decode_actual_error_with_trailing_data() public {
+        vm.expectRevert(bytes("reason"));
+        counter.revertWithData(
+            abi.encodePacked(abi.encodeWithSignature("Error(string)", "reason"), uint256(2))
+        );
+    }
+    function test_decode_error_with_trailing_data() public {
+        vm.expectRevert(
+            abi.encodePacked(abi.encodeWithSignature("Error(string)", "reason"), uint256(2))
+        );
+        counter.revertWithMessage("reason");
+    }
+    function test_decode_with_trailing_data() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(Counter.NumberNotEven.selector, uint256(1), uint256(2))
+        );
+        counter.setNumber(1);
+    }
 }
    "#,
     );
 
-    cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
+    cmd.args(["test", "--match-test", "test_decode_actual_error_with_trailing_data"])
+        .assert_success();
+
+    cmd.forge_fuse().args(["test"]).assert_failure().stdout_eq(str![[r#"
 ...
 [FAIL: Error != expected error: NumberNotEven(1) != RandomError()] test_decode() ([GAS])
+[PASS] test_decode_actual_error_with_trailing_data() ([GAS])
+[FAIL: Error != expected error: 0x[..] != 0x[..]] test_decode_error_with_trailing_data() ([GAS])
 [FAIL: Error != expected error: NumberNotEven(1) != NumberNotEven(2)] test_decode_with_args() ([GAS])
+[FAIL: Error != expected error: 0x[..] != 0x[..]] test_decode_with_trailing_data() ([GAS])
 ...
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -3098,9 +3098,6 @@ contract Counter {
         }
         number = newNumber;
     }
-    function revertWithMessage(string memory message) public pure {
-        revert(message);
-    }
     function revertWithData(bytes memory data) public pure {
         assembly ("memory-safe") {
             revert(add(data, 0x20), mload(data))
@@ -3121,20 +3118,20 @@ contract CounterTest is Test {
         vm.expectRevert(abi.encodePacked(Counter.NumberNotEven.selector, uint(2)));
         counter.setNumber(1);
     }
-    // https://github.com/foundry-rs/foundry/issues/16424
-    function test_decode_actual_error_with_trailing_data() public {
+    function test_raw_message_matches_error_with_trailing_data() public {
         vm.expectRevert(bytes("reason"));
         counter.revertWithData(
             abi.encodePacked(abi.encodeWithSignature("Error(string)", "reason"), uint256(2))
         );
     }
-    function test_decode_error_with_trailing_data() public {
+    function test_rejects_trailing_expected_error_data() public {
         vm.expectRevert(
             abi.encodePacked(abi.encodeWithSignature("Error(string)", "reason"), uint256(2))
         );
-        counter.revertWithMessage("reason");
+        counter.revertWithData(abi.encodeWithSignature("Error(string)", "reason"));
     }
-    function test_decode_with_trailing_data() public {
+    // https://github.com/foundry-rs/foundry/issues/16424
+    function test_rejects_trailing_expected_custom_error_data() public {
         vm.expectRevert(
             abi.encodeWithSelector(Counter.NumberNotEven.selector, uint256(1), uint256(2))
         );
@@ -3144,16 +3141,16 @@ contract CounterTest is Test {
    "#,
     );
 
-    cmd.args(["test", "--match-test", "test_decode_actual_error_with_trailing_data"])
+    cmd.args(["test", "--match-test", "test_raw_message_matches_error_with_trailing_data"])
         .assert_success();
 
     cmd.forge_fuse().args(["test"]).assert_failure().stdout_eq(str![[r#"
 ...
 [FAIL: Error != expected error: NumberNotEven(1) != RandomError()] test_decode() ([GAS])
-[PASS] test_decode_actual_error_with_trailing_data() ([GAS])
-[FAIL: Error != expected error: 0x[..] != 0x[..]] test_decode_error_with_trailing_data() ([GAS])
 [FAIL: Error != expected error: NumberNotEven(1) != NumberNotEven(2)] test_decode_with_args() ([GAS])
-[FAIL: Error != expected error: 0x[..] != 0x[..]] test_decode_with_trailing_data() ([GAS])
+[PASS] test_raw_message_matches_error_with_trailing_data() ([GAS])
+[FAIL: Error != expected error: 0x[..] != 0x[..]] test_rejects_trailing_expected_custom_error_data() ([GAS])
+[FAIL: Error != expected error: 0x[..] != 0x[..]] test_rejects_trailing_expected_error_data() ([GAS])
 ...
 "#]]);
 });


### PR DESCRIPTION
`vm.expectRevert(bytes)` compared best-effort decoded error strings after complete payloads failed equality. Because the ABI decoder tolerates trailing data, distinct expected custom-error payloads could render identically and be accepted.

Structured expectations now require exact raw payloads, while existing raw-message matching for actual `Error(string)` wrappers remains compatible with noncanonical returndata. Known-error decoding is diagnostic-only, and colliding decoded diagnostics fall back to raw hex. Regression coverage rejects trailing expected `Error(string)` and custom-error data while preserving legacy raw-message expectations. Fixes #16424.

AI assistance disclosure: Codex assisted with codebase analysis, implementation, tests, and this pull request description.
