### PR TITLE
fix(config): preserve hoisted scoped npm packages

### DIFF
--- a/.changelog/scoped-npm-contextual-remappings.md
+++ b/.changelog/scoped-npm-contextual-remappings.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-config: patch
+---
+
+Fixed auto-detected remappings for scoped npm dependencies that mix nested and hoisted packages.

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -356,6 +356,7 @@ impl RemappingsProvider<'_> {
             for remapping in contextual
                 .into_iter()
                 .filter(|remapping| ambiguous_aliases.contains(&remapping.name))
+                .flat_map(expand_scoped_contextual_remapping)
             {
                 if let Some(overlays) = contextual_overlays(&authoritative_remappings, &remapping) {
                     contextual_remappings.extend(overlays);
@@ -596,6 +597,41 @@ fn context_starts_with(path: &str, base: &str) -> bool {
     }
     #[cfg(not(windows))]
     Path::new(path).starts_with(base)
+}
+
+/// Narrows an npm scope mapping to its installed packages so missing siblings can use the global
+/// hoisted-package fallback.
+fn expand_scoped_contextual_remapping(remapping: Remapping) -> Vec<Remapping> {
+    let scope = remapping.name.trim_end_matches('/');
+    let path = Path::new(&remapping.path);
+    if !scope.starts_with('@')
+        || path.file_name().and_then(|name| name.to_str()) != Some(scope)
+        || path.parent().and_then(|parent| parent.file_name()).and_then(|name| name.to_str())
+            != Some("node_modules")
+    {
+        return vec![remapping];
+    }
+
+    let Ok(entries) = fs::read_dir(path) else { return vec![remapping] };
+    let mut packages = Vec::new();
+    for entry in entries {
+        let Ok(entry) = entry else { return vec![remapping] };
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let Ok(name) = entry.file_name().into_string() else { return vec![remapping] };
+        let mut path = entry.path().display().to_string();
+        if !path.ends_with(['/', '\\']) {
+            path.push(MAIN_SEPARATOR);
+        }
+        packages.push(Remapping {
+            context: remapping.context.clone(),
+            name: format!("{scope}/{name}/"),
+            path,
+        });
+    }
+    packages.sort_by(|a, b| a.name.cmp(&b.name));
+    if packages.is_empty() { vec![remapping] } else { packages }
 }
 
 fn configured_auto_remapping(

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1236,6 +1236,40 @@ shared/=deps-a/a/lib/shared/src/
     cmd.forge_fuse().arg("remappings").assert_success().stdout_eq(expected);
 });
 
+forgetest!(scoped_npm_context_preserves_hoisted_sibling_fallback, |prj, cmd| {
+    let owner = prj.root().join("node_modules/@bananapus/router-terminal-v6");
+    let nested_v3 = owner.join("node_modules/@uniswap/v3-core/src");
+    let hoisted_v3 = prj.root().join("node_modules/@uniswap/v3-core/src");
+    let hoisted_v4 = prj.root().join("node_modules/@uniswap/v4-core/src");
+    for dependency in [&owner.join("src"), &nested_v3, &hoisted_v3, &hoisted_v4] {
+        pretty_err(dependency, fs::create_dir_all(dependency));
+    }
+    prj.update_config(|config| config.libs = vec!["node_modules".into()]);
+    pretty_err(
+        &owner,
+        fs::write(
+            owner.join("src/RouterTerminal.sol"),
+            "import {NestedV3} from \"@uniswap/v3-core/src/Version.sol\"; import {HoistedV4} from \"@uniswap/v4-core/src/Version.sol\"; contract RouterTerminal is NestedV3, HoistedV4 {}\n",
+        ),
+    );
+    pretty_err(&nested_v3, fs::write(nested_v3.join("Version.sol"), "contract NestedV3 {}\n"));
+    pretty_err(&hoisted_v3, fs::write(hoisted_v3.join("Version.sol"), "contract HoistedV3 {}\n"));
+    pretty_err(&hoisted_v4, fs::write(hoisted_v4.join("Version.sol"), "contract HoistedV4 {}\n"));
+    prj.add_source(
+        "UsesRouterTerminal.sol",
+        "import {RouterTerminal} from \"@bananapus/router-terminal-v6/src/RouterTerminal.sol\"; import {HoistedV3} from \"@uniswap/v3-core/src/Version.sol\"; contract UsesRouterTerminal is RouterTerminal, HoistedV3 {}\n",
+    );
+
+    cmd.arg("remappings").assert_success().stdout_eq(str![[r#"
+node_modules/@bananapus/router-terminal-v6/:@uniswap/v3-core/=node_modules/@bananapus/router-terminal-v6/node_modules/@uniswap/v3-core/
+@bananapus/=node_modules/@bananapus/
+@uniswap/=node_modules/@uniswap/
+
+"#]]);
+    cmd.forge_fuse().arg("build").assert_success();
+    cmd.forge_fuse().arg("lint").assert_success();
+});
+
 forgetest!(contextual_remapping_dedup_uses_context_and_name, |prj, cmd| {
     let a = prj.root().join("lib/a");
     let z = prj.root().join("lib/z");


### PR DESCRIPTION
## Summary

- Expand generated ambiguous contextual npm scope remappings into the packages actually installed under that nested scope.
- Keep the global scope remapping as a fallback for hoisted sibling packages.
- Leave explicit, unscoped, non-ambiguous, and non-node_modules scoped remappings unchanged.

## Why this is a Foundry regression

Foundry [#16125](https://github.com/foundry-rs/foundry/pull/16125), commit [93b1b49](https://github.com/foundry-rs/foundry/commit/93b1b4949ba74300263de91dab45ac98a867fde9), first released in v1.8.0, began contextualizing ambiguous transitive remappings. For a dependency with nested @uniswap/v3-core but hoisted @uniswap/v4-core, it emits one broad contextual @uniswap/ mapping. That incorrectly captures the independent v4 package and points it into the nested scope, where v4 is absent.

The Bananapus layout is valid npm behavior, not an undeclared downstream dependency. Router Terminal declares both v3-core and v4-core. npm nests the conflicting v3 version and deduplicates the compatible v4 version at the root; [Node resolution](https://nodejs.org/api/modules.html#loading-from-node_modules-folders) checks the nearest node_modules and then walks upward. A scope directory groups independent packages—it is not itself the resolution unit.

The exact artifact build passes on Foundry v1.7.1, fails on v1.8.0 with 16 missing imports, and passes with this patch. The generated context is narrowed to @uniswap/v3-core/, while the global @uniswap/ mapping continues to resolve hoisted siblings. No Bananapus or Uniswap special case is introduced.

## Tests

- Focused CLI regression — exact remappings, build, and lint pass
- Config remapping suite — 16 passed
- Forge remapping-filtered CLI suite — 24 passed
- cargo clippy -p foundry-config --lib -- -D warnings
- cargo +nightly fmt --all -- --check
- Exact [Bananapus/deploy-all-v6#242](https://github.com/Bananapus/deploy-all-v6/pull/242) checkout: 126 files compile with Solc 0.8.28; the pre-fix candidate fails with 16 missing imports

If the nested scope cannot be enumerated safely, the provider conservatively keeps the previous broad mapping.