### PR TITLE
feat(forge): inspect on-chain contracts by address

### DIFF
--- a/.changelog/inspect-onchain-address.md
+++ b/.changelog/inspect-onchain-address.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+`forge inspect` accepts the address of a verified on-chain contract, fetching its sources from the block explorer instead of requiring a local project.

--- a/.changelog/inspect-onchain-address.md
+++ b/.changelog/inspect-onchain-address.md
@@ -2,4 +2,4 @@
 forge: minor
 ---
 
-`forge inspect` accepts the address of a verified on-chain contract, fetching its sources from the block explorer instead of requiring a local project.
+`forge inspect` accepts the address of a verified on-chain contract, fetching its sources from the block explorer instead of requiring a local project. For proxies, `--implementation` inspects the implementation contract instead.

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -128,7 +128,7 @@ pub fn run_command(args: Forge) -> Result<()> {
         }
         ForgeSubcommand::Config(cmd) => cmd.run(),
         ForgeSubcommand::Flatten(cmd) => cmd.run(),
-        ForgeSubcommand::Inspect(cmd) => cmd.run(),
+        ForgeSubcommand::Inspect(cmd) => global.block_on(cmd.run()),
         ForgeSubcommand::Tree(cmd) => cmd.run(),
         ForgeSubcommand::Geiger(cmd) => global.block_on(cmd.run()),
         ForgeSubcommand::Doc(cmd) => {

--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -136,58 +136,6 @@ pub struct CloneArgs {
     pub install: DependencyInstallOpts,
 }
 
-/// Downloads the verified sources of an on-chain contract into `root` and returns the name of the
-/// contract at `address`.
-///
-/// The project written to `root` carries the compiler settings the contract was verified with, so
-/// compiling it reproduces the on-chain artifact.
-pub(crate) async fn dump_verified_sources(
-    address: Address,
-    root: &Path,
-    etherscan: &EtherscanOpts,
-) -> Result<String> {
-    let config = etherscan.load_config()?;
-    let chain = config.chain.unwrap_or_default();
-    let client = config
-        .get_etherscan_config_with_chain(Some(chain))?
-        .ok_or_else(|| eyre::eyre!("No Etherscan API key configured for chain {chain}"))?
-        .into_client_with_no_proxy(config.eth_rpc_no_proxy)?;
-
-    dump_verified_sources_with_client(&client, address, root, chain).await
-}
-
-/// Downloads the verified sources of `address` from `client` into `root`, returning the name of
-/// the contract.
-async fn dump_verified_sources_with_client<C: ExplorerClient>(
-    client: &C,
-    address: Address,
-    root: &Path,
-    chain: Chain,
-) -> Result<String> {
-    sh_status!("Downloading the source code of {address} from Etherscan...")?;
-    let (_, meta) = CloneArgs::collect_metadata_from_client(address, client, false).await?;
-
-    // The sources come with their own remappings, so the project needs no dependencies and no
-    // git repository of its own.
-    let init = InitArgs {
-        root: root.to_path_buf(),
-        install: DependencyInstallOpts { no_git: true, ..Default::default() },
-        empty: true,
-        offline: true,
-        ..Default::default()
-    };
-    init.run().await.map_err(|e| eyre::eyre!("Project init error: {:?}", e))?;
-    // Dumping the sources expects a library directory, which an offline init never creates
-    // because it installs no dependencies.
-    let path_config = ProjectPathsConfig::builder().build_with_root::<Solc>(root);
-    fs::create_dir_all(&path_config.libraries[0])?;
-
-    let root = dunce::canonicalize(root)?;
-    CloneArgs::parse_metadata(&meta, chain, &root, false, false).await?;
-
-    Ok(meta.contract_name)
-}
-
 impl CloneArgs {
     pub async fn run(self) -> Result<()> {
         let Self {
@@ -217,12 +165,7 @@ impl CloneArgs {
         // step 1. get the metadata from client based on source type
         let (address, meta, explorer_name, sourcify_client) = match source {
             SourceExplorer::Etherscan => {
-                let client = config
-                    .get_etherscan_config_with_chain(Some(chain))?
-                    .ok_or_else(|| {
-                        eyre::eyre!("No Etherscan API key configured for chain {chain}")
-                    })?
-                    .into_client_with_no_proxy(config.eth_rpc_no_proxy)?;
+                let client = etherscan_client(&config, chain)?;
                 sh_status!("Downloading the source code of {address} from Etherscan...")?;
                 let (address, meta) =
                     Self::collect_metadata_from_client(address, &client, implementation).await?;
@@ -443,6 +386,62 @@ impl CloneArgs {
     }
 }
 
+/// Downloads the verified sources of an on-chain contract into `root` and returns its metadata.
+///
+/// The project written to `root` carries the compiler settings the contract was verified with, so
+/// compiling it reproduces the on-chain artifact. With `implementation`, a proxy `address` is
+/// resolved to its implementation contract, whose sources are downloaded instead.
+pub(crate) async fn dump_verified_sources(
+    address: Address,
+    root: &Path,
+    etherscan: &EtherscanOpts,
+    implementation: bool,
+) -> Result<Metadata> {
+    let config = etherscan.load_config()?;
+    let chain = config.chain.unwrap_or_default();
+    let client = etherscan_client(&config, chain)?;
+
+    dump_verified_sources_with_client(&client, address, root, chain, implementation).await
+}
+
+/// Downloads the verified sources of `address` from `client` into `root`, returning the metadata
+/// of the contract.
+async fn dump_verified_sources_with_client<C: ExplorerClient>(
+    client: &C,
+    address: Address,
+    root: &Path,
+    chain: Chain,
+    implementation: bool,
+) -> Result<Metadata> {
+    sh_status!("Downloading the source code of {address} from Etherscan...")?;
+    let (_, meta) =
+        CloneArgs::collect_metadata_from_client(address, client, implementation).await?;
+
+    // The sources come with their own remappings, so the project needs no dependencies and no
+    // git repository of its own.
+    let init = InitArgs {
+        root: root.to_path_buf(),
+        install: DependencyInstallOpts { no_git: true, ..Default::default() },
+        empty: true,
+        offline: true,
+        ..Default::default()
+    };
+    init.run().await.map_err(|e| eyre::eyre!("Project init error: {:?}", e))?;
+
+    let root = dunce::canonicalize(root)?;
+    CloneArgs::parse_metadata(&meta, chain, &root, false, false).await?;
+
+    Ok(meta)
+}
+
+/// Creates an Etherscan client for `chain`, failing if no API key is configured.
+fn etherscan_client(config: &Config, chain: Chain) -> Result<Client> {
+    Ok(config
+        .get_etherscan_config_with_chain(Some(chain))?
+        .ok_or_else(|| eyre::eyre!("No Etherscan API key configured for chain {chain}"))?
+        .into_client_with_no_proxy(config.eth_rpc_no_proxy)?)
+}
+
 /// Update the configuration file with the metadata.
 /// This function will update the configuration file with the metadata from the contract.
 /// It will update the following fields:
@@ -617,9 +616,10 @@ fn dump_sources(meta: &Metadata, root: &PathBuf, no_reorg: bool) -> Result<Vec<R
                 || folder_name.to_string_lossy().starts_with('@')
         });
 
-    // ensure `src` and `lib` directories exist
-    eyre::ensure!(Path::exists(&root.join(src_dir)), "`src` directory must exists");
-    eyre::ensure!(Path::exists(&root.join(lib_dir)), "`lib` directory must exists");
+    // ensure `src` and `lib` directories exist; an offline empty init does not create `lib`
+    // because it installs no dependencies.
+    fs::create_dir_all(root.join(src_dir))?;
+    fs::create_dir_all(root.join(lib_dir))?;
 
     // move source files
     for entry in std::fs::read_dir(tmp_dump_dir.join(contract_name))? {
@@ -1456,18 +1456,53 @@ mod tests {
         client.expect_contract_source_code().times(1).returning(move |_| Ok(metadata.clone()));
 
         let temp_dir = tempfile::tempdir().unwrap();
-        let name = super::dump_verified_sources_with_client(
+        let meta = super::dump_verified_sources_with_client(
             &client,
             address,
             temp_dir.path(),
             Chain::mainnet(),
+            false,
         )
         .await
         .unwrap();
 
         let root = dunce::canonicalize(temp_dir.path()).unwrap();
         let output = assert_successful_compilation(&root);
-        find_main_contract(&output, &name).expect("cloned contract not found in the project");
+        find_main_contract(&output, &meta.contract_name)
+            .expect("cloned contract not found in the project");
+    }
+
+    // With `--implementation`, inspecting a proxy address must dump the implementation's sources.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_dump_verified_sources_follows_proxy() {
+        let proxy = "0x0000000000000000000000000000000000000001".parse().unwrap();
+        let implementation = "0x0000000000000000000000000000000000000002".parse().unwrap();
+        let proxy_meta = contract_metadata("Proxy", true, Some(implementation));
+        let implementation_meta = contract_metadata("Implementation", false, None);
+        let mut client = super::MockExplorerClient::new();
+        client.expect_contract_source_code().times(2).returning(move |address| {
+            if address == proxy {
+                Ok(proxy_meta.clone())
+            } else if address == implementation {
+                Ok(implementation_meta.clone())
+            } else {
+                unreachable!("unexpected address: {address}")
+            }
+        });
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let meta = super::dump_verified_sources_with_client(
+            &client,
+            proxy,
+            temp_dir.path(),
+            Chain::mainnet(),
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(meta.contract_name, "Implementation");
+        assert!(temp_dir.path().join("foundry.toml").exists());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -136,6 +136,58 @@ pub struct CloneArgs {
     pub install: DependencyInstallOpts,
 }
 
+/// Downloads the verified sources of an on-chain contract into `root` and returns the name of the
+/// contract at `address`.
+///
+/// The project written to `root` carries the compiler settings the contract was verified with, so
+/// compiling it reproduces the on-chain artifact.
+pub(crate) async fn dump_verified_sources(
+    address: Address,
+    root: &Path,
+    etherscan: &EtherscanOpts,
+) -> Result<String> {
+    let config = etherscan.load_config()?;
+    let chain = config.chain.unwrap_or_default();
+    let client = config
+        .get_etherscan_config_with_chain(Some(chain))?
+        .ok_or_else(|| eyre::eyre!("No Etherscan API key configured for chain {chain}"))?
+        .into_client_with_no_proxy(config.eth_rpc_no_proxy)?;
+
+    dump_verified_sources_with_client(&client, address, root, chain).await
+}
+
+/// Downloads the verified sources of `address` from `client` into `root`, returning the name of
+/// the contract.
+async fn dump_verified_sources_with_client<C: ExplorerClient>(
+    client: &C,
+    address: Address,
+    root: &Path,
+    chain: Chain,
+) -> Result<String> {
+    sh_status!("Downloading the source code of {address} from Etherscan...")?;
+    let (_, meta) = CloneArgs::collect_metadata_from_client(address, client, false).await?;
+
+    // The sources come with their own remappings, so the project needs no dependencies and no
+    // git repository of its own.
+    let init = InitArgs {
+        root: root.to_path_buf(),
+        install: DependencyInstallOpts { no_git: true, ..Default::default() },
+        empty: true,
+        offline: true,
+        ..Default::default()
+    };
+    init.run().await.map_err(|e| eyre::eyre!("Project init error: {:?}", e))?;
+    // Dumping the sources expects a library directory, which an offline init never creates
+    // because it installs no dependencies.
+    let path_config = ProjectPathsConfig::builder().build_with_root::<Solc>(root);
+    fs::create_dir_all(&path_config.libraries[0])?;
+
+    let root = dunce::canonicalize(root)?;
+    CloneArgs::parse_metadata(&meta, chain, &root, false, false).await?;
+
+    Ok(meta.contract_name)
+}
+
 impl CloneArgs {
     pub async fn run(self) -> Result<()> {
         let Self {
@@ -1386,6 +1438,36 @@ mod tests {
                 pick_creation_info(&address.to_string()).expect("creation code not found");
             assert_compilation_result(rv, contract_name, stripped_creation_code);
         }
+    }
+
+    // `forge inspect <address>` needs only the sources, so this path must not depend on the
+    // creation data that `forge clone` additionally fetches, and the project it writes must
+    // compile on its own.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_dump_verified_sources() {
+        let address: Address = "0x35Fb958109b70799a8f9Bc2a8b1Ee4cC62034193".parse().unwrap();
+        let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../testdata/etherscan")
+            .join(address.to_string())
+            .join("metadata.json");
+        let metadata: ContractMetadata =
+            serde_json::from_str(&std::fs::read_to_string(metadata_file).unwrap()).unwrap();
+        let mut client = super::MockExplorerClient::new();
+        client.expect_contract_source_code().times(1).returning(move |_| Ok(metadata.clone()));
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let name = super::dump_verified_sources_with_client(
+            &client,
+            address,
+            temp_dir.path(),
+            Chain::mainnet(),
+        )
+        .await
+        .unwrap();
+
+        let root = dunce::canonicalize(temp_dir.path()).unwrap();
+        let output = assert_successful_compilation(&root);
+        find_main_contract(&output, &name).expect("cloned contract not found in the project");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -1,11 +1,13 @@
+use super::clone::dump_verified_sources;
 use alloy_json_abi::{Event, EventParam, InternalType, JsonAbi, Param};
+use alloy_primitives::Address;
 use clap::Parser;
 use comfy_table::{
     Cell, Table,
     presets::{ASCII_FULL, ASCII_MARKDOWN},
 };
 use eyre::{Result, eyre};
-use foundry_cli::opts::{BuildOpts, CompilerOpts};
+use foundry_cli::opts::{BuildOpts, CompilerOpts, EtherscanOpts};
 use foundry_common::{
     compile::{PathOrContractInfo, ProjectCompiler},
     find_matching_contract_artifact, find_target_path, shell,
@@ -27,12 +29,35 @@ use serde_json::{Map, Value};
 use solar::sema::interface::source_map::FileName;
 use std::{collections::BTreeMap, fmt, ops::ControlFlow, path::Path, str::FromStr, sync::LazyLock};
 
+/// The contract to inspect: either one in the current project, or a verified contract on chain.
+#[derive(Clone, Debug)]
+pub enum InspectTarget {
+    /// A contract in the current project, as `(<path>:)?<contractname>`.
+    Local(PathOrContractInfo),
+    /// A verified contract deployed at this address, on the chain given by `--chain`.
+    OnChain(Address),
+}
+
+impl FromStr for InspectTarget {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self> {
+        // An address is never a valid contract identifier, so it unambiguously selects an
+        // on-chain target.
+        if let Ok(address) = Address::from_str(s) {
+            return Ok(Self::OnChain(address));
+        }
+        PathOrContractInfo::from_str(s).map(Self::Local)
+    }
+}
+
 /// CLI arguments for `forge inspect`.
 #[derive(Clone, Debug, Parser)]
 pub struct InspectArgs {
-    /// The identifier of the contract to inspect in the form `(<path>:)?<contractname>`.
-    #[arg(value_parser = PathOrContractInfo::from_str)]
-    pub contract: PathOrContractInfo,
+    /// The contract to inspect, either as `(<path>:)?<contractname>` in the current project, or as
+    /// the address of a verified contract on the chain given by `--chain`.
+    #[arg(value_parser = InspectTarget::from_str)]
+    pub contract: InspectTarget,
 
     /// The contract artifact field to inspect.
     #[arg(value_enum)]
@@ -41,6 +66,10 @@ pub struct InspectArgs {
     /// All build arguments are supported
     #[command(flatten)]
     build: BuildOpts,
+
+    /// Block explorer options, used to fetch the sources of an on-chain contract.
+    #[command(flatten)]
+    etherscan: EtherscanOpts,
 
     /// Whether to remove comments when inspecting `ir` and `irOptimized` artifact fields.
     #[arg(long, short, help_heading = "Display options")]
@@ -52,8 +81,21 @@ pub struct InspectArgs {
 }
 
 impl InspectArgs {
-    pub fn run(self) -> Result<()> {
-        let Self { contract, field, build, strip_yul_comments, wrap } = self;
+    pub async fn run(self) -> Result<()> {
+        let Self { contract, field, mut build, strip_yul_comments, wrap, etherscan } = self;
+
+        // An on-chain contract is downloaded into a throwaway project, which then takes exactly
+        // the same compile-and-inspect path as a local one. The directory is held until the end
+        // of the command so it outlives the compilation.
+        let (contract, _tmp_project) = match contract {
+            InspectTarget::Local(contract) => (contract, None),
+            InspectTarget::OnChain(address) => {
+                let tmp = tempfile::tempdir()?;
+                let name = dump_verified_sources(address, tmp.path(), &etherscan).await?;
+                build.project_paths.root = Some(tmp.path().to_path_buf());
+                (PathOrContractInfo::from_str(&name)?, Some(tmp))
+            }
+        };
 
         trace!(target: "forge", ?field, ?contract, "running forge inspect");
 
@@ -881,6 +923,24 @@ mod tests {
                     assert_eq!(alias.parse::<ContractArtifactField>().unwrap(), field);
                 }
             }
+        }
+    }
+
+    // An address selects the on-chain target; anything else stays a local contract identifier,
+    // including names and paths that merely look hex-ish.
+    #[test]
+    fn parse_inspect_target() {
+        let address = "0x35Fb958109b70799a8f9Bc2a8b1Ee4cC62034193";
+        assert!(matches!(
+            InspectTarget::from_str(address).unwrap(),
+            InspectTarget::OnChain(parsed) if parsed == Address::from_str(address).unwrap()
+        ));
+
+        for local in ["Counter", "src/Counter.sol:Counter", "0xContract"] {
+            assert!(
+                matches!(InspectTarget::from_str(local).unwrap(), InspectTarget::Local(_)),
+                "{local} should be a local target"
+            );
         }
     }
 }

--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -71,6 +71,10 @@ pub struct InspectArgs {
     #[command(flatten)]
     etherscan: EtherscanOpts,
 
+    /// Inspect the implementation contract if the target address is a proxy.
+    #[arg(long)]
+    pub implementation: bool,
+
     /// Whether to remove comments when inspecting `ir` and `irOptimized` artifact fields.
     #[arg(long, short, help_heading = "Display options")]
     pub strip_yul_comments: bool,
@@ -82,18 +86,57 @@ pub struct InspectArgs {
 
 impl InspectArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { contract, field, mut build, strip_yul_comments, wrap, etherscan } = self;
+        let Self {
+            contract,
+            field,
+            mut build,
+            strip_yul_comments,
+            wrap,
+            etherscan,
+            implementation,
+        } = self;
 
         // An on-chain contract is downloaded into a throwaway project, which then takes exactly
         // the same compile-and-inspect path as a local one. The directory is held until the end
         // of the command so it outlives the compilation.
         let (contract, _tmp_project) = match contract {
-            InspectTarget::Local(contract) => (contract, None),
+            InspectTarget::Local(contract) => {
+                eyre::ensure!(
+                    !implementation,
+                    "--implementation is only supported when inspecting an on-chain contract by \
+                     address"
+                );
+                (contract, None)
+            }
             InspectTarget::OnChain(address) => {
+                eyre::ensure!(
+                    build.project_paths.root.is_none(),
+                    "--root is not supported when inspecting an on-chain contract; the sources \
+                     are fetched into a temporary project"
+                );
                 let tmp = tempfile::tempdir()?;
-                let name = dump_verified_sources(address, tmp.path(), &etherscan).await?;
+                let meta =
+                    dump_verified_sources(address, tmp.path(), &etherscan, implementation).await?;
+                if !implementation
+                    && meta.proxy != 0
+                    && let Some(impl_addr) = meta.implementation
+                {
+                    sh_warn!(
+                        "{address} is a proxy; pass --implementation to inspect its \
+                         implementation at {impl_addr}"
+                    )?;
+                }
+                if field == ContractArtifactField::StorageLayout
+                    && let Ok(version) = meta.compiler_version()
+                    && version < semver::Version::new(0, 5, 13)
+                {
+                    sh_warn!(
+                        "the contract was verified with solc {version}, which does not emit \
+                         storage layouts; the layout will be empty"
+                    )?;
+                }
                 build.project_paths.root = Some(tmp.path().to_path_buf());
-                (PathOrContractInfo::from_str(&name)?, Some(tmp))
+                (PathOrContractInfo::from_str(&meta.contract_name)?, Some(tmp))
             }
         };
 

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -201,7 +201,7 @@ pub enum ForgeSubcommand {
     /// - forge inspect Counter abi
     /// - forge inspect Counter bytecode
     /// - forge inspect src/Counter.sol:Counter storageLayout
-    /// - forge inspect 0xdAC17F958D2ee523a2206206994597C13D831ec7 storageLayout --chain mainnet
+    /// - forge inspect 0x1F98431c8aD98523631AE4a59f267346ea31F984 storageLayout --chain mainnet
     #[command(verbatim_doc_comment, visible_alias = "in")]
     Inspect(inspect::InspectArgs),
 

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -201,6 +201,7 @@ pub enum ForgeSubcommand {
     /// - forge inspect Counter abi
     /// - forge inspect Counter bytecode
     /// - forge inspect src/Counter.sol:Counter storageLayout
+    /// - forge inspect 0xdAC17F958D2ee523a2206206994597C13D831ec7 storageLayout --chain mainnet
     #[command(verbatim_doc_comment, visible_alias = "in")]
     Inspect(inspect::InspectArgs),
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1556,6 +1556,31 @@ Error: linearization inspection is only supported for Solidity contracts (.sol t
 "#]]);
 });
 
+// The on-chain inspect target fetches sources into a temporary project, so `--root` has nothing
+// to point at, and `--implementation` only makes sense for an address target.
+forgetest!(inspect_onchain_target_flag_guards, |prj, cmd| {
+    cmd.args([
+        "inspect",
+        "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+        "abi",
+        "--root",
+        prj.root().to_str().unwrap(),
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+Error: --root is not supported when inspecting an on-chain contract; the sources are fetched into a temporary project
+
+"#]]);
+
+    cmd.forge_fuse()
+        .args(["inspect", "Counter", "abi", "--implementation"])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: --implementation is only supported when inspecting an on-chain contract by address
+
+"#]]);
+});
+
 // test that `forge snapshot` commands work
 forgetest!(can_check_snapshot, |prj, cmd| {
     prj.insert_ds_test();


### PR DESCRIPTION
Comparing storage layouts across an upgrade currently takes two steps: download the contract, then inspect what you downloaded. This makes the first step implicit, where `forge inspect` expects a contract identifier it now also accepts an address, downloads the verified sources into a temporary project, and inspects that. Everything after the download is the existing path, so every field works unchanged and the command needs no local project at all.

The download reuses the `forge clone` pipeline, with two deliberate differences. It stops short of fetching the creation data, which only the `.clone.meta` file needs and which would otherwise add an explorer round-trip and a failure mode to an inspection that never reads it. And it initializes the temporary project offline and without git, since nothing about a throwaway directory justifies cloning forge-std or creating a repository.

An address at a proxy resolves to the proxy itself by default; since layout diffs usually want the logic contract, `--implementation` follows the proxy to its implementation like `forge clone` does, and a warning points at the implementation address when the flag is not passed. A warning is also emitted when the contract was verified with a compiler that predates storage layout output (solc < 0.5.13), which would otherwise silently print an empty layout.

```sh
forge inspect 0x1F98431c8aD98523631AE4a59f267346ea31F984 storageLayout --chain mainnet
```

Closes #11231
