### PR TITLE
fix(anvil): gate access list by hash on fork ancestry

### DIFF
--- a/.changelog/anvil-fork-block-access-list-by-hash.md
+++ b/.changelog/anvil-fork-block-access-list-by-hash.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed `eth_getBlockAccessListByBlockHash` forwarding locally mined block hashes to the forked upstream node.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2625,15 +2625,17 @@ impl EthApi<FoundryNetwork> {
         block_hash: B256,
     ) -> Result<Option<serde_json::Value>> {
         node_info!("eth_getBlockAccessListByBlockHash");
-        let Some(block) = self.backend.block_by_hash(block_hash).await? else { return Ok(None) };
+        let Some(fork) = self.get_fork() else { return Ok(None) };
 
-        if let Some(fork) = self.get_fork()
-            && fork.predates_fork_inclusive(block.header.number)
+        // Only blocks we know to be mined after the fork point are guaranteed to be unknown
+        // upstream. Anything else, including hashes we cannot resolve locally, is left to the fork.
+        if let Some(block) = self.backend.get_block_by_hash(block_hash)
+            && !fork.predates_fork_inclusive(block.header.number)
         {
-            return Ok(fork.block_access_list_by_hash(block_hash).await?);
+            return Ok(None);
         }
 
-        Ok(None)
+        Ok(fork.block_access_list_by_hash(block_hash).await?)
     }
 
     /// Returns the EIP-7928 block access list for a block number.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2625,9 +2625,14 @@ impl EthApi<FoundryNetwork> {
         block_hash: B256,
     ) -> Result<Option<serde_json::Value>> {
         node_info!("eth_getBlockAccessListByBlockHash");
-        if let Some(fork) = self.get_fork() {
+        let Some(block) = self.backend.block_by_hash(block_hash).await? else { return Ok(None) };
+
+        if let Some(fork) = self.get_fork()
+            && fork.predates_fork_inclusive(block.header.number)
+        {
             return Ok(fork.block_access_list_by_hash(block_hash).await?);
         }
+
         Ok(None)
     }
 

--- a/crates/anvil/tests/it/eip7928.rs
+++ b/crates/anvil/tests/it/eip7928.rs
@@ -1,0 +1,50 @@
+//! EIP-7928 block access list tests.
+
+use alloy_rpc_types::BlockNumberOrTag;
+use anvil::{NodeConfig, spawn};
+use foundry_test_utils::rpc::spawn_rpc_proxy_canned_method;
+use serde_json::json;
+use std::sync::atomic::Ordering;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_block_access_list_skips_locally_mined_blocks() {
+    let (_origin_api, origin) = spawn(NodeConfig::test()).await;
+    let (fork_url, upstream_calls) = spawn_rpc_proxy_canned_method(
+        origin.http_endpoint(),
+        "eth_getBlockAccessListByBlockNumber",
+        json!({"blockAccessList": []}),
+    )
+    .await;
+    let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
+
+    api.mine_one().await.unwrap();
+    let number = api.block_number().unwrap().to::<u64>();
+    assert!(number > 0, "expected a locally mined block");
+
+    let access_list =
+        api.block_access_list_by_number(BlockNumberOrTag::Number(number)).await.unwrap();
+
+    assert_eq!(access_list, None);
+    assert_eq!(upstream_calls.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_block_access_list_by_hash_skips_locally_mined_blocks() {
+    let (_origin_api, origin) = spawn(NodeConfig::test()).await;
+    let (fork_url, upstream_calls) = spawn_rpc_proxy_canned_method(
+        origin.http_endpoint(),
+        "eth_getBlockAccessListByBlockHash",
+        json!({"blockAccessList": []}),
+    )
+    .await;
+    let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
+
+    api.mine_one().await.unwrap();
+    let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert!(block.header.number > 0, "expected a locally mined block");
+
+    let access_list = api.block_access_list_by_hash(block.header.hash).await.unwrap();
+
+    assert_eq!(access_list, None);
+    assert_eq!(upstream_calls.load(Ordering::Relaxed), 0);
+}

--- a/crates/anvil/tests/it/eip7928.rs
+++ b/crates/anvil/tests/it/eip7928.rs
@@ -1,5 +1,6 @@
 //! EIP-7928 block access list tests.
 
+use alloy_primitives::B256;
 use alloy_rpc_types::BlockNumberOrTag;
 use anvil::{NodeConfig, spawn};
 use foundry_test_utils::rpc::spawn_rpc_proxy_canned_method;
@@ -47,4 +48,21 @@ async fn test_fork_block_access_list_by_hash_skips_locally_mined_blocks() {
 
     assert_eq!(access_list, None);
     assert_eq!(upstream_calls.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_block_access_list_by_hash_forwards_unknown_blocks() {
+    let (_origin_api, origin) = spawn(NodeConfig::test()).await;
+    let (fork_url, upstream_calls) = spawn_rpc_proxy_canned_method(
+        origin.http_endpoint(),
+        "eth_getBlockAccessListByBlockHash",
+        json!({"blockAccessList": []}),
+    )
+    .await;
+    let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
+
+    let access_list = api.block_access_list_by_hash(B256::random()).await.unwrap();
+
+    assert_eq!(access_list, Some(json!({"blockAccessList": []})));
+    assert_eq!(upstream_calls.load(Ordering::Relaxed), 1);
 }

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -6,6 +6,7 @@ mod beacon_api;
 mod eip2935;
 mod eip4844;
 mod eip7702;
+mod eip7928;
 mod fork;
 mod gas;
 mod genesis;

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -346,6 +346,55 @@ pub async fn spawn_rpc_proxy_internal_error_after(
     .await
 }
 
+/// Spawns an RPC proxy that answers `method` with `result` instead of forwarding it upstream.
+///
+/// All other methods are forwarded. The returned counter tracks how many `method` calls reached the
+/// proxy, which lets tests assert that a request was never sent upstream.
+pub async fn spawn_rpc_proxy_canned_method(
+    endpoint: String,
+    method: &'static str,
+    result: Value,
+) -> (String, Arc<AtomicUsize>) {
+    let client = reqwest::Client::new();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let proxy_calls = calls.clone();
+    let router = Router::new().route(
+        "/",
+        post(move |Json(request): Json<Value>| {
+            let client = client.clone();
+            let endpoint = endpoint.clone();
+            let calls = proxy_calls.clone();
+            let result = result.clone();
+            async move {
+                if request.get("method").and_then(Value::as_str) == Some(method) {
+                    calls.fetch_add(1, Ordering::Relaxed);
+                    let id = request.get("id").cloned().unwrap_or(Value::Null);
+                    return Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": result,
+                    }));
+                }
+
+                let response = client
+                    .post(endpoint)
+                    .json(&request)
+                    .send()
+                    .await
+                    .unwrap()
+                    .json::<Value>()
+                    .await
+                    .unwrap();
+                Json(response)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    (format!("http://{address}"), calls)
+}
+
 #[derive(Clone)]
 enum RpcMethodRejection {
     Before(usize),


### PR DESCRIPTION
`eth_getBlockAccessListByBlockHash` forwarded every request to the forked upstream node whenever a fork was configured, without checking whether the requested block predates the fork point. A hash for a block mined locally after the fork was sent upstream to a node that has never seen it, so the caller got the upstream's answer instead of null. The three sibling endpoints already gate on `predates_fork_inclusive`; this one did not.

The gate short-circuits on the one case that is actually provable: a block present in anvil's local storage whose number is after the fork point. Pre-fork blocks and hashes that do not resolve locally still forward, so anvil never claims authority over a block it has not seen. The lookup reads local storage directly rather than going through `Backend::block_by_hash`, which would have consulted the fork just to learn the number.

Tests cover the locally mined skip on both the hash and number endpoints, plus an unresolvable hash still reaching upstream. They fork one anvil from another through a counting proxy that answers the access-list method with a canned non-null result. The canned result is what makes the assertions meaningful: a plain anvil upstream returns null for this method itself, so a forwarded call would otherwise be indistinguishable from a skipped one.

This PR was written primarily by Claude Code.
