### PR TITLE
fix(lint): suppress findings reported in other files

### DIFF
--- a/.changelog/lint-suppress-inherited-spans.md
+++ b/.changelog/lint-suppress-inherited-spans.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+`forge lint` inline directives now suppress findings reported in an inherited base contract or a dependency, where previously only project-wide `exclude_lints` worked.

--- a/crates/common/src/comments/inline_config.rs
+++ b/crates/common/src/comments/inline_config.rs
@@ -184,6 +184,16 @@ impl<I: ItemIdIterator> InlineConfig<I> {
         Self { disabled_ranges: HashMap::new() }
     }
 
+    /// Merges the disabled ranges of another config into this one.
+    ///
+    /// Ranges are absolute positions in the shared source map and never cross a file boundary,
+    /// so configs built from different files stay unambiguous once merged.
+    pub fn extend(&mut self, other: Self) {
+        for (id, ranges) in other.disabled_ranges {
+            self.disabled_ranges.entry(id).or_default().extend(ranges);
+        }
+    }
+
     fn disable_many(&mut self, ids: I, range: DisabledRange) {
         for id in ids.into_iter() {
             self.disable(id, range);

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -18,7 +18,7 @@ use solar::{
         ColorChoice, Session,
         diagnostics::{HumanEmitter, JsonEmitter, Level, SilentEmitter},
     },
-    sema::Compiler,
+    sema::{Compiler, Gcx},
 };
 use solar_lint::{LintRegistry, LintRunContext, LintRunError, LintSource, LintSuite, run_lints};
 use std::{
@@ -54,8 +54,11 @@ static ALL_REGISTERED_LINTS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
 static DEFAULT_LINT_SPECIFIC_CONFIG: LazyLock<LintSpecificConfig> =
     LazyLock::new(LintSpecificConfig::default);
 
+/// Prefix of an inline lint directive comment.
+const INLINE_CONFIG_PREFIX: &str = "forge-lint:";
+
 struct OwnedLintPolicy {
-    inline: Option<InlineConfig<Vec<String>>>,
+    inline: Option<Arc<InlineConfig<Vec<String>>>>,
     active: Vec<&'static str>,
 }
 
@@ -73,6 +76,7 @@ impl LintPolicy for OwnedLintPolicy {
 #[derive(Clone)]
 pub struct ForgeLintSuite {
     path_config: ProjectPathsConfig,
+    inline: Arc<InlineConfig<Vec<String>>>,
     severity: Option<Vec<Severity>>,
     lints_included: Option<Vec<SolLint>>,
     lints_excluded: Option<Vec<SolLint>>,
@@ -126,9 +130,11 @@ impl LintSuite for ForgeLintSuite {
     }
 
     fn source_policy(&self, source: LintSource<'_, '_>) -> Arc<dyn LintPolicy> {
-        let comments = Comments::new(source.file, source.session.source_map(), false, false, None);
+        // The directives of every source are shared by every policy: a late pass visiting this
+        // source can report a span that belongs to another file, and only that file's directives
+        // can suppress it.
         Arc::new(OwnedLintPolicy {
-            inline: Some(parse_inline_config(source.session, &comments, source.ast)),
+            inline: Some(self.inline.clone()),
             active: self.active_lints(Some(source.path)),
         })
     }
@@ -203,7 +209,7 @@ impl<'a> SolidityLinter<'a> {
     }
 
     /// Returns an owned lint suite suitable for CLI or LSP execution.
-    pub fn to_suite(&self) -> ForgeLintSuite {
+    pub fn to_suite(&self, inline: InlineConfig<Vec<String>>) -> ForgeLintSuite {
         let lint_specific = Arc::new(self.lint_specific.clone());
         let mut registry = LintRegistry::new();
         high::register_lints(&mut registry, &lint_specific);
@@ -215,6 +221,7 @@ impl<'a> SolidityLinter<'a> {
 
         ForgeLintSuite {
             path_config: self.path_config.clone(),
+            inline: Arc::new(inline),
             severity: self.severity.clone(),
             lints_included: self.lints_included.clone(),
             lints_excluded: self.lints_excluded.clone(),
@@ -292,7 +299,7 @@ impl<'a> Linter for SolidityLinter<'a> {
                 }
             }
 
-            let suite = self.to_suite();
+            let suite = self.to_suite(collect_inline_config(gcx, &targets));
             run_lints(
                 &suite,
                 LintRunContext {
@@ -361,10 +368,35 @@ impl<'a> Linter for SolidityLinter<'a> {
     }
 }
 
+/// Collects the inline `forge-lint:` directives of every parsed source into a single config.
+///
+/// A late pass walks the HIR reachable from the source it visits, so it can report a span that
+/// lives in an inherited base contract or in a dependency. Disabled ranges are absolute positions
+/// in the shared source map and never cross a file boundary, so merging the directives of every
+/// source lets a directive suppress a finding wherever it is reported, without widening its reach
+/// beyond its own file.
+fn collect_inline_config(gcx: Gcx<'_>, targets: &[PathBuf]) -> InlineConfig<Vec<String>> {
+    let sess = gcx.sess;
+    let mut config = InlineConfig::default();
+    for source in gcx.sources.iter() {
+        // Lexing the comments of every dependency is wasted work when it holds no directive.
+        let Some(ast) = source.ast.as_ref() else { continue };
+        if !source.file.src.contains(INLINE_CONFIG_PREFIX) {
+            continue;
+        }
+        // A malformed directive is only actionable in a file the user asked to lint.
+        let report_errors = targets.iter().any(|target| source.file.name == **target);
+        let comments = Comments::new(&source.file, sess.source_map(), false, false, None);
+        config.extend(parse_inline_config(sess, &comments, ast, report_errors));
+    }
+    config
+}
+
 fn parse_inline_config<'ast>(
     sess: &Session,
     comments: &Comments,
     ast: &'ast ast::SourceUnit<'ast>,
+    report_errors: bool,
 ) -> InlineConfig<Vec<String>> {
     let items = comments.iter().filter_map(|comment| {
         let mut item = comment.lines.first()?.as_str();
@@ -374,12 +406,14 @@ fn parse_inline_config<'ast>(
         if let Some(suffix) = comment.suffix() {
             item = item.strip_suffix(suffix).unwrap_or(item);
         }
-        let item = item.trim_start().strip_prefix("forge-lint:")?.trim();
+        let item = item.trim_start().strip_prefix(INLINE_CONFIG_PREFIX)?.trim();
         let span = comment.span;
         match InlineConfigItem::parse(item, &ALL_REGISTERED_LINTS) {
             Ok(item) => Some((span, item)),
             Err(e) => {
-                sess.dcx.warn(e.to_string()).span(span).emit();
+                if report_errors {
+                    sess.dcx.warn(e.to_string()).span(span).emit();
+                }
                 None
             }
         }

--- a/crates/lint/testdata/InlineConfigInherited.sol
+++ b/crates/lint/testdata/InlineConfigInherited.sol
@@ -1,0 +1,15 @@
+//@compile-flags: --only-lint uninitialized-state
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Linting this file reports the base contract's declarations, whose spans lie in the imported
+// file. The directive next to `suppressed` must silence it from there, while `reported` still
+// comes through.
+import {InlineConfigBase} from "./auxiliary/InlineConfigInheritedBase.sol";
+
+contract InlineConfigInherited is InlineConfigBase {
+    function value() public view returns (uint256) {
+        return total();
+    }
+}

--- a/crates/lint/testdata/InlineConfigInherited.stderr
+++ b/crates/lint/testdata/InlineConfigInherited.stderr
@@ -1,0 +1,8 @@
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/auxiliary/InlineConfigInheritedBase.sol:LL:CC
+   │
+LL │     uint256 internal reported;
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+

--- a/crates/lint/testdata/auxiliary/InlineConfigInheritedBase.sol
+++ b/crates/lint/testdata/auxiliary/InlineConfigInheritedBase.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Declarations reported by a late pass while it visits a contract that inherits them. The span of
+// such a finding belongs to this file, so a directive here is the only placement a user can reach
+// it from.
+abstract contract InlineConfigBase {
+    // forge-lint: disable-next-item(uninitialized-state)
+    uint256 internal suppressed;
+
+    uint256 internal reported;
+
+    function total() internal view returns (uint256) {
+        return suppressed + reported;
+    }
+}


### PR DESCRIPTION
An inline `forge-lint:` directive could not suppress a finding whose span points outside the source being visited — into an inherited base contract, or into a dependency under `lib/`. Late passes walk the HIR reachable from the visited source, so they report spans belonging to other files, while the policy handed to them was built from the visited file alone. A directive in the file that owns the span was never consulted, and one in the visited file covered a byte range the span could not fall into, leaving project-wide `exclude_lints` as the only way to silence the finding.

The fix turns out not to need any per-file lookup at suppression time. Disabled ranges are absolute positions in the shared source map, and no range crosses a file boundary — even an unterminated `disable-start` falls back to the end of its own file — so the directives of every parsed source can be merged into a single config that every policy shares. Each range stays bound to the file it came from, and a directive now suppresses the finding wherever it is reported. The suppression check itself is unchanged.

The directives are collected once before the run rather than as sources are visited, because `source_policy` is invoked in parallel and a diagnostic can point at a file that has not been visited yet, or that is not a lint target at all. Only sources that actually contain `forge-lint:` are lexed, so a large dependency tree costs nothing, and a malformed directive still warns only for files the user asked to lint, since dependencies are now parsed too and a typo in solmate is not actionable.

The fixture covers both directions: the base contract's `suppressed` variable is silenced from the file that declares it, while `reported` still comes through. Reverting the source change makes it fail.

Closes #16436