### PR TITLE
test(anvil): add fork smoke tests for popular chains

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,6 +40,12 @@ default-filter = "test(/flaky_/)"
 retries = { backoff = "exponential", count = 5, delay = "10s", jitter = true }
 slow-timeout = { period = "60s", terminate-after = 3 }
 
+# The fork smoke tests report an unreachable endpoint by skipping instead of failing, so keep
+# their output on success to show which chains a run actually exercised.
+[[profile.flaky.overrides]]
+filter = "test(/fork_chains::/)"
+success-output = "final"
+
 # Profile for the on-chain deploy+verify tests (used by the nightly test-deploy-verify workflow).
 # Requires <NETWORK>_RPC_URL plus TESTNET_DEPLOYER_PRIVATE_KEY to do anything.
 # Run with: cargo nextest run --profile deploy-verify

--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -50,6 +50,7 @@ jobs:
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
           ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
           ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
+          CELO_RPC: ${{ secrets.CELO_RPC }}
           GNOSIS_RPC: ${{ secrets.GNOSIS_RPC }}
           HYPERLIQUID_RPC: ${{ secrets.HYPERLIQUID_RPC }}
           ROBINHOOD_RPC: ${{ secrets.ROBINHOOD_RPC }}

--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -50,6 +50,9 @@ jobs:
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
           ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
           ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
+          GNOSIS_RPC: ${{ secrets.GNOSIS_RPC }}
+          HYPERLIQUID_RPC: ${{ secrets.HYPERLIQUID_RPC }}
+          ROBINHOOD_RPC: ${{ secrets.ROBINHOOD_RPC }}
         run: cargo nextest run --locked --profile flaky --no-fail-fast
 
   # If any of the jobs fail, this will create a normal-priority issue to signal so.

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -2405,11 +2405,13 @@ async fn flaky_test_arb_fork_mining() {
 // <https://github.com/foundry-rs/foundry/issues/6749>
 #[tokio::test(flavor = "multi_thread")]
 async fn flaky_test_arbitrum_fork_block_number() {
+    // Every fork below must observe the same chain head, so reuse one endpoint: providers are a few
+    // blocks apart and refetching would otherwise fork at a block the next provider has not seen.
+    let fork_rpc = next_rpc_endpoint(NamedChain::Arbitrum);
+
     // fork to get initial block for test
     let (_, handle) = spawn(
-        fork_config()
-            .with_fork_block_number(None::<u64>)
-            .with_eth_rpc_url(Some(next_rpc_endpoint(NamedChain::Arbitrum))),
+        fork_config().with_fork_block_number(None::<u64>).with_eth_rpc_url(Some(fork_rpc.clone())),
     )
     .await;
     let provider = handle.http_provider();
@@ -2421,7 +2423,7 @@ async fn flaky_test_arbitrum_fork_block_number() {
     let (api, _) = spawn(
         fork_config()
             .with_fork_block_number(Some(initial_block_number))
-            .with_eth_rpc_url(Some(next_rpc_endpoint(NamedChain::Arbitrum))),
+            .with_eth_rpc_url(Some(fork_rpc.clone())),
     )
     .await;
     let block_number = api.block_number().unwrap().to::<u64>();
@@ -2447,7 +2449,7 @@ async fn flaky_test_arbitrum_fork_block_number() {
 
     // reset fork to different block number and compare with block returned by `eth_blockNumber`
     api.anvil_reset(Some(Forking {
-        json_rpc_url: Some(next_rpc_endpoint(NamedChain::Arbitrum)),
+        json_rpc_url: Some(fork_rpc),
         block_number: Some(initial_block_number - 2),
     }))
     .await

--- a/crates/anvil/tests/it/fork_chains.rs
+++ b/crates/anvil/tests/it/fork_chains.rs
@@ -25,8 +25,8 @@ use std::fmt::{Debug, Display};
 
 /// Highest EIP-2718 transaction type every chain is expected to serve in the standard shape.
 ///
-/// Chain specific system transactions above this range, such as Arbitrum's `0x6a` or OP-stack
-/// deposits, are not part of the surface these tests assert on.
+/// Chain specific transactions above this range, such as Arbitrum's `0x6a`, Celo's CIP-64 `0x7b`,
+/// or OP-stack deposits, are not part of the surface these tests assert on.
 const MAX_STANDARD_TX_TYPE: u8 = 4;
 
 /// Number of blocks scanned back from the fork head when looking for a transaction to round-trip.
@@ -47,6 +47,11 @@ async fn flaky_test_fork_arbitrum() {
 #[tokio::test(flavor = "multi_thread")]
 async fn flaky_test_fork_base() {
     assert_can_fork(NamedChain::Base).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flaky_test_fork_celo() {
+    assert_can_fork(NamedChain::Celo).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/fork_chains.rs
+++ b/crates/anvil/tests/it/fork_chains.rs
@@ -86,7 +86,7 @@ async fn fork_and_assert(chain: NamedChain) -> Option<()> {
     let genesis_balance = config.genesis_balance;
     let (api, handle) = fork_ok(chain, "fork setup", try_spawn(config).await)?;
 
-    assert_eq!(api.chain_id(), chain as u64, "{chain} fork adopted the wrong chain id");
+    assert_eq!(api.chain_id(), chain as u64, "{chain:?} fork adopted the wrong chain id");
 
     let fork_block = api.block_number().unwrap().to::<u64>();
     if fork_block == 0 {
@@ -96,19 +96,19 @@ async fn fork_and_assert(chain: NamedChain) -> Option<()> {
 
     for wallet in handle.dev_wallets() {
         let balance = api.balance(wallet.address(), None).await.unwrap();
-        assert_eq!(balance, genesis_balance, "{chain} fork did not fund the dev accounts");
+        assert_eq!(balance, genesis_balance, "{chain:?} fork did not fund the dev accounts");
     }
 
     let (block_number, tx_hash) = standard_transaction(chain, &api, fork_block).await?;
 
     let tx = fork_ok(chain, "eth_getTransactionByHash", api.transaction_by_hash(tx_hash).await)?
-        .unwrap_or_else(|| panic!("{chain} fork lost transaction {tx_hash}"));
+        .unwrap_or_else(|| panic!("{chain:?} fork lost transaction {tx_hash}"));
     assert_eq!(tx.tx_hash(), tx_hash);
     assert_eq!(tx.block_number, Some(block_number));
 
     let receipt =
         fork_ok(chain, "eth_getTransactionReceipt", api.transaction_receipt(tx_hash).await)?
-            .unwrap_or_else(|| panic!("{chain} fork lost the receipt for {tx_hash}"));
+            .unwrap_or_else(|| panic!("{chain:?} fork lost the receipt for {tx_hash}"));
     assert_eq!(receipt.transaction_hash(), tx_hash);
     assert_eq!(receipt.block_number(), Some(block_number));
 
@@ -133,7 +133,7 @@ async fn standard_transaction(
             api.block_by_number_full(BlockNumberOrTag::Number(number)).await,
         )?;
         let Some(block) = block else { continue };
-        assert_eq!(block.header.number, number, "{chain} fork returned the wrong block");
+        assert_eq!(block.header.number, number, "{chain:?} fork returned the wrong block");
 
         if let Some(transactions) = block.transactions.as_transactions()
             && let Some(tx) = transactions.iter().find(|tx| tx.inner.ty() <= MAX_STANDARD_TX_TYPE)
@@ -154,14 +154,18 @@ fn fork_ok<T, E: ForkError + Debug>(
     match result {
         Ok(value) => Some(value),
         Err(err) if is_endpoint_unavailable(&err) => skip(chain, request, err.render()),
-        Err(err) => panic!("{chain} fork: {request} failed: {err:?}"),
+        Err(err) => panic!("{chain:?} fork: {request} failed: {err:?}"),
     }
 }
 
 /// Reports why a chain's fork test stopped early, so skipped runs stay visible in CI logs.
+///
+/// The flaky nextest profile keeps the output of these tests on success so the report is not
+/// swallowed. Chains are named by their variant rather than their canonical name, which does not
+/// always match, so the line points at the test that produced it.
 #[expect(clippy::disallowed_macros)]
 fn skip<T>(chain: NamedChain, request: &str, reason: impl Display) -> Option<T> {
-    eprintln!("skipping {chain} fork test: {request}: {reason}");
+    eprintln!("skipping {chain:?} fork test: {request}: {reason}");
     None
 }
 

--- a/crates/anvil/tests/it/fork_chains.rs
+++ b/crates/anvil/tests/it/fork_chains.rs
@@ -87,7 +87,10 @@ async fn assert_can_fork(chain: NamedChain) {
 
 /// Runs the fork assertions for `chain`, returning `None` once the endpoint stopped serving.
 async fn fork_and_assert(chain: NamedChain) -> Option<()> {
-    let config = NodeConfig::test().with_eth_rpc_url(Some(next_rpc_endpoint(chain)));
+    // Both forks below must reach the same provider: the Arbitrum endpoints rotate and their heads
+    // are a few blocks apart.
+    let fork_rpc = next_rpc_endpoint(chain);
+    let config = NodeConfig::test().with_eth_rpc_url(Some(fork_rpc.clone()));
     let genesis_balance = config.genesis_balance;
     let (api, handle) = fork_ok(chain, "fork setup", try_spawn(config).await)?;
 
@@ -106,13 +109,22 @@ async fn fork_and_assert(chain: NamedChain) -> Option<()> {
 
     let (block_number, tx_hash) = standard_transaction(chain, &api, fork_block).await?;
 
-    let tx = fork_ok(chain, "eth_getTransactionByHash", api.transaction_by_hash(tx_hash).await)?
-        .unwrap_or_else(|| panic!("{chain:?} fork lost transaction {tx_hash}"));
+    // Selecting the transaction cached the whole block on `api`, which would serve the lookups
+    // below without ever calling the endpoint. Use a fork that has not read that block instead,
+    // so both responses are decoded as the endpoint returns them.
+    let lookup_config = NodeConfig::test()
+        .with_eth_rpc_url(Some(fork_rpc))
+        .with_fork_block_number(Some(fork_block));
+    let (lookup_api, _) = fork_ok(chain, "transaction fork setup", try_spawn(lookup_config).await)?;
+
+    let tx =
+        fork_ok(chain, "eth_getTransactionByHash", lookup_api.transaction_by_hash(tx_hash).await)?
+            .unwrap_or_else(|| panic!("{chain:?} fork lost transaction {tx_hash}"));
     assert_eq!(tx.tx_hash(), tx_hash);
     assert_eq!(tx.block_number, Some(block_number));
 
     let receipt =
-        fork_ok(chain, "eth_getTransactionReceipt", api.transaction_receipt(tx_hash).await)?
+        fork_ok(chain, "eth_getTransactionReceipt", lookup_api.transaction_receipt(tx_hash).await)?
             .unwrap_or_else(|| panic!("{chain:?} fork lost the receipt for {tx_hash}"));
     assert_eq!(receipt.transaction_hash(), tx_hash);
     assert_eq!(receipt.block_number(), Some(block_number));

--- a/crates/anvil/tests/it/fork_chains.rs
+++ b/crates/anvil/tests/it/fork_chains.rs
@@ -1,0 +1,218 @@
+//! Fork tests for popular chains that serve RPC responses differing from Ethereum mainnet.
+//!
+//! Every chain runs through [`assert_can_fork`], so chain specific response shapes such as Arbitrum
+//! Orbit system transactions, OP-stack deposits, or vendor specific header fields are covered by
+//! the same assertions.
+//!
+//! These tests fork from public endpoints and are therefore prefixed with `flaky_` so they only run
+//! in the nightly flaky job. A request the endpoint fails to serve skips the test; a response anvil
+//! cannot decode still fails it, because covering those response shapes is the point.
+
+use alloy_chains::NamedChain;
+use alloy_eips::Typed2718;
+use alloy_network::{ReceiptResponse, TransactionResponse};
+use alloy_primitives::B256;
+use alloy_rpc_types::BlockNumberOrTag;
+use alloy_transport::{RpcError, TransportError};
+use anvil::{
+    NodeConfig,
+    eth::{EthApi, error::BlockchainError},
+    try_spawn,
+};
+use foundry_primitives::FoundryNetwork;
+use foundry_test_utils::rpc::next_rpc_endpoint;
+use std::fmt::{Debug, Display};
+
+/// Highest EIP-2718 transaction type every chain is expected to serve in the standard shape.
+///
+/// Chain specific system transactions above this range, such as Arbitrum's `0x6a` or OP-stack
+/// deposits, are not part of the surface these tests assert on.
+const MAX_STANDARD_TX_TYPE: u8 = 4;
+
+/// Number of blocks scanned back from the fork head when looking for a transaction to round-trip.
+const TRANSACTION_LOOKBACK: u64 = 8;
+
+/// Fragments public endpoints use to report that they refused to serve a request.
+///
+/// Every gateway spells this differently and there is no shared error code, so the rendered error
+/// is matched instead.
+const SERVICE_REFUSALS: &[&str] =
+    &["rate limit", "too many requests", "usage limit", "limit exceeded", "quota", "capacity"];
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flaky_test_fork_arbitrum() {
+    assert_can_fork(NamedChain::Arbitrum).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flaky_test_fork_base() {
+    assert_can_fork(NamedChain::Base).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flaky_test_fork_gnosis() {
+    assert_can_fork(NamedChain::Gnosis).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flaky_test_fork_hyperliquid() {
+    assert_can_fork(NamedChain::Hyperliquid).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flaky_test_fork_optimism() {
+    assert_can_fork(NamedChain::Optimism).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flaky_test_fork_polygon() {
+    assert_can_fork(NamedChain::Polygon).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flaky_test_fork_robinhood() {
+    assert_can_fork(NamedChain::Robinhood).await;
+}
+
+/// Forks `chain` at its latest block and exercises the RPC surface fork mode depends on.
+async fn assert_can_fork(chain: NamedChain) {
+    // A `None` result means the endpoint failed to serve a request; the reason is already reported.
+    let _ = fork_and_assert(chain).await;
+}
+
+/// Runs the fork assertions for `chain`, returning `None` once the endpoint stopped serving.
+async fn fork_and_assert(chain: NamedChain) -> Option<()> {
+    let config = NodeConfig::test().with_eth_rpc_url(Some(next_rpc_endpoint(chain)));
+    let genesis_balance = config.genesis_balance;
+    let (api, handle) = fork_ok(chain, "fork setup", try_spawn(config).await)?;
+
+    assert_eq!(api.chain_id(), chain as u64, "{chain} fork adopted the wrong chain id");
+
+    let fork_block = api.block_number().unwrap().to::<u64>();
+    if fork_block == 0 {
+        // Public endpoints occasionally report block zero while they are unhealthy.
+        return skip(chain, "fork head", "endpoint reported block zero");
+    }
+
+    for wallet in handle.dev_wallets() {
+        let balance = api.balance(wallet.address(), None).await.unwrap();
+        assert_eq!(balance, genesis_balance, "{chain} fork did not fund the dev accounts");
+    }
+
+    let (block_number, tx_hash) = standard_transaction(chain, &api, fork_block).await?;
+
+    let tx = fork_ok(chain, "eth_getTransactionByHash", api.transaction_by_hash(tx_hash).await)?
+        .unwrap_or_else(|| panic!("{chain} fork lost transaction {tx_hash}"));
+    assert_eq!(tx.tx_hash(), tx_hash);
+    assert_eq!(tx.block_number, Some(block_number));
+
+    let receipt =
+        fork_ok(chain, "eth_getTransactionReceipt", api.transaction_receipt(tx_hash).await)?
+            .unwrap_or_else(|| panic!("{chain} fork lost the receipt for {tx_hash}"));
+    assert_eq!(receipt.transaction_hash(), tx_hash);
+    assert_eq!(receipt.block_number(), Some(block_number));
+
+    // Local mining continues from the forked head.
+    api.mine_one().await.unwrap();
+    assert_eq!(api.block_number().unwrap().to::<u64>(), fork_block + 1);
+
+    Some(())
+}
+
+/// Returns the block number and hash of a transaction with a standard EIP-2718 type, searching
+/// backwards from the fork head.
+async fn standard_transaction(
+    chain: NamedChain,
+    api: &EthApi<FoundryNetwork>,
+    head: u64,
+) -> Option<(u64, B256)> {
+    for number in (head.saturating_sub(TRANSACTION_LOOKBACK)..=head).rev() {
+        let block = fork_ok(
+            chain,
+            "eth_getBlockByNumber",
+            api.block_by_number_full(BlockNumberOrTag::Number(number)).await,
+        )?;
+        let Some(block) = block else { continue };
+        assert_eq!(block.header.number, number, "{chain} fork returned the wrong block");
+
+        if let Some(transactions) = block.transactions.as_transactions()
+            && let Some(tx) = transactions.iter().find(|tx| tx.inner.ty() <= MAX_STANDARD_TX_TYPE)
+        {
+            return Some((number, tx.tx_hash()));
+        }
+    }
+
+    skip(chain, "transaction lookup", "no standard transaction near the fork head")
+}
+
+/// Unwraps a fork response, returning `None` once the endpoint failed to serve the request.
+fn fork_ok<T, E: ForkError + Debug>(
+    chain: NamedChain,
+    request: &str,
+    result: Result<T, E>,
+) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(err) if is_endpoint_unavailable(&err) => skip(chain, request, err.render()),
+        Err(err) => panic!("{chain} fork: {request} failed: {err:?}"),
+    }
+}
+
+/// Reports why a chain's fork test stopped early, so skipped runs stay visible in CI logs.
+#[expect(clippy::disallowed_macros)]
+fn skip<T>(chain: NamedChain, request: &str, reason: impl Display) -> Option<T> {
+    eprintln!("skipping {chain} fork test: {request}: {reason}");
+    None
+}
+
+/// An error raised while exercising a public fork endpoint.
+trait ForkError {
+    /// Returns the transport error the fork endpoint reported, if this error still carries one.
+    fn transport_error(&self) -> Option<&TransportError>;
+
+    /// Renders the error together with its causes.
+    fn render(&self) -> String;
+}
+
+impl ForkError for eyre::Report {
+    fn transport_error(&self) -> Option<&TransportError> {
+        self.downcast_ref::<TransportError>()
+    }
+
+    fn render(&self) -> String {
+        format!("{self:#}")
+    }
+}
+
+impl ForkError for BlockchainError {
+    fn transport_error(&self) -> Option<&TransportError> {
+        match self {
+            Self::AlloyForkProvider(err) => Some(err),
+            _ => None,
+        }
+    }
+
+    fn render(&self) -> String {
+        self.to_string()
+    }
+}
+
+/// Returns whether the fork endpoint failed to serve the request at all.
+///
+/// Connection failures and refusals mean the endpoint never answered, which public endpoints do
+/// often enough that failing on them would turn these tests into noise. Everything else stays a
+/// failure, in particular a response anvil cannot decode.
+fn is_endpoint_unavailable(err: &impl ForkError) -> bool {
+    match err.transport_error() {
+        // The endpoint never answered.
+        Some(RpcError::Transport(_)) => return true,
+        // A response anvil could not decode is the shape mismatch these tests exist to catch.
+        Some(RpcError::DeserError { .. }) => return false,
+        // Fork state fetches render the endpoint's response into their message instead of keeping
+        // the transport error, so refusals are matched on the rendered error.
+        _ => {}
+    }
+
+    let rendered = err.render().to_lowercase();
+    SERVICE_REFUSALS.iter().any(|refusal| rendered.contains(refusal))
+}

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -8,6 +8,7 @@ mod eip4844;
 mod eip7702;
 mod eip7928;
 mod fork;
+mod fork_chains;
 mod gas;
 mod genesis;
 mod ipc;

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -4,7 +4,8 @@ use alloy_primitives::B256;
 use axum::{Json, Router, http::StatusCode, response::IntoResponse, routing::post};
 use foundry_config::{
     NamedChain::{
-        self, Arbitrum, Base, BinanceSmartChainTestnet, Celo, Mainnet, Optimism, Polygon, Sepolia,
+        self, Arbitrum, Base, BinanceSmartChainTestnet, Celo, Gnosis, Hyperliquid, Mainnet,
+        Optimism, Polygon, Robinhood, Sepolia,
     },
     RpcEndpointUrl, RpcEndpoints,
 };
@@ -192,19 +193,32 @@ fn next_url_inner(is_ws: bool, chain: NamedChain) -> String {
         return "https://celo.drpc.org".to_string();
     }
 
+    if matches!(chain, Gnosis) {
+        return env_rpc_url("GNOSIS_RPC")
+            .unwrap_or_else(|| "https://rpc.gnosischain.com".to_string());
+    }
+
+    if matches!(chain, Hyperliquid) {
+        return env_rpc_url("HYPERLIQUID_RPC")
+            .unwrap_or_else(|| "https://rpc.hyperliquid.xyz/evm".to_string());
+    }
+
+    if matches!(chain, Robinhood) {
+        return env_rpc_url("ROBINHOOD_RPC")
+            .unwrap_or_else(|| "https://rpc.mainnet.chain.robinhood.com".to_string());
+    }
+
     if matches!(chain, Sepolia) {
-        let rpc_url = env::var("ETH_SEPOLIA_RPC").unwrap_or_default();
-        if !rpc_url.is_empty() {
+        if let Some(rpc_url) = env_rpc_url("ETH_SEPOLIA_RPC") {
             return rpc_url;
         }
         return "https://ethereum-sepolia-rpc.publicnode.com".to_string();
     }
 
-    if matches!(chain, Arbitrum) {
-        let rpc_url = env::var("ARBITRUM_RPC").unwrap_or_default();
-        if !rpc_url.is_empty() {
-            return rpc_url;
-        }
+    if matches!(chain, Arbitrum)
+        && let Some(rpc_url) = env_rpc_url("ARBITRUM_RPC")
+    {
+        return rpc_url;
     }
 
     let reth_works = true;
@@ -224,6 +238,11 @@ fn next_url_inner(is_ws: bool, chain: NamedChain) -> String {
     };
 
     if is_ws { format!("wss://{domain}") } else { format!("https://{domain}") }
+}
+
+/// Returns the RPC URL configured in the `var` environment variable, if it is set and non-empty.
+fn env_rpc_url(var: &str) -> Option<String> {
+    env::var(var).ok().filter(|url| !url.is_empty())
 }
 
 /// Basic redaction for debugging RPC URLs.

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -205,7 +205,9 @@ fn next_url_inner(is_ws: bool, chain: NamedChain) -> String {
     }
 
     if matches!(chain, Celo) {
-        return "https://celo.drpc.org".to_string();
+        // Not `celo.drpc.org`: it load balances across upstreams that disagree on the chain head,
+        // so a fork of it regularly fails to fetch the block it just resolved.
+        return env_rpc_url("CELO_RPC").unwrap_or_else(|| "https://forno.celo.org".to_string());
     }
 
     if matches!(chain, Gnosis) {

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -73,6 +73,21 @@ shuffled_list!(
     ],
 );
 
+// Public Arbitrum endpoints, rotated so that a retry reaches a different provider.
+//
+// Every entry must serve archive state: `fork::flaky_test_arb_fork_mining` forks at a pinned block
+// far behind the head, which non-archive endpoints such as `arb1.arbitrum.io` reject with
+// `missing trie node`. The DRPC keys used for the other chains do not qualify: their Arbitrum quota
+// is exhausted and every fork of it fails.
+shuffled_list!(
+    ARBITRUM_URLS,
+    vec![
+        //
+        "https://arb-pokt.nodies.app",
+        "https://arbitrum.gateway.tenderly.co",
+    ],
+);
+
 // List of general purpose DRPC keys to rotate through
 shuffled_list!(
     DRPC_KEYS,
@@ -215,10 +230,8 @@ fn next_url_inner(is_ws: bool, chain: NamedChain) -> String {
         return "https://ethereum-sepolia-rpc.publicnode.com".to_string();
     }
 
-    if matches!(chain, Arbitrum)
-        && let Some(rpc_url) = env_rpc_url("ARBITRUM_RPC")
-    {
-        return rpc_url;
+    if matches!(chain, Arbitrum) {
+        return env_rpc_url("ARBITRUM_RPC").unwrap_or_else(|| (*ARBITRUM_URLS.next()).to_string());
     }
 
     let reth_works = true;
@@ -230,7 +243,6 @@ fn next_url_inner(is_ws: bool, chain: NamedChain) -> String {
         let network = match chain {
             Mainnet => "ethereum",
             Polygon => "polygon",
-            Arbitrum => "arbitrum",
             Sepolia => "sepolia",
             _ => "",
         };


### PR DESCRIPTION
Anvil had no fork coverage for Gnosis, HyperEVM, Robinhood Chain, Celo, or Polygon, and only narrow coverage for Arbitrum and Base, so the response shapes these chains serve were effectively untested. Robinhood Chain is an Arbitrum Orbit chain, HyperEVM sends back a zeroed state root on latest blocks, and Celo mixes OP-stack deposits with CIP-64 fee-currency transactions — exactly the kind of difference that should be caught by a test rather than a bug report.

The new `fork_chains` module runs every chain through one helper. It forks at the latest block and then checks the chain id, that the dev accounts are funded, that a full block round-trips, that a transaction and its receipt decode, and that local mining continues from the forked head. Only transactions with a standard EIP-2718 type are round-tripped, so chain specific system transactions such as Arbitrum's `0x6a` or OP-stack deposits stay out of scope. Anvil cannot decode receipts for either Arbitrum's `0x6a` or Celo's CIP-64 `0x7b`, which also breaks `eth_getBlockReceipts` for most blocks on those chains: #16465 covers the Arbitrum side and #16482 tracks Celo. Raising `MAX_STANDARD_TX_TYPE` in `fork_chains.rs` reproduces both through these tests once they are fixed.

The tests talk to public endpoints, so they are prefixed with `flaky_` and only run in the nightly flaky job. A request the endpoint fails to serve — a dead connection or a usage limit — skips the test with the reason printed; a response anvil cannot decode still fails it, since covering those shapes is the point. Because nextest swallows the output of passing tests, the flaky profile keeps the output of these tests on success, so each nightly run states which chains it actually exercised. Gnosis, HyperEVM, and Robinhood Chain get default public endpoints in `foundry-test-utils`, each overridable through `GNOSIS_RPC`, `HYPERLIQUID_RPC`, and `ROBINHOOD_RPC` the same way Arbitrum and Sepolia already are. Celo moves to `forno.celo.org` under a new `CELO_RPC`, because `celo.drpc.org` load balances across upstreams that disagree on the chain head and fails to fetch the block it just resolved in roughly half of local attempts.

Arbitrum needed the same treatment for a different reason. Its only endpoint was DRPC, whose Arbitrum quota is exhausted; CI does not notice because the flaky workflow supplies `ARBITRUM_RPC` from a secret, but pinned to DRPC three of the four Arbitrum fork tests fail outright locally. It now rotates over two public endpoints verified to serve archive state at the block `flaky_test_arb_fork_mining` pins — archive access is the binding constraint and rules out most public endpoints, including the official `arb1.arbitrum.io`, which answers `missing trie node`. `flaky_test_arbitrum_fork_block_number` resolves its endpoint once as part of that: it forks three times and every fork has to observe the same chain head, which stops holding once each call can reach a different provider. Over three local runs of the four Arbitrum fork tests, 12 of 12 passed with one retry, against 2 of 8 when pinned to DRPC.

A manual dispatch of the nightly flaky workflow on this branch passed 79 of 79, with the first seven new tests green: https://github.com/foundry-rs/foundry/actions/runs/33262204803

This is test-only, so it needs the `L-ignore` label rather than a changelog entry.

