### PR TITLE
test(forge): add optimism deployCode coverage

### DIFF
--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -174,6 +174,63 @@ forgetest!(flaky_testdata, |_prj, cmd| {
     cmd.args(["test", &mc]).assert_success();
 });
 
+// Ensures `vm.deployCode` works with the optimism network family active, covering the OP EVM's
+// nested frame execution path which is only reachable through this cheatcode.
+forgetest_init!(deploy_code_cheatcode_on_optimism_network, |prj, cmd| {
+    prj.update_config(|config| {
+        config.networks = foundry_evm_networks::NetworkConfigs::with_optimism();
+    });
+
+    prj.add_source(
+        "OpCounter.sol",
+        r#"
+contract OpCounter {
+    uint256 public number;
+
+    constructor(uint256 initial) {
+        number = initial;
+    }
+
+    function increment() external {
+        number++;
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "OpDeployCode.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {OpCounter} from "../src/OpCounter.sol";
+
+contract OpDeployCodeTest is Test {
+    function testDeployCodeOnOptimism() public {
+        address deployed = vm.deployCode("src/OpCounter.sol:OpCounter", abi.encode(41));
+        assertGt(deployed.code.length, 0);
+
+        OpCounter counter = OpCounter(deployed);
+        assertEq(counter.number(), 41);
+        counter.increment();
+        assertEq(counter.number(), 42);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--match-contract", "OpDeployCodeTest"]).assert_success().stdout_eq(str![[
+        r#"
+...
+Ran 1 test for test/OpDeployCode.t.sol:OpDeployCodeTest
+[PASS] testDeployCodeOnOptimism() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#
+    ]]);
+});
+
 // tests that test filters are handled correctly
 forgetest!(can_set_filter_values, |prj, cmd| {
     let patt = regex::Regex::new("test*").unwrap();


### PR DESCRIPTION
Follow-up to #16419. `NestedEvm::run_execution` is reachable only through `vm.deployCode`, and the optimism family was the sole network without coverage of that path — eth, monad, and tempo each exercise it, so a regression confined to the OP instantiation of the shared frame execution (including its `map_op_error` mapping and `OpHandler`'s deposit-aware `last_frame_result` override) would ship with CI green.

The test activates the optimism family via config, deploys a contract through `vm.deployCode` with a constructor argument, and asserts the deployed code is present and callable. It runs in default CI: `optimism` is a default feature of `forge`, and the network is selected purely through `foundry.toml`.

Test-only change, needs `L-ignore`.

AI-assisted.
