### PR TITLE
fix(anvil): initialize blob env for Polygon forks

### DIFF
--- a/.changelog/anvil-polygon-blob-env.md
+++ b/.changelog/anvil-polygon-blob-env.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed post-Cancun calls on Polygon PoS forks, whose headers intentionally omit Ethereum blob gas fields.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     mem::{self, in_memory_db::StateRootDb},
 };
-use alloy_chains::NamedChain;
+use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_evm::EvmEnv;
@@ -1977,9 +1977,10 @@ latest block number: {latest_block}"
         };
         let fork_hardfork = self.hardfork.or(inferred_hardfork);
         let effective_hardfork = fork_hardfork.unwrap_or_else(|| self.get_hardfork());
-        evm_env.cfg_env.set_spec_and_mainnet_gas_params(SpecId::from(effective_hardfork));
+        let effective_spec = SpecId::from(effective_hardfork);
+        evm_env.cfg_env.set_spec_and_mainnet_gas_params(effective_spec);
         fees.set_execution_rules(
-            SpecId::from(effective_hardfork),
+            effective_spec,
             self.networks.base_fee_params(block.header.timestamp()),
             self.networks.is_tempo().then(|| TempoHardfork::from(effective_hardfork)),
         );
@@ -2005,7 +2006,13 @@ latest block number: {latest_block}"
         let blob_params = get_blob_params(source_chain_id, block.header.timestamp());
         fees.set_blob_params(blob_params);
         let blob_update_fraction = blob_params.update_fraction as u64;
-        let blob_excess_gas = block.header.excess_blob_gas();
+        let blob_excess_gas = block.header.excess_blob_gas().or_else(|| {
+            // Polygon enables Cancun EVM features without EIP-4844, so Bor headers omit the blob
+            // fields. REVM still requires a valid blob environment for the Cancun spec; zero is
+            // the neutral excess-gas value.
+            (effective_spec >= SpecId::CANCUN && Chain::from_id(source_chain_id).is_polygon())
+                .then_some(0)
+        });
         evm_env.block_env.blob_excess_gas_and_price =
             blob_excess_gas.map(|excess| BlobExcessGasAndPrice::new(excess, blob_update_fraction));
         let next_block_blob_excess_gas = blob_excess_gas.map_or(0, |excess| {

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -38,6 +38,7 @@ use anvil::{
     eth::{EthApi, fees::INITIAL_BASE_FEE},
     spawn, try_spawn,
 };
+use axum::{Json, Router, routing::post};
 use foundry_common::provider::get_http_provider;
 use foundry_config::Config;
 use foundry_evm_networks::NetworkConfigs;
@@ -50,8 +51,9 @@ use foundry_test_utils::rpc::{
 use futures::StreamExt;
 use revm::{
     context::BlockEnv, context_interface::block::BlobExcessGasAndPrice,
-    precompile::PrecompileStatus,
+    precompile::PrecompileStatus, primitives::hardfork::SpecId,
 };
+use serde_json::Value;
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::{Arc, atomic::Ordering},
@@ -3204,6 +3206,158 @@ async fn test_fork_reset_to_new_url_updates_source_chain_id() {
     api.anvil_reset(None).await.unwrap();
     assert_eq!(provider.get_chain_id().await.unwrap(), 31337);
     assert!(send().await.unwrap().get_receipt().await.unwrap().status());
+}
+
+async fn spawn_rpc_proxy_without_blob_header_fields(endpoint: String) -> String {
+    let client = reqwest::Client::new();
+    let router = Router::new().route(
+        "/",
+        post(move |Json(request): Json<Value>| {
+            let client = client.clone();
+            let endpoint = endpoint.clone();
+            async move {
+                let mut response = client
+                    .post(endpoint)
+                    .json(&request)
+                    .send()
+                    .await
+                    .unwrap()
+                    .json::<Value>()
+                    .await
+                    .unwrap();
+                if matches!(
+                    request.get("method").and_then(Value::as_str),
+                    Some("eth_getBlockByHash" | "eth_getBlockByNumber")
+                ) && let Some(block) = response.get_mut("result").and_then(Value::as_object_mut)
+                {
+                    block.remove("blobGasUsed");
+                    block.remove("excessBlobGas");
+                }
+                Json(response)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    format!("http://{address}")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_polygon_fork_missing_blob_fields_is_chain_scoped_across_reset() {
+    // Polygon's Bor headers omit the EIP-4844 fields even though Anvil executes the fork with a
+    // post-Cancun spec. Local origins provide deterministic state while the proxies reproduce that
+    // header shape and hide Anvil metadata, matching an external endpoint.
+    let token = address!("0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270");
+    let return_zero = bytes!("600060005260206000f3");
+    let (polygon_api, polygon_origin) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(NamedChain::Polygon as u64))
+            .with_hardfork(Some(EthereumHardfork::Shanghai.into()))
+            .with_genesis_timestamp(Some(1_750_000_000u64)),
+    )
+    .await;
+    polygon_api.anvil_set_code(token, return_zero.clone()).await.unwrap();
+    let polygon_url =
+        spawn_rpc_proxy_without_blob_header_fields(polygon_origin.http_endpoint()).await;
+    let polygon_url =
+        spawn_rpc_proxy_rejecting_method_after(polygon_url, "anvil_nodeInfo", 0).await;
+
+    let (pre_cancun_api, pre_cancun_origin) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(NamedChain::Arbitrum as u64))
+            .with_hardfork(Some(EthereumHardfork::Shanghai.into()))
+            .with_genesis_timestamp(EthereumHardfork::Shanghai.arbitrum_activation_timestamp()),
+    )
+    .await;
+    pre_cancun_api.anvil_set_code(token, return_zero.clone()).await.unwrap();
+    let pre_cancun_url =
+        spawn_rpc_proxy_without_blob_header_fields(pre_cancun_origin.http_endpoint()).await;
+    let pre_cancun_url =
+        spawn_rpc_proxy_rejecting_method_after(pre_cancun_url, "anvil_nodeInfo", 0).await;
+
+    // A canonical Ethereum endpoint that drops required post-Cancun fields must remain invalid;
+    // the Polygon compatibility fallback must not hide that upstream error.
+    let (ethereum_api, ethereum_origin) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(NamedChain::Mainnet as u64))
+            .with_hardfork(Some(EthereumHardfork::Cancun.into()))
+            .with_genesis_timestamp(EthereumHardfork::Cancun.mainnet_activation_timestamp()),
+    )
+    .await;
+    ethereum_api.anvil_set_code(token, return_zero).await.unwrap();
+    let ethereum_url =
+        spawn_rpc_proxy_without_blob_header_fields(ethereum_origin.http_endpoint()).await;
+    let ethereum_url =
+        spawn_rpc_proxy_rejecting_method_after(ethereum_url, "anvil_nodeInfo", 0).await;
+
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_no_storage_caching(true)
+            .with_eth_rpc_url(Some(polygon_url.clone()))
+            .with_fork_block_number(Some(0u64)),
+    )
+    .await;
+    let provider = handle.http_provider();
+    // This is the WMATIC `balanceOf` call from the Balancer failure report.
+    let call = || {
+        provider
+            .call(
+                TransactionRequest {
+                    to: Some(TxKind::Call(token)),
+                    input: TransactionInput::new(bytes!(
+                        "70a08231000000000000000000000000625ac8caddc5dfb99c98176cb6e79d55c7c14e63"
+                    )),
+                    ..Default::default()
+                }
+                .into(),
+            )
+            .block(BlockId::latest())
+    };
+
+    assert!(api.backend.spec_id() >= SpecId::CANCUN);
+    assert_eq!(call().await.unwrap(), Bytes::from(vec![0; 32]));
+    assert_eq!(
+        api.backend
+            .evm_env()
+            .read()
+            .block_env
+            .blob_excess_gas_and_price
+            .as_ref()
+            .map(|blob| blob.excess_blob_gas),
+        Some(0)
+    );
+
+    api.anvil_reset(Some(Forking { json_rpc_url: Some(pre_cancun_url), block_number: Some(0) }))
+        .await
+        .unwrap();
+    assert!(api.backend.spec_id() < SpecId::CANCUN);
+    assert!(api.backend.evm_env().read().block_env.blob_excess_gas_and_price.is_none());
+    assert_eq!(call().await.unwrap(), Bytes::from(vec![0; 32]));
+
+    api.anvil_reset(Some(Forking { json_rpc_url: Some(ethereum_url), block_number: Some(0) }))
+        .await
+        .unwrap();
+    assert!(api.backend.spec_id() >= SpecId::CANCUN);
+    assert!(api.backend.evm_env().read().block_env.blob_excess_gas_and_price.is_none());
+    let err = call().await.unwrap_err();
+    assert!(err.to_string().contains("Excess blob gas not set"), "{err:?}");
+
+    api.anvil_reset(Some(Forking { json_rpc_url: Some(polygon_url), block_number: Some(0) }))
+        .await
+        .unwrap();
+    assert!(api.backend.spec_id() >= SpecId::CANCUN);
+    assert_eq!(call().await.unwrap(), Bytes::from(vec![0; 32]));
+    assert_eq!(
+        api.backend
+            .evm_env()
+            .read()
+            .block_env
+            .blob_excess_gas_and_price
+            .as_ref()
+            .map(|blob| blob.excess_blob_gas),
+        Some(0)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- Initialize a neutral zero-excess blob environment only for Polygon and Amoy forks that execute Cancun-or-newer rules while their Bor headers omit Ethereum EIP-4844 fields.
- Preserve blob fields supplied by the upstream header.
- Keep pre-Cancun and non-Polygon missing fields unset, including a negative regression case for a post-Cancun Ethereum source.
- Cover Polygon -> pre-Cancun -> invalid Ethereum -> Polygon resets so fork state cannot leak across sources.

## Why

Foundry commit [f584cc9](https://github.com/foundry-rs/foundry/commit/f584cc910284a901a39dbef1015c9595197d9ef0), released in 1.8.0, changed an absent fork-header blob field from preserving Anvil's initialized neutral environment to explicitly clearing it to None. REVM then rejects ordinary post-Cancun calls with Excess blob gas not set. The identical Polygon call succeeds on Foundry 1.7.2 and fails on the pre-fix 1.8 candidate.

This is not a malformed Polygon header. [PIP-31](https://github.com/0xPolygon/Polygon-Improvement-Proposals/blob/c0077814b616a121ec3f35188639099665f75caf/PIPs/PIP-31.md) adopts Cancun EVM features while explicitly excluding the blob EIPs, and Bor deliberately omits the blob header fields. The Balancer regression is documented in [issue #2717](https://github.com/balancer/frontend-monorepo/issues/2717); [their workaround](https://github.com/balancer/frontend-monorepo/pull/2718) forces Shanghai and therefore disables Polygon-supported Cancun opcodes.

## Scope

The fallback is deliberately keyed to Chain::is_polygon(), which covers Polygon and Amoy. Unknown and other non-Ethereum chains are not silently repaired: if a post-Cancun endpoint that should provide blob state omits it, execution remains invalid. Zero is used only as the neutral REVM compatibility environment for Polygon's documented no-blob Cancun profile.

## Tests

- cargo test -p anvil --test it test_polygon_fork_missing_blob_fields_is_chain_scoped_across_reset -- --nocapture
- cargo test -p anvil --test it blob_schedule_in_both_directions — 2 passed
- Exact live reproduction against Polygon block 67867894: the WMATIC balanceOf call returns 0; the pre-fix candidate returned Excess blob gas not set
- cargo +nightly fmt --all -- --check

The deterministic test uses local Polygon-like, pre-Cancun Arbitrum, and post-Cancun Ethereum origins; strips blob fields at an RPC proxy; hides Anvil metadata; and verifies both the Polygon fallback and the strict non-Polygon boundary.