### PR TITLE
feat(script): warn when a sender cannot cover the run

### DIFF
--- a/.changelog/script-sender-balance-check.md
+++ b/.changelog/script-sender-balance-check.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+`forge script` warns when a sender's balance does not cover the transactions it is about to send, during the simulation that precedes broadcasting.

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -4917,6 +4917,63 @@ contract DeployTempoAA is Script {
     }
 });
 
+// https://github.com/foundry-rs/foundry/issues/12234
+// The warning has to land while the estimate is on screen, before the first transaction goes out,
+// so a sender that cannot pay for the whole run is known upfront rather than after a partial
+// deployment.
+forgetest_async!(script_warns_when_sender_cannot_cover_the_run, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    let script = prj.add_script(
+        "DeployBroke.s.sol",
+        r#"
+import "forge-std/Script.sol";
+
+contract Deployed {}
+
+contract DeployBroke is Script {
+    function run() external {
+        vm.startBroadcast();
+        new Deployed();
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    let sender = handle.dev_wallets().next().unwrap().address();
+    // Enough to pay for a transaction or two, nowhere near enough for the deployment.
+    api.anvil_set_balance(sender, U256::from(1_000)).await.unwrap();
+    let sender = format!("{sender:?}");
+
+    let assert = cmd
+        .arg("script")
+        .arg(&script)
+        .args(["--rpc-url", &rpc, "--sender", &sender, "--unlocked", "--broadcast"])
+        .assert_failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(stderr.contains("the script may run out of funds"), "{stderr}");
+    // The warning prints the checksummed form, the flag took the lowercase one.
+    assert!(stderr.to_lowercase().contains(&sender.to_lowercase()), "{stderr}");
+
+    // A funded sender must not warn.
+    api.anvil_set_balance(
+        handle.dev_wallets().next().unwrap().address(),
+        U256::from(10).pow(U256::from(20)),
+    )
+    .await
+    .unwrap();
+    cmd.forge_fuse();
+    let assert = cmd
+        .arg("script")
+        .arg(&script)
+        .args(["--rpc-url", &rpc, "--sender", &sender, "--unlocked", "--broadcast"])
+        .assert_success();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(!stderr.contains("the script may run out of funds"), "{stderr}");
+});
+
 forgetest_async!(tempo_aa_script_broadcasts_with_local_sponsor, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
     let script = prj.add_script(

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -7,11 +7,12 @@ use crate::{
     broadcast::{BundledState, estimate_gas},
     build::LinkedBuildData,
     execute::{ExecutionArtifacts, ExecutionData, build_trace_decoder_for_context},
+    providers::ProviderInfo,
     sequence::get_commit_hash,
 };
 use alloy_chains::{Chain, NamedChain};
 use alloy_evm::revm::context::Block;
-use alloy_network::TransactionBuilder;
+use alloy_network::{Network, TransactionBuilder};
 use alloy_primitives::{Address, U256, map::HashMap, utils::format_units};
 use alloy_provider::Provider;
 use dialoguer::Confirm;
@@ -20,8 +21,8 @@ use forge_script_sequence::{ScriptSequence, TransactionWithMetadata};
 use foundry_cheatcodes::Wallets;
 use foundry_cli::utils::{has_different_gas_calc, now};
 use foundry_common::{
-    ContractData, ContractsByArtifact, provider::fee::resolve_broadcast_eip1559_fees, shell,
-    tempo::known_fee_token_symbol,
+    ContractData, ContractsByArtifact, provider::fee::resolve_broadcast_eip1559_fees, sh_warn,
+    shell, tempo::known_fee_token_symbol,
 };
 use foundry_evm::{
     core::{FoundryBlock, evm::FoundryEvmNetwork},
@@ -610,6 +611,38 @@ mod tests {
     }
 }
 
+/// Warns about every sender whose balance does not cover the transactions it is about to send.
+///
+/// The check is best effort: it runs on the estimate the simulation just printed, and a balance
+/// that cannot be fetched is not worth failing the run over.
+async fn warn_on_insufficient_balance<N: Network>(
+    provider_info: &ProviderInfo<N>,
+    costs: Option<&HashMap<Address, (u128, U256)>>,
+    per_gas: u128,
+    token_symbol: &str,
+) {
+    let Some(costs) = costs else { return };
+
+    for (sender, (gas, value)) in costs {
+        let required = U256::from(*gas).saturating_mul(U256::from(per_gas)).saturating_add(*value);
+        let Ok(balance) = provider_info.provider.get_balance(*sender).await else { continue };
+        if balance >= required {
+            continue;
+        }
+
+        let fmt = |amount: U256| {
+            format_units(amount, 18).unwrap_or_else(|_| "[Could not calculate]".to_string())
+        };
+        let _ = sh_warn!(
+            "{sender} needs {} {token_symbol} on chain {} but holds {} {token_symbol}; \
+             the script may run out of funds before it finishes",
+            fmt(required),
+            provider_info.chain,
+            fmt(balance),
+        );
+    }
+}
+
 /// At this point we have converted transactions collected during script execution to
 /// [TransactionWithMetadata] objects which contain additional metadata needed for broadcasting and
 /// verification.
@@ -637,6 +670,10 @@ impl<FEN: FoundryEvmNetwork> FilledTransactionsState<FEN> {
         }
 
         let mut total_gas_per_rpc: HashMap<String, u128> = HashMap::default();
+        // What each sender is expected to spend on each rpc, so its balance can be checked before
+        // any transaction goes out.
+        let mut cost_per_sender: HashMap<String, HashMap<Address, (u128, U256)>> =
+            HashMap::default();
 
         // Batches sequence of transactions from different rpcs.
         let mut new_sequence = VecDeque::new();
@@ -699,8 +736,19 @@ impl<FEN: FoundryEvmNetwork> FilledTransactionsState<FEN> {
                     }
                 }
 
+                let gas = tx.gas().expect("gas is set");
                 let total_gas = total_gas_per_rpc.entry(tx_rpc.clone()).or_insert(0);
-                *total_gas += tx.gas().expect("gas is set");
+                *total_gas += gas;
+
+                if let Some(sender) = tx.from() {
+                    let (sender_gas, sender_value) = cost_per_sender
+                        .entry(tx_rpc.clone())
+                        .or_default()
+                        .entry(sender)
+                        .or_insert((0, U256::ZERO));
+                    *sender_gas += gas;
+                    *sender_value += tx.value().unwrap_or_default();
+                }
             }
 
             new_sequence.push_back(tx);
@@ -831,6 +879,22 @@ impl<FEN: FoundryEvmNetwork> FilledTransactionsState<FEN> {
                     sh_println!("\nEstimated total gas used for script: {total_gas}")?;
                     sh_println!("\nEstimated amount required: {estimated_amount} {token_symbol}")?;
                     sh_println!("\n==========================")?;
+                }
+
+                // A sender that cannot cover its share of the run stops it halfway through and
+                // leaves a partial deployment behind, so say so while the estimate is still on
+                // screen and nothing has been broadcast yet. Only when broadcasting: a plain
+                // simulation is routinely run with a placeholder sender that holds nothing, and
+                // warning there would be noise. Tempo pays fees in a TIP-20 token rather than the
+                // native balance, so the comparison does not apply to it.
+                if self.args.broadcast && !self.script_config.evm_opts.networks.is_tempo() {
+                    warn_on_insufficient_balance(
+                        provider_info,
+                        cost_per_sender.get(&rpc),
+                        per_gas,
+                        &token_symbol,
+                    )
+                    .await;
                 }
             }
         }


### PR DESCRIPTION
A script that runs out of funds halfway through leaves a partial deployment behind, and the only signal beforehand is an estimate the user has to compare against a balance by hand.

`bundle()` already computes the total gas per RPC and the price behind the "Estimated amount required" line it prints. This accumulates the same figures per sender, adds the value each one sends, and compares the total against the sender's balance right after the estimate is printed, before the first transaction goes out.

The warning is gated on `--broadcast`. Running it on every simulation was the first version and two existing tests rejected it: a plain simulation is routinely run with a placeholder sender holding nothing, so the warning fired where the user was not spending anything. It still happens during the simulation phase, ahead of any broadcast, which is the point of the check, only now it fires when there is something to lose.

It warns rather than failing, because a script can fund one sender from another mid-sequence and the aggregation here does not model that; a hard error would reject legitimate runs. Turning it into one is a maintainer call. Tempo is skipped, since fees there are paid in a TIP-20 token rather than the native balance, and a balance lookup that fails is not worth aborting a run over.

This covers the balance half of #12234. The Etherscan key check needs an API call per chain in the critical path (the concern raised on #13417) so it belongs in its own change, once the endpoint is agreed on the issue.

Part of #12234