### PR TITLE
test(anvil): cover untested RPC endpoints

### DIFF
--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1970,3 +1970,99 @@ async fn can_get_default_base_fee_tempo_t0() {
         "T0 base fee should be 10 billion attodollars"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_automine_state() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+
+    assert!(api.anvil_get_auto_mine().unwrap());
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+    assert!(!api.anvil_get_auto_mine().unwrap());
+
+    // Interval mining is a separate mode and also reports automining as disabled.
+    api.anvil_set_interval_mining(1).unwrap();
+    assert!(!api.anvil_get_auto_mine().unwrap());
+
+    api.anvil_set_auto_mine(true).await.unwrap();
+    assert!(api.anvil_get_auto_mine().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_drop_all_transactions() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let provider = handle.http_provider();
+    let sender = handle.dev_wallets().next().unwrap().address();
+
+    for nonce in 0..3u64 {
+        api.send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .with_from(sender)
+                .with_to(Address::repeat_byte(0x22))
+                .with_value(U256::from(1))
+                .with_nonce(nonce),
+        ))
+        .await
+        .unwrap();
+    }
+    assert_eq!(provider.txpool_status().await.unwrap().pending, 3);
+
+    api.anvil_drop_all_transactions().await.unwrap();
+
+    let status = provider.txpool_status().await.unwrap();
+    assert_eq!(status.pending, 0);
+    assert_eq!(status.queued, 0);
+
+    // Dropping an empty pool is a no-op rather than an error.
+    api.anvil_drop_all_transactions().await.unwrap();
+
+    // The chain did not advance as a result of dropping.
+    assert_eq!(provider.get_block_number().await.unwrap(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_send_unsigned_transaction() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    // Any address can send, without a signer and without impersonating it first.
+    let sender = Address::repeat_byte(0x77);
+    let recipient = Address::repeat_byte(0x88);
+    api.anvil_set_balance(sender, U256::from(1e18 as u64)).await.unwrap();
+
+    // Mine explicitly: the handler returns as soon as the transaction is pooled.
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let hash = api
+        .eth_send_unsigned_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .with_from(sender)
+                .with_to(recipient)
+                .with_value(U256::from(1234)),
+        ))
+        .await
+        .unwrap();
+    api.mine_one().await.unwrap();
+
+    let receipt = provider.get_transaction_receipt(hash).await.unwrap().unwrap();
+    assert!(receipt.status());
+    assert_eq!(receipt.from, sender);
+    assert_eq!(provider.get_balance(recipient).await.unwrap(), U256::from(1234));
+    assert_eq!(provider.get_transaction_count(sender).await.unwrap(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn send_unsigned_transaction_requires_a_sender() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+
+    let err = api
+        .eth_send_unsigned_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .with_to(Address::repeat_byte(0x99))
+                .with_value(U256::from(1)),
+        ))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("No signer available"), "unexpected error: {err}");
+}

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -9,7 +9,7 @@ use alloy_chains::NamedChain;
 use alloy_consensus::{SignableTransaction, TxEip1559};
 use alloy_eips::eip2718::Decodable2718;
 use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder, TxSignerSync};
-use alloy_primitives::{Address, Bytes, TxKind, U256, address, b256, fixed_bytes, keccak256};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256, fixed_bytes, keccak256};
 use alloy_provider::{Provider, ext::TxPoolApi};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, TransactionRequest,
@@ -1973,19 +1973,25 @@ async fn can_get_default_base_fee_tempo_t0() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_automine_state() {
-    let (api, _handle) = spawn(NodeConfig::test()).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
 
-    assert!(api.anvil_get_auto_mine().unwrap());
+    // Queried over RPC so the request name, parameter handling and dispatch arm are covered too,
+    // not just the handler.
+    let automine =
+        async || provider.client().request_noparams::<bool>("anvil_getAutomine").await.unwrap();
+
+    assert!(automine().await);
 
     api.anvil_set_auto_mine(false).await.unwrap();
-    assert!(!api.anvil_get_auto_mine().unwrap());
+    assert!(!automine().await);
 
     // Interval mining is a separate mode and also reports automining as disabled.
     api.anvil_set_interval_mining(1).unwrap();
-    assert!(!api.anvil_get_auto_mine().unwrap());
+    assert!(!automine().await);
 
     api.anvil_set_auto_mine(true).await.unwrap();
-    assert!(api.anvil_get_auto_mine().unwrap());
+    assert!(automine().await);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2009,14 +2015,14 @@ async fn can_drop_all_transactions() {
     }
     assert_eq!(provider.txpool_status().await.unwrap().pending, 3);
 
-    api.anvil_drop_all_transactions().await.unwrap();
+    let _: () = provider.client().request_noparams("anvil_dropAllTransactions").await.unwrap();
 
     let status = provider.txpool_status().await.unwrap();
     assert_eq!(status.pending, 0);
     assert_eq!(status.queued, 0);
 
     // Dropping an empty pool is a no-op rather than an error.
-    api.anvil_drop_all_transactions().await.unwrap();
+    let _: () = provider.client().request_noparams("anvil_dropAllTransactions").await.unwrap();
 
     // The chain did not advance as a result of dropping.
     assert_eq!(provider.get_block_number().await.unwrap(), 0);
@@ -2034,13 +2040,17 @@ async fn can_send_unsigned_transaction() {
 
     // Mine explicitly: the handler returns as soon as the transaction is pooled.
     api.anvil_set_auto_mine(false).await.unwrap();
-    let hash = api
-        .eth_send_unsigned_transaction(WithOtherFields::new(
-            TransactionRequest::default()
-                .with_from(sender)
-                .with_to(recipient)
-                .with_value(U256::from(1234)),
-        ))
+    let hash: B256 = provider
+        .client()
+        .request(
+            "eth_sendUnsignedTransaction",
+            (WithOtherFields::new(
+                TransactionRequest::default()
+                    .with_from(sender)
+                    .with_to(recipient)
+                    .with_value(U256::from(1234)),
+            ),),
+        )
         .await
         .unwrap();
     api.mine_one().await.unwrap();
@@ -2054,15 +2064,22 @@ async fn can_send_unsigned_transaction() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn send_unsigned_transaction_requires_a_sender() {
-    let (api, _handle) = spawn(NodeConfig::test()).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
 
-    let err = api
-        .eth_send_unsigned_transaction(WithOtherFields::new(
-            TransactionRequest::default()
-                .with_to(Address::repeat_byte(0x99))
-                .with_value(U256::from(1)),
-        ))
+    let err = provider
+        .client()
+        .request::<_, B256>(
+            "eth_sendUnsignedTransaction",
+            (WithOtherFields::new(
+                TransactionRequest::default()
+                    .with_to(Address::repeat_byte(0x99))
+                    .with_value(U256::from(1)),
+            ),),
+        )
         .await
         .unwrap_err();
-    assert!(err.to_string().contains("No signer available"), "unexpected error: {err}");
+    let err = err.as_error_resp().unwrap();
+    assert_eq!(err.code, -32602);
+    assert!(err.message.contains("No Signer available"), "unexpected error: {err}");
 }

--- a/crates/anvil/tests/it/block_index.rs
+++ b/crates/anvil/tests/it/block_index.rs
@@ -1,0 +1,195 @@
+//! Tests for the block-and-index transaction and uncle endpoints.
+//!
+//! Anvil never produces uncles, so the uncle endpoints exist for compatibility and forward to the
+//! forked node for blocks that predate the fork.
+
+use crate::utils::http_provider_with_signer;
+use alloy_network::{EthereumWallet, TransactionBuilder};
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_provider::Provider;
+use alloy_rpc_types::{BlockNumberOrTag, Index, TransactionRequest};
+use alloy_serde::WithOtherFields;
+use anvil::{NodeConfig, spawn};
+use foundry_test_utils::rpc::spawn_rpc_proxy_canned_method;
+use serde_json::{Value, json};
+use std::sync::atomic::Ordering;
+
+/// Mines a block holding a single transfer and returns its hash, number and transaction hash.
+async fn mine_block_with_transfer(handle: &anvil::NodeHandle) -> (B256, u64, B256) {
+    let wallet = handle.dev_wallets().next().unwrap();
+    let sender = wallet.address();
+    let signer: EthereumWallet = wallet.into();
+    let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
+
+    let receipt = provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .with_from(sender)
+                .with_to(Address::repeat_byte(0x11))
+                .with_value(U256::from(1)),
+        ))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    let block = provider.get_block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    (block.header.hash, block.header.number, receipt.transaction_hash)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn transaction_by_block_hash_and_index_matches_the_mined_transaction() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let (block_hash, _number, tx_hash) = mine_block_with_transfer(&handle).await;
+    let provider = handle.http_provider();
+
+    let tx: Option<Value> = provider
+        .client()
+        .request("eth_getTransactionByBlockHashAndIndex", (block_hash, Index::from(0)))
+        .await
+        .unwrap();
+    let tx = tx.expect("expected a transaction at index 0");
+    assert_eq!(tx["hash"].as_str().unwrap().parse::<B256>().unwrap(), tx_hash);
+
+    // Indexing past the end of the block is not an error.
+    let missing: Option<Value> = provider
+        .client()
+        .request("eth_getTransactionByBlockHashAndIndex", (block_hash, Index::from(1)))
+        .await
+        .unwrap();
+    assert_eq!(missing, None);
+
+    let unknown_block: Option<Value> = provider
+        .client()
+        .request("eth_getTransactionByBlockHashAndIndex", (B256::random(), Index::from(0)))
+        .await
+        .unwrap();
+    assert_eq!(unknown_block, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn raw_transaction_by_block_and_index_matches_by_hash() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let (block_hash, number, tx_hash) = mine_block_with_transfer(&handle).await;
+    let provider = handle.http_provider();
+
+    let expected: Option<Bytes> =
+        provider.client().request("eth_getRawTransactionByHash", (tx_hash,)).await.unwrap();
+    let expected = expected.expect("expected a raw transaction");
+
+    let by_hash: Option<Bytes> = provider
+        .client()
+        .request("eth_getRawTransactionByBlockHashAndIndex", (block_hash, Index::from(0)))
+        .await
+        .unwrap();
+    assert_eq!(by_hash, Some(expected.clone()));
+
+    let by_number: Option<Bytes> = provider
+        .client()
+        .request(
+            "eth_getRawTransactionByBlockNumberAndIndex",
+            (BlockNumberOrTag::Number(number), Index::from(0)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(by_number, Some(expected));
+
+    // Out-of-range indices report no transaction rather than failing.
+    let missing: Option<Bytes> = provider
+        .client()
+        .request(
+            "eth_getRawTransactionByBlockNumberAndIndex",
+            (BlockNumberOrTag::Number(number), Index::from(7)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn uncle_endpoints_report_no_uncles() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    api.mine_one().await.unwrap();
+    let block = provider.get_block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    let (hash, number) = (block.header.hash, block.header.number);
+
+    let count: U256 =
+        provider.client().request("eth_getUncleCountByBlockHash", (hash,)).await.unwrap();
+    assert_eq!(count, U256::ZERO);
+
+    let count: U256 = provider
+        .client()
+        .request("eth_getUncleCountByBlockNumber", (BlockNumberOrTag::Number(number),))
+        .await
+        .unwrap();
+    assert_eq!(count, U256::ZERO);
+
+    let uncle: Option<Value> = provider
+        .client()
+        .request("eth_getUncleByBlockHashAndIndex", (hash, Index::from(0)))
+        .await
+        .unwrap();
+    assert_eq!(uncle, None);
+
+    let uncle: Option<Value> = provider
+        .client()
+        .request(
+            "eth_getUncleByBlockNumberAndIndex",
+            (BlockNumberOrTag::Number(number), Index::from(0)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(uncle, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn uncle_count_rejects_unknown_blocks() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    // `BlockNotFound` surfaces as the JSON-RPC resource-not-found code.
+    let err = provider
+        .client()
+        .request::<_, U256>("eth_getUncleCountByBlockHash", (B256::random(),))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("Resource not found"), "unexpected error: {err}");
+
+    let err = provider
+        .client()
+        .request::<_, U256>("eth_getUncleCountByBlockNumber", (BlockNumberOrTag::Number(9999),))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("Resource not found"), "unexpected error: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_uncle_by_index_skips_locally_mined_blocks() {
+    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let (proxy, calls) = spawn_rpc_proxy_canned_method(
+        origin_handle.http_endpoint(),
+        "eth_getUncleByBlockNumberAndIndex",
+        json!(null),
+    )
+    .await;
+
+    let (api, handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(proxy))).await;
+    let provider = handle.http_provider();
+
+    api.mine_one().await.unwrap();
+    let local = provider.get_block_number().await.unwrap();
+
+    let uncle: Option<Value> = provider
+        .client()
+        .request(
+            "eth_getUncleByBlockNumberAndIndex",
+            (BlockNumberOrTag::Number(local), Index::from(0)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(uncle, None);
+    assert_eq!(calls.load(Ordering::Relaxed), 0, "locally mined block should not be forwarded");
+}

--- a/crates/anvil/tests/it/block_index.rs
+++ b/crates/anvil/tests/it/block_index.rs
@@ -156,14 +156,14 @@ async fn uncle_count_rejects_unknown_blocks() {
         .request::<_, U256>("eth_getUncleCountByBlockHash", (B256::random(),))
         .await
         .unwrap_err();
-    assert!(err.to_string().contains("Resource not found"), "unexpected error: {err}");
+    assert_eq!(err.as_error_resp().unwrap().code, -32001);
 
     let err = provider
         .client()
         .request::<_, U256>("eth_getUncleCountByBlockNumber", (BlockNumberOrTag::Number(9999),))
         .await
         .unwrap_err();
-    assert!(err.to_string().contains("Resource not found"), "unexpected error: {err}");
+    assert_eq!(err.as_error_resp().unwrap().code, -32001);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/eip7928.rs
+++ b/crates/anvil/tests/it/eip7928.rs
@@ -1,11 +1,105 @@
 //! EIP-7928 block access list tests.
+//!
+//! Anvil does not build block access lists itself; the endpoints exist for fork compatibility and
+//! forward to the forked node for blocks that predate the fork. Everything else answers `null`.
 
-use alloy_primitives::B256;
-use alloy_rpc_types::BlockNumberOrTag;
+use alloy_network::Network;
+use alloy_primitives::{B256, Bytes};
+use alloy_provider::Provider;
+use alloy_rpc_types::{BlockId, BlockNumberOrTag};
 use anvil::{NodeConfig, spawn};
 use foundry_test_utils::rpc::spawn_rpc_proxy_canned_method;
-use serde_json::json;
+use serde_json::{Value, json};
 use std::sync::atomic::Ordering;
+
+/// The four endpoints, paired with the params each takes for a block that exists.
+async fn assert_all_null<N: Network>(provider: &impl Provider<N>, hash: B256, number: u64) {
+    let by_id: Option<Value> = provider
+        .client()
+        .request("eth_getBlockAccessList", (BlockId::number(number),))
+        .await
+        .unwrap();
+    assert_eq!(by_id, None);
+
+    let by_hash: Option<Value> =
+        provider.client().request("eth_getBlockAccessListByBlockHash", (hash,)).await.unwrap();
+    assert_eq!(by_hash, None);
+
+    let by_number: Option<Value> = provider
+        .client()
+        .request("eth_getBlockAccessListByBlockNumber", (BlockNumberOrTag::Number(number),))
+        .await
+        .unwrap();
+    assert_eq!(by_number, None);
+
+    let raw: Option<Bytes> = provider
+        .client()
+        .request("eth_getBlockAccessListRaw", (BlockId::number(number),))
+        .await
+        .unwrap();
+    assert_eq!(raw, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn block_access_list_is_null_without_a_fork() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    api.mine_one().await.unwrap();
+    let block = provider.get_block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+
+    assert_all_null(&provider, block.header.hash, block.header.number).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn block_access_list_rejects_out_of_range_blocks() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    // Block resolution happens before the fork check, so an out-of-range number is an error
+    // rather than a `null` access list.
+    for method in ["eth_getBlockAccessList", "eth_getBlockAccessListRaw"] {
+        let err = provider
+            .client()
+            .request::<_, Option<Value>>(method, (BlockId::number(9999),))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("BlockOutOfRangeError"), "{method}: unexpected {err}");
+    }
+
+    // An unknown hash has no range to check and simply reports no access list.
+    let by_hash: Option<Value> = provider
+        .client()
+        .request("eth_getBlockAccessListByBlockHash", (B256::random(),))
+        .await
+        .unwrap();
+    assert_eq!(by_hash, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_block_access_list_forwards_pre_fork_blocks() {
+    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let canned = json!({ "blockAccessList": [] });
+    let (proxy, calls) = spawn_rpc_proxy_canned_method(
+        origin_handle.http_endpoint(),
+        "eth_getBlockAccessList",
+        canned.clone(),
+    )
+    .await;
+
+    let (_api, handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(proxy))).await;
+    let provider = handle.http_provider();
+
+    // The fork block itself predates the fork, so the request reaches the upstream node.
+    let fork_block = provider.get_block_number().await.unwrap();
+    let forwarded: Option<Value> = provider
+        .client()
+        .request("eth_getBlockAccessList", (BlockId::number(fork_block),))
+        .await
+        .unwrap();
+    assert_eq!(forwarded, Some(canned));
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_block_access_list_skips_locally_mined_blocks() {

--- a/crates/anvil/tests/it/filter.rs
+++ b/crates/anvil/tests/it/filter.rs
@@ -1,0 +1,182 @@
+//! Tests for the polling-based `eth_*Filter` RPC surface.
+//!
+//! Log filter *changes* are covered in [`crate::logs`]; these tests cover filter installation,
+//! draining, `eth_getFilterLogs`, uninstallation, and the error paths for unknown ids.
+
+use crate::{abi::SimpleStorage, utils::http_provider_with_signer};
+use alloy_network::EthereumWallet;
+use alloy_primitives::B256;
+use alloy_provider::Provider;
+use alloy_rpc_types::{BlockNumberOrTag, Filter, Log};
+use anvil::{NodeConfig, spawn};
+
+/// An id that was never handed out by `eth_new*Filter`.
+const UNKNOWN_FILTER_ID: &str = "0xdeadbeefdeadbeefdeadbeefdeadbeef";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn block_filter_drains_new_block_hashes() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let filter_id: String = provider.client().request_noparams("eth_newBlockFilter").await.unwrap();
+
+    // A filter installed on an idle node has nothing to report yet.
+    let changes: Vec<B256> =
+        provider.client().request("eth_getFilterChanges", (filter_id.clone(),)).await.unwrap();
+    assert!(changes.is_empty(), "expected no blocks before mining, got {changes:?}");
+
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
+
+    let changes: Vec<B256> =
+        provider.client().request("eth_getFilterChanges", (filter_id.clone(),)).await.unwrap();
+    let mut expected = Vec::new();
+    for number in [1u64, 2] {
+        let block =
+            provider.get_block_by_number(BlockNumberOrTag::Number(number)).await.unwrap().unwrap();
+        expected.push(block.header.hash);
+    }
+    assert_eq!(changes, expected);
+
+    // Polling drains the filter: the same blocks are not reported twice.
+    let changes: Vec<B256> =
+        provider.client().request("eth_getFilterChanges", (filter_id,)).await.unwrap();
+    assert!(changes.is_empty(), "expected drained filter, got {changes:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn new_filter_seeds_historic_logs_only_with_from_block() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+
+    let wallet = handle.dev_wallets().next().unwrap();
+    let signer: EthereumWallet = wallet.into();
+    let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
+
+    // The constructor emits a `ValueChanged` log before either filter is installed.
+    let contract =
+        SimpleStorage::deploy(provider.clone(), "initial value".to_string()).await.unwrap();
+
+    // A filter with a past `fromBlock` replays the logs that predate it.
+    let historic =
+        Filter::new().address(*contract.address()).from_block(BlockNumberOrTag::Earliest);
+    let historic_id: String =
+        provider.client().request("eth_newFilter", (historic,)).await.unwrap();
+
+    // A filter without a block range only reports logs emitted from now on.
+    let live = Filter::new().address(*contract.address());
+    let live_id: String = provider.client().request("eth_newFilter", (live,)).await.unwrap();
+
+    let changes: Vec<Log> =
+        provider.client().request("eth_getFilterChanges", (historic_id,)).await.unwrap();
+    assert_eq!(changes.len(), 1, "expected the constructor log to be replayed");
+
+    let changes: Vec<Log> =
+        provider.client().request("eth_getFilterChanges", (live_id,)).await.unwrap();
+    assert!(changes.is_empty(), "expected no historic logs, got {changes:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_filter_logs_ignores_poll_position() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+
+    let wallet = handle.dev_wallets().next().unwrap();
+    let account = wallet.address();
+    let signer: EthereumWallet = wallet.into();
+    let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
+
+    let contract =
+        SimpleStorage::deploy(provider.clone(), "initial value".to_string()).await.unwrap();
+
+    let filter = Filter::new().address(*contract.address()).from_block(BlockNumberOrTag::Earliest);
+    let filter_id: String = provider.client().request("eth_newFilter", (filter,)).await.unwrap();
+
+    contract
+        .setValue("hi".to_string())
+        .from(account)
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    // Drain the filter so that a subsequent `eth_getFilterChanges` would report nothing.
+    let changes: Vec<Log> =
+        provider.client().request("eth_getFilterChanges", (filter_id.clone(),)).await.unwrap();
+    assert_eq!(changes.len(), 2, "expected the constructor and `setValue` logs");
+
+    let changes: Vec<Log> =
+        provider.client().request("eth_getFilterChanges", (filter_id.clone(),)).await.unwrap();
+    assert!(changes.is_empty(), "expected drained filter, got {changes:?}");
+
+    // `eth_getFilterLogs` re-evaluates the filter instead of continuing from the poll position.
+    let logs: Vec<Log> =
+        provider.client().request("eth_getFilterLogs", (filter_id,)).await.unwrap();
+    assert_eq!(logs.len(), 2, "expected all matching logs regardless of prior polling");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_filter_logs_rejects_non_log_filters() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let block_filter: String =
+        provider.client().request_noparams("eth_newBlockFilter").await.unwrap();
+    let err = provider
+        .client()
+        .request::<_, Vec<Log>>("eth_getFilterLogs", (block_filter,))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("filter not found"), "unexpected error: {err}");
+
+    let pending_filter: String =
+        provider.client().request("eth_newPendingTransactionFilter", (false,)).await.unwrap();
+    let err = provider
+        .client()
+        .request::<_, Vec<Log>>("eth_getFilterLogs", (pending_filter,))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("filter not found"), "unexpected error: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn uninstall_filter_reports_whether_a_filter_was_removed() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let filter_id: String = provider.client().request_noparams("eth_newBlockFilter").await.unwrap();
+
+    let removed: bool =
+        provider.client().request("eth_uninstallFilter", (filter_id.clone(),)).await.unwrap();
+    assert!(removed);
+
+    // Uninstalling twice is not an error, but reports that nothing was removed.
+    let removed: bool =
+        provider.client().request("eth_uninstallFilter", (filter_id.clone(),)).await.unwrap();
+    assert!(!removed);
+
+    let removed: bool =
+        provider.client().request("eth_uninstallFilter", (UNKNOWN_FILTER_ID,)).await.unwrap();
+    assert!(!removed);
+
+    // An uninstalled filter can no longer be polled.
+    let err = provider
+        .client()
+        .request::<_, Vec<B256>>("eth_getFilterChanges", (filter_id,))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("filter not found"), "unexpected error: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_filter_changes_rejects_unknown_ids() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let err = provider
+        .client()
+        .request::<_, Vec<B256>>("eth_getFilterChanges", (UNKNOWN_FILTER_ID,))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("filter not found"), "unexpected error: {err}");
+}

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -3,6 +3,7 @@ mod anvil;
 mod anvil_api;
 mod api;
 mod beacon_api;
+mod block_index;
 mod eip2935;
 mod eip4844;
 mod eip7702;
@@ -25,6 +26,7 @@ mod sign;
 mod simulate;
 #[cfg(feature = "cmd")]
 mod state;
+mod storage_values;
 mod tempo;
 mod traces;
 mod transaction;

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -7,6 +7,7 @@ mod eip2935;
 mod eip4844;
 mod eip7702;
 mod eip7928;
+mod filter;
 mod fork;
 mod gas;
 mod genesis;

--- a/crates/anvil/tests/it/storage_values.rs
+++ b/crates/anvil/tests/it/storage_values.rs
@@ -1,0 +1,171 @@
+//! Tests for the `eth_getStorageValues` batch storage endpoint.
+
+use alloy_primitives::{Address, B256, U256, map::HashMap};
+use alloy_provider::Provider;
+use alloy_rpc_types::BlockId;
+use anvil::{NodeConfig, spawn};
+use foundry_test_utils::rpc::spawn_rpc_proxy_canned_method;
+use std::sync::atomic::Ordering;
+
+fn slot(n: u64) -> B256 {
+    B256::from(U256::from(n))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn storage_values_batches_multiple_accounts() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let first = Address::repeat_byte(0x01);
+    let second = Address::repeat_byte(0x02);
+    api.anvil_set_storage_at(first, U256::from(0), B256::with_last_byte(0xaa)).await.unwrap();
+    api.anvil_set_storage_at(first, U256::from(1), B256::with_last_byte(0xbb)).await.unwrap();
+    api.anvil_set_storage_at(second, U256::from(0), B256::with_last_byte(0xcc)).await.unwrap();
+
+    let requests = HashMap::<Address, Vec<B256>>::from_iter([
+        (first, vec![slot(0), slot(1), slot(2)]),
+        (second, vec![slot(0)]),
+    ]);
+    let values: HashMap<Address, Vec<B256>> = provider
+        .client()
+        .request("eth_getStorageValues", (requests, BlockId::latest()))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        values[&first],
+        vec![B256::with_last_byte(0xaa), B256::with_last_byte(0xbb), B256::ZERO],
+        "unset slots read as zero"
+    );
+    assert_eq!(values[&second], vec![B256::with_last_byte(0xcc)]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn storage_values_rejects_more_than_1024_slots() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let address = Address::repeat_byte(0x03);
+
+    let at_limit = HashMap::<Address, Vec<B256>>::from_iter([(
+        address,
+        (0..1024).map(slot).collect::<Vec<_>>(),
+    )]);
+    let values: HashMap<Address, Vec<B256>> = provider
+        .client()
+        .request("eth_getStorageValues", (at_limit, BlockId::latest()))
+        .await
+        .unwrap();
+    assert_eq!(values[&address].len(), 1024);
+
+    // The limit is on the total slot count, not per account.
+    let over_limit = HashMap::<Address, Vec<B256>>::from_iter([
+        (address, (0..1024).map(slot).collect::<Vec<_>>()),
+        (Address::repeat_byte(0x04), vec![slot(0)]),
+    ]);
+    let err = provider
+        .client()
+        .request::<_, HashMap<Address, Vec<B256>>>(
+            "eth_getStorageValues",
+            (over_limit, BlockId::latest()),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("total slot count 1025 exceeds limit 1024"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn storage_values_agrees_with_get_storage_at() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let address = Address::repeat_byte(0x05);
+
+    api.anvil_set_storage_at(address, U256::from(0), B256::with_last_byte(0x11)).await.unwrap();
+    api.mine_one().await.unwrap();
+    let first = provider.get_block_number().await.unwrap();
+
+    api.anvil_set_storage_at(address, U256::from(1), B256::with_last_byte(0x22)).await.unwrap();
+    api.mine_one().await.unwrap();
+    let second = provider.get_block_number().await.unwrap();
+
+    // The batch endpoint must agree with the single-slot endpoint at every block it is asked
+    // about, which is the property that matters for callers migrating between the two.
+    let requests = HashMap::<Address, Vec<B256>>::from_iter([(address, vec![slot(0), slot(1)])]);
+    for block in [first, second] {
+        let batched: HashMap<Address, Vec<B256>> = provider
+            .client()
+            .request("eth_getStorageValues", (requests.clone(), BlockId::number(block)))
+            .await
+            .unwrap();
+
+        let mut expected = Vec::new();
+        for index in [U256::from(0), U256::from(1)] {
+            let value = provider
+                .get_storage_at(address, index)
+                .block_id(BlockId::number(block))
+                .await
+                .unwrap();
+            expected.push(B256::from(value));
+        }
+        assert_eq!(batched[&address], expected, "divergence at block {block}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_storage_values_skips_upstream_for_local_state() {
+    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let (proxy, calls) = spawn_rpc_proxy_canned_method(
+        origin_handle.http_endpoint(),
+        "eth_getStorageAt",
+        serde_json::json!(B256::with_last_byte(0xff)),
+    )
+    .await;
+
+    let (api, handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(proxy))).await;
+    let provider = handle.http_provider();
+    let address = Address::repeat_byte(0x06);
+
+    api.anvil_set_storage_at(address, U256::from(0), B256::with_last_byte(0x33)).await.unwrap();
+    api.mine_one().await.unwrap();
+
+    // State at or after the fork point is served locally, without querying the forked node.
+    // Only the delta matters: spawning a fork legitimately reads storage for other reasons.
+    let before = calls.load(Ordering::Relaxed);
+    let requests = HashMap::<Address, Vec<B256>>::from_iter([(address, vec![slot(0)])]);
+    let values: HashMap<Address, Vec<B256>> = provider
+        .client()
+        .request("eth_getStorageValues", (requests, BlockId::latest()))
+        .await
+        .unwrap();
+    assert_eq!(values[&address], vec![B256::with_last_byte(0x33)]);
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        before,
+        "post-fork state should not be fetched upstream"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn storage_values_requires_an_explicit_block_parameter() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    // Like `eth_getStorageAt`, the trailing block parameter has to be present, even as `null`.
+    let requests =
+        HashMap::<Address, Vec<B256>>::from_iter([(Address::repeat_byte(0x07), vec![slot(0)])]);
+    let err = provider
+        .client()
+        .request::<_, HashMap<Address, Vec<B256>>>("eth_getStorageValues", (requests.clone(),))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("expected tuple variant"), "unexpected error: {err}");
+
+    let values: HashMap<Address, Vec<B256>> = provider
+        .client()
+        .request("eth_getStorageValues", (requests, Option::<BlockId>::None))
+        .await
+        .unwrap();
+    assert_eq!(values[&Address::repeat_byte(0x07)], vec![B256::ZERO]);
+}


### PR DESCRIPTION
Auditing the `EthRequest` dispatch table against the anvil, cast and forge test suites turned up 22 of 177 RPC variants with no test reference anywhere. This covers the ones with real behaviour behind them, leaving the `RpcUnimplemented` stubs and constant getters alone.

The filter lifecycle was the largest gap: `eth_newBlockFilter`, `eth_getFilterLogs` and `eth_uninstallFilter` had no coverage at all, and the existing log-filter test only exercised `eth_getFilterChanges`. The new tests cover installation, draining, the distinction between `eth_getFilterLogs` and `eth_getFilterChanges` after a poll has drained the filter, `eth_getFilterLogs` rejecting non-log filter ids, and the unknown-id error paths. The EIP-7928 block access list endpoints have been untested since #15476.

`spawn_rpc_proxy_canned_method` is added alongside the existing `spawn_rpc_proxy_*` helpers. It answers one method with a canned result and counts how many times it was asked, which lets the fork tests assert that a fork-ancestry check short-circuited before reaching the upstream node rather than just observing a null result that both branches would produce. Forking one anvil from another keeps these offline, so no test here depends on a live chain or on one that implements EIP-7928.

Two behaviours the tests pin down rather than assume. Unknown blocks on the uncle endpoints report the JSON-RPC resource-not-found code instead of returning null. And `eth_getStorageValues` requires its trailing block parameter to be present even as `null`, matching `eth_getStorageAt`, `eth_getAccount` and `eth_getAccountInfo`; only `eth_newPendingTransactionFilter` uses `optional_sequence`. `eth_getStorageValues` is asserted against `eth_getStorageAt` at each block rather than against hardcoded values, so the batch endpoint cannot drift from the single-slot one.

Writing the access list tests turned up `eth_getBlockAccessListByBlockHash` missing the fork-ancestry check its three siblings have, so a block hash mined locally after the fork point was forwarded to an upstream node that had never seen it. That is fixed and merged as #16466, which also brought `spawn_rpc_proxy_canned_method` in with it; this branch has been rebased onto it and no longer carries its own copy of the helper.

The access list tests here are the ones #16466 does not cover: the non-fork case across all four endpoints, out-of-range blocks, and forwarding a pre-fork block. The skip-on-locally-mined case is left to #16466's version, which asserts the same property on the sibling by-number handler.

This is test-only, so it needs `L-ignore` rather than a changelog entry.
