### PR TITLE
fix(cast): stop re-validating mined transactions on replay

### DIFF
--- a/.changelog/cast-run-historical-validation.md
+++ b/.changelog/cast-run-historical-validation.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Stopped `cast run` from re-validating mined transactions against the block gas limit and from requiring a parent beacon block root, which made BSC, Polygon and Scroll transactions unreplayable.

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -133,6 +133,8 @@ pub struct RunArgs {
     pub with_local_artifacts: bool,
 
     /// Disable block gas limit check.
+    ///
+    /// Always implied: a mined transaction already passed its chain's own check.
     #[arg(long)]
     pub disable_block_gas_limit: bool,
 
@@ -393,7 +395,11 @@ impl RunArgs {
         )?;
 
         let mut evm_version = self.evm_version;
-        evm_env.cfg_env.disable_block_gas_limit = self.disable_block_gas_limit;
+        // Mined transactions already passed the block gas limit check their chain applies, and
+        // some chains admit transactions whose gas limit exceeds it: BSC validator transactions
+        // carry a gas limit of `i64::MAX`. Re-applying the check can only reject a transaction
+        // the chain accepted.
+        evm_env.cfg_env.disable_block_gas_limit = true;
 
         // By default do not enforce transaction gas limits imposed by Osaka (EIP-7825).
         // Users can opt-in to enable these limits by setting `enable_tx_gas_limit` to true.
@@ -733,11 +739,10 @@ fn parent_beacon_block_root_for_network(
         return Ok(None);
     }
 
-    parent_beacon_block_root.map(Some).ok_or_else(|| {
-        eyre::eyre!(
-            "MissingParentBeaconBlockRoot: missing parent beacon block root for Cancun block"
-        )
-    })
+    // Chains that run a Cancun or later EVM without Ethereum's beacon chain, such as Polygon and
+    // Scroll, never populate this header field and never deploy the EIP-4788 contract, so there
+    // is no root to apply. Requiring one makes their blocks unreplayable.
+    Ok(parent_beacon_block_root)
 }
 
 pub fn fetch_contracts_bytecode_from_trace<FEN: FoundryEvmNetwork>(
@@ -969,10 +974,13 @@ mod tests {
     }
 
     #[test]
-    fn parent_beacon_block_root_is_required_for_cancun() {
+    fn parent_beacon_block_root_is_applied_only_when_the_header_has_one() {
         let networks = NetworkConfigs::default();
-        let err = parent_beacon_block_root_for_network(networks, SpecId::CANCUN, None).unwrap_err();
-        assert!(err.to_string().contains("MissingParentBeaconBlockRoot"));
+        // Polygon and Scroll run a Cancun or later EVM without populating the header field.
+        assert_eq!(
+            parent_beacon_block_root_for_network(networks, SpecId::CANCUN, None).unwrap(),
+            None
+        );
 
         let root = B256::repeat_byte(0x42);
         assert_eq!(

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -471,7 +471,7 @@ impl RunArgs {
         let spec_id = (*evm_env.cfg_env.spec()).into();
 
         if let Some(parent_beacon_block_root) =
-            parent_beacon_block_root_for_network(networks, spec_id, parent_beacon_block_root)?
+            parent_beacon_block_root_for_network(networks, spec_id, parent_beacon_block_root)
         {
             executor.apply_beacon_root(parent_beacon_block_root)?;
         }
@@ -730,19 +730,19 @@ fn ensure_remote_transaction_inclusion(
     Ok(())
 }
 
-fn parent_beacon_block_root_for_network(
+const fn parent_beacon_block_root_for_network(
     networks: NetworkConfigs,
     spec_id: SpecId,
     parent_beacon_block_root: Option<B256>,
-) -> Result<Option<B256>> {
+) -> Option<B256> {
     if networks.is_monad() || !spec_id.is_enabled_in(SpecId::CANCUN) {
-        return Ok(None);
+        return None;
     }
 
     // Chains that run a Cancun or later EVM without Ethereum's beacon chain, such as Polygon and
     // Scroll, never populate this header field and never deploy the EIP-4788 contract, so there
     // is no root to apply. Requiring one makes their blocks unreplayable.
-    Ok(parent_beacon_block_root)
+    parent_beacon_block_root
 }
 
 pub fn fetch_contracts_bytecode_from_trace<FEN: FoundryEvmNetwork>(
@@ -977,24 +977,18 @@ mod tests {
     fn parent_beacon_block_root_is_applied_only_when_the_header_has_one() {
         let networks = NetworkConfigs::default();
         // Polygon and Scroll run a Cancun or later EVM without populating the header field.
-        assert_eq!(
-            parent_beacon_block_root_for_network(networks, SpecId::CANCUN, None).unwrap(),
-            None
-        );
+        assert_eq!(parent_beacon_block_root_for_network(networks, SpecId::CANCUN, None), None);
 
         let root = B256::repeat_byte(0x42);
         assert_eq!(
-            parent_beacon_block_root_for_network(networks, SpecId::CANCUN, Some(root)).unwrap(),
+            parent_beacon_block_root_for_network(networks, SpecId::CANCUN, Some(root)),
             Some(root),
         );
         assert_eq!(
-            parent_beacon_block_root_for_network(networks, SpecId::SHANGHAI, Some(root)).unwrap(),
+            parent_beacon_block_root_for_network(networks, SpecId::SHANGHAI, Some(root)),
             None,
         );
-        assert_eq!(
-            parent_beacon_block_root_for_network(networks, SpecId::SHANGHAI, None).unwrap(),
-            None,
-        );
+        assert_eq!(parent_beacon_block_root_for_network(networks, SpecId::SHANGHAI, None), None,);
     }
 
     #[cfg(feature = "monad")]
@@ -1002,17 +996,13 @@ mod tests {
     fn parent_beacon_block_root_is_not_used_by_monad() {
         let networks = NetworkConfigs::with_monad();
         for spec_id in [SpecId::PRAGUE, SpecId::OSAKA] {
-            assert_eq!(
-                parent_beacon_block_root_for_network(networks, spec_id, None).unwrap(),
-                None,
-            );
+            assert_eq!(parent_beacon_block_root_for_network(networks, spec_id, None), None,);
             assert_eq!(
                 parent_beacon_block_root_for_network(
                     networks,
                     spec_id,
                     Some(B256::repeat_byte(0x42)),
-                )
-                .unwrap(),
+                ),
                 None,
             );
         }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -5160,7 +5160,7 @@ casttest!(block_number_hash, |_prj, cmd| {
 // <https://github.com/foundry-rs/foundry/pull/9996>
 // Equivalent transaction on Binance Smart Chain Testnet:
 // <https://testnet.bscscan.com/tx/0x0db4f279fc4d47dca1e6ace180f45f50c5bf12e2b968f210c217f57031e02744>
-casttest!(run_disable_block_gas_limit_check, |_prj, cmd| {
+casttest!(run_replays_transaction_over_block_gas_limit, |_prj, cmd| {
     let bsc_testnet_rpc_url = next_rpc_endpoint(NamedChain::BinanceSmartChainTestnet);
 
     let latest_block_json: serde_json::Value = serde_json::from_str(
@@ -5182,18 +5182,19 @@ casttest!(run_disable_block_gas_limit_check, |_prj, cmd| {
             let tx_hash =
                 tx.get("hash").and_then(|h| h.as_str()).expect("Transaction missing hash");
 
-            // If --disable-block-gas-limit is not provided, the transaction should fail as the gas
-            // limit exceeds the block gas limit.
+            // The chain accepted this transaction even though its gas limit exceeds the block
+            // gas limit, so replay must not re-apply the check.
             cmd.cast_fuse()
                 .args(["run", "-v", tx_hash, "--quick", "--rpc-url", bsc_testnet_rpc_url.as_str()])
-                .assert_failure()
-                .stderr_eq(str![[r#"
-Error: EVM error; transaction validation error: caller gas limit exceeds the block gas limit
+                .assert_success()
+                .stdout_eq(str![[r#"
+...
+Transaction successfully executed.
+[GAS]
 
 "#]]);
 
-            // If --disable-block-gas-limit is provided, the transaction should succeed
-            // despite the gas limit exceeding the block gas limit.
+            // `--disable-block-gas-limit` is now implied and must not change the outcome.
             cmd.cast_fuse()
                 .args([
                     "run",


### PR DESCRIPTION
`cast run` re-applied two checks that a mined transaction has already passed on-chain, and each one made whole chains unreplayable.

The block gas limit check rejects transactions that some chains admit anyway. BSC validator transactions carry a gas limit of `i64::MAX`, well past the 55M block limit, so replaying one failed with `transaction validation error: caller gas limit exceeds the block gas limit`. Replay now always skips the check, which is what `cast call --trace` already does; `--disable-block-gas-limit` stays accepted and is now implied.

Requiring a parent beacon block root for Cancun bakes in Ethereum's beacon chain. Polygon and Scroll run a Cancun or later EVM without one and never deploy the EIP-4788 contract, so *every* transaction on them failed with `MissingParentBeaconBlockRoot`, at every `--evm-version` from Cancun up — there was no flag that got past it. The root is applied when the header carries one and skipped when it does not, so Ethereum replay is unaffected and chains without a beacon chain simply have no root to apply.

Found by replaying recent blocks on twelve chains and diffing against `eth_getBlockReceipts`. After the change, Scroll transactions replay and match receipt gas exactly, Polygon transactions replay, and Ethereum, Avalanche and Optimism are unchanged.

---

This PR was written by Claude Code, including the survey behind it and this description. Verified against live nodes for each chain named above.
