### PR TITLE
refactor(fmt): share signature formatting

### DIFF
--- a/crates/common/fmt/src/ui.rs
+++ b/crates/common/fmt/src/ui.rs
@@ -776,12 +776,7 @@ pub trait UIfmtSignatureExt {
 
 impl UIfmtSignatureExt for TxEnvelope {
     fn signature_pretty(&self) -> Option<(String, String, String)> {
-        let sig = self.signature();
-        Some((
-            FixedBytes::from(sig.r()).pretty(),
-            FixedBytes::from(sig.s()).pretty(),
-            U8::from_le_slice(&sig.as_bytes()[64..]).pretty(),
-        ))
+        Some(pretty_signature_fields(self.signature()))
     }
 }
 
@@ -794,13 +789,7 @@ impl UIfmtSignatureExt for AnyTxEnvelope {
 #[cfg(feature = "optimism")]
 impl UIfmtSignatureExt for OpTxEnvelope {
     fn signature_pretty(&self) -> Option<(String, String, String)> {
-        self.signature().map(|sig| {
-            (
-                FixedBytes::from(sig.r()).pretty(),
-                FixedBytes::from(sig.s()).pretty(),
-                U8::from_le_slice(&sig.as_bytes()[64..]).pretty(),
-            )
-        })
+        self.signature().map(pretty_signature_fields)
     }
 }
 
@@ -821,12 +810,16 @@ impl UIfmtSignatureExt for TempoTxEnvelope {
                 }
             }
         }?;
-        Some((
-            FixedBytes::from(sig.r()).pretty(),
-            FixedBytes::from(sig.s()).pretty(),
-            U8::from_le_slice(&sig.as_bytes()[64..]).pretty(),
-        ))
+        Some(pretty_signature_fields(sig))
     }
+}
+
+fn pretty_signature_fields(signature: &Signature) -> (String, String, String) {
+    (
+        FixedBytes::from(signature.r()).pretty(),
+        FixedBytes::from(signature.s()).pretty(),
+        U8::from_le_slice(&signature.as_bytes()[64..]).pretty(),
+    )
 }
 
 pub trait UIfmtReceiptExt {


### PR DESCRIPTION
Ethereum, OP, and Tempo transaction envelopes repeat the same formatting for the `r`, `s`, and `v` signature fields.

Extract this into a shared helper and reuse it across each envelope implementation. Behavior remains unchanged.

Base can use the same helper instead of adding another copy of this formatting logic.