### PR TITLE
fix(cheatcodes): preserve gas snapshots

### DIFF
--- a/.changelog/cheatcode-state-gas.md
+++ b/.changelog/cheatcode-state-gas.md
@@ -2,4 +2,4 @@
 forge: minor
 ---
 
-Added `gasStateUsed` to the `Vm.Gas` values returned by `lastCallGas` and `lastFrameGas`.
+Added `gasStateUsed` to the `Vm.Gas` values returned by `lastCallGas` and `lastFrameGas` while preserving existing gas snapshot totals.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -950,10 +950,6 @@ impl Cheatcode for snapshotValue_1Call {
     }
 }
 
-const fn snapshot_gas_used(gas: &Gas) -> u64 {
-    gas.gasLimit.saturating_sub(gas.gasRemaining)
-}
-
 impl Cheatcode for snapshotGasLastCall_0Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { name } = self;
@@ -1757,6 +1753,10 @@ fn inner_value_snapshot<FEN: FoundryEvmNetwork>(
     Ok(Default::default())
 }
 
+const fn snapshot_gas_used(gas: &Gas) -> u64 {
+    gas.gasLimit.saturating_sub(gas.gasRemaining)
+}
+
 fn inner_last_gas_snapshot<FEN: FoundryEvmNetwork>(
     ccx: &mut CheatsCtxt<'_, '_, FEN>,
     group: Option<String>,
@@ -2370,17 +2370,22 @@ mod tests {
 
     #[test]
     fn snapshot_gas_preserves_total_used() {
-        let mut gas = Gas {
-            gasLimit: 100_000,
-            gasTotalUsed: 1_000,
-            gasMemoryUsed: 0,
-            gasRefunded: 0,
-            gasRemaining: 79_000,
-            gasStateUsed: 20_000,
-        };
-        assert_eq!(snapshot_gas_used(&gas), 21_000);
-
-        gas.gasRemaining = 99_000;
-        assert_eq!(snapshot_gas_used(&gas), 1_000);
+        for (case, gas_total_used, gas_remaining, gas_refunded, gas_state_used, expected) in [
+            ("state gas spill", 1_000, 79_000, 5_000, 20_000, 21_000),
+            ("state gas reservoir", 1_000, 99_000, 0, 20_000, 1_000),
+            ("reverted frame", 1_000, 99_000, 0, 0, 1_000),
+            ("halted frame", 100_000, 0, 0, 0, 100_000),
+            ("nested state gas refund", 0, 100_000, 0, -20_000, 0),
+        ] {
+            let gas = Gas {
+                gasLimit: 100_000,
+                gasTotalUsed: gas_total_used,
+                gasMemoryUsed: 0,
+                gasRefunded: gas_refunded,
+                gasRemaining: gas_remaining,
+                gasStateUsed: gas_state_used,
+            };
+            assert_eq!(snapshot_gas_used(&gas), expected, "{case}");
+        }
     }
 }

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -950,13 +950,18 @@ impl Cheatcode for snapshotValue_1Call {
     }
 }
 
+const fn snapshot_gas_used(gas: &Gas) -> u64 {
+    gas.gasLimit.saturating_sub(gas.gasRemaining)
+}
+
 impl Cheatcode for snapshotGasLastCall_0Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { name } = self;
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
         };
-        inner_last_gas_snapshot(ccx, None, Some(name.clone()), last_call_gas.gasTotalUsed)
+        let gas_used = snapshot_gas_used(last_call_gas);
+        inner_last_gas_snapshot(ccx, None, Some(name.clone()), gas_used)
     }
 }
 
@@ -966,12 +971,8 @@ impl Cheatcode for snapshotGasLastCall_1Call {
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
         };
-        inner_last_gas_snapshot(
-            ccx,
-            Some(group.clone()),
-            Some(name.clone()),
-            last_call_gas.gasTotalUsed,
-        )
+        let gas_used = snapshot_gas_used(last_call_gas);
+        inner_last_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()), gas_used)
     }
 }
 
@@ -981,7 +982,8 @@ impl Cheatcode for snapshotGasLastFrame_0Call {
         let Some(last_frame_gas) = &ccx.state.gas_metering.last_frame_gas else {
             bail!("no external call or create was made yet");
         };
-        inner_last_gas_snapshot(ccx, None, Some(name.clone()), last_frame_gas.gasTotalUsed)
+        let gas_used = snapshot_gas_used(last_frame_gas);
+        inner_last_gas_snapshot(ccx, None, Some(name.clone()), gas_used)
     }
 }
 
@@ -991,12 +993,8 @@ impl Cheatcode for snapshotGasLastFrame_1Call {
         let Some(last_frame_gas) = &ccx.state.gas_metering.last_frame_gas else {
             bail!("no external call or create was made yet");
         };
-        inner_last_gas_snapshot(
-            ccx,
-            Some(group.clone()),
-            Some(name.clone()),
-            last_frame_gas.gasTotalUsed,
-        )
+        let gas_used = snapshot_gas_used(last_frame_gas);
+        inner_last_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()), gas_used)
     }
 }
 
@@ -2363,5 +2361,26 @@ fn set_cold_slot<FEN: FoundryEvmNetwork>(
         && let Some(storage_slot) = account.storage.get_mut(&slot)
     {
         storage_slot.is_cold = cold;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_gas_preserves_total_used() {
+        let mut gas = Gas {
+            gasLimit: 100_000,
+            gasTotalUsed: 1_000,
+            gasMemoryUsed: 0,
+            gasRefunded: 0,
+            gasRemaining: 79_000,
+            gasStateUsed: 20_000,
+        };
+        assert_eq!(snapshot_gas_used(&gas), 21_000);
+
+        gas.gasRemaining = 99_000;
+        assert_eq!(snapshot_gas_used(&gas), 1_000);
     }
 }

--- a/crates/forge/tests/cli/svm.rs
+++ b/crates/forge/tests/cli/svm.rs
@@ -103,6 +103,8 @@ interface VmGas {
 
     function lastCallGas() external view returns (Gas memory gas);
     function lastFrameGas() external view returns (Gas memory gas);
+    function snapshotGasLastCall(string calldata name) external returns (uint256 gasUsed);
+    function snapshotGasLastFrame(string calldata name) external returns (uint256 gasUsed);
 }
 
 contract StateGasTarget {
@@ -131,10 +133,28 @@ contract StateGasTest is Test {
 
     function testReportsStateGas() public {
         StateGasTarget target = new StateGasTarget();
+        VmGas.Gas memory createGas = VM_GAS.lastFrameGas();
+        assertEq(
+            VM_GAS.snapshotGasLastFrame("stateGasCreate"),
+            createGas.gasLimit - createGas.gasRemaining,
+            "create snapshot changed"
+        );
         target.setValue();
 
-        assertStorageWriteGas(VM_GAS.lastCallGas());
-        assertStorageWriteGas(VM_GAS.lastFrameGas());
+        VmGas.Gas memory callGas = VM_GAS.lastCallGas();
+        VmGas.Gas memory frameGas = VM_GAS.lastFrameGas();
+        assertStorageWriteGas(callGas);
+        assertStorageWriteGas(frameGas);
+        assertEq(
+            VM_GAS.snapshotGasLastCall("stateGasCall"),
+            callGas.gasLimit - callGas.gasRemaining,
+            "last call snapshot changed"
+        );
+        assertEq(
+            VM_GAS.snapshotGasLastFrame("stateGasFrame"),
+            frameGas.gasLimit - frameGas.gasRemaining,
+            "last frame snapshot changed"
+        );
 
         StateGasTarget revertingTarget = new StateGasTarget();
         (bool success,) = address(revertingTarget).call(

--- a/crates/forge/tests/cli/svm.rs
+++ b/crates/forge/tests/cli/svm.rs
@@ -161,7 +161,13 @@ contract StateGasTest is Test {
             abi.encodeCall(revertingTarget.setValueAndRevert, ())
         );
         assertFalse(success, "state gas call should revert");
-        assertEq(VM_GAS.lastFrameGas().gasStateUsed, 0, "reverted frame used state gas");
+        VmGas.Gas memory revertedGas = VM_GAS.lastFrameGas();
+        assertEq(revertedGas.gasStateUsed, 0, "reverted frame used state gas");
+        assertEq(
+            VM_GAS.snapshotGasLastFrame("stateGasRevert"),
+            revertedGas.gasLimit - revertedGas.gasRemaining,
+            "reverted frame snapshot changed"
+        );
     }
 
     /// forge-config: default.isolate = true


### PR DESCRIPTION
Preserve the historical totals returned by `snapshotGasLastCall` and `snapshotGasLastFrame` after #16387 split regular and state gas in `Vm.Gas`. Snapshots now derive the original total from `gasLimit - gasRemaining`, while `gasTotalUsed` remains regular-only and `gasStateUsed` remains independently available.

AI assistance was used to implement and test this change.
