### PR TITLE
docs(cheatcodes): align revert matching docs with behavior

### DIFF
--- a/.changelog/cheatcode-revert-doc-wording.md
+++ b/.changelog/cheatcode-revert-doc-wording.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-cheatcodes: patch
+foundry-cheatcodes-spec: patch
+---
+
+Corrected `_expectCheatcodeRevert(bytes)` and `PotentialRevert.partialMatch` docs to state the implemented matching semantics.

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -658,7 +658,7 @@
         {
           "name": "partialMatch",
           "ty": "bool",
-          "description": "When true, only matches on the beginning of the revert data, otherwise, matches on entire revert data"
+          "description": "When true, only matches on the first 4 bytes (usually the selector) of the revert data, otherwise, matches on entire revert data"
         },
         {
           "name": "revertData",
@@ -728,7 +728,7 @@
     {
       "func": {
         "id": "_expectCheatcodeRevert_2",
-        "description": "Expects an error on next cheatcode call that exactly matches the revert data.",
+        "description": "Expects an error on next cheatcode call that contains the revert data.",
         "declaration": "function _expectCheatcodeRevert(bytes calldata revertData) external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -355,7 +355,7 @@ interface Vm {
     struct PotentialRevert {
         /// The allowed origin of the revert opcode; address(0) allows reverts from any address
         address reverter;
-        /// When true, only matches on the beginning of the revert data, otherwise, matches on entire revert data
+        /// When true, only matches on the first 4 bytes (usually the selector) of the revert data, otherwise, matches on entire revert data
         bool partialMatch;
         /// The data to use to match encountered reverts
         bytes revertData;
@@ -1375,7 +1375,7 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Unsafe, status = Internal)]
     function _expectCheatcodeRevert(bytes4 revertData) external;
 
-    /// Expects an error on next cheatcode call that exactly matches the revert data.
+    /// Expects an error on next cheatcode call that contains the revert data.
     #[cheatcode(group = Testing, safety = Unsafe, status = Internal)]
     function _expectCheatcodeRevert(bytes calldata revertData) external;
 


### PR DESCRIPTION
`_expectCheatcodeRevert(bytes)` is documented as matching the revert data exactly, but the implementation matches by containment — the expected bytes only need to appear within the cheatcode error — and callers rely on that (e.g. the assertion failure tests match message fragments). `PotentialRevert.partialMatch` says it matches "on the beginning of the revert data" while the implementation compares exactly the first 4 bytes. Both doc comments now state the implemented semantics. Doc-only change; cheatcode JSON assets regenerated with `cargo cheats`.

AI assistance disclosure: written with Claude Code.
