### PR TITLE
fix(cast): skip HyperEVM system transactions on replay

### DIFF
--- a/.changelog/cast-hyperliquid-system-sender.md
+++ b/.changelog/cast-hyperliquid-system-sender.md
@@ -1,0 +1,7 @@
+---
+foundry-common: patch
+cast: patch
+forge: patch
+---
+
+Recognized the HyperEVM system sender that credits HyperCore transfers, so replaying transactions from a block that contains one no longer fails base fee validation.

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -42,6 +42,13 @@ pub const OPTIMISM_SYSTEM_ADDRESS: Address = address!("0xdeaddeaddeaddeaddeaddea
 /// The system address, the sender of the first transaction in every block:
 pub const MONAD_SYSTEM_ADDRESS: Address = address!("0x6f49a8F621353f12378d0046E7d7e4b9B249DC9e");
 
+/// HyperEVM system address that credits HyperCore -> HyperEVM native transfers.
+///
+/// These are legacy envelopes with `gasPrice = 0` and a receipt `gasUsed` of `0`, so replaying one
+/// as a regular transaction fails base fee validation and aborts the whole block replay.
+pub const HYPERLIQUID_SYSTEM_ADDRESS: Address =
+    address!("0x2222222222222222222222222222222222222222");
+
 /// MegaETH system address for `Set Slots` in the MegaETH oracle.
 ///
 /// Transactions from this sender are submitted with gas price 0.
@@ -62,14 +69,15 @@ pub const TYPE_BINDING_PREFIX: &str = "string constant schema_";
 ///
 /// Transactions from these senders usually don't have a any fee information OR set absurdly high fees that exceed the gas limit (See: <https://github.com/foundry-rs/foundry/pull/10608>)
 ///
-/// See: [ARBITRUM_SENDER], [OPTIMISM_SYSTEM_ADDRESS], [MONAD_SYSTEM_ADDRESS], [MEGA_SYSTEM_ADDRESS]
-/// and [Address::ZERO]
+/// See: [ARBITRUM_SENDER], [OPTIMISM_SYSTEM_ADDRESS], [MONAD_SYSTEM_ADDRESS],
+/// [MEGA_SYSTEM_ADDRESS], [HYPERLIQUID_SYSTEM_ADDRESS] and [Address::ZERO]
 pub fn is_known_system_sender(sender: Address) -> bool {
     [
         ARBITRUM_SENDER,
         OPTIMISM_SYSTEM_ADDRESS,
         MONAD_SYSTEM_ADDRESS,
         MEGA_SYSTEM_ADDRESS,
+        HYPERLIQUID_SYSTEM_ADDRESS,
         Address::ZERO,
     ]
     .contains(&sender)


### PR DESCRIPTION
HyperCore credits native HYPE to HyperEVM accounts through transactions sent by `0x2222222222222222222222222222222222222222`. They are legacy envelopes with `gasPrice = 0`, an `r`/`s` of `1`, and a receipt `gasUsed` of `0`. That sender was not in `is_known_system_sender`, so block replay executed them like regular transactions and aborted with `transaction validation error: gas price is less than basefee` — which takes down `cast run` for every transaction in the block, not just the credit itself. Sparse sampling of recent HyperEVM blocks put these in roughly 1% of them.

Adding the address to the known system senders makes both `cast run` and the fork backend skip them, the same way Arbitrum, Optimism, Monad and MegaETH system transactions are already skipped. Skipping is also the right state: the credit lands in the block being replayed, and the fork DB resolves balances at the parent, so the pre-credit balance is what the following transactions should see.

Before, every transaction in HyperEVM block 44427759 failed the base fee check. After, all four user transactions replay to the exact receipt gas (134377, 134365, 39302, 119578), and targeting the credit itself reports `is a system transaction` instead of an EVM error. Transactions in blocks without a credit are unaffected.

Found while looking into how well the suite reproduces HyperEVM execution. With this and an archive RPC, `cast run` matched the receipts on 22 of 24 sampled transactions; the two that still differ call the node-native HyperCore read precompiles at `0x0800`-`0x0810`, which is a separate problem and relates to #7262.

Related: #10863, #10827, #10820.

---

This PR was written by Claude Code: the investigation that found the bug, the change, and this description. Verified against live HyperEVM blocks as described above.
