### PR TITLE
fix(cheatcodes): require 4-byte prefixes for partial revert match

### DIFF
--- a/.changelog/partial-revert-short-prefix.md
+++ b/.changelog/partial-revert-short-prefix.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-cheatcodes: patch
+---
+
+Fixed `assumeNoRevert` partial matching accepting any revert shorter than four bytes.

--- a/crates/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/cheatcodes/src/test/revert_handlers.rs
@@ -79,7 +79,11 @@ fn handle_revert(
     };
 
     // Compare only the first 4 bytes if partial match.
-    if revert_params.partial_match() && actual_revert.get(..4) == expected_reason.get(..4) {
+    if revert_params.partial_match()
+        && let (Some(actual_prefix), Some(expected_prefix)) =
+            (actual_revert.get(..4), expected_reason.get(..4))
+        && actual_prefix == expected_prefix
+    {
         return Ok(());
     }
 

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -597,3 +597,49 @@ Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 "#]],
     );
 });
+
+// An `assumeNoRevert` partial-match reason shorter than a selector must not match revert data
+// that is also shorter than 4 bytes; the revert should surface as a failure instead of being
+// discarded as anticipated.
+forgetest_init!(assume_no_revert_short_partial_should_fail, |prj, cmd| {
+    prj.add_test(
+        "AssumeShortPartial.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {VmSafe} from "forge-std/Vm.sol";
+
+contract ShortReverter {
+    function revertShort() external pure {
+        assembly {
+            mstore(0x00, shl(240, 0xffff))
+            revert(0x00, 0x02)
+        }
+    }
+}
+
+contract AssumeShortPartialTest is Test {
+    ShortReverter reverter;
+
+    function setUp() public {
+        reverter = new ShortReverter();
+    }
+
+    function testShortPartialDoesNotMatch(uint256) public view {
+        vm.assumeNoRevert(
+            VmSafe.PotentialRevert({revertData: hex"ff", partialMatch: true, reverter: address(0)})
+        );
+        reverter.revertShort();
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--match-contract", "AssumeShortPartialTest"]).assert_failure().stdout_eq(
+        str![[r#"
+...
+[FAIL: EvmError: Revert; counterexample: calldata=[..] args=[..]] testShortPartialDoesNotMatch(uint256) (runs: 0, [AVG_GAS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+...
+"#]],
+    );
+});


### PR DESCRIPTION
The partial match in `handle_revert` compares `actual_revert.get(..4) == expected_reason.get(..4)`; when both payloads are shorter than 4 bytes, both sides are `None` and the comparison succeeds. An `assumeNoRevert` reason shorter than a selector with `partialMatch: true` therefore silently matches any sub-4-byte revert and discards the fuzz run as anticipated, hiding unrelated reverts. The partial match now requires both payloads to carry a full 4-byte prefix. `expectPartialRevert` is unaffected since its `bytes4` reason always has one.


AI assistance disclosure: written with Claude Code.
