### PR TITLE
fix(fork): derive hardfork from the fork block header

### DIFF
--- a/.changelog/fork-hardfork-from-block-header.md
+++ b/.changelog/fork-hardfork-from-block-header.md
@@ -1,0 +1,9 @@
+---
+foundry-evm-core: patch
+foundry-evm: patch
+cast: patch
+anvil: patch
+forge-verify: patch
+---
+
+Derived the execution hardfork from the fork block header for chains without a known activation schedule, so `cast run`, `cast call --trace` and `anvil --fork-url` no longer run ahead of the forked chain.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -73,7 +73,7 @@ use yansi::Paint;
 pub use foundry_common::version::SHORT_VERSION as VERSION_MESSAGE;
 use foundry_evm::{
     traces::{CallTraceDecoderBuilder, identifier::SignaturesIdentifier},
-    utils::{get_blob_params, get_blob_params_by_hardfork},
+    utils::{ethereum_hardfork_from_header, get_blob_params, get_blob_params_by_hardfork},
 };
 use foundry_evm_networks::{NetworkConfigs, NetworkVariant};
 use tempo_precompiles::TIP_FEE_MANAGER_ADDRESS;
@@ -1971,6 +1971,14 @@ latest block number: {latest_block}"
                     .filter(|hardfork| {
                         hardfork.namespace() == effective_network.hardfork_namespace()
                     })
+                })
+                // Chains without an activation schedule would otherwise fall back to Anvil's own
+                // default, which is the latest hardfork and can run ahead of the forked chain.
+                .or_else(|| {
+                    (effective_network == NetworkVariant::Ethereum)
+                        .then(|| ethereum_hardfork_from_header(&block.header))
+                        .flatten()
+                        .map(FoundryHardfork::Ethereum)
                 })
         } else {
             None

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -623,7 +623,7 @@ impl CallArgs {
 
             let create2_deployer = evm_opts.create2_deployer;
             let verbosity = tracing.verbosity;
-            let (mut evm_env, tx_env, fork, chain, networks, endpoint_hardfork) =
+            let (mut evm_env, tx_env, fork, chain, networks, hardforks) =
                 TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts).await?;
             let context_block_number = evm_env.block_env.number().saturating_to();
             // Modify settings usually set in eth_call while keeping execution gas bounded.
@@ -643,7 +643,7 @@ impl CallArgs {
                 &config,
                 networks,
                 chain.id(),
-                endpoint_hardfork,
+                hardforks,
                 &mut evm_env,
                 evm_version,
             );

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -55,7 +55,7 @@ use foundry_evm::{
         evm::{EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, context_for_child_transaction},
     },
     executors::TracingExecutor,
-    opts::EvmOpts,
+    opts::{EvmOpts, ExecutionSpecContext},
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements},
 };
 use foundry_evm_networks::NetworkConfigs;
@@ -623,7 +623,7 @@ impl CallArgs {
 
             let create2_deployer = evm_opts.create2_deployer;
             let verbosity = tracing.verbosity;
-            let (mut evm_env, tx_env, fork, chain, networks, hardforks) =
+            let (mut evm_env, tx_env, fork, chain, networks, fork_context) =
                 TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts).await?;
             let context_block_number = evm_env.block_env.number().saturating_to();
             // Modify settings usually set in eth_call while keeping execution gas bounded.
@@ -639,11 +639,10 @@ impl CallArgs {
                     evm_env.block_env.set_timestamp(U256::from(time));
                 }
             }
-            let resolved_hardfork = TracingExecutor::<FEN>::resolve_spec_for_chain(
+            let resolved_hardfork = TracingExecutor::<FEN>::resolve_spec(
                 &config,
                 networks,
-                chain.id(),
-                hardforks,
+                ExecutionSpecContext::historical_from_fork(fork_context),
                 &mut evm_env,
                 evm_version,
             );

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -386,13 +386,13 @@ impl RunArgs {
 
         let create2_deployer = evm_opts.create2_deployer;
         let verbosity = tracing.verbosity;
-        let (block, (mut evm_env, tx_env, fork, chain, networks, endpoint_hardfork)) = tokio::try_join!(
+        let (block, (mut evm_env, tx_env, fork, chain, networks, hardforks)) = tokio::try_join!(
             // fetch the block the transaction was mined in
             provider.get_block(tx_block_number.into()).full().into_future().map_err(Into::into),
             TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts)
         )?;
 
-        let mut evm_version = self.evm_version;
+        let evm_version = self.evm_version;
         evm_env.cfg_env.disable_block_gas_limit = self.disable_block_gas_limit;
 
         // By default do not enforce transaction gas limits imposed by Osaka (EIP-7825).
@@ -409,18 +409,6 @@ impl RunArgs {
             evm_env.block_env = block_env_from_header(block.header());
             parent_beacon_block_root = block.header().parent_beacon_block_root();
 
-            // Unless explicitly configured, resolve the correct spec for the block using the same
-            // approach as reth: walk known chain activation conditions to find the latest active
-            // fork. Falls back to a blob-gas heuristic for unknown chains.
-            if evm_version.is_none()
-                && config.hardfork.is_none()
-                && FoundryHardfork::from_chain_and_timestamp(chain.id(), block.header().timestamp())
-                    .is_none()
-                && block.header().excess_blob_gas().is_some()
-            {
-                // TODO: add glamsterdam header field checks in the future
-                evm_version = Some(EvmVersion::Cancun);
-            }
             apply_chain_and_block_specific_env_changes_for_chain::<FEN::Network, _, _>(
                 &mut evm_env,
                 block,
@@ -432,7 +420,7 @@ impl RunArgs {
             &config,
             networks,
             chain.id(),
-            endpoint_hardfork,
+            hardforks,
             &mut evm_env,
             evm_version,
         );

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -53,7 +53,7 @@ use foundry_evm::{
     },
     executors::{EvmError, Executor, TracingExecutor},
     hardforks::FoundryHardfork,
-    opts::EvmOpts,
+    opts::{EvmOpts, ExecutionSpecContext},
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
 };
 use foundry_evm_networks::NetworkConfigs;
@@ -386,7 +386,7 @@ impl RunArgs {
 
         let create2_deployer = evm_opts.create2_deployer;
         let verbosity = tracing.verbosity;
-        let (block, (mut evm_env, tx_env, fork, chain, networks, hardforks)) = tokio::try_join!(
+        let (block, (mut evm_env, tx_env, fork, chain, networks, fork_context)) = tokio::try_join!(
             // fetch the block the transaction was mined in
             provider.get_block(tx_block_number.into()).full().into_future().map_err(Into::into),
             TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts)
@@ -416,11 +416,10 @@ impl RunArgs {
                 config.networks,
             );
         }
-        let resolved_hardfork = TracingExecutor::<FEN>::resolve_spec_for_chain(
+        let resolved_hardfork = TracingExecutor::<FEN>::resolve_spec(
             &config,
             networks,
-            chain.id(),
-            hardforks,
+            ExecutionSpecContext::historical_from_fork(fork_context),
             &mut evm_env,
             evm_version,
         );

--- a/crates/cast/tests/cli/remote_trace.rs
+++ b/crates/cast/tests/cli/remote_trace.rs
@@ -1,12 +1,13 @@
 //! Tests for pinning remote traces to one canonical block context.
 
+use alloy_hardforks::EthereumHardfork;
 use alloy_network::{BlockResponse, TransactionBuilder, primitives::HeaderResponse};
 use alloy_primitives::{B256, address, hex};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
 use anvil::{NodeConfig, NodeHandle};
 use axum::{Json, Router, routing::post};
-use foundry_test_utils::util::OutputExt;
+use foundry_test_utils::{str, util::OutputExt};
 use serde_json::{Value, json};
 use std::{
     slice,
@@ -19,6 +20,8 @@ use std::{
 #[derive(Clone)]
 enum ResponseMutation {
     None,
+    /// Rejects the `anvil_` namespace so the endpoint looks like a plain non-Anvil node.
+    HideAnvilNamespace,
     ReceiptBlockHash {
         tx_hash: String,
         replacement: String,
@@ -97,6 +100,16 @@ fn mutate_rpc_response(request: &Value, response: &mut Value, mutation: &Respons
 fn mutate_rpc_result(request: &Value, response: &mut Value, mutation: &ResponseMutation) {
     let Some(method) = request.get("method").and_then(Value::as_str) else { return };
     let requested_target = request.pointer("/params/0").and_then(Value::as_str);
+
+    if matches!(mutation, ResponseMutation::HideAnvilNamespace) && method.starts_with("anvil_") {
+        let id = response.get("id").cloned().unwrap_or(Value::Null);
+        *response = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": { "code": -32601, "message": "Method not found" }
+        });
+        return;
+    }
 
     if let ResponseMutation::MissingTransactionBlock { block_hash } = mutation
         && method == "eth_getBlockByHash"
@@ -372,4 +385,42 @@ casttest!(cast_run_remote_trace_rejects_canonical_block_mismatch, async |_prj, c
         .stderr_lossy();
     assert!(output.contains("canonical block lookup reported block"), "{output}");
     assert!(output.contains("changed inclusion"), "{output}");
+});
+
+casttest!(cast_call_fork_trace_uses_header_hardfork_for_unknown_chain, async |_prj, cmd| {
+    // Chain 999 has no activation schedule Foundry knows about, and hiding the `anvil_`
+    // namespace makes the endpoint look like a plain node, so the fork block header is the only
+    // evidence for the chain's hardfork.
+    let (api, handle) = anvil::spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(999u64))
+            .with_hardfork(Some(EthereumHardfork::Cancun.into())),
+    )
+    .await;
+    api.mine_one().await.unwrap();
+    let (endpoint, _) =
+        spawn_recording_rpc_proxy(handle.http_endpoint(), ResponseMutation::HideAnvilNamespace)
+            .await;
+
+    // At Cancun `0x0b` is an empty account and the call succeeds without consuming gas;
+    // resolving ahead of the chain would activate the BLS12-381 G1 add precompile there, which
+    // rejects empty input with a `PrecompileError`.
+    cmd.args([
+        "call",
+        "0x000000000000000000000000000000000000000B",
+        "--trace",
+        "--rpc-url",
+        &endpoint,
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+Traces:
+  [0] PRECOMPILES::bls12G1Add(0x, 0x)
+    └─ ← [Stop] 0x
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
 });

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -791,6 +791,7 @@ mod tests {
             network_profile: NetworkConfigs::default(),
             block_number,
             hardfork: None,
+            header_hardfork: None,
             instance_id: None,
             source_fork_block_number: None,
             source_fork_block_hash: None,

--- a/crates/evm/core/src/fork/resolved.rs
+++ b/crates/evm/core/src/fork/resolved.rs
@@ -175,6 +175,7 @@ mod tests {
             network_profile: NetworkConfigs::default(),
             block_number,
             hardfork: None,
+            header_hardfork: None,
             instance_id: None,
             source_fork_block_number: None,
             source_fork_block_hash: None,

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -2,7 +2,10 @@ use crate::{
     EvmEnv, FoundryBlock, FoundryTransaction,
     constants::DEFAULT_CREATE2_DEPLOYER,
     fork::{CreateFork, ResolvedFork},
-    utils::{apply_chain_and_block_specific_env_changes_for_chain, block_env_from_header},
+    utils::{
+        apply_chain_and_block_specific_env_changes_for_chain, block_env_from_header,
+        ethereum_hardfork_from_header,
+    },
 };
 #[cfg(test)]
 use alloy_chains::NamedChain;
@@ -257,6 +260,11 @@ pub struct ForkContext {
     pub block_number: BlockNumber,
     /// Exact hardfork reported by the fork endpoint, when available.
     pub hardfork: Option<FoundryHardfork>,
+    /// Hardfork implied by the fork block header, when its mandatory fields identify one.
+    ///
+    /// This is a fallback for chains Foundry has no activation schedule for, so it is only
+    /// derived for the Ethereum network family.
+    pub header_hardfork: Option<FoundryHardfork>,
     /// Anvil instance identifier, when exposed by the endpoint.
     pub instance_id: Option<B256>,
     /// Block number from which the endpoint itself was forked.
@@ -265,7 +273,30 @@ pub struct ForkContext {
     pub source_fork_block_hash: Option<B256>,
 }
 
+/// The hardfork evidence a fork endpoint and its fork block provide.
+///
+/// Kept together so callers cannot mix up two same-typed hardfork options.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ForkHardforks {
+    /// Exact hardfork reported by the fork endpoint, when available.
+    pub endpoint: Option<FoundryHardfork>,
+    /// Hardfork implied by the fork block header, when its mandatory fields identify one.
+    pub header: Option<FoundryHardfork>,
+}
+
+impl ForkHardforks {
+    /// Returns the evidence for an endpoint that reported an exact hardfork.
+    pub const fn from_endpoint(endpoint: Option<FoundryHardfork>) -> Self {
+        Self { endpoint, header: None }
+    }
+}
+
 impl ForkContext {
+    /// Returns the hardfork evidence this fork provides.
+    pub const fn hardforks(self) -> ForkHardforks {
+        ForkHardforks { endpoint: self.hardfork, header: self.header_hardfork }
+    }
+
     /// Returns whether this block context belongs to `identity`.
     pub fn matches_identity(self, identity: &ForkEndpointIdentity) -> bool {
         self.execution_chain_id == identity.execution_chain_id
@@ -1167,6 +1198,10 @@ impl EvmOpts {
             network_profile: identity.network_profile,
             block_number: actual.number,
             hardfork: identity.hardfork,
+            header_hardfork: (identity.network == NetworkVariant::Ethereum)
+                .then(|| ethereum_hardfork_from_header(block.header()))
+                .flatten()
+                .map(FoundryHardfork::Ethereum),
             instance_id: identity.instance_id,
             source_fork_block_number: identity.source_fork_block_number,
             source_fork_block_hash: identity.source_fork_block_hash,
@@ -1427,6 +1462,8 @@ pub enum ExecutionSpecContext {
         source_chain_id: ChainId,
         /// Exact hardfork reported by the endpoint.
         endpoint_hardfork: Option<FoundryHardfork>,
+        /// Hardfork implied by the source block header, when its mandatory fields identify one.
+        header_hardfork: Option<FoundryHardfork>,
     },
 }
 
@@ -1455,8 +1492,9 @@ impl ExecutionSpecContext {
     pub const fn historical(
         source_chain_id: ChainId,
         endpoint_hardfork: Option<FoundryHardfork>,
+        header_hardfork: Option<FoundryHardfork>,
     ) -> Self {
-        Self::Historical { source_chain_id, endpoint_hardfork }
+        Self::Historical { source_chain_id, endpoint_hardfork, header_hardfork }
     }
 
     fn endpoint_hardfork(self, networks: NetworkConfigs) -> Option<FoundryHardfork> {
@@ -1465,6 +1503,18 @@ impl ExecutionSpecContext {
             Self::Fork { endpoint_hardfork, .. } if networks.active_network_name().is_some() => {
                 endpoint_hardfork
             }
+            Self::Local | Self::Fork { .. } => None,
+        }
+    }
+
+    /// Returns the hardfork implied by the source block header.
+    ///
+    /// Only historical execution uses it: it must reproduce the source block, while a local fork
+    /// deliberately keeps Foundry's configured EVM version so tests run at the version their
+    /// contracts were compiled for.
+    const fn header_hardfork(self) -> Option<FoundryHardfork> {
+        match self {
+            Self::Historical { header_hardfork, .. } => header_hardfork,
             Self::Local | Self::Fork { .. } => None,
         }
     }
@@ -1485,7 +1535,10 @@ impl ExecutionSpecContext {
 /// A direct caller override takes precedence over a configured namespaced hardfork, followed by
 /// exact endpoint metadata and the hardfork selected from the source schedule. Local Ethereum
 /// forks retain Foundry's configured EVM version, namespaced local networks follow their source
-/// identity, and historical execution always follows the source block's identity.
+/// identity, and historical execution always follows the source block's identity. When no
+/// schedule covers the source chain, historical execution falls back to the hardfork implied by
+/// the source block header instead of Foundry's own default, which would otherwise run a chain
+/// ahead of the fork it is actually on.
 ///
 /// Returns the exact namespaced hardfork, when applicable, so execution and trace decoding can use
 /// the same hardfork.
@@ -1514,6 +1567,7 @@ where
             )
         })
         .filter(|&hardfork| supports(hardfork));
+    let header_hardfork = context.header_hardfork().filter(|&hardfork| supports(hardfork));
     let fallback_hardfork = if networks.is_tempo() {
         Some(FoundryHardfork::Tempo(config.evm_spec_id::<TempoHardfork>()))
     } else {
@@ -1529,7 +1583,11 @@ where
     let resolved_hardfork = if explicit_spec.is_some() {
         explicit_hardfork
     } else {
-        configured_hardfork.or(endpoint_hardfork).or(timestamp_hardfork).or(fallback_hardfork)
+        configured_hardfork
+            .or(endpoint_hardfork)
+            .or(timestamp_hardfork)
+            .or(fallback_hardfork)
+            .or(header_hardfork)
     };
     let spec = explicit_spec
         .or_else(|| resolved_hardfork.and_then(SPEC::from_foundry_hardfork))
@@ -1608,6 +1666,7 @@ async fn option_try_or_else<T, E>(
 
 #[cfg(test)]
 mod tests {
+    use alloy_hardforks::EthereumHardfork;
     use alloy_network::TransactionBuilder;
     use alloy_primitives::bytes;
     use alloy_rpc_types::TransactionRequest;
@@ -1630,6 +1689,7 @@ mod tests {
             network_profile: NetworkConfigs::default(),
             block_number,
             hardfork: None,
+            header_hardfork: None,
             instance_id: None,
             source_fork_block_number: None,
             source_fork_block_hash: None,
@@ -1666,6 +1726,7 @@ mod tests {
             network_profile: NetworkConfigs::default(),
             block_number: 10,
             hardfork: None,
+            header_hardfork: None,
             instance_id: None,
             source_fork_block_number: None,
             source_fork_block_hash: None,
@@ -1841,6 +1902,7 @@ mod tests {
             network_profile: identity.network_profile,
             block_number: 123,
             hardfork: identity.hardfork,
+            header_hardfork: None,
             instance_id: identity.instance_id,
             source_fork_block_number: identity.source_fork_block_number,
             source_fork_block_hash: identity.source_fork_block_hash,
@@ -2077,13 +2139,100 @@ mod tests {
                 &config,
                 NetworkConfigs::default(),
                 &mut env,
-                ExecutionSpecContext::historical(NamedChain::Mainnet as u64, None),
+                ExecutionSpecContext::historical(NamedChain::Mainnet as u64, None, None),
                 None,
                 None,
             ),
             Some(expected)
         );
         assert_eq!(env.cfg_env.spec, SpecId::from(expected));
+    }
+
+    #[test]
+    fn resolve_execution_spec_falls_back_to_header_hardfork_for_unknown_chains() {
+        // Hyperliquid is not covered by any activation schedule Foundry knows about.
+        let unknown_chain_id = 999;
+        let config = Config::default();
+        let header_hardfork = Some(FoundryHardfork::Ethereum(EthereumHardfork::Cancun));
+        let mut env = EvmEnv::new(CfgEnv::new_with_spec(SpecId::LONDON), BlockEnv::default());
+
+        assert_eq!(
+            resolve_execution_spec(
+                &config,
+                NetworkConfigs::default(),
+                &mut env,
+                ExecutionSpecContext::historical(unknown_chain_id, None, header_hardfork),
+                None,
+                None,
+            ),
+            header_hardfork
+        );
+        assert_eq!(env.cfg_env.spec, SpecId::CANCUN);
+
+        // Without header evidence the configured EVM version still applies.
+        let mut env = EvmEnv::new(CfgEnv::new_with_spec(SpecId::LONDON), BlockEnv::default());
+        assert_eq!(
+            resolve_execution_spec(
+                &config,
+                NetworkConfigs::default(),
+                &mut env,
+                ExecutionSpecContext::historical(unknown_chain_id, None, None),
+                None,
+                None,
+            ),
+            None
+        );
+        assert_eq!(env.cfg_env.spec, config.evm_spec_id::<SpecId>());
+    }
+
+    #[test]
+    fn resolve_execution_spec_prefers_source_schedule_over_header_hardfork() {
+        let config = Config::default();
+        let timestamp = 1_500_000_000u64;
+        let expected =
+            FoundryHardfork::from_chain_and_timestamp(NamedChain::Mainnet as u64, timestamp)
+                .unwrap();
+        let mut block = BlockEnv::default();
+        block.set_timestamp(U256::from(timestamp));
+        let mut env = EvmEnv::new(CfgEnv::new_with_spec(SpecId::LONDON), block);
+
+        assert_eq!(
+            resolve_execution_spec(
+                &config,
+                NetworkConfigs::default(),
+                &mut env,
+                ExecutionSpecContext::historical(
+                    NamedChain::Mainnet as u64,
+                    None,
+                    Some(FoundryHardfork::Ethereum(EthereumHardfork::Cancun)),
+                ),
+                None,
+                None,
+            ),
+            Some(expected)
+        );
+        assert_eq!(env.cfg_env.spec, SpecId::from(expected));
+    }
+
+    #[test]
+    fn resolve_execution_spec_ignores_header_hardfork_for_local_forks() {
+        // Local forks deliberately keep the configured EVM version so tests run at the version
+        // their contracts were compiled for.
+        let config = Config::default();
+        let mut env = EvmEnv::new(CfgEnv::new_with_spec(SpecId::LONDON), BlockEnv::default());
+
+        assert_eq!(
+            resolve_execution_spec(
+                &config,
+                NetworkConfigs::default(),
+                &mut env,
+                ExecutionSpecContext::fork(999, None),
+                None,
+                None,
+            ),
+            None
+        );
+        assert_eq!(env.cfg_env.spec, config.evm_spec_id::<SpecId>());
     }
 
     #[test]

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -273,30 +273,7 @@ pub struct ForkContext {
     pub source_fork_block_hash: Option<B256>,
 }
 
-/// The hardfork evidence a fork endpoint and its fork block provide.
-///
-/// Kept together so callers cannot mix up two same-typed hardfork options.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct ForkHardforks {
-    /// Exact hardfork reported by the fork endpoint, when available.
-    pub endpoint: Option<FoundryHardfork>,
-    /// Hardfork implied by the fork block header, when its mandatory fields identify one.
-    pub header: Option<FoundryHardfork>,
-}
-
-impl ForkHardforks {
-    /// Returns the evidence for an endpoint that reported an exact hardfork.
-    pub const fn from_endpoint(endpoint: Option<FoundryHardfork>) -> Self {
-        Self { endpoint, header: None }
-    }
-}
-
 impl ForkContext {
-    /// Returns the hardfork evidence this fork provides.
-    pub const fn hardforks(self) -> ForkHardforks {
-        ForkHardforks { endpoint: self.hardfork, header: self.header_hardfork }
-    }
-
     /// Returns whether this block context belongs to `identity`.
     pub fn matches_identity(self, identity: &ForkEndpointIdentity) -> bool {
         self.execution_chain_id == identity.execution_chain_id
@@ -1495,6 +1472,16 @@ impl ExecutionSpecContext {
         header_hardfork: Option<FoundryHardfork>,
     ) -> Self {
         Self::Historical { source_chain_id, endpoint_hardfork, header_hardfork }
+    }
+
+    /// Returns the historical execution context for a block fetched from a resolved fork,
+    /// carrying the fork's endpoint and header hardfork evidence.
+    pub const fn historical_from_fork(context: ForkContext) -> Self {
+        Self::Historical {
+            source_chain_id: context.source_chain_id,
+            endpoint_hardfork: context.hardfork,
+            header_hardfork: context.header_hardfork,
+        }
     }
 
     fn endpoint_hardfork(self, networks: NetworkConfigs) -> Option<FoundryHardfork> {

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -30,6 +30,17 @@ pub fn block_env_from_header<BLOCK: FoundryBlock + Default>(header: &impl BlockH
     block
 }
 
+/// Returns the Ethereum hardfork a block header pins its chain to, when the mandatory header
+/// fields identify one.
+///
+/// Cancun made `excessBlobGas` mandatory and Prague made `requestsHash` mandatory, so a header
+/// that carries blob gas without a requests hash proves the chain runs Cancun. Every other header
+/// shape is ambiguous, so this returns `None` and leaves the caller on its own default.
+pub fn ethereum_hardfork_from_header(header: &impl BlockHeader) -> Option<EthereumHardfork> {
+    (header.excess_blob_gas().is_some() && header.requests_hash().is_none())
+        .then_some(EthereumHardfork::Cancun)
+}
+
 /// Applies chain-specific changes required to replay transactions accepted on-chain.
 pub fn apply_chain_specific_tx_replay_env_changes<SPEC, BLOCK>(evm_env: &mut EvmEnv<SPEC, BLOCK>) {
     let chain_id = evm_env.cfg_env.chain_id;
@@ -323,6 +334,24 @@ mod tests {
             get_blob_base_fee_update_fraction_by_spec_id(SpecId::AMSTERDAM),
             BlobParams::bpo2().update_fraction as u64
         );
+    }
+
+    #[test]
+    fn ethereum_hardfork_from_header_identifies_cancun_only_chains() {
+        // Blob fields without a requests hash pin the chain to Cancun.
+        let cancun = AnyHeader { excess_blob_gas: Some(0), ..Default::default() };
+        assert_eq!(ethereum_hardfork_from_header(&cancun), Some(EthereumHardfork::Cancun));
+
+        // A requests hash means Prague or later, which the header cannot narrow down.
+        let prague = AnyHeader {
+            excess_blob_gas: Some(0),
+            requests_hash: Some(B256::ZERO),
+            ..Default::default()
+        };
+        assert_eq!(ethereum_hardfork_from_header(&prague), None);
+
+        // Pre-Cancun headers carry no blob fields and stay ambiguous.
+        assert_eq!(ethereum_hardfork_from_header(&AnyHeader::default()), None);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -1,5 +1,5 @@
 use crate::executors::{Executor, ExecutorBuilder};
-use alloy_primitives::{Address, ChainId, U256, map::HashMap};
+use alloy_primitives::{Address, U256, map::HashMap};
 use alloy_rpc_types::state::StateOverride;
 use eyre::{Context, ContextCompat};
 use foundry_compilers::artifacts::EvmVersion;
@@ -8,7 +8,7 @@ use foundry_evm_core::{
     backend::Backend,
     evm::{BlockEnvFor, EvmEnvFor, FoundryEvmNetwork, SpecFor, TxEnvFor},
     fork::CreateFork,
-    opts::{EvmOpts, ExecutionSpecContext, ForkHardforks, resolve_execution_spec},
+    opts::{EvmOpts, ExecutionSpecContext, ForkContext, resolve_execution_spec},
 };
 use foundry_evm_hardforks::{FoundryHardfork, TempoHardfork};
 use foundry_evm_networks::NetworkConfigs;
@@ -78,29 +78,11 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         self.executor.spec_id()
     }
 
-    /// Resolves and applies the execution spec for the effective block environment.
+    /// Resolves and applies the execution spec for the given execution context.
     pub fn resolve_spec(
         config: &Config,
         networks: NetworkConfigs,
-        evm_env: &mut EvmEnvFor<FEN>,
-        evm_version: Option<EvmVersion>,
-    ) -> Option<FoundryHardfork> {
-        Self::resolve_spec_for_chain(
-            config,
-            networks,
-            evm_env.cfg_env.chain_id,
-            ForkHardforks::default(),
-            evm_env,
-            evm_version,
-        )
-    }
-
-    /// Resolves and applies the execution spec using the source chain's hardfork schedule.
-    pub fn resolve_spec_for_chain(
-        config: &Config,
-        networks: NetworkConfigs,
-        source_chain_id: ChainId,
-        hardforks: ForkHardforks,
+        spec_context: ExecutionSpecContext,
         evm_env: &mut EvmEnvFor<FEN>,
         evm_version: Option<EvmVersion>,
     ) -> Option<FoundryHardfork> {
@@ -110,7 +92,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
             config,
             networks,
             evm_env,
-            ExecutionSpecContext::historical(source_chain_id, hardforks.endpoint, hardforks.header),
+            spec_context,
             evm_version.map(evm_spec_id::<SpecFor<FEN>>),
             explicit_hardfork,
         )
@@ -129,14 +111,8 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
     pub async fn get_fork_material(
         config: &mut Config,
         mut evm_opts: EvmOpts,
-    ) -> eyre::Result<(
-        EvmEnvFor<FEN>,
-        TxEnvFor<FEN>,
-        CreateFork,
-        Chain,
-        NetworkConfigs,
-        ForkHardforks,
-    )> {
+    ) -> eyre::Result<(EvmEnvFor<FEN>, TxEnvFor<FEN>, CreateFork, Chain, NetworkConfigs, ForkContext)>
+    {
         evm_opts.fork_url = Some(config.get_rpc_url_or_localhost_http()?.into_owned());
         evm_opts.fork_block_number = config.fork_block_number;
         evm_opts.infer_network_from_fork().await?;
@@ -150,7 +126,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         let fork_context = resolved.context();
 
         let chain = fork_context.source_chain_id.into();
-        Ok((evm_env, tx_env, fork, chain, networks, fork_context.hardforks()))
+        Ok((evm_env, tx_env, fork, chain, networks, fork_context))
     }
 }
 

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -8,7 +8,7 @@ use foundry_evm_core::{
     backend::Backend,
     evm::{BlockEnvFor, EvmEnvFor, FoundryEvmNetwork, SpecFor, TxEnvFor},
     fork::CreateFork,
-    opts::{EvmOpts, ExecutionSpecContext, resolve_execution_spec},
+    opts::{EvmOpts, ExecutionSpecContext, ForkHardforks, resolve_execution_spec},
 };
 use foundry_evm_hardforks::{FoundryHardfork, TempoHardfork};
 use foundry_evm_networks::NetworkConfigs;
@@ -89,7 +89,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
             config,
             networks,
             evm_env.cfg_env.chain_id,
-            None,
+            ForkHardforks::default(),
             evm_env,
             evm_version,
         )
@@ -100,7 +100,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         config: &Config,
         networks: NetworkConfigs,
         source_chain_id: ChainId,
-        endpoint_hardfork: Option<FoundryHardfork>,
+        hardforks: ForkHardforks,
         evm_env: &mut EvmEnvFor<FEN>,
         evm_version: Option<EvmVersion>,
     ) -> Option<FoundryHardfork> {
@@ -110,7 +110,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
             config,
             networks,
             evm_env,
-            ExecutionSpecContext::historical(source_chain_id, endpoint_hardfork),
+            ExecutionSpecContext::historical(source_chain_id, hardforks.endpoint, hardforks.header),
             evm_version.map(evm_spec_id::<SpecFor<FEN>>),
             explicit_hardfork,
         )
@@ -135,7 +135,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         CreateFork,
         Chain,
         NetworkConfigs,
-        Option<FoundryHardfork>,
+        ForkHardforks,
     )> {
         evm_opts.fork_url = Some(config.get_rpc_url_or_localhost_http()?.into_owned());
         evm_opts.fork_block_number = config.fork_block_number;
@@ -150,7 +150,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         let fork_context = resolved.context();
 
         let chain = fork_context.source_chain_id.into();
-        Ok((evm_env, tx_env, fork, chain, networks, fork_context.hardfork))
+        Ok((evm_env, tx_env, fork, chain, networks, fork_context.hardforks()))
     }
 }
 

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -34,7 +34,7 @@ use foundry_evm::{
         },
     },
     executors::TracingExecutor,
-    opts::EvmOpts,
+    opts::{EvmOpts, ForkHardforks},
     traces::TraceRequirements,
     utils::{apply_chain_and_block_specific_env_changes_for_chain, block_env_from_header},
 };
@@ -334,20 +334,15 @@ where
     fork_config.fork_block_number = Some(fork_blk_num);
 
     let create2_deployer = evm_opts.create2_deployer;
-    let (mut evm_env, tx_env, fork, chain, networks, endpoint_hardfork) =
+    let (mut evm_env, tx_env, fork, chain, networks, hardforks) =
         TracingExecutor::<FEN>::get_fork_material(fork_config, evm_opts).await?;
 
     evm_env.block_env.set_number(U256::from(execution_blk_num));
     if let Some(block) = execution_block {
         configure_env_block::<FEN>(&mut evm_env, block, chain.id(), networks);
     }
-    let resolved_hardfork = resolve_runtime_spec::<FEN>(
-        fork_config,
-        networks,
-        chain.id(),
-        endpoint_hardfork,
-        &mut evm_env,
-    );
+    let resolved_hardfork =
+        resolve_runtime_spec::<FEN>(fork_config, networks, chain.id(), hardforks, &mut evm_env);
     TracingExecutor::<FEN>::extend_precompile_labels(fork_config, networks, resolved_hardfork);
 
     let executor = TracingExecutor::<FEN>::new(
@@ -367,7 +362,7 @@ fn resolve_runtime_spec<FEN>(
     config: &Config,
     networks: NetworkConfigs,
     source_chain_id: ChainId,
-    endpoint_hardfork: Option<FoundryHardfork>,
+    hardforks: ForkHardforks,
     evm_env: &mut EvmEnvFor<FEN>,
 ) -> Option<FoundryHardfork>
 where
@@ -377,7 +372,7 @@ where
         config,
         networks,
         source_chain_id,
-        endpoint_hardfork,
+        hardforks,
         evm_env,
         None,
     )
@@ -669,7 +664,7 @@ contract Broken {
             &before_config,
             NetworkConfigs::with_monad(),
             NamedChain::Monad as u64,
-            None,
+            ForkHardforks::default(),
             &mut before_env,
         );
 
@@ -689,7 +684,7 @@ contract Broken {
             &after_config,
             NetworkConfigs::with_monad(),
             NamedChain::Monad as u64,
-            None,
+            ForkHardforks::default(),
             &mut after_env,
         );
 
@@ -718,7 +713,9 @@ contract Broken {
             &config,
             networks,
             NamedChain::Monad as u64,
-            Some(foundry_evm::hardforks::MonadHardfork::MonadNine.into()),
+            ForkHardforks::from_endpoint(Some(
+                foundry_evm::hardforks::MonadHardfork::MonadNine.into(),
+            )),
             &mut env,
         );
         TracingExecutor::<foundry_evm::core::evm::MonadEvmNetwork>::extend_precompile_labels(

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -34,7 +34,7 @@ use foundry_evm::{
         },
     },
     executors::TracingExecutor,
-    opts::{EvmOpts, ForkHardforks},
+    opts::{EvmOpts, ExecutionSpecContext},
     traces::TraceRequirements,
     utils::{apply_chain_and_block_specific_env_changes_for_chain, block_env_from_header},
 };
@@ -334,15 +334,19 @@ where
     fork_config.fork_block_number = Some(fork_blk_num);
 
     let create2_deployer = evm_opts.create2_deployer;
-    let (mut evm_env, tx_env, fork, chain, networks, hardforks) =
+    let (mut evm_env, tx_env, fork, chain, networks, fork_context) =
         TracingExecutor::<FEN>::get_fork_material(fork_config, evm_opts).await?;
 
     evm_env.block_env.set_number(U256::from(execution_blk_num));
     if let Some(block) = execution_block {
         configure_env_block::<FEN>(&mut evm_env, block, chain.id(), networks);
     }
-    let resolved_hardfork =
-        resolve_runtime_spec::<FEN>(fork_config, networks, chain.id(), hardforks, &mut evm_env);
+    let resolved_hardfork = resolve_runtime_spec::<FEN>(
+        fork_config,
+        networks,
+        ExecutionSpecContext::historical_from_fork(fork_context),
+        &mut evm_env,
+    );
     TracingExecutor::<FEN>::extend_precompile_labels(fork_config, networks, resolved_hardfork);
 
     let executor = TracingExecutor::<FEN>::new(
@@ -361,21 +365,13 @@ where
 fn resolve_runtime_spec<FEN>(
     config: &Config,
     networks: NetworkConfigs,
-    source_chain_id: ChainId,
-    hardforks: ForkHardforks,
+    spec_context: ExecutionSpecContext,
     evm_env: &mut EvmEnvFor<FEN>,
 ) -> Option<FoundryHardfork>
 where
     FEN: FoundryEvmNetwork,
 {
-    TracingExecutor::<FEN>::resolve_spec_for_chain(
-        config,
-        networks,
-        source_chain_id,
-        hardforks,
-        evm_env,
-        None,
-    )
+    TracingExecutor::<FEN>::resolve_spec(config, networks, spec_context, evm_env, None)
 }
 
 pub fn configure_env_block<FEN>(
@@ -663,8 +659,7 @@ contract Broken {
         let before = resolve_runtime_spec::<foundry_evm::core::evm::MonadEvmNetwork>(
             &before_config,
             NetworkConfigs::with_monad(),
-            NamedChain::Monad as u64,
-            ForkHardforks::default(),
+            ExecutionSpecContext::historical(NamedChain::Monad as u64, None, None),
             &mut before_env,
         );
 
@@ -683,8 +678,7 @@ contract Broken {
         let after = resolve_runtime_spec::<foundry_evm::core::evm::MonadEvmNetwork>(
             &after_config,
             NetworkConfigs::with_monad(),
-            NamedChain::Monad as u64,
-            ForkHardforks::default(),
+            ExecutionSpecContext::historical(NamedChain::Monad as u64, None, None),
             &mut after_env,
         );
 
@@ -712,10 +706,11 @@ contract Broken {
         let resolved = resolve_runtime_spec::<foundry_evm::core::evm::MonadEvmNetwork>(
             &config,
             networks,
-            NamedChain::Monad as u64,
-            ForkHardforks::from_endpoint(Some(
-                foundry_evm::hardforks::MonadHardfork::MonadNine.into(),
-            )),
+            ExecutionSpecContext::historical(
+                NamedChain::Monad as u64,
+                Some(foundry_evm::hardforks::MonadHardfork::MonadNine.into()),
+                None,
+            ),
             &mut env,
         );
         TracingExecutor::<foundry_evm::core::evm::MonadEvmNetwork>::extend_precompile_labels(


### PR DESCRIPTION
When no activation schedule covers the forked chain, spec resolution fell through to Foundry's own default EVM version, which is the latest hardfork. Hyperliquid is a good example: chain 999 runs Cancun, but `cast run` and `cast call --trace` executed it at Osaka and `anvil --fork-url` at Bpo1, so a staticcall to `0x0b` resolved the BLS precompile locally while the same call on-chain hits an empty account. `cast run` worked around this with an inline blob-gas check that pinned *any* unknown chain with blob fields to Cancun, including chains already past Prague.

Header fields settle this more precisely. Cancun made `excessBlobGas` mandatory and Prague made `requestsHash` mandatory, so a header carrying blob gas without a requests hash proves the chain is on Cancun. `ethereum_hardfork_from_header` returns that and `None` for every other header shape, which stays ambiguous and keeps the existing behavior. The value is derived once where the fork block is already fetched, carried on `ForkContext`, and consulted last in `resolve_execution_spec` so a configured hardfork, endpoint metadata, and the source schedule all still win. Anvil applies the same fallback in its fork setup, where it previously landed on `EthereumHardfork::default()`.

`ForkContext` carries the derived value because `cast call --trace` is the one consumer with no other access to the header: the fork block is fetched and dropped inside the fork env resolution, and `BlockEnv` cannot substitute since it lacks `requestsHash`. `get_fork_material` now hands the `ForkContext` back directly and spec resolution takes an `ExecutionSpecContext` built from it, so the endpoint and header evidence travel as named fields of existing types instead of a dedicated carrier struct.

Local forks are deliberately unchanged. They keep Foundry's configured EVM version because that is also the version the contracts under test were compiled for, and clamping the EVM below it would break tests whose own bytecode targets a newer fork. A warning when the configured version runs ahead of the forked chain would be a better fit there, and is worth doing separately.

Verified against live chains. Forking Hyperliquid, `anvil_nodeInfo` now reports Cancun instead of Bpo1 and the `0x0b` probe returns `1` from both the node and `cast call --trace`, where it previously returned `0` locally. Forking mainnet is unchanged: Bpo2, probe `0` on both sides, and `cast run` still reproduces receipt gas exactly on both chains.

---

This PR was written by Claude Code, including the investigation behind it and this description. Verified against live Hyperliquid and Ethereum mainnet endpoints as described above.
