### PR TITLE
fix: backport v1.8.1 fixes

### DIFF
--- a/.changelog/bump-version-1.8.1.md
+++ b/.changelog/bump-version-1.8.1.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Prepared the workspace for the Foundry 1.8.1 release.

--- a/.changelog/preserve-anvil-node-info-errors.md
+++ b/.changelog/preserve-anvil-node-info-errors.md
@@ -1,8 +1,0 @@
----
-anvil: patch
-cast: patch
-chisel: patch
-forge: patch
----
-
-Preserved non-method-not-found `anvil_nodeInfo` errors during fork endpoint detection.

--- a/.changelog/relax-anvil-node-info-probe.md
+++ b/.changelog/relax-anvil-node-info-probe.md
@@ -1,0 +1,12 @@
+---
+anvil: patch
+cast: patch
+chisel: patch
+forge: patch
+foundry-common: patch
+foundry-evm-core: patch
+---
+
+Treated `anvil_nodeInfo` as optional until an endpoint returns valid node info, while keeping later
+Anvil identity checks strict across discovery and resets. This allows non-Anvil fork endpoints with
+vendor-specific rejection codes to proceed through standard RPC discovery.

--- a/.changelog/remove-project-trust-warnings.md
+++ b/.changelog/remove-project-trust-warnings.md
@@ -1,0 +1,10 @@
+---
+forge: patch
+cast: patch
+anvil: patch
+chisel: patch
+foundry-cli: patch
+foundry-config: patch
+---
+
+Removed warnings when loading project dotenv files and running project-configured local compiler executables.

--- a/.changelog/root-lint-import-resolution.md
+++ b/.changelog/root-lint-import-resolution.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed post-build lint import resolution when using `forge build --root` from outside the project directory.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-core"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-rpc"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-server"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anvil-rpc",
  "axum",
@@ -2952,7 +2952,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cast"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "chisel"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -5296,7 +5296,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "forge"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "forge-doc"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "forge-fmt"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "foundry-common",
  "foundry-config",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "forge-lint"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script-sequence"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "forge-sol-macro-gen"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -5516,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "forge-verify"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-bench"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "chrono",
  "clap",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes-spec"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli-markdown"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "clap",
  "pretty_assertions",
@@ -5729,7 +5729,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common-fmt"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-config"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-debugger"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
@@ -6022,7 +6022,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-abi"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-core"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-coverage"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-fuzz"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-hardforks"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -6150,7 +6150,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-networks"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -6168,11 +6168,11 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-sancov"
-version = "1.8.0"
+version = "1.8.1"
 
 [[package]]
 name = "foundry-evm-symbolic"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -6197,7 +6197,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-traces"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -6259,7 +6259,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-linking"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "foundry-compilers",
@@ -6270,7 +6270,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-macros"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -6280,7 +6280,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-primitives"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-test-utils"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6336,7 +6336,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-tui"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -11893,7 +11893,7 @@ dependencies = [
 
 [[package]]
 name = "solar"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "solar-cli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.0"
+version = "1.8.1"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Foundry Contributors"]

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -104,7 +104,12 @@ struct StableForkSnapshot {
     gas_price: u128,
 }
 
-/// Tracks whether `anvil_nodeInfo` has positively identified the endpoint as Anvil.
+/// Best-effort Anvil detection that becomes strict after positive identification.
+///
+/// Before the first successful `anvil_nodeInfo` response, any probe failure means that the
+/// optional capability is unavailable. Mandatory standard RPC reads still expose endpoint-wide
+/// failures. Once a response or cached endpoint identity identifies Anvil, every later probe
+/// failure is returned so it cannot hide an endpoint reset or execution-profile change.
 #[derive(Clone, Copy, Debug, Default)]
 struct AnvilNodeInfoProbe {
     identified: bool,
@@ -121,7 +126,7 @@ impl AnvilNodeInfoProbe {
                 self.identified = true;
                 Ok(Some(node_info))
             }
-            Err(error) if !self.identified && is_rpc_method_not_found(&error) => Ok(None),
+            Err(_) if !self.identified => Ok(None),
             Err(error) => {
                 Err(error).wrap_err("failed to determine network family from fork endpoint")
             }
@@ -216,6 +221,8 @@ pub struct NodeConfig {
     pub fork_source_chain_id: Option<u64>,
     /// Chain ID exposed by the active fork endpoint.
     pub fork_execution_chain_id: Option<u64>,
+    /// Whether the active fork endpoint has positively identified itself as Anvil.
+    pub(crate) fork_endpoint_is_anvil: bool,
     /// Network family most recently inferred from a fork endpoint.
     inferred_fork_network: Option<NetworkVariant>,
     /// Network configuration replaced by chain-ID inference, if any.
@@ -606,6 +613,7 @@ impl Default for NodeConfig {
             fork_chain_id: None,
             fork_source_chain_id: None,
             fork_execution_chain_id: None,
+            fork_endpoint_is_anvil: false,
             inferred_fork_network: None,
             chain_id_network_base: None,
             fork_overrides: None,
@@ -1010,7 +1018,11 @@ impl NodeConfig {
     #[must_use]
     pub fn with_eth_rpc_url<U: Into<String>>(mut self, eth_rpc_url: Option<U>) -> Self {
         if let Some(url) = eth_rpc_url {
-            self.fork_urls = vec![url.into()];
+            let fork_urls = vec![url.into()];
+            if self.fork_urls != fork_urls {
+                self.fork_endpoint_is_anvil = false;
+            }
+            self.fork_urls = fork_urls;
         }
         self
     }
@@ -1018,6 +1030,9 @@ impl NodeConfig {
     /// Sets the fork URLs for load-balanced multi-endpoint forking.
     #[must_use]
     pub fn with_fork_urls(mut self, fork_urls: Vec<String>) -> Self {
+        if self.fork_urls != fork_urls {
+            self.fork_endpoint_is_anvil = false;
+        }
         self.fork_urls = fork_urls;
         self
     }
@@ -1681,7 +1696,7 @@ impl NodeConfig {
         provider: &Arc<RetryProvider>,
         fork_overrides: ForkOverrides,
     ) -> Result<StableForkSnapshot> {
-        let mut node_info_probe = AnvilNodeInfoProbe::default();
+        let mut node_info_probe = AnvilNodeInfoProbe::new(self.fork_endpoint_is_anvil);
         for _ in 0..3 {
             let before =
                 self.resolved_fork_endpoint_identity(provider, &mut node_info_probe).await?;
@@ -1847,6 +1862,7 @@ impl NodeConfig {
             block,
             gas_price,
         } = self.stable_fork_snapshot(&provider, fork_overrides).await?;
+        self.fork_endpoint_is_anvil = fork_identity.is_authoritative();
 
         let target_network = fork_identity.network.unwrap_or(NetworkVariant::Ethereum);
         let target_profile = fork_identity.network_profile.unwrap_or_default();

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -634,6 +634,7 @@ impl<N: Network> EthApi<N> {
             config.fork_urls = vec![url.clone()];
             config.fork_chain_id = None;
             config.endpoint_identity = endpoint_identity;
+            node_config.fork_endpoint_is_anvil = endpoint_identity.is_authoritative();
         }
         // Keep node_config in sync so a subsequent URL-less fork reset uses the updated endpoint.
         node_config.fork_urls = vec![url];

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -77,7 +77,9 @@ impl ForkEndpointIdentity {
     }
 }
 
-/// Ensures the fork network can be executed by Anvil's EVM backend.
+/// Ensures Anvil's EVM backend can execute the resolved upstream source chain.
+///
+/// Anvil's execution chain-ID override does not change the bytecode format in remote fork state.
 pub(crate) fn ensure_fork_network_supported(chain_id: u64) -> Result<(), BlockchainError> {
     if matches!(NamedChain::try_from(chain_id), Ok(NamedChain::ZkSync | NamedChain::ZkSyncTestnet))
     {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4305,6 +4305,13 @@ impl<N: Network> Backend<N> {
         if rpc_url_was_provided {
             staged_config.fork_chain_id = None;
         }
+        let configured_endpoint_is_anvil = staged_config.fork_endpoint_is_anvil
+            && staged_config.fork_urls.contains(target_rpc_url);
+        let cached_endpoint_is_anvil = previous_source.as_ref().is_some_and(|source| {
+            source.rpc_url == *target_rpc_url && source.endpoint_identity.is_authoritative()
+        });
+        staged_config.fork_endpoint_is_anvil =
+            configured_endpoint_is_anvil || cached_endpoint_is_anvil;
         staged_config.fork_urls = target_rpc_urls.to_vec();
         staged_config.fork_choice = block_number.map(|number| ForkChoice::Block(number as i128));
         let mut staged_env = self.evm_env.read().clone();
@@ -4537,6 +4544,7 @@ impl<N: Network> Backend<N> {
         let mut staged_config = self.node_config.read().await.clone();
         staged_config.fork_source_chain_id = None;
         staged_config.fork_execution_chain_id = None;
+        staged_config.fork_endpoint_is_anvil = false;
         staged_config.restore_fork_overrides();
         let local_chain_id = staged_config.get_chain_id();
         staged_config.update_wallet_chain_id(local_chain_id);

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -43,8 +43,9 @@ use foundry_config::Config;
 use foundry_evm_networks::NetworkConfigs;
 use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope};
 use foundry_test_utils::rpc::{
-    self, next_http_rpc_endpoint, next_rpc_endpoint, spawn_rpc_proxy_erroring_method_after,
+    self, next_http_rpc_endpoint, next_rpc_endpoint, spawn_rpc_proxy_internal_error_after,
     spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
+    spawn_rpc_proxy_rejecting_method_when_enabled,
 };
 use futures::StreamExt;
 use revm::{
@@ -53,7 +54,7 @@ use revm::{
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::Arc,
+    sync::{Arc, atomic::Ordering},
     time::Duration,
 };
 
@@ -95,19 +96,15 @@ pub fn fork_config() -> NodeConfig {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_fork_rejects_anvil_node_info_rpc_error() {
+async fn test_fork_ignores_initial_anvil_node_info_rpc_error() {
     let (_api, origin) =
         spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
     let fork_url =
-        spawn_rpc_proxy_erroring_method_after(origin.http_endpoint(), "anvil_nodeInfo", 0).await;
+        spawn_rpc_proxy_internal_error_after(origin.http_endpoint(), "anvil_nodeInfo", 0).await;
 
-    let result = try_spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
-    let Err(error) = result else { panic!("expected fork startup to fail") };
+    let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
 
-    assert!(
-        error.to_string().contains("failed to determine network family from fork endpoint"),
-        "{error}"
-    );
+    assert_eq!(api.chain_id(), NamedChain::Mainnet as u64);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -137,6 +134,89 @@ async fn test_fork_reset_keeps_node_info_probe_strict_after_identification_durin
 
     let error = api
         .anvil_reset(Some(Forking { json_rpc_url: Some(fork_url), block_number: None }))
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("failed to determine network family from fork endpoint"),
+        "{error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_keeps_cached_anvil_node_info_probe_strict() {
+    let (_origin_api, origin) = spawn(NodeConfig::test()).await;
+    let (fork_url, reject_node_info) =
+        spawn_rpc_proxy_rejecting_method_when_enabled(origin.http_endpoint(), "anvil_nodeInfo")
+            .await;
+    let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url.clone()))).await;
+    api.anvil_reset(None).await.unwrap();
+    reject_node_info.store(true, Ordering::SeqCst);
+
+    let error = api
+        .anvil_reset(Some(Forking { json_rpc_url: Some(fork_url), block_number: None }))
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("failed to determine network family from fork endpoint"),
+        "{error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_does_not_carry_anvil_identity_to_new_endpoint() {
+    let (_initial_api, initial_origin) = spawn(NodeConfig::test()).await;
+    let (api, handle) =
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(initial_origin.http_endpoint()))).await;
+    let (_target_api, target_origin) = spawn(NodeConfig::test().with_chain_id(Some(56u64))).await;
+    let target_url =
+        spawn_rpc_proxy_rejecting_method_after(target_origin.http_endpoint(), "anvil_nodeInfo", 0)
+            .await;
+
+    api.anvil_reset(Some(Forking { json_rpc_url: Some(target_url), block_number: None }))
+        .await
+        .unwrap();
+
+    assert_eq!(handle.http_provider().get_chain_id().await.unwrap(), 56);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_keeps_set_rpc_url_anvil_node_info_probe_strict() {
+    let (_initial_api, initial_origin) = spawn(NodeConfig::test()).await;
+    let (api, _handle) =
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(initial_origin.http_endpoint()))).await;
+    let (replacement_url, reject_node_info) = spawn_rpc_proxy_rejecting_method_when_enabled(
+        initial_origin.http_endpoint(),
+        "anvil_nodeInfo",
+    )
+    .await;
+    api.anvil_set_rpc_url(replacement_url).await.unwrap();
+    reject_node_info.store(true, Ordering::SeqCst);
+
+    let error = api
+        .anvil_reset(Some(Forking { json_rpc_url: None, block_number: None }))
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("failed to determine network family from fork endpoint"),
+        "{error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_keeps_validated_mirror_anvil_node_info_probe_strict() {
+    let (_origin_api, origin) = spawn(NodeConfig::test()).await;
+    let primary_url = origin.http_endpoint();
+    let (mirror_url, reject_node_info) =
+        spawn_rpc_proxy_rejecting_method_when_enabled(primary_url.clone(), "anvil_nodeInfo").await;
+    let (api, _handle) =
+        spawn(NodeConfig::test().with_fork_urls(vec![primary_url, mirror_url.clone()])).await;
+    reject_node_info.store(true, Ordering::SeqCst);
+
+    let error = api
+        .anvil_reset(Some(Forking { json_rpc_url: Some(mirror_url), block_number: None }))
         .await
         .unwrap_err();
 

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -21,7 +21,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     FoundryTransactionBuilder,
-    provider::ProviderBuilder,
+    provider::{ProviderBuilder, is_rpc_method_not_found},
     sh_warn, shell,
     tempo::{
         self, AccountsStoreView, KeyType, maybe_print_fee_token, read_tempo_accounts_store,
@@ -3844,10 +3844,6 @@ fn active_from_anvil_node_info(info: &AnvilNodeInfo, hardfork: TempoHardfork) ->
     })
 }
 
-fn is_rpc_method_not_found(err: &TransportError) -> bool {
-    err.as_error_resp().is_some_and(|payload| payload.code == -32601)
-}
-
 fn resolve_key_metadata(
     key_address: Address,
     root_account: Option<Address>,
@@ -4293,7 +4289,6 @@ fn decoded_entry_key_authorization(entry: &tempo::KeyEntry) -> Option<SignedKeyA
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_json_rpc::ErrorPayload;
     use std::str::FromStr;
 
     #[test]
@@ -5272,19 +5267,5 @@ mod tests {
 
         assert!(sanitized.contains("private-key://<redacted>"));
         assert!(!sanitized.contains("super-secret"));
-    }
-
-    #[test]
-    fn test_rpc_method_not_found_detection() {
-        let method_missing: TransportError =
-            TransportError::ErrorResp(ErrorPayload::method_not_found());
-        assert!(is_rpc_method_not_found(&method_missing));
-
-        let internal_error: TransportError =
-            TransportError::ErrorResp(ErrorPayload::internal_error());
-        assert!(!is_rpc_method_not_found(&internal_error));
-
-        let transport_error = alloy_transport::TransportErrorKind::backend_gone();
-        assert!(!is_rpc_method_not_found(&transport_error));
     }
 }

--- a/crates/cli/src/opts/build/utils.rs
+++ b/crates/cli/src/opts/build/utils.rs
@@ -319,8 +319,9 @@ fn configure_pcx_from_solc_cli(
     project_paths: &ProjectPathsConfig,
     cli_settings: &foundry_compilers::solc::CliSettings,
 ) {
-    pcx.file_resolver
-        .set_current_dir(cli_settings.base_path.as_ref().unwrap_or(&project_paths.root));
+    let base_path = cli_settings.base_path.as_ref().unwrap_or(&project_paths.root);
+    pcx.file_resolver.set_base_path(base_path);
+    pcx.file_resolver.set_current_dir(base_path);
     for remapping in &project_paths.remappings {
         let context = remapping.context.clone().unwrap_or_default();
         // Solar compares the context directly with the parent source path. Match the slash form

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -205,10 +205,7 @@ pub fn common_setup() {
     enable_paint();
 }
 
-/// Loads dotenv files from the cwd and project root after warning, ignoring parse failures.
-///
-/// The warning is written directly because dotenv may configure logging before the tracing
-/// subscriber is initialized.
+/// Loads dotenv files from the cwd and project root, ignoring parse failures.
 pub fn load_dotenv() {
     // we only want the .env file of the cwd and project root
     // `find_project_root` calls `current_dir` internally so both paths are either both `Ok` or
@@ -226,25 +223,6 @@ pub fn load_dotenv() {
                 paths.push(cwd_env);
             }
         }
-    }
-
-    if paths.is_empty() {
-        return;
-    }
-
-    {
-        use std::io::Write as _;
-
-        let mut stderr = std::io::stderr().lock();
-        let _ = writeln!(stderr, "Warning: loading project dotenv files:");
-        for path in &paths {
-            let _ = writeln!(stderr, "  {path:?}");
-        }
-        let _ = writeln!(
-            stderr,
-            "Project environment variables can affect executable and library loading. Only run \
-             commands in projects you trust."
-        );
     }
 
     for path in paths {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -47,11 +47,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::{
     borrow::Cow,
     collections::BTreeMap,
-    fs,
-    io::{self, Write as _},
+    fs, io,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::Mutex,
 };
 
 mod macros;
@@ -155,7 +153,6 @@ pub use semver;
 
 #[cfg(not(test))]
 static SELECTED_PROFILE: std::sync::OnceLock<Profile> = std::sync::OnceLock::new();
-static WARNED_LOCAL_COMPILERS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
 /// Foundry configuration
 ///
@@ -1506,7 +1503,6 @@ impl Config {
                     if !solc.is_file() {
                         return Err(SolcError::msg(format!("`solc` {solc:?} does not exist")));
                     }
-                    warn_local_compiler(solc);
                     Solc::new(solc)?
                 }
             };
@@ -1595,7 +1591,6 @@ impl Config {
             return Ok(None);
         }
         let vyper = if let Some(path) = &self.vyper.path {
-            warn_local_compiler(path);
             Some(Vyper::new(path)?)
         } else {
             Vyper::new("vyper").ok()
@@ -3114,10 +3109,7 @@ impl SolcReq {
     pub fn try_version(&self) -> Result<Version, SolcError> {
         match self {
             Self::Version(version) => Ok(version.clone()),
-            Self::Local(path) => {
-                warn_local_compiler(path);
-                Solc::new(path).map(|solc| solc.version)
-            }
+            Self::Local(path) => Solc::new(path).map(|solc| solc.version),
         }
     }
 }
@@ -3261,21 +3253,6 @@ pub(crate) mod from_str_lowercase {
     {
         String::deserialize(deserializer)?.to_lowercase().parse().map_err(serde::de::Error::custom)
     }
-}
-
-fn warn_local_compiler(path: &Path) {
-    let mut warned = WARNED_LOCAL_COMPILERS.lock().unwrap_or_else(|err| err.into_inner());
-    if warned.iter().any(|warned_path| warned_path == path) {
-        return;
-    }
-    warned.push(path.to_path_buf());
-
-    let mut stderr = io::stderr().lock();
-    let _ = writeln!(
-        stderr,
-        "Warning: this project is configured to use a local compiler executable:\n  {path:?}\n\
-         Running this executable may execute arbitrary code."
-    );
 }
 
 fn canonic(path: impl Into<PathBuf>) -> PathBuf {

--- a/crates/evm/core/src/fork/resolved.rs
+++ b/crates/evm/core/src/fork/resolved.rs
@@ -3,11 +3,13 @@ use alloy_eips::{BlockId, BlockNumHash};
 use alloy_primitives::{B256, BlockNumber, keccak256};
 use std::fmt;
 
-/// A fork selector and block identity resolved from a configured RPC source.
+/// An exact fork snapshot resolved from a fully configured RPC source.
 ///
-/// This context binds exact preflight reads and EVM environment reconstruction to the source,
-/// selector, and block that were resolved together. The fork database uses the resolved hash for
-/// state reads and block ancestry.
+/// The snapshot binds three layers that must travel together: the source URL, request headers, and
+/// JWT; the configured selector (`latest` or a block number); and the observed exact block (number
+/// and hash) plus endpoint context. `latest` is retained as the configured selector, while `block`
+/// is always exact. Reusing this value keeps preflight reads, environment reconstruction, cache
+/// identity, and backend construction on the same remote state.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ResolvedFork {
     source: ForkSource,
@@ -104,7 +106,7 @@ impl ResolvedFork {
         resolved
     }
 
-    /// Returns an opaque identity for the complete authenticated RPC source.
+    /// Returns an opaque identity for the complete configured RPC source.
     pub(crate) fn source_id(&self) -> B256 {
         let mut encoded = Vec::new();
         encoded.extend_from_slice(b"foundry-resolved-fork-source-v1");
@@ -214,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn authenticated_source_identity_is_unambiguous() {
+    fn configured_source_identity_is_unambiguous() {
         let block = BlockNumHash::new(1, B256::with_last_byte(1));
         let context = context(1);
         let plain = ResolvedFork::new("http://localhost:8545", None, None, None, block, context);

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -28,6 +28,15 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Write;
 use url::Url;
 
+/// EVM execution options, including the configured remote fork.
+///
+/// Fork handling separates two responsibilities. Endpoint discovery identifies and caches the
+/// execution family without selecting a block. Exact resolution binds the configured source and
+/// selector to a block number, hash, and endpoint context. Forge normally performs discovery
+/// before resolution, while callers that already know the network can resolve directly.
+///
+/// An implicit `latest` selector remains unchanged in these options; only the returned
+/// [`ResolvedFork`] is pinned to the exact block observed during resolution.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EvmOpts {
     /// The EVM environment configuration.
@@ -116,11 +125,11 @@ pub struct EvmOpts {
     /// The CREATE2 deployer's address.
     pub create2_deployer: Address,
 
-    /// Identity discovered from the configured fork endpoint.
+    /// Most recently discovered endpoint identity, cached for network dispatch and revalidation.
     #[serde(skip)]
     pub fork_endpoint: Option<ForkEndpointIdentity>,
 
-    /// Endpoint identity that must remain stable while constructing local execution state.
+    /// Endpoint identity promoted to an invariant that later discovery must match.
     #[serde(skip)]
     pub expected_fork_endpoint: Option<ForkEndpointIdentity>,
 
@@ -137,10 +146,18 @@ pub struct EvmOpts {
     pub fork_block_number_is_inferred: bool,
 }
 
-/// Execution and source identity exposed by a fork endpoint.
+/// A snapshot of the execution and upstream-source identity exposed by an RPC endpoint.
+///
+/// This identity is independent of the block selector Forge resolves. In particular,
+/// `source_fork_block_*` describes the upstream block from which an Anvil endpoint was itself
+/// forked; the target block selected for local execution belongs to [`ResolvedFork`]. Equality
+/// detects observable endpoint identity changes, including Anvil instance resets, and
+/// execution-profile changes between related RPC reads.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ForkEndpointIdentity {
     /// RPC URL from which this identity was discovered.
+    ///
+    /// Request headers and JWT credentials are bound separately by [`ResolvedFork`].
     pub endpoint: String,
     /// Chain ID exposed through `eth_chainId`.
     pub execution_chain_id: ChainId,
@@ -164,11 +181,18 @@ pub struct ForkEndpointIdentity {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum EndpointHardforkPolicy {
+    /// Permit an unrecognized hardfork during early network-family discovery.
     Optional,
+    /// Require a recognized hardfork before constructing an execution environment.
     Required,
 }
 
-/// Tracks whether `anvil_nodeInfo` has positively identified the endpoint as Anvil.
+/// Best-effort Anvil detection that becomes strict after positive identification.
+///
+/// Before the first successful `anvil_nodeInfo` response, any probe failure means that the
+/// optional capability is unavailable. Mandatory standard RPC reads still expose endpoint-wide
+/// failures. Once a response or cached endpoint identity identifies Anvil, every later probe
+/// failure is returned so it cannot hide an endpoint reset or execution-profile change.
 #[derive(Clone, Copy, Debug, Default)]
 struct AnvilNodeInfoProbe {
     identified: bool,
@@ -188,7 +212,7 @@ impl AnvilNodeInfoProbe {
                 self.identified = true;
                 Ok(Some(node_info))
             }
-            Err(error) if !self.identified && is_rpc_method_not_found(&error) => Ok(None),
+            Err(_) if !self.identified => Ok(None),
             Err(error) => Err(error).wrap_err("failed to determine network family from endpoint"),
         }
     }
@@ -214,9 +238,11 @@ fn endpoint_hardfork(
     }
 }
 
-/// Identity and block context of the remote chain backing a fork.
+/// Endpoint identity paired with the remote block number backing a fork.
 ///
-/// The source chain ID remains distinct from the configured `CHAINID` opcode override.
+/// [`ResolvedFork`] adds the exact block hash and configured RPC source. The remote
+/// `block_number` may differ from a remapped EVM block number on L2s, and the source chain ID
+/// remains distinct from a configured `CHAINID` opcode override.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize)]
 pub struct ForkContext {
     /// Chain ID exposed through `eth_chainId`.
@@ -424,7 +450,12 @@ impl EvmOpts {
         )
     }
 
-    /// Resolves and pins an unpinned fork to the current latest block.
+    /// Converts an implicit `latest` selector into a block-number selector in place.
+    ///
+    /// This only reads the endpoint's current block number; it does not resolve a block hash or
+    /// endpoint identity and is therefore not a reorg-safe fork snapshot. Use
+    /// [`Self::resolve_fork`] when later reads and backend construction must share an exact
+    /// identity.
     pub async fn pin_fork_block(&mut self) -> eyre::Result<Option<BlockNumber>> {
         if self.fork_block_number.is_none()
             && let Some(fork_url) = &self.fork_url
@@ -437,7 +468,13 @@ impl EvmOpts {
         Ok(self.fork_block_number)
     }
 
-    /// Resolves the configured fork selector without changing it.
+    /// Resolves the configured fork source and selector to an exact snapshot without changing
+    /// `self`.
+    ///
+    /// Endpoint identity is read before and after the target block and the operation is retried if
+    /// it changes. The result binds the configured RPC source, configured selector, exact block
+    /// number and hash, and [`ForkContext`]. When the selector is implicit `latest`, only the
+    /// returned [`ResolvedFork`] is pinned.
     pub async fn resolve_fork(&self) -> eyre::Result<Option<ResolvedFork>> {
         let Some(fork_url) = &self.fork_url else { return Ok(None) };
         let provider = self.fork_provider_with_url::<AnyNetwork>(fork_url)?;
@@ -576,10 +613,12 @@ impl EvmOpts {
         builder.build()
     }
 
-    /// Infers the network configuration and exact endpoint identity for a fork.
+    /// Discovers and caches the network configuration and endpoint identity for a fork.
     ///
-    /// Explicit network selections are preserved, while endpoint identity is still cached so
-    /// downstream execution can honor an Anvil endpoint's exact hardfork.
+    /// This is the dispatch phase of fork setup: explicit network selections are preserved, while
+    /// inferred chain and network settings are applied when no override exists. The method does not
+    /// resolve or pin a fork block; block resolution happens later through [`Self::resolve_fork`]
+    /// or [`Self::env_resolved`].
     pub async fn infer_network_from_fork(&mut self) -> eyre::Result<()> {
         let previous_identity = self.fork_endpoint.clone();
         let Some(fork_url) = self.fork_url.clone() else {
@@ -631,7 +670,13 @@ impl EvmOpts {
         Ok(())
     }
 
-    /// Discovers the complete identity exposed by the configured fork endpoint.
+    /// Discovers a stable identity snapshot without selecting a fork block.
+    ///
+    /// Each attempt reads `eth_chainId` and the optional Anvil identity methods before and after,
+    /// and returns only when both snapshots agree. Before Anvil is positively identified, a failed
+    /// `anvil_nodeInfo` probe is treated as absence of optional Anvil identity information for that
+    /// snapshot. Later probe failures are strict. This method does not mutate or cache the returned
+    /// identity in `self`.
     pub async fn discover_fork_endpoint(&self) -> eyre::Result<ForkEndpointIdentity> {
         let fork_url = self.fork_url.as_deref().ok_or_eyre("fork URL is not configured")?;
         let provider = self.fork_provider_with_url::<AnyNetwork>(fork_url)?;
@@ -676,8 +721,11 @@ impl EvmOpts {
         );
     }
 
-    /// Resolves one endpoint identity snapshot, using Anvil's authoritative node metadata when it
-    /// is already known to be available.
+    /// Reads one endpoint identity snapshot without performing a stability check.
+    ///
+    /// The shared node-info probe starts permissive for endpoints that do not expose Anvil methods
+    /// and becomes strict after Anvil is identified. Callers either bracket mutable remote reads
+    /// with two snapshots or use this helper to revalidate an already resolved fork.
     async fn resolve_fork_endpoint_once<N: Network, P: Provider<N>>(
         &self,
         provider: &P,
@@ -719,6 +767,9 @@ impl EvmOpts {
         Ok((identity.execution_chain_id, identity.network))
     }
 
+    /// Builds an identity from one observed chain ID and optional Anvil node-info response.
+    ///
+    /// Anvil metadata is consulted only after node info has positively identified the endpoint.
     async fn resolve_fork_endpoint_identity<N: Network, P: Provider<N>>(
         provider: &P,
         endpoint: &str,
@@ -828,7 +879,11 @@ impl EvmOpts {
         Ok((evm_env, tx, fork.as_ref().map(ResolvedFork::number)))
     }
 
-    /// Returns the EVM and transaction environments with their resolved fork context.
+    /// Returns the EVM and transaction environments with an exact resolved fork snapshot.
+    ///
+    /// Resolution brackets block and gas-price reads with endpoint identity checks and retries if
+    /// the endpoint changes. Downstream preflight reads and backend construction should reuse the
+    /// returned [`ResolvedFork`] instead of carrying only its block number.
     pub async fn env_resolved<
         SPEC: Into<SpecId> + Default + Copy,
         BLOCK: FoundryBlock + Default,
@@ -1558,7 +1613,8 @@ mod tests {
     use alloy_rpc_types::TransactionRequest;
     use alloy_serde::WithOtherFields;
     use foundry_test_utils::rpc::{
-        spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
+        spawn_rpc_proxy_internal_error_after, spawn_rpc_proxy_method_not_found_before,
+        spawn_rpc_proxy_rejecting_method_after,
     };
     #[cfg(feature = "optimism")]
     use op_revm::OpSpecId;
@@ -2242,21 +2298,18 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn fork_non_anvil_node_info_rpc_error_is_visible() {
+    async fn fork_non_anvil_node_info_rpc_error_is_optional() {
         let (_api, handle) =
             anvil::spawn(anvil::NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64)))
                 .await;
         let fork_url =
-            spawn_rpc_proxy_rejecting_method_after(handle.http_endpoint(), "anvil_nodeInfo", 0)
-                .await;
+            spawn_rpc_proxy_internal_error_after(handle.http_endpoint(), "anvil_nodeInfo", 0).await;
         let mut evm_opts = EvmOpts { fork_url: Some(fork_url), ..Default::default() };
 
-        let error = evm_opts.infer_network_from_fork().await.unwrap_err();
+        evm_opts.infer_network_from_fork().await.unwrap();
 
-        assert!(
-            error.to_string().contains("failed to determine network family from endpoint"),
-            "{error}"
-        );
+        assert_eq!(evm_opts.networks, NetworkConfigs::default());
+        assert_eq!(evm_opts.env.chain_id, Some(NamedChain::Mainnet as u64));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -33,7 +33,7 @@ fn add_local_submodule(root: &Path, path: &str) -> String {
 }
 
 #[cfg(unix)]
-forgetest!(local_compiler_warns_and_runs, |prj, cmd| {
+forgetest!(local_compiler_runs_without_warning, |prj, cmd| {
     let solc = prj.root().join("payload");
     let invoked = prj.root().join("payload.invoked");
     fs::write(
@@ -59,36 +59,18 @@ exit 1
 
     let output = cmd.arg("build").assert_failure();
     let stderr = output.get_output().stderr_lossy();
-    assert!(stderr.contains("configured to use a local compiler executable"), "{stderr}");
-    assert!(invoked.exists(), "local compiler did not run after warning");
+    assert!(!stderr.contains("configured to use a local compiler executable"), "{stderr}");
+    assert!(invoked.exists(), "local compiler did not run");
 });
 
-forgetest!(project_dotenv_loads_with_warning, |prj, cmd| {
+forgetest!(project_dotenv_loads_without_warning, |prj, cmd| {
     fs::write(prj.root().join(".env"), "FOUNDRY_SRC=dotenv-src").unwrap();
 
     let output = cmd.args(["config", "--json"]).assert_success();
     let stderr = output.get_output().stderr_lossy();
-    assert!(stderr.contains("Warning: loading project dotenv"), "{stderr}");
+    assert!(!stderr.contains("Warning: loading project dotenv"), "{stderr}");
     let config: serde_json::Value = serde_json::from_slice(&output.get_output().stdout).unwrap();
     assert_eq!(config["src"], "dotenv-src");
-});
-
-#[cfg(unix)]
-forgetest!(local_compiler_path_escapes_control_characters, |prj, cmd| {
-    let solc = prj.root().join("payload\n\u{1b}[2Jspoofed");
-    fs::write(&solc, "#!/bin/sh\nexit 1\n").unwrap();
-    let mut permissions = fs::metadata(&solc).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&solc, permissions).unwrap();
-    prj.add_source("Contract", "contract Contract {}");
-    prj.update_config(|config| {
-        config.solc = Some(foundry_config::SolcReq::Local(solc.clone()));
-    });
-
-    let output = cmd.arg("build").assert_failure();
-    let stderr = output.get_output().stderr_lossy();
-    assert!(stderr.contains(r"payload\n\u{1b}[2Jspoofed"), "{stderr:?}");
-    assert!(!stderr.contains("payload\n\u{1b}[2Jspoofed"), "{stderr:?}");
 });
 
 forgetest!(

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -897,6 +897,32 @@ note[mixed-case-variable]: mutable variables should use mixedCase
 "#]]);
 });
 
+forgetest!(build_lint_resolves_imports_with_explicit_root, |prj, cmd| {
+    prj.add_source("Imported", "contract Imported {}");
+    prj.add_source(
+        "RelativeImporter",
+        r#"
+import {Imported} from "./Imported.sol";
+
+contract RelativeImporter is Imported {}
+"#,
+    );
+    prj.add_source(
+        "Importer",
+        r#"
+import {RelativeImporter} from "src/RelativeImporter.sol";
+
+contract Importer is RelativeImporter {}
+"#,
+    );
+
+    let root = prj.root();
+    cmd.current_dir(root.parent().unwrap())
+        .args(["build", "--force", "--no-cache", "--root"])
+        .arg(root.file_name().unwrap())
+        .assert_success();
+});
+
 forgetest!(build_no_lint_flag_skips_lint, |prj, cmd| {
     prj.add_source("ContractWithLints", CONTRACT);
 

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -1266,6 +1266,29 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/16413>
+forgetest_async!(fork_endpoint_without_anvil_node_info, |prj, cmd| {
+    let (api, handle) = spawn(NodeConfig::test().with_chain_id(Some(1u64))).await;
+    api.anvil_mine(Some(U256::ONE), None).await.unwrap();
+    let endpoint =
+        rpc::spawn_rpc_proxy_rejecting_method_after(handle.http_endpoint(), "anvil_nodeInfo", 0)
+            .await;
+
+    prj.add_test(
+        "NonAnvilFork.t.sol",
+        r#"
+contract NonAnvilForkTest {
+    function testFork() external view {
+        require(block.chainid == 1, "wrong chain");
+        require(block.number == 1, "wrong block");
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--fork-url", &endpoint, "--match-test", "testFork"]).assert_success();
+});
+
 // <https://github.com/foundry-rs/foundry/issues/7574>
 forgetest_async!(failed_fork_test_reports_block_number, |prj, cmd| {
     let (api, handle) = spawn(NodeConfig::test()).await;

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -13,8 +13,8 @@ use serde_json::{Value, json};
 use std::{
     env,
     sync::{
-        LazyLock,
-        atomic::{AtomicUsize, Ordering},
+        Arc, LazyLock,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -292,21 +292,22 @@ pub async fn spawn_rpc_proxy_rejecting_method_after(
     .await
 }
 
-/// Spawns an RPC proxy that rejects the first `rejected_calls` requests to `method`.
-pub async fn spawn_rpc_proxy_rejecting_method_before(
+/// Spawns an RPC proxy whose rejection of `method` can be enabled after startup.
+pub async fn spawn_rpc_proxy_rejecting_method_when_enabled(
     endpoint: String,
     method: &'static str,
-    rejected_calls: usize,
-) -> String {
-    spawn_rpc_proxy_rejecting_method(
+) -> (String, Arc<AtomicBool>) {
+    let enabled = Arc::new(AtomicBool::new(false));
+    let proxy = spawn_rpc_proxy_rejecting_method(
         endpoint,
         method,
-        RpcMethodRejection::Before(rejected_calls),
+        RpcMethodRejection::Enabled(enabled.clone()),
         StatusCode::FORBIDDEN,
         -32004,
         "method is not allowed",
     )
-    .await
+    .await;
+    (proxy, enabled)
 }
 
 /// Spawns an RPC proxy that returns method-not-found for the first `unavailable_calls` requests to
@@ -327,9 +328,9 @@ pub async fn spawn_rpc_proxy_method_not_found_before(
     .await
 }
 
-/// Spawns an RPC proxy that returns a vendor-specific JSON-RPC error for `method` after
-/// forwarding `successful_calls` requests.
-pub async fn spawn_rpc_proxy_erroring_method_after(
+/// Spawns an RPC proxy that returns a JSON-RPC internal error for `method` after forwarding
+/// `successful_calls` requests.
+pub async fn spawn_rpc_proxy_internal_error_after(
     endpoint: String,
     method: &'static str,
     successful_calls: usize,
@@ -339,23 +340,25 @@ pub async fn spawn_rpc_proxy_erroring_method_after(
         method,
         RpcMethodRejection::After(successful_calls),
         StatusCode::OK,
-        -32004,
-        "method is not allowed",
+        -32603,
+        "internal error",
     )
     .await
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 enum RpcMethodRejection {
     Before(usize),
     After(usize),
+    Enabled(Arc<AtomicBool>),
 }
 
 impl RpcMethodRejection {
-    const fn rejects(self, call: usize) -> bool {
+    fn rejects(&self, call: usize) -> bool {
         match self {
-            Self::Before(rejected_calls) => call < rejected_calls,
-            Self::After(successful_calls) => call >= successful_calls,
+            Self::Before(rejected_calls) => call < *rejected_calls,
+            Self::After(successful_calls) => call >= *successful_calls,
+            Self::Enabled(enabled) => enabled.load(Ordering::SeqCst),
         }
     }
 }
@@ -376,6 +379,7 @@ async fn spawn_rpc_proxy_rejecting_method(
             let client = client.clone();
             let endpoint = endpoint.clone();
             let calls = calls.clone();
+            let rejection = rejection.clone();
             async move {
                 if request.get("method").and_then(Value::as_str) == Some(method)
                     && rejection.rejects(calls.fetch_add(1, Ordering::Relaxed))


### PR DESCRIPTION
Backports [#16427](https://github.com/foundry-rs/foundry/pull/16427), [#16426](https://github.com/foundry-rs/foundry/pull/16426), [#16425](https://github.com/foundry-rs/foundry/pull/16425), and [#16423](https://github.com/foundry-rs/foundry/pull/16423) to `release-1.8.0`. This bumps the workspace to 1.8.1, removes project trust warnings, treats an initial `anvil_nodeInfo` failure as optional while keeping later probes strict after Anvil is identified, and fixes lint import resolution when `--root` differs from the process working directory.

This PR was prepared by Centaur with AI assistance; the requested upstream commits were cherry-picked and the release-branch conflicts were resolved with AI assistance.

Prompted by: @grandizzy
