### PR TITLE
test: add regression coverage for expectRevert matching

### DIFF
--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -3160,20 +3160,29 @@ contract CounterTest is Test {
         );
         counter.setNumber(1);
     }
+    function test_rejects_bare_string_actual() public {
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "reason"));
+        counter.revertWithData(bytes("reason"));
+    }
+    function test_rejects_padded_custom_error_data() public {
+        vm.expectRevert(abi.encodeWithSelector(Counter.NumberNotEven.selector, uint256(1)));
+        counter.revertWithData(
+            abi.encodePacked(abi.encodeWithSelector(Counter.NumberNotEven.selector, uint256(1)), bytes28(0))
+        );
+    }
 }
    "#,
     );
 
-    cmd.args(["test", "--match-test", "test_raw_message_matches_error_with_trailing_data"])
-        .assert_success();
-
-    cmd.forge_fuse().args(["test"]).assert_failure().stdout_eq(str![[r#"
+    cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
 ...
 [FAIL: Error != expected error: NumberNotEven(1) != RandomError()] test_decode() ([GAS])
 [FAIL: Error != expected error: NumberNotEven(1) != NumberNotEven(2)] test_decode_with_args() ([GAS])
 [PASS] test_raw_message_matches_error_with_trailing_data() ([GAS])
-[FAIL: Error != expected error: 0x[..] != 0x[..]] test_rejects_trailing_expected_custom_error_data() ([GAS])
-[FAIL: Error != expected error: 0x[..] != 0x[..]] test_rejects_trailing_expected_error_data() ([GAS])
+[FAIL: Error != expected error: 0x726561736f6e != 0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000006726561736f6e0000000000000000000000000000000000000000000000000000] test_rejects_bare_string_actual() ([GAS])
+[FAIL: Error != expected error: 0xeb598fa3000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000 != 0xeb598fa30000000000000000000000000000000000000000000000000000000000000001] test_rejects_padded_custom_error_data() ([GAS])
+[FAIL: Error != expected error: 0xeb598fa30000000000000000000000000000000000000000000000000000000000000001 != 0xeb598fa300000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002] test_rejects_trailing_expected_custom_error_data() ([GAS])
+[FAIL: Error != expected error: 0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000006726561736f6e0000000000000000000000000000000000000000000000000000 != 0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000006726561736f6e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002] test_rejects_trailing_expected_error_data() ([GAS])
 ...
 "#]]);
 });

--- a/testdata/default/cheats/AssumeNoRevert.t.sol
+++ b/testdata/default/cheats/AssumeNoRevert.t.sol
@@ -57,6 +57,13 @@ contract Reverter {
         }
         return true;
     }
+
+    function revertWithMessageIf2(uint256 value) public pure returns (bool) {
+        if (value == 2) {
+            revert("revert message");
+        }
+        return true;
+    }
 }
 
 contract ReverterTest is Test {
@@ -130,6 +137,26 @@ contract ReverterTest is Test {
         });
         vm.assumeNoRevert(revertData);
         reverter.twoPossibleReverts(x);
+    }
+
+    /// @dev Test that `assumeNoRevert` anticipates a byte-exact ABI-encoded `Error(string)` payload
+    function testAssumeErrorStringExact(uint256 x) public view {
+        vm.assumeNoRevert(
+            Vm.PotentialRevert({
+                revertData: abi.encodeWithSignature("Error(string)", "revert message"),
+                partialMatch: false,
+                reverter: address(0)
+            })
+        );
+        reverter.revertWithMessageIf2(x);
+    }
+
+    /// @dev Test that `assumeNoRevert` anticipates a bare string reason for a standard `revert(string)`
+    function testAssumeErrorStringBareReason(uint256 x) public view {
+        vm.assumeNoRevert(
+            Vm.PotentialRevert({revertData: bytes("revert message"), partialMatch: false, reverter: address(0)})
+        );
+        reverter.revertWithMessageIf2(x);
     }
 
     /// @dev Test that `assumeNoRevert` correctly interacts with itself when partially matching on the error selector

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -568,6 +568,27 @@ contract ExpectRevertWithErrorTest is Test {
         this.f(v1);
     }
 
+    /// `expectRevert(bytes)` must accept byte-identical revert data of any shape.
+    /// Ref: <https://github.com/foundry-rs/foundry/issues/12511>
+    function testExpectRevertExactMatchAnyRevertData(bytes calldata data) external {
+        vm.expectRevert(data);
+        this.f(data);
+    }
+
+    /// `expectPartialRevert(bytes4)` must accept any revert data starting with the selector.
+    function testExpectPartialRevertMatchesAnySuffix(bytes4 selector, bytes calldata suffix) external {
+        vm.expectPartialRevert(selector);
+        this.f(abi.encodePacked(selector, suffix));
+    }
+
+    /// A bare-message expectation matches an actual `Error(string)` payload even when the
+    /// wrapper carries trailing bytes: the actual revert data is unwrapped leniently.
+    /// Ref: <https://github.com/foundry-rs/foundry/issues/16424>
+    function testExpectRevertActualErrorStringWithTrailingData() external {
+        vm.expectRevert(bytes("reason"));
+        this.f(abi.encodePacked(abi.encodeWithSignature("Error(string)", "reason"), uint256(2)));
+    }
+
     function f(bytes memory v) external pure {
         assembly {
             revert(add(v, 32), mload(v))


### PR DESCRIPTION
#16428 tightened `vm.expectRevert(bytes)` to exact raw payload matching. This follow-up pins the resulting matcher contract so a future change to revert matching trips a test instead of silently shifting semantics.

The testdata suite gains a fuzzed exact-match property (`expectRevert(v)` against a revert of exactly `v` for arbitrary `v`, generalizing the #12511 regression test), a fuzzed prefix property for `expectPartialRevert`, a pin for the deliberate leniency where a bare-message expectation matches an actual `Error(string)` payload carrying trailing bytes, and `assumeNoRevert` vectors for `Error(string)` reasons (byte-exact wrapped payload and bare message), which had no string-reason coverage at all.

The CLI snapshot test gains failure vectors for the now-strict classes: a word-padded custom error against a canonical expectation, and a bare-string revert against an `Error(string)`-wrapped expectation. The mismatch snapshots now pin the full raw hex operands instead of `0x[..]`, so a change to what the raw-data fallback prints (or which buffer it prints) fails the snapshot. The redundant `--match-test` invocation is dropped: the full-run snapshot already asserts that test's `[PASS]` line, and a non-matching filter exits 0, so it guarded nothing.

Tests only, so this should not appear in release notes; a maintainer needs to apply `L-ignore` for the changelog check.


AI assistance disclosure: written with Claude Code.
