### PR TITLE
fix(cast): bound local trace gas

### DIFF
--- a/.changelog/pr-16441.md
+++ b/.changelog/pr-16441.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Bound local `cast call --trace` execution to the configured or explicit gas limit while retaining the block gas limit bypass.

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -626,6 +626,9 @@ impl CallArgs {
             let (mut evm_env, tx_env, fork, chain, networks, endpoint_hardfork) =
                 TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts).await?;
             let context_block_number = evm_env.block_env.number().saturating_to();
+            // Modify settings usually set in eth_call while keeping execution gas bounded.
+            evm_env.cfg_env.disable_block_gas_limit = true;
+            evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
 
             // Apply the block overrides.
             if let Some(block_overrides) = block_overrides {

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -626,10 +626,6 @@ impl CallArgs {
             let (mut evm_env, tx_env, fork, chain, networks, endpoint_hardfork) =
                 TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts).await?;
             let context_block_number = evm_env.block_env.number().saturating_to();
-            // modify settings that usually set in eth_call
-            evm_env.cfg_env.disable_block_gas_limit = true;
-            evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
-            evm_env.block_env.set_gas_limit(u64::MAX);
 
             // Apply the block overrides.
             if let Some(block_overrides) = block_overrides {
@@ -679,8 +675,7 @@ impl CallArgs {
 
             // Apply a user-provided `--gas-limit` to the executor. `build_test_env` propagates the
             // executor's gas limit to the executed call/deploy, so setting it here is what takes
-            // effect; writing it onto the tx env directly would be overwritten. When no limit is
-            // given, the executor keeps the block gas limit (`u64::MAX`) set above.
+            // effect; writing it onto the tx env directly would be overwritten.
             if let Some(gas_limit) = tx.gas_limit() {
                 executor.set_gas_limit(gas_limit);
             }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -8954,20 +8954,21 @@ casttest!(cast_call_trace_selects_tempo_network, async |_prj, cmd| {
     }
 });
 
-// tests that `cast call --trace` executes the call with the gas limit given via `--gas-limit`,
-// matching a plain `cast call` rather than running with an unbounded gas limit.
+// tests that `cast call --trace` executes the call with the configured gas limit or the limit given
+// via `--gas-limit` rather than running with an unbounded gas limit.
 // <https://github.com/foundry-rs/foundry/issues/15357>
-forgetest_async!(cast_call_trace_respects_gas_limit, |prj, cmd| {
+forgetest_async!(cast_call_trace_respects_gas_limits, |prj, cmd| {
     let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
     let endpoint = handle.http_endpoint();
+    prj.update_config(|config| config.gas_limit = 1_000_000.into());
 
     // Contract that reverts when the call is given an unrealistically large gas limit.
     prj.add_source(
         "GasDependent",
         r#"
 contract GasDependent {
-    function run() external view returns (uint256) {
-        require(gasleft() < 30_000_000, "unrealistic gas limit");
+    function run(uint256 maxGas) external view returns (uint256) {
+        require(gasleft() < maxGas, "unrealistic gas limit");
         return gasleft();
     }
 }
@@ -9000,7 +9001,20 @@ contract GasDependent {
 
     // A plain `cast call` (eth_call) uses a realistic gas limit, so it succeeds.
     cmd.cast_fuse()
-        .args(["call", &address, "run()(uint256)", "--rpc-url", &endpoint])
+        .args(["call", &address, "run(uint256)(uint256)", "30000000", "--rpc-url", &endpoint])
+        .assert_success();
+
+    // `--trace` uses the configured gas limit when no CLI limit is provided.
+    cmd.cast_fuse()
+        .args([
+            "call",
+            &address,
+            "run(uint256)(uint256)",
+            "2000000",
+            "--trace",
+            "--rpc-url",
+            &endpoint,
+        ])
         .assert_success();
 
     // `--trace` with an explicit `--gas-limit` executes the call with that limit, so it succeeds
@@ -9010,10 +9024,11 @@ contract GasDependent {
         .args([
             "call",
             &address,
-            "run()(uint256)",
+            "run(uint256)(uint256)",
+            "750000",
             "--trace",
             "--gas-limit",
-            "1000000",
+            "500000",
             "--rpc-url",
             &endpoint,
         ])


### PR DESCRIPTION
`cast call --trace` builds a raw transaction, so `tx.gas_limit()` is unset unless the user passes `--gas-limit`. The tracing executor therefore takes its default execution budget from `block_env.gas_limit`. Setting that block value to `u64::MAX` made the call itself run with `u64::MAX` gas, which allowed malformed or non-terminating bytecode to consume CPU indefinitely.

This removes only `block_env.set_gas_limit(u64::MAX)`. Local traces still disable the block gas limit check and retain the EIP-7825 transaction-cap bypass. Without `--gas-limit`, execution now uses the configured gas limit, which defaults to `1 << 30`; with `--gas-limit`, the existing executor override uses the requested value.

History:

- #8496 introduced the disabled block check and `U256::MAX` block gas value in July 2024 so the large call from #6937 could exceed the prior 30 million gas ceiling.
- #10183 converted the value to `u64::MAX`, #11427 added the separate EIP-7825 cap bypass, and #14119 changed the direct assignment to `set_gas_limit(u64::MAX)` during later EVM refactors.

The audit found that the remaining maximum gas-related values either disable the EIP-7825 policy cap without changing transaction gas, implement explicit `--disable-block-gas-limit` opt-ins, or run calls bounded by a request or configured limit. This extends the regression coverage from #15357 to the configured limit.
