### PR TITLE
fix(forge): preserve prank semantics in linked creates

### DIFF
--- a/.changelog/dtl-prank-create.md
+++ b/.changelog/dtl-prank-create.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-cheatcodes: patch
+---
+
+Fixed dynamically linked contract creation to consume one-shot pranks and preserve the pranked `tx.origin`.

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -13,7 +13,7 @@ use dialoguer::{Input, Password};
 use forge_script_sequence::{BroadcastReader, TransactionWithMetadata};
 use foundry_common::{contracts::ContractData, fs};
 use foundry_config::fs_permissions::FsAccessKind;
-use foundry_evm_core::evm::FoundryEvmNetwork;
+use foundry_evm_core::{FoundryTransaction, env::FoundryContextExt, evm::FoundryEvmNetwork};
 use revm::{
     context::{Cfg, ContextTr, CreateScheme, JournalTr},
     interpreter::CreateInputs,
@@ -513,9 +513,31 @@ fn deploy_code<FEN: FoundryEvmNetwork>(
     let scheme =
         if let Some(salt) = salt { CreateScheme::Create2 { salt } } else { CreateScheme::Create };
 
-    // If prank active at current depth, then use it as caller for create input.
-    let caller =
-        ccx.state.get_prank(ccx.ecx.journal().depth()).map_or(ccx.caller, |prank| prank.new_caller);
+    // The nested EVM executes the synthetic create one level deeper, so apply the prank at the
+    // original depth just as the native create inspector would.
+    let depth = ccx.ecx.journal().depth();
+    let mut caller = ccx.caller;
+    if let Some(prank) = ccx.state.get_prank(depth).copied()
+        && depth >= prank.depth
+        && caller == prank.prank_caller
+    {
+        let prank_applied = if depth == prank.depth {
+            caller = prank.new_caller;
+            true
+        } else {
+            false
+        };
+        let prank_applied = if let Some(new_origin) = prank.new_origin {
+            ccx.ecx.tx_mut().set_caller(new_origin);
+            true
+        } else {
+            prank_applied
+        };
+
+        if prank_applied && let Some(applied_prank) = prank.first_time_applied() {
+            ccx.state.pranks.insert(depth, applied_prank);
+        }
+    }
 
     let outcome = exec_create(
         executor,
@@ -528,7 +550,19 @@ fn deploy_code<FEN: FoundryEvmNetwork>(
             0,
         ),
         ccx,
-    )?;
+    );
+
+    // Restore the prank state at the original depth as native create cleanup would.
+    if let Some(prank) = ccx.state.get_prank(depth).copied()
+        && depth == prank.depth
+    {
+        ccx.ecx.tx_mut().set_caller(prank.prank_origin);
+        if prank.single_call {
+            std::mem::take(&mut ccx.state.pranks);
+        }
+    }
+
+    let outcome = outcome?;
 
     if !outcome.result.result.is_ok() {
         return Err(crate::Error::from(outcome.result.output));

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -149,10 +149,12 @@ pub(crate) fn exec_create<FEN: FoundryEvmNetwork>(
     ccx: &mut CheatsCtxt<'_, '_, FEN>,
 ) -> std::result::Result<CreateOutcome, EVMError<DatabaseError>> {
     let fee_token = ccx.ecx.tx().fee_token();
+    let tx_origin = ccx.ecx.tx().caller();
     let mut inputs = Some(inputs);
     let mut outcome = None;
     executor.with_nested_evm(ccx.state, ccx.ecx, &mut |evm| {
         evm.tx_mut().set_fee_token(fee_token);
+        evm.tx_mut().set_caller(tx_origin);
         let inputs = inputs.take().unwrap();
         evm.journal_inner_mut().depth += 1;
 

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -1817,9 +1817,11 @@ forgetest_init!(preprocess_contract_with_active_prank, |prj, cmd| {
 contract Counter {
     uint256 public number;
     address public deployer;
+    address public origin;
 
     constructor() {
         deployer = msg.sender;
+        origin = tx.origin;
     }
 }
     "#,
@@ -1834,9 +1836,35 @@ import {Counter} from "../src/Counter.sol";
 contract CounterTest is Test {
     function test_deployer() public {
         address deployer = makeAddr("deployer");
-        vm.startPrank(deployer);
-        Counter counter = new Counter{salt: 0}();
-        assertEq(counter.deployer(), deployer);
+        address origin = makeAddr("origin");
+        vm.startPrank(deployer, origin);
+        Counter first = new Counter{salt: 0}();
+        Counter second = new Counter{salt: bytes32(uint256(1))}();
+        assertEq(first.deployer(), deployer);
+        assertEq(first.origin(), origin);
+        assertEq(second.deployer(), deployer);
+        assertEq(second.origin(), origin);
+    }
+
+    function test_consecutive_single_call_pranks() public {
+        address firstDeployer = makeAddr("firstDeployer");
+        address firstOrigin = makeAddr("firstOrigin");
+        vm.prank(firstDeployer, firstOrigin);
+        Counter first = new Counter();
+
+        address secondDeployer = makeAddr("secondDeployer");
+        address secondOrigin = makeAddr("secondOrigin");
+        vm.prank(secondDeployer, secondOrigin);
+        Counter second = new Counter();
+
+        assertEq(first.deployer(), firstDeployer);
+        assertEq(first.origin(), firstOrigin);
+        assertEq(second.deployer(), secondDeployer);
+        assertEq(second.origin(), secondOrigin);
+
+        Counter unpranked = new Counter();
+        assertEq(unpranked.deployer(), address(this));
+        assertEq(unpranked.origin(), tx.origin);
     }
 }
     "#,
@@ -1847,11 +1875,12 @@ contract CounterTest is Test {
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
-Ran 1 test for test/Counter.t.sol:CounterTest
+Ran 2 tests for test/Counter.t.sol:CounterTest
+[PASS] test_consecutive_single_call_pranks() ([GAS])
 [PASS] test_deployer() ([GAS])
-Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
-Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 
 "#]]);
 });


### PR DESCRIPTION
## Summary

- Preserve the outer tx.origin in the nested EVM used for dynamically linked contract creation.
- Apply prank caller/origin state at the original call depth and consume one-shot pranks after the synthetic CREATE, matching native CREATE cleanup.
- Cover persistent and consecutive one-shot pranks with DTL explicitly enabled.

## Why this is a Foundry regression

Dynamic test linking rewrites a native Solidity CREATE into vm.deployCode as a compilation optimization. Foundry already classified lost prank semantics on that rewrite as a Forge bug in [issue #11978](https://github.com/foundry-rs/foundry/issues/11978) and merged [#12005](https://github.com/foundry-rs/foundry/pull/12005), explicitly titled "dynamic test linking should follow pranks." That fix copied the pranked caller but remained incomplete: the synthetic nested CREATE lost tx.origin and skipped native one-shot prank cleanup.

Commit [75fd6f9](https://github.com/foundry-rs/foundry/commit/75fd6f9822c7463134c36e15d945858ff9058891) made DTL the default in v1.8.0, turning the latent opt-in defect into a default upgrade regression for unchanged projects:

- v1.7.1 default: passes.
- v1.7.1 with DTL: fails with the stale-prank error.
- v1.8.0 default: fails identically.
- v1.8.0 with no dynamic test linking: passes.

The exact BitChillRSK reproduction is entirely local and uses no RSK fork or RPC, so this is not chain adaptation. The documented no-dynamic-test-linking flag remains a valid temporary escape hatch, but it does not make sender/origin divergence an intended DTL semantic.

## Tests

- cargo test -p forge --test cli preprocess_contract_with_active_prank
- DeployCode cheatcode suite — 9 passed
- cargo test -p foundry-cheatcodes — 73 passed
- cargo clippy -p foundry-cheatcodes --lib -- -D warnings
- Exact [BitChillRSK/dca-contracts#79](https://github.com/BitChillRSK/dca-contracts/issues/79) reproduction — 566 passed, 0 failed, 12 skipped; all 10 previously affected suites pass
- cargo +nightly fmt --all -- --check

Also reported downstream in [LamaSu/physical-capability-cloud#296](https://github.com/LamaSu/physical-capability-cloud/pull/296) and [jose-compu/curated-erc#49](https://github.com/jose-compu/curated-erc/pull/49).