### PR TITLE
fix: backport additional v1.8 regressions

### DIFF
--- a/.changelog/anvil-polygon-blob-env.md
+++ b/.changelog/anvil-polygon-blob-env.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed post-Cancun calls on Polygon PoS forks, whose headers intentionally omit Ethereum blob gas fields.

--- a/.changelog/dtl-prank-create.md
+++ b/.changelog/dtl-prank-create.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-cheatcodes: patch
+---
+
+Fixed dynamically linked contract creation to consume one-shot pranks and preserve the pranked `tx.origin`.

--- a/.changelog/lint-span-owner-suppressions.md
+++ b/.changelog/lint-span-owner-suppressions.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed inline lint directives and ignored paths for findings reported in inherited source files.

--- a/.changelog/scoped-npm-contextual-remappings.md
+++ b/.changelog/scoped-npm-contextual-remappings.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-config: patch
+---
+
+Fixed auto-detected remappings for scoped npm dependencies that mix nested and hoisted packages.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     mem::{self, in_memory_db::StateRootDb},
 };
-use alloy_chains::NamedChain;
+use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_evm::EvmEnv;
@@ -1977,9 +1977,10 @@ latest block number: {latest_block}"
         };
         let fork_hardfork = self.hardfork.or(inferred_hardfork);
         let effective_hardfork = fork_hardfork.unwrap_or_else(|| self.get_hardfork());
-        evm_env.cfg_env.set_spec_and_mainnet_gas_params(SpecId::from(effective_hardfork));
+        let effective_spec = SpecId::from(effective_hardfork);
+        evm_env.cfg_env.set_spec_and_mainnet_gas_params(effective_spec);
         fees.set_execution_rules(
-            SpecId::from(effective_hardfork),
+            effective_spec,
             self.networks.base_fee_params(block.header.timestamp()),
             self.networks.is_tempo().then(|| TempoHardfork::from(effective_hardfork)),
         );
@@ -2005,7 +2006,13 @@ latest block number: {latest_block}"
         let blob_params = get_blob_params(source_chain_id, block.header.timestamp());
         fees.set_blob_params(blob_params);
         let blob_update_fraction = blob_params.update_fraction as u64;
-        let blob_excess_gas = block.header.excess_blob_gas();
+        let blob_excess_gas = block.header.excess_blob_gas().or_else(|| {
+            // Polygon enables Cancun EVM features without EIP-4844, so Bor headers omit the blob
+            // fields. REVM still requires a valid blob environment for the Cancun spec; zero is
+            // the neutral excess-gas value.
+            (effective_spec >= SpecId::CANCUN && Chain::from_id(source_chain_id).is_polygon())
+                .then_some(0)
+        });
         evm_env.block_env.blob_excess_gas_and_price =
             blob_excess_gas.map(|excess| BlobExcessGasAndPrice::new(excess, blob_update_fraction));
         let next_block_blob_excess_gas = blob_excess_gas.map_or(0, |excess| {

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -38,6 +38,7 @@ use anvil::{
     eth::{EthApi, fees::INITIAL_BASE_FEE},
     spawn, try_spawn,
 };
+use axum::{Json, Router, routing::post};
 use foundry_common::provider::get_http_provider;
 use foundry_config::Config;
 use foundry_evm_networks::NetworkConfigs;
@@ -50,8 +51,9 @@ use foundry_test_utils::rpc::{
 use futures::StreamExt;
 use revm::{
     context::BlockEnv, context_interface::block::BlobExcessGasAndPrice,
-    precompile::PrecompileStatus,
+    precompile::PrecompileStatus, primitives::hardfork::SpecId,
 };
+use serde_json::Value;
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::{Arc, atomic::Ordering},
@@ -3204,6 +3206,158 @@ async fn test_fork_reset_to_new_url_updates_source_chain_id() {
     api.anvil_reset(None).await.unwrap();
     assert_eq!(provider.get_chain_id().await.unwrap(), 31337);
     assert!(send().await.unwrap().get_receipt().await.unwrap().status());
+}
+
+async fn spawn_rpc_proxy_without_blob_header_fields(endpoint: String) -> String {
+    let client = reqwest::Client::new();
+    let router = Router::new().route(
+        "/",
+        post(move |Json(request): Json<Value>| {
+            let client = client.clone();
+            let endpoint = endpoint.clone();
+            async move {
+                let mut response = client
+                    .post(endpoint)
+                    .json(&request)
+                    .send()
+                    .await
+                    .unwrap()
+                    .json::<Value>()
+                    .await
+                    .unwrap();
+                if matches!(
+                    request.get("method").and_then(Value::as_str),
+                    Some("eth_getBlockByHash" | "eth_getBlockByNumber")
+                ) && let Some(block) = response.get_mut("result").and_then(Value::as_object_mut)
+                {
+                    block.remove("blobGasUsed");
+                    block.remove("excessBlobGas");
+                }
+                Json(response)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    format!("http://{address}")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_polygon_fork_missing_blob_fields_is_chain_scoped_across_reset() {
+    // Polygon's Bor headers omit the EIP-4844 fields even though Anvil executes the fork with a
+    // post-Cancun spec. Local origins provide deterministic state while the proxies reproduce that
+    // header shape and hide Anvil metadata, matching an external endpoint.
+    let token = address!("0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270");
+    let return_zero = bytes!("600060005260206000f3");
+    let (polygon_api, polygon_origin) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(NamedChain::Polygon as u64))
+            .with_hardfork(Some(EthereumHardfork::Shanghai.into()))
+            .with_genesis_timestamp(Some(1_750_000_000u64)),
+    )
+    .await;
+    polygon_api.anvil_set_code(token, return_zero.clone()).await.unwrap();
+    let polygon_url =
+        spawn_rpc_proxy_without_blob_header_fields(polygon_origin.http_endpoint()).await;
+    let polygon_url =
+        spawn_rpc_proxy_rejecting_method_after(polygon_url, "anvil_nodeInfo", 0).await;
+
+    let (pre_cancun_api, pre_cancun_origin) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(NamedChain::Arbitrum as u64))
+            .with_hardfork(Some(EthereumHardfork::Shanghai.into()))
+            .with_genesis_timestamp(EthereumHardfork::Shanghai.arbitrum_activation_timestamp()),
+    )
+    .await;
+    pre_cancun_api.anvil_set_code(token, return_zero.clone()).await.unwrap();
+    let pre_cancun_url =
+        spawn_rpc_proxy_without_blob_header_fields(pre_cancun_origin.http_endpoint()).await;
+    let pre_cancun_url =
+        spawn_rpc_proxy_rejecting_method_after(pre_cancun_url, "anvil_nodeInfo", 0).await;
+
+    // A canonical Ethereum endpoint that drops required post-Cancun fields must remain invalid;
+    // the Polygon compatibility fallback must not hide that upstream error.
+    let (ethereum_api, ethereum_origin) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(NamedChain::Mainnet as u64))
+            .with_hardfork(Some(EthereumHardfork::Cancun.into()))
+            .with_genesis_timestamp(EthereumHardfork::Cancun.mainnet_activation_timestamp()),
+    )
+    .await;
+    ethereum_api.anvil_set_code(token, return_zero).await.unwrap();
+    let ethereum_url =
+        spawn_rpc_proxy_without_blob_header_fields(ethereum_origin.http_endpoint()).await;
+    let ethereum_url =
+        spawn_rpc_proxy_rejecting_method_after(ethereum_url, "anvil_nodeInfo", 0).await;
+
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_no_storage_caching(true)
+            .with_eth_rpc_url(Some(polygon_url.clone()))
+            .with_fork_block_number(Some(0u64)),
+    )
+    .await;
+    let provider = handle.http_provider();
+    // This is the WMATIC `balanceOf` call from the Balancer failure report.
+    let call = || {
+        provider
+            .call(
+                TransactionRequest {
+                    to: Some(TxKind::Call(token)),
+                    input: TransactionInput::new(bytes!(
+                        "70a08231000000000000000000000000625ac8caddc5dfb99c98176cb6e79d55c7c14e63"
+                    )),
+                    ..Default::default()
+                }
+                .into(),
+            )
+            .block(BlockId::latest())
+    };
+
+    assert!(api.backend.spec_id() >= SpecId::CANCUN);
+    assert_eq!(call().await.unwrap(), Bytes::from(vec![0; 32]));
+    assert_eq!(
+        api.backend
+            .evm_env()
+            .read()
+            .block_env
+            .blob_excess_gas_and_price
+            .as_ref()
+            .map(|blob| blob.excess_blob_gas),
+        Some(0)
+    );
+
+    api.anvil_reset(Some(Forking { json_rpc_url: Some(pre_cancun_url), block_number: Some(0) }))
+        .await
+        .unwrap();
+    assert!(api.backend.spec_id() < SpecId::CANCUN);
+    assert!(api.backend.evm_env().read().block_env.blob_excess_gas_and_price.is_none());
+    assert_eq!(call().await.unwrap(), Bytes::from(vec![0; 32]));
+
+    api.anvil_reset(Some(Forking { json_rpc_url: Some(ethereum_url), block_number: Some(0) }))
+        .await
+        .unwrap();
+    assert!(api.backend.spec_id() >= SpecId::CANCUN);
+    assert!(api.backend.evm_env().read().block_env.blob_excess_gas_and_price.is_none());
+    let err = call().await.unwrap_err();
+    assert!(err.to_string().contains("Excess blob gas not set"), "{err:?}");
+
+    api.anvil_reset(Some(Forking { json_rpc_url: Some(polygon_url), block_number: Some(0) }))
+        .await
+        .unwrap();
+    assert!(api.backend.spec_id() >= SpecId::CANCUN);
+    assert_eq!(call().await.unwrap(), Bytes::from(vec![0; 32]));
+    assert_eq!(
+        api.backend
+            .evm_env()
+            .read()
+            .block_env
+            .blob_excess_gas_and_price
+            .as_ref()
+            .map(|blob| blob.excess_blob_gas),
+        Some(0)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -13,7 +13,7 @@ use dialoguer::{Input, Password};
 use forge_script_sequence::{BroadcastReader, TransactionWithMetadata};
 use foundry_common::{contracts::ContractData, fs};
 use foundry_config::fs_permissions::FsAccessKind;
-use foundry_evm_core::evm::FoundryEvmNetwork;
+use foundry_evm_core::{FoundryTransaction, env::FoundryContextExt, evm::FoundryEvmNetwork};
 use revm::{
     context::{Cfg, ContextTr, CreateScheme, JournalTr},
     interpreter::CreateInputs,
@@ -513,9 +513,31 @@ fn deploy_code<FEN: FoundryEvmNetwork>(
     let scheme =
         if let Some(salt) = salt { CreateScheme::Create2 { salt } } else { CreateScheme::Create };
 
-    // If prank active at current depth, then use it as caller for create input.
-    let caller =
-        ccx.state.get_prank(ccx.ecx.journal().depth()).map_or(ccx.caller, |prank| prank.new_caller);
+    // The nested EVM executes the synthetic create one level deeper, so apply the prank at the
+    // original depth just as the native create inspector would.
+    let depth = ccx.ecx.journal().depth();
+    let mut caller = ccx.caller;
+    if let Some(prank) = ccx.state.get_prank(depth).copied()
+        && depth >= prank.depth
+        && caller == prank.prank_caller
+    {
+        let prank_applied = if depth == prank.depth {
+            caller = prank.new_caller;
+            true
+        } else {
+            false
+        };
+        let prank_applied = if let Some(new_origin) = prank.new_origin {
+            ccx.ecx.tx_mut().set_caller(new_origin);
+            true
+        } else {
+            prank_applied
+        };
+
+        if prank_applied && let Some(applied_prank) = prank.first_time_applied() {
+            ccx.state.pranks.insert(depth, applied_prank);
+        }
+    }
 
     let outcome = exec_create(
         executor,
@@ -528,7 +550,19 @@ fn deploy_code<FEN: FoundryEvmNetwork>(
             0,
         ),
         ccx,
-    )?;
+    );
+
+    // Restore the prank state at the original depth as native create cleanup would.
+    if let Some(prank) = ccx.state.get_prank(depth).copied()
+        && depth == prank.depth
+    {
+        ccx.ecx.tx_mut().set_caller(prank.prank_origin);
+        if prank.single_call {
+            std::mem::take(&mut ccx.state.pranks);
+        }
+    }
+
+    let outcome = outcome?;
 
     if !outcome.result.result.is_ok() {
         return Err(crate::Error::from(outcome.result.output));

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -149,10 +149,12 @@ pub(crate) fn exec_create<FEN: FoundryEvmNetwork>(
     ccx: &mut CheatsCtxt<'_, '_, FEN>,
 ) -> std::result::Result<CreateOutcome, EVMError<DatabaseError>> {
     let fee_token = ccx.ecx.tx().fee_token();
+    let tx_origin = ccx.ecx.tx().caller();
     let mut inputs = Some(inputs);
     let mut outcome = None;
     executor.with_nested_evm(ccx.state, ccx.ecx, &mut |evm| {
         evm.tx_mut().set_fee_token(fee_token);
+        evm.tx_mut().set_caller(tx_origin);
         let inputs = inputs.take().unwrap();
         evm.journal_inner_mut().depth += 1;
 

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -356,6 +356,7 @@ impl RemappingsProvider<'_> {
             for remapping in contextual
                 .into_iter()
                 .filter(|remapping| ambiguous_aliases.contains(&remapping.name))
+                .flat_map(expand_scoped_contextual_remapping)
             {
                 if let Some(overlays) = contextual_overlays(&authoritative_remappings, &remapping) {
                     contextual_remappings.extend(overlays);
@@ -596,6 +597,41 @@ fn context_starts_with(path: &str, base: &str) -> bool {
     }
     #[cfg(not(windows))]
     Path::new(path).starts_with(base)
+}
+
+/// Narrows an npm scope mapping to its installed packages so missing siblings can use the global
+/// hoisted-package fallback.
+fn expand_scoped_contextual_remapping(remapping: Remapping) -> Vec<Remapping> {
+    let scope = remapping.name.trim_end_matches('/');
+    let path = Path::new(&remapping.path);
+    if !scope.starts_with('@')
+        || path.file_name().and_then(|name| name.to_str()) != Some(scope)
+        || path.parent().and_then(|parent| parent.file_name()).and_then(|name| name.to_str())
+            != Some("node_modules")
+    {
+        return vec![remapping];
+    }
+
+    let Ok(entries) = fs::read_dir(path) else { return vec![remapping] };
+    let mut packages = Vec::new();
+    for entry in entries {
+        let Ok(entry) = entry else { return vec![remapping] };
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let Ok(name) = entry.file_name().into_string() else { return vec![remapping] };
+        let mut path = entry.path().display().to_string();
+        if !path.ends_with(['/', '\\']) {
+            path.push(MAIN_SEPARATOR);
+        }
+        packages.push(Remapping {
+            context: remapping.context.clone(),
+            name: format!("{scope}/{name}/"),
+            path,
+        });
+    }
+    packages.sort_by(|a, b| a.name.cmp(&b.name));
+    if packages.is_empty() { vec![remapping] } else { packages }
 }
 
 fn configured_auto_remapping(

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1236,6 +1236,40 @@ shared/=deps-a/a/lib/shared/src/
     cmd.forge_fuse().arg("remappings").assert_success().stdout_eq(expected);
 });
 
+forgetest!(scoped_npm_context_preserves_hoisted_sibling_fallback, |prj, cmd| {
+    let owner = prj.root().join("node_modules/@bananapus/router-terminal-v6");
+    let nested_v3 = owner.join("node_modules/@uniswap/v3-core/src");
+    let hoisted_v3 = prj.root().join("node_modules/@uniswap/v3-core/src");
+    let hoisted_v4 = prj.root().join("node_modules/@uniswap/v4-core/src");
+    for dependency in [&owner.join("src"), &nested_v3, &hoisted_v3, &hoisted_v4] {
+        pretty_err(dependency, fs::create_dir_all(dependency));
+    }
+    prj.update_config(|config| config.libs = vec!["node_modules".into()]);
+    pretty_err(
+        &owner,
+        fs::write(
+            owner.join("src/RouterTerminal.sol"),
+            "import {NestedV3} from \"@uniswap/v3-core/src/Version.sol\"; import {HoistedV4} from \"@uniswap/v4-core/src/Version.sol\"; contract RouterTerminal is NestedV3, HoistedV4 {}\n",
+        ),
+    );
+    pretty_err(&nested_v3, fs::write(nested_v3.join("Version.sol"), "contract NestedV3 {}\n"));
+    pretty_err(&hoisted_v3, fs::write(hoisted_v3.join("Version.sol"), "contract HoistedV3 {}\n"));
+    pretty_err(&hoisted_v4, fs::write(hoisted_v4.join("Version.sol"), "contract HoistedV4 {}\n"));
+    prj.add_source(
+        "UsesRouterTerminal.sol",
+        "import {RouterTerminal} from \"@bananapus/router-terminal-v6/src/RouterTerminal.sol\"; import {HoistedV3} from \"@uniswap/v3-core/src/Version.sol\"; contract UsesRouterTerminal is RouterTerminal, HoistedV3 {}\n",
+    );
+
+    cmd.arg("remappings").assert_success().stdout_eq(str![[r#"
+node_modules/@bananapus/router-terminal-v6/:@uniswap/v3-core/=node_modules/@bananapus/router-terminal-v6/node_modules/@uniswap/v3-core/
+@bananapus/=node_modules/@bananapus/
+@uniswap/=node_modules/@uniswap/
+
+"#]]);
+    cmd.forge_fuse().arg("build").assert_success();
+    cmd.forge_fuse().arg("lint").assert_success();
+});
+
 forgetest!(contextual_remapping_dedup_uses_context_and_name, |prj, cmd| {
     let a = prj.root().join("lib/a");
     let z = prj.root().join("lib/z");

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -288,6 +288,92 @@ nothing to lint
 "#]]);
 });
 
+forgetest!(inline_config_suppresses_lint_in_inherited_source, |prj, cmd| {
+    prj.add_source(
+        "Base",
+        r#"
+abstract contract Base {
+    uint256 public value;
+}
+"#,
+    );
+    prj.add_source(
+        "Concrete",
+        r#"
+import {Base} from "./Base.sol";
+
+contract Concrete is Base {
+    function readValue() external view returns (uint256) {
+        return value;
+    }
+}
+"#,
+    );
+
+    cmd.args(["lint", "--only-lint", "uninitialized-state", "-D", "warnings"]).assert_failure();
+
+    prj.add_source(
+        "Base",
+        r#"
+abstract contract Base {
+    // forge-lint: disable-next-line(uninitialized-state)
+    uint256 public value;
+}
+"#,
+    );
+    cmd.forge_fuse()
+        .args(["lint", "--only-lint", "uninitialized-state", "-D", "warnings"])
+        .assert_success()
+        .stderr_eq("");
+});
+
+forgetest!(ignored_inherited_source_does_not_receive_lints, |prj, cmd| {
+    prj.add_source(
+        "Base",
+        r#"
+abstract contract Base {
+    uint256 public value;
+}
+"#,
+    );
+    prj.add_source(
+        "Concrete",
+        r#"
+import {Base} from "./Base.sol";
+
+contract Concrete is Base {
+    function readValue() external view returns (uint256) {
+        return value;
+    }
+}
+"#,
+    );
+    prj.update_config(|config| config.lint.ignore = vec!["src/Base.sol".into()]);
+
+    cmd.args(["lint", "--only-lint", "uninitialized-state"]).assert_success().stderr_eq("");
+});
+
+forgetest!(span_owner_activates_lint_for_inherited_source, |prj, cmd| {
+    prj.add_source(
+        "Base",
+        r#"
+contract Base {
+    uint256 public value = 1;
+}
+"#,
+    );
+    prj.add_test(
+        "Concrete",
+        r#"
+import {Base} from "../src/Base.sol";
+
+contract ConcreteTest is Base {}
+"#,
+    );
+
+    cmd.args(["lint", "--only-lint", "could-be-constant", "-D", "notes"]).assert_failure();
+});
+
 forgetest!(default_lint_severity_includes_info, |prj, cmd| {
     prj.add_source("DefaultInfoLintsImport", DEFAULT_INFO_LINTS_IMPORT);
     prj.add_source("DefaultInfoLints", DEFAULT_INFO_LINTS);

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -1817,9 +1817,11 @@ forgetest_init!(preprocess_contract_with_active_prank, |prj, cmd| {
 contract Counter {
     uint256 public number;
     address public deployer;
+    address public origin;
 
     constructor() {
         deployer = msg.sender;
+        origin = tx.origin;
     }
 }
     "#,
@@ -1834,9 +1836,35 @@ import {Counter} from "../src/Counter.sol";
 contract CounterTest is Test {
     function test_deployer() public {
         address deployer = makeAddr("deployer");
-        vm.startPrank(deployer);
-        Counter counter = new Counter{salt: 0}();
-        assertEq(counter.deployer(), deployer);
+        address origin = makeAddr("origin");
+        vm.startPrank(deployer, origin);
+        Counter first = new Counter{salt: 0}();
+        Counter second = new Counter{salt: bytes32(uint256(1))}();
+        assertEq(first.deployer(), deployer);
+        assertEq(first.origin(), origin);
+        assertEq(second.deployer(), deployer);
+        assertEq(second.origin(), origin);
+    }
+
+    function test_consecutive_single_call_pranks() public {
+        address firstDeployer = makeAddr("firstDeployer");
+        address firstOrigin = makeAddr("firstOrigin");
+        vm.prank(firstDeployer, firstOrigin);
+        Counter first = new Counter();
+
+        address secondDeployer = makeAddr("secondDeployer");
+        address secondOrigin = makeAddr("secondOrigin");
+        vm.prank(secondDeployer, secondOrigin);
+        Counter second = new Counter();
+
+        assertEq(first.deployer(), firstDeployer);
+        assertEq(first.origin(), firstOrigin);
+        assertEq(second.deployer(), secondDeployer);
+        assertEq(second.origin(), secondOrigin);
+
+        Counter unpranked = new Counter();
+        assertEq(unpranked.deployer(), address(this));
+        assertEq(unpranked.origin(), tx.origin);
     }
 }
     "#,
@@ -1847,11 +1875,12 @@ contract CounterTest is Test {
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
-Ran 1 test for test/Counter.t.sol:CounterTest
+Ran 2 tests for test/Counter.t.sol:CounterTest
+[PASS] test_consecutive_single_call_pranks() ([GAS])
 [PASS] test_deployer() ([GAS])
-Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
-Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 
 "#]]);
 });

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -55,7 +55,14 @@ static DEFAULT_LINT_SPECIFIC_CONFIG: LazyLock<LintSpecificConfig> =
     LazyLock::new(LintSpecificConfig::default);
 
 struct OwnedLintPolicy {
-    inline: Option<InlineConfig<Vec<String>>>,
+    inline: Option<Arc<InlineConfig<Vec<String>>>>,
+    active: Arc<Vec<&'static str>>,
+    sources: Option<Arc<Vec<SourceLintPolicy>>>,
+}
+
+struct SourceLintPolicy {
+    file: Arc<solar::interface::source_map::SourceFile>,
+    inline: Arc<InlineConfig<Vec<String>>>,
     active: Vec<&'static str>,
 }
 
@@ -65,6 +72,20 @@ impl LintPolicy for OwnedLintPolicy {
     }
 
     fn is_lint_suppressed(&self, id: &str, span: solar::interface::Span) -> bool {
+        if !span.is_dummy()
+            && let Some(sources) = &self.sources
+        {
+            // Late passes can follow inheritance or calls into another file. Apply the policy of
+            // the file that owns the diagnostic span, not the file whose visitor emitted it.
+            let source = sources
+                .partition_point(|source| source.file.start_pos <= span.lo())
+                .checked_sub(1)
+                .map(|idx| &sources[idx])
+                .filter(|source| source.file.contains(span.lo()));
+            return source.is_none_or(|source| {
+                !source.active.contains(&id) || source.inline.is_id_disabled(span, id)
+            });
+        }
         self.inline.as_ref().is_some_and(|inline| inline.is_id_disabled(span, id))
     }
 }
@@ -77,6 +98,8 @@ pub struct ForgeLintSuite {
     lints_included: Option<Vec<SolLint>>,
     lints_excluded: Option<Vec<SolLint>>,
     registry: Arc<LintRegistry>,
+    sources: Option<Arc<Vec<SourceLintPolicy>>>,
+    run_active: Option<Arc<Vec<&'static str>>>,
 }
 
 impl std::fmt::Debug for ForgeLintSuite {
@@ -126,15 +149,36 @@ impl LintSuite for ForgeLintSuite {
     }
 
     fn source_policy(&self, source: LintSource<'_, '_>) -> Arc<dyn LintPolicy> {
-        let comments = Comments::new(source.file, source.session.source_map(), false, false, None);
+        let inline = self
+            .sources
+            .as_ref()
+            .and_then(|sources| {
+                sources
+                    .binary_search_by_key(&source.file.start_pos, |source| source.file.start_pos)
+                    .ok()
+                    .map(|idx| sources[idx].inline.clone())
+            })
+            .unwrap_or_else(|| {
+                let comments =
+                    Comments::new(source.file, source.session.source_map(), false, false, None);
+                Arc::new(parse_inline_config(source.session, &comments, source.ast))
+            });
         Arc::new(OwnedLintPolicy {
-            inline: Some(parse_inline_config(source.session, &comments, source.ast)),
-            active: self.active_lints(Some(source.path)),
+            inline: Some(inline),
+            active: self
+                .run_active
+                .clone()
+                .unwrap_or_else(|| Arc::new(self.active_lints(Some(source.path)))),
+            sources: self.sources.clone(),
         })
     }
 
     fn project_policy(&self) -> Arc<dyn LintPolicy> {
-        Arc::new(OwnedLintPolicy { inline: None, active: self.active_lints(None) })
+        Arc::new(OwnedLintPolicy {
+            inline: None,
+            active: Arc::new(self.active_lints(None)),
+            sources: None,
+        })
     }
 }
 
@@ -219,6 +263,8 @@ impl<'a> SolidityLinter<'a> {
             lints_included: self.lints_included.clone(),
             lints_excluded: self.lints_excluded.clone(),
             registry: Arc::new(registry),
+            sources: None,
+            run_active: None,
         }
     }
 }
@@ -292,7 +338,31 @@ impl<'a> Linter for SolidityLinter<'a> {
                 }
             }
 
-            let suite = self.to_suite();
+            let mut suite = self.to_suite();
+            let mut sources = targets
+                .iter()
+                .map(|path| {
+                    let (_, source) =
+                        gcx.get_ast_source(path).expect("lint target was validated above");
+                    let ast = source.ast.as_ref().expect("lint target AST was validated above");
+                    let comments =
+                        Comments::new(&source.file, gcx.sess.source_map(), false, false, None);
+                    SourceLintPolicy {
+                        file: source.file.clone(),
+                        inline: Arc::new(parse_inline_config(gcx.sess, &comments, ast)),
+                        active: suite.active_lints(Some(path)),
+                    }
+                })
+                .collect::<Vec<_>>();
+            sources.sort_unstable_by_key(|source| source.file.start_pos);
+            suite.run_active = Some(Arc::new(
+                suite
+                    .active_lints(None)
+                    .into_iter()
+                    .filter(|id| sources.iter().any(|source| source.active.contains(id)))
+                    .collect(),
+            ));
+            suite.sources = Some(Arc::new(sources));
             run_lints(
                 &suite,
                 LintRunContext {


### PR DESCRIPTION
Backports [#16431](https://github.com/foundry-rs/foundry/pull/16431), [#16432](https://github.com/foundry-rs/foundry/pull/16432), [#16434](https://github.com/foundry-rs/foundry/pull/16434), and [#16437](https://github.com/foundry-rs/foundry/pull/16437) to `release-1.8.0`. Together these preserve single-use prank semantics under dynamic test linking, initialize the blob environment for Polygon/Bor forks, preserve hoisted siblings under scoped npm contextual remappings, and honor cross-file lint suppressions.

The commits were cherry-picked in the requested order without conflicts. Focused regression tests and the nightly formatting check pass.

AI assistance was used to perform and validate the backport.

Prompted by: fig
