### PR TITLE
test(verify): add on-chain deploy+verify coverage for five testnets

### DIFF
--- a/.changelog/testnet-deploy-verify-coverage.md
+++ b/.changelog/testnet-deploy-verify-coverage.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Added nightly on-chain deploy and verify coverage for Hoodi, Sepolia, Base Sepolia, Monad testnet and Robinhood testnet across the Etherscan, Sourcify and Blockscout verifiers.

--- a/.changelog/testnet-deploy-verify-coverage.md
+++ b/.changelog/testnet-deploy-verify-coverage.md
@@ -2,4 +2,4 @@
 forge: patch
 ---
 
-Added nightly on-chain deploy and verify coverage for Hoodi, Sepolia, Base Sepolia, Monad testnet and Robinhood testnet across the Etherscan, Sourcify and Blockscout verifiers.
+Added nightly on-chain deploy and verify coverage for Hoodi, Sepolia, Base Sepolia, Arbitrum Sepolia, Monad testnet and Robinhood testnet across the Etherscan, Sourcify and Blockscout verifiers.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,10 +1,15 @@
 [test-groups]
+# The on-chain deploy+verify tests share one funded deployer per network and one Etherscan key.
+# Running them concurrently collides on the account nonce and trips Etherscan's 3 calls/sec limit.
+deploy-verify = { max-threads = 1 }
 
 [profile.default]
 retries = { backoff = "exponential", count = 2, delay = "5s", jitter = true }
 slow-timeout = { period = "30s", terminate-after = 3 }
-# Exclude flaky tests from regular CI runs - they run in nightly test-flaky workflow
-default-filter = "not test(/flaky_/)"
+# Exclude flaky tests from regular CI runs - they run in nightly test-flaky workflow.
+# Exclude the on-chain deploy+verify tests too - they spend testnet funds and depend on external
+# verifier services, so they run in the nightly test-deploy-verify workflow.
+default-filter = "not test(/flaky_/) and not test(/deploy_verify_/)"
 
 [[profile.default.overrides]]
 filter = "test(/ext_integration/)"
@@ -34,3 +39,16 @@ retries = 0
 default-filter = "test(/flaky_/)"
 retries = { backoff = "exponential", count = 5, delay = "10s", jitter = true }
 slow-timeout = { period = "60s", terminate-after = 3 }
+
+# Profile for the on-chain deploy+verify tests (used by the nightly test-deploy-verify workflow).
+# Requires <NETWORK>_RPC_URL plus TEST_PRIVATE_KEY (or <NETWORK>_PRIVATE_KEY) to do anything.
+# Run with: cargo nextest run --profile deploy-verify
+[profile.deploy-verify]
+default-filter = "test(/deploy_verify_/)"
+retries = 1
+# A deploy plus verifier round trip is minutes, not seconds.
+slow-timeout = { period = "120s", terminate-after = 5 }
+
+[[profile.deploy-verify.overrides]]
+filter = "test(/deploy_verify_/)"
+test-group = "deploy-verify"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -41,7 +41,7 @@ retries = { backoff = "exponential", count = 5, delay = "10s", jitter = true }
 slow-timeout = { period = "60s", terminate-after = 3 }
 
 # Profile for the on-chain deploy+verify tests (used by the nightly test-deploy-verify workflow).
-# Requires <NETWORK>_RPC_URL plus TEST_PRIVATE_KEY (or <NETWORK>_PRIVATE_KEY) to do anything.
+# Requires <NETWORK>_RPC_URL plus TESTNET_DEPLOYER_PRIVATE_KEY to do anything.
 # Run with: cargo nextest run --profile deploy-verify
 [profile.deploy-verify]
 default-filter = "test(/deploy_verify_/)"

--- a/.github/DEPLOY_VERIFY_FAILURE_TEMPLATE.md
+++ b/.github/DEPLOY_VERIFY_FAILURE_TEMPLATE.md
@@ -3,7 +3,7 @@ title: "bug: deploy + verify workflow failed"
 labels: P-normal, T-bug
 ---
 
-The nightly on-chain deploy + verify workflow has failed. This exercises `forge create` followed by `forge verify-contract` against Hoodi, Sepolia, Base Sepolia, Monad testnet and Robinhood testnet, using Etherscan, Sourcify and Blockscout.
+The nightly on-chain deploy + verify workflow has failed. This exercises `forge create` followed by `forge verify-contract` against Hoodi, Sepolia, Base Sepolia, Arbitrum Sepolia, Monad testnet and Robinhood testnet, using Etherscan, Sourcify and Blockscout.
 
 The most common cause is the shared deployer running out of testnet funds. The deployer is `0x14459e92f32B68125525B5e3cdF3A239618e40D8`, held in the `FUNDED_TESTNET_PKEY` secret, and the workflow logs its balance on every network before running the tests. Monad testnet drains fastest, at roughly 0.08 MON per run. Top it up from a faucet to fix.
 

--- a/.github/DEPLOY_VERIFY_FAILURE_TEMPLATE.md
+++ b/.github/DEPLOY_VERIFY_FAILURE_TEMPLATE.md
@@ -5,7 +5,9 @@ labels: P-normal, T-bug
 
 The nightly on-chain deploy + verify workflow has failed. This exercises `forge create` followed by `forge verify-contract` against Hoodi, Sepolia, Base Sepolia, Monad testnet and Robinhood testnet, using Etherscan, Sourcify and Blockscout.
 
-The most common cause is the shared deployer account running out of testnet funds; the workflow logs its balance on every network before running the tests. Other likely causes are a testnet RPC being down, a verifier service being unavailable, or Etherscan rate limiting.
+The most common cause is the shared deployer running out of testnet funds. The deployer is `0x14459e92f32B68125525B5e3cdF3A239618e40D8`, held in the `FUNDED_TESTNET_PKEY` secret, and the workflow logs its balance on every network before running the tests. Monad testnet drains fastest, at roughly 0.08 MON per run. Top it up from a faucet to fix.
+
+Other likely causes are a testnet RPC being down, a verifier service being unavailable, or Etherscan rate limiting.
 
 Check the [deploy + verify workflow page]({{ env.WORKFLOW_URL }}) for details.
 

--- a/.github/DEPLOY_VERIFY_FAILURE_TEMPLATE.md
+++ b/.github/DEPLOY_VERIFY_FAILURE_TEMPLATE.md
@@ -1,0 +1,12 @@
+---
+title: "bug: deploy + verify workflow failed"
+labels: P-normal, T-bug
+---
+
+The nightly on-chain deploy + verify workflow has failed. This exercises `forge create` followed by `forge verify-contract` against Hoodi, Sepolia, Base Sepolia, Monad testnet and Robinhood testnet, using Etherscan, Sourcify and Blockscout.
+
+The most common cause is the shared deployer account running out of testnet funds; the workflow logs its balance on every network before running the tests. Other likely causes are a testnet RPC being down, a verifier service being unavailable, or Etherscan rate limiting.
+
+Check the [deploy + verify workflow page]({{ env.WORKFLOW_URL }}) for details.
+
+This issue was raised by the workflow at `.github/workflows/test-deploy-verify.yml`.

--- a/.github/DEPLOY_VERIFY_REFUND_TEMPLATE.md
+++ b/.github/DEPLOY_VERIFY_REFUND_TEMPLATE.md
@@ -1,0 +1,20 @@
+---
+title: "chore: refund the testnet deploy+verify deployer"
+labels: P-normal, T-chore
+---
+
+The shared deployer for the nightly on-chain deploy + verify workflow is running low on at least one network. The tests may still be passing right now; this is raised early so the account can be topped up before they start failing.
+
+Refund `{{ env.DEPLOYER }}` on:
+
+```
+{{ env.LOW_NETWORKS }}
+```
+
+Each entry is `NETWORK=current(min threshold)`. Thresholds are set at roughly twenty more runs at the measured per-run burn, so there is room to act. Monad testnet drains fastest at about 0.08 MON per run; the L2s are effectively free and should only appear here if something has gone wrong.
+
+The key lives in the `FUNDED_TESTNET_PKEY` secret and holds testnet funds only. Public faucets cover every network involved.
+
+Check the [deploy + verify workflow page]({{ env.WORKFLOW_URL }}) for the full balance report.
+
+This issue was raised by the workflow at `.github/workflows/test-deploy-verify.yml`.

--- a/.github/workflows/test-deploy-verify.yml
+++ b/.github/workflows/test-deploy-verify.yml
@@ -52,14 +52,14 @@ jobs:
           BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL || 'https://sepolia.base.org' }}
           MONAD_TESTNET_RPC_URL: ${{ secrets.MONAD_TESTNET_RPC_URL || 'https://testnet-rpc.monad.xyz' }}
           ROBINHOOD_TESTNET_RPC_URL: ${{ secrets.ROBINHOOD_TESTNET_RPC_URL || 'https://rpc.testnet.chain.robinhood.com' }}
-          TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+          TESTNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.FUNDED_TESTNET_PKEY }}
         shell: bash
         run: |
-          if [[ -z "$TEST_PRIVATE_KEY" ]]; then
-            echo "::error::TEST_PRIVATE_KEY is not set; every deploy+verify test would silently no-op."
+          if [[ -z "$TESTNET_DEPLOYER_PRIVATE_KEY" ]]; then
+            echo "::error::FUNDED_TESTNET_PKEY is not set; every deploy+verify test would silently no-op."
             exit 1
           fi
-          cargo run --locked --bin cast -- wallet address "$TEST_PRIVATE_KEY" > deployer.txt
+          cargo run --locked --bin cast -- wallet address "$TESTNET_DEPLOYER_PRIVATE_KEY" > deployer.txt
           addr=$(cat deployer.txt)
           echo "Deployer: $addr"
           for net in HOODI SEPOLIA BASE_SEPOLIA MONAD_TESTNET ROBINHOOD_TESTNET; do
@@ -84,9 +84,9 @@ jobs:
           BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL || 'https://sepolia.base.org' }}
           MONAD_TESTNET_RPC_URL: ${{ secrets.MONAD_TESTNET_RPC_URL || 'https://testnet-rpc.monad.xyz' }}
           ROBINHOOD_TESTNET_RPC_URL: ${{ secrets.ROBINHOOD_TESTNET_RPC_URL || 'https://rpc.testnet.chain.robinhood.com' }}
-          # Funded deployer, shared by every network. A per-network override is possible via
-          # <NETWORK>_PRIVATE_KEY.
-          TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+          # Funded throwaway deployer, shared by every network. Holds testnet funds only, and is
+          # topped up by hand; a per-network override is possible via <NETWORK>_PRIVATE_KEY.
+          TESTNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.FUNDED_TESTNET_PKEY }}
           # `etherscan_key` reads ETHERSCAN_API_KEY, which is a different variable from the
           # ETHERSCAN_KEY that the regular test workflow exports for `foundry_test_utils::rpc`.
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}

--- a/.github/workflows/test-deploy-verify.yml
+++ b/.github/workflows/test-deploy-verify.yml
@@ -1,0 +1,115 @@
+# Daily CI job running the on-chain deploy + verify tests against public testnets.
+#
+# These are excluded from regular CI via the nextest default-filter: they spend testnet funds from
+# a shared deployer account and depend on three external verifier services (Etherscan, Sourcify,
+# Blockscout), so they are too slow and too flaky to gate pull requests on.
+
+name: test-deploy-verify
+
+permissions: {}
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # Run daily at 3 AM UTC (offset from the other nightlies)
+  workflow_dispatch: # Needed so we can run it manually
+
+concurrency:
+  # Never run two of these at once: they share one deployer account per network, and concurrent
+  # runs would collide on the account nonce.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  test:
+    name: deploy + verify
+    runs-on: depot-ubuntu-latest-16
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
+      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        with:
+          tool: nextest
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: Report deployer balances
+        env:
+          HOODI_RPC_URL: ${{ secrets.HOODI_RPC_URL || 'https://ethereum-hoodi-rpc.publicnode.com' }}
+          SEPOLIA_RPC_URL: ${{ secrets.ETH_SEPOLIA_RPC || 'https://ethereum-sepolia-rpc.publicnode.com' }}
+          BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL || 'https://sepolia.base.org' }}
+          MONAD_TESTNET_RPC_URL: ${{ secrets.MONAD_TESTNET_RPC_URL || 'https://testnet-rpc.monad.xyz' }}
+          ROBINHOOD_TESTNET_RPC_URL: ${{ secrets.ROBINHOOD_TESTNET_RPC_URL || 'https://rpc.testnet.chain.robinhood.com' }}
+          TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          if [[ -z "$TEST_PRIVATE_KEY" ]]; then
+            echo "::error::TEST_PRIVATE_KEY is not set; every deploy+verify test would silently no-op."
+            exit 1
+          fi
+          cargo run --locked --bin cast -- wallet address "$TEST_PRIVATE_KEY" > deployer.txt
+          addr=$(cat deployer.txt)
+          echo "Deployer: $addr"
+          for net in HOODI SEPOLIA BASE_SEPOLIA MONAD_TESTNET ROBINHOOD_TESTNET; do
+            url_var="${net}_RPC_URL"
+            bal=$(cargo run --quiet --locked --bin cast -- balance "$addr" --rpc-url "${!url_var}" 2>/dev/null || echo "")
+            if [[ -z "$bal" ]]; then
+              echo "::warning::$net: could not read balance"
+            elif [[ "$bal" == "0" ]]; then
+              echo "::error::$net: deployer is out of funds"
+            else
+              echo "$net: $(cargo run --quiet --locked --bin cast -- from-wei "$bal")"
+            fi
+          done
+
+      - name: Deploy and verify on testnets
+        env:
+          SVM_TARGET_PLATFORM: linux-amd64
+          # Read by `EnvExternalities::deploy_verify` as <NETWORK>_RPC_URL. Public endpoints are
+          # fine here; the secrets exist so a network can be repointed without a code change.
+          HOODI_RPC_URL: ${{ secrets.HOODI_RPC_URL || 'https://ethereum-hoodi-rpc.publicnode.com' }}
+          SEPOLIA_RPC_URL: ${{ secrets.ETH_SEPOLIA_RPC || 'https://ethereum-sepolia-rpc.publicnode.com' }}
+          BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL || 'https://sepolia.base.org' }}
+          MONAD_TESTNET_RPC_URL: ${{ secrets.MONAD_TESTNET_RPC_URL || 'https://testnet-rpc.monad.xyz' }}
+          ROBINHOOD_TESTNET_RPC_URL: ${{ secrets.ROBINHOOD_TESTNET_RPC_URL || 'https://rpc.testnet.chain.robinhood.com' }}
+          # Funded deployer, shared by every network. A per-network override is possible via
+          # <NETWORK>_PRIVATE_KEY.
+          TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+          # `etherscan_key` reads ETHERSCAN_API_KEY, which is a different variable from the
+          # ETHERSCAN_KEY that the regular test workflow exports for `foundry_test_utils::rpc`.
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+        run: cargo nextest run --locked --profile deploy-verify --no-fail-fast
+
+  # If the nightly run fails, this will create a normal-priority issue to signal so.
+  issue:
+    name: Open an issue
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_URL: |
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/DEPLOY_VERIFY_FAILURE_TEMPLATE.md

--- a/.github/workflows/test-deploy-verify.yml
+++ b/.github/workflows/test-deploy-verify.yml
@@ -31,6 +31,9 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+    outputs:
+      deployer: ${{ steps.balances.outputs.deployer }}
+      low: ${{ steps.balances.outputs.low }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -58,9 +61,11 @@ jobs:
           fi
           echo "Deployer key is configured."
 
-      # Purely diagnostic: running dry is the most likely failure, so the balances are worth having
-      # at the top of the log. Never fail the run over it - the tests themselves are the signal.
+      # Running dry is the most likely failure, so balances go at the top of the log and anything
+      # under its threshold is reported to the refund job below. Never fail the run over this - the
+      # tests themselves are the signal, and one dry network should not stop the others.
       - name: Report deployer balances
+        id: balances
         continue-on-error: true
         env:
           HOODI_RPC_URL: ${{ secrets.HOODI_RPC_URL || 'https://ethereum-hoodi-rpc.publicnode.com' }}
@@ -75,16 +80,28 @@ jobs:
           cast=./target/debug/cast
           addr=$("$cast" wallet address "$TESTNET_DEPLOYER_PRIVATE_KEY")
           echo "Deployer: $addr"
-          for net in HOODI SEPOLIA BASE_SEPOLIA MONAD_TESTNET ROBINHOOD_TESTNET; do
+          echo "deployer=$addr" >> "$GITHUB_OUTPUT"
+
+          # Thresholds are roughly 20 more runs at the measured per-run burn. Monad testnet is the
+          # expensive one at ~0.08 MON per run; the L2s are effectively free.
+          low=""
+          for spec in HOODI:0.05 SEPOLIA:0.05 BASE_SEPOLIA:0.01 MONAD_TESTNET:2.0 ROBINHOOD_TESTNET:0.01; do
+            net="${spec%%:*}"
+            min="${spec##*:}"
             url_var="${net}_RPC_URL"
             if ! bal=$("$cast" balance "$addr" --rpc-url "${!url_var}" 2>/dev/null); then
               echo "::warning::$net: could not read balance"
-            elif [[ "$bal" == "0" ]]; then
-              echo "::warning::$net: deployer is out of funds"
+              continue
+            fi
+            human=$("$cast" from-wei "$bal")
+            if awk -v b="$human" -v m="$min" 'BEGIN { exit !(b + 0 < m + 0) }'; then
+              echo "::warning::$net: $human is below the $min top-up threshold"
+              low="$low $net=$human(min $min)"
             else
-              echo "$net: $("$cast" from-wei "$bal")"
+              echo "$net: $human"
             fi
           done
+          echo "low=${low# }" >> "$GITHUB_OUTPUT"
 
       - name: Deploy and verify on testnets
         env:
@@ -103,6 +120,31 @@ jobs:
           # ETHERSCAN_KEY that the regular test workflow exports for `foundry_test_utils::rpc`.
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: cargo nextest run --locked --profile deploy-verify --no-fail-fast
+
+  # Raised before the account actually runs dry, so the tests keep passing while someone tops it
+  # up. Independent of whether the tests passed - a low balance is worth reporting either way.
+  refund:
+    name: Open a refund issue
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always() && github.event_name == 'schedule' && needs.test.outputs.low != ''
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOYER: ${{ needs.test.outputs.deployer }}
+          LOW_NETWORKS: ${{ needs.test.outputs.low }}
+          WORKFLOW_URL: |
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/DEPLOY_VERIFY_REFUND_TEMPLATE.md
 
   # If the nightly run fails, this will create a normal-priority issue to signal so.
   issue:

--- a/.github/workflows/test-deploy-verify.yml
+++ b/.github/workflows/test-deploy-verify.yml
@@ -45,7 +45,23 @@ jobs:
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
+      # Fatal and cheap: without the key every test below would quietly pass as a no-op, which
+      # is the exact failure mode this workflow exists to avoid.
+      - name: Check deployer key is configured
+        env:
+          TESTNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.FUNDED_TESTNET_PKEY }}
+        shell: bash
+        run: |
+          if [[ -z "$TESTNET_DEPLOYER_PRIVATE_KEY" ]]; then
+            echo "::error::FUNDED_TESTNET_PKEY is not set; every deploy+verify test would silently no-op."
+            exit 1
+          fi
+          echo "Deployer key is configured."
+
+      # Purely diagnostic: running dry is the most likely failure, so the balances are worth having
+      # at the top of the log. Never fail the run over it - the tests themselves are the signal.
       - name: Report deployer balances
+        continue-on-error: true
         env:
           HOODI_RPC_URL: ${{ secrets.HOODI_RPC_URL || 'https://ethereum-hoodi-rpc.publicnode.com' }}
           SEPOLIA_RPC_URL: ${{ secrets.ETH_SEPOLIA_RPC || 'https://ethereum-sepolia-rpc.publicnode.com' }}
@@ -55,22 +71,18 @@ jobs:
           TESTNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.FUNDED_TESTNET_PKEY }}
         shell: bash
         run: |
-          if [[ -z "$TESTNET_DEPLOYER_PRIVATE_KEY" ]]; then
-            echo "::error::FUNDED_TESTNET_PKEY is not set; every deploy+verify test would silently no-op."
-            exit 1
-          fi
-          cargo run --locked --bin cast -- wallet address "$TESTNET_DEPLOYER_PRIVATE_KEY" > deployer.txt
-          addr=$(cat deployer.txt)
+          cargo build --locked --bin cast
+          cast=./target/debug/cast
+          addr=$("$cast" wallet address "$TESTNET_DEPLOYER_PRIVATE_KEY")
           echo "Deployer: $addr"
           for net in HOODI SEPOLIA BASE_SEPOLIA MONAD_TESTNET ROBINHOOD_TESTNET; do
             url_var="${net}_RPC_URL"
-            bal=$(cargo run --quiet --locked --bin cast -- balance "$addr" --rpc-url "${!url_var}" 2>/dev/null || echo "")
-            if [[ -z "$bal" ]]; then
+            if ! bal=$("$cast" balance "$addr" --rpc-url "${!url_var}" 2>/dev/null); then
               echo "::warning::$net: could not read balance"
             elif [[ "$bal" == "0" ]]; then
-              echo "::error::$net: deployer is out of funds"
+              echo "::warning::$net: deployer is out of funds"
             else
-              echo "$net: $(cargo run --quiet --locked --bin cast -- from-wei "$bal")"
+              echo "$net: $("$cast" from-wei "$bal")"
             fi
           done
 

--- a/.github/workflows/test-deploy-verify.yml
+++ b/.github/workflows/test-deploy-verify.yml
@@ -71,6 +71,7 @@ jobs:
           HOODI_RPC_URL: ${{ secrets.HOODI_RPC_URL || 'https://ethereum-hoodi-rpc.publicnode.com' }}
           SEPOLIA_RPC_URL: ${{ secrets.ETH_SEPOLIA_RPC || 'https://ethereum-sepolia-rpc.publicnode.com' }}
           BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL || 'https://sepolia.base.org' }}
+          ARBITRUM_SEPOLIA_RPC_URL: ${{ secrets.ARBITRUM_SEPOLIA_RPC_URL || 'https://sepolia-rollup.arbitrum.io/rpc' }}
           MONAD_TESTNET_RPC_URL: ${{ secrets.MONAD_TESTNET_RPC_URL || 'https://testnet-rpc.monad.xyz' }}
           ROBINHOOD_TESTNET_RPC_URL: ${{ secrets.ROBINHOOD_TESTNET_RPC_URL || 'https://rpc.testnet.chain.robinhood.com' }}
           TESTNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.FUNDED_TESTNET_PKEY }}
@@ -85,7 +86,7 @@ jobs:
           # Thresholds are roughly 20 more runs at the measured per-run burn. Monad testnet is the
           # expensive one at ~0.08 MON per run; the L2s are effectively free.
           low=""
-          for spec in HOODI:0.05 SEPOLIA:0.05 BASE_SEPOLIA:0.01 MONAD_TESTNET:2.0 ROBINHOOD_TESTNET:0.01; do
+          for spec in HOODI:0.05 SEPOLIA:0.05 BASE_SEPOLIA:0.01 ARBITRUM_SEPOLIA:0.01 MONAD_TESTNET:2.0 ROBINHOOD_TESTNET:0.01; do
             net="${spec%%:*}"
             min="${spec##*:}"
             url_var="${net}_RPC_URL"
@@ -111,6 +112,7 @@ jobs:
           HOODI_RPC_URL: ${{ secrets.HOODI_RPC_URL || 'https://ethereum-hoodi-rpc.publicnode.com' }}
           SEPOLIA_RPC_URL: ${{ secrets.ETH_SEPOLIA_RPC || 'https://ethereum-sepolia-rpc.publicnode.com' }}
           BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL || 'https://sepolia.base.org' }}
+          ARBITRUM_SEPOLIA_RPC_URL: ${{ secrets.ARBITRUM_SEPOLIA_RPC_URL || 'https://sepolia-rollup.arbitrum.io/rpc' }}
           MONAD_TESTNET_RPC_URL: ${{ secrets.MONAD_TESTNET_RPC_URL || 'https://testnet-rpc.monad.xyz' }}
           ROBINHOOD_TESTNET_RPC_URL: ${{ secrets.ROBINHOOD_TESTNET_RPC_URL || 'https://rpc.testnet.chain.robinhood.com' }}
           # Funded throwaway deployer, shared by every network. Holds testnet funds only, and is

--- a/crates/forge/tests/cli/utils.rs
+++ b/crates/forge/tests/cli/utils.rs
@@ -30,9 +30,20 @@ pub fn network_rpc_key(chain: &str) -> Option<String> {
     std::env::var(key).ok()
 }
 
+/// Resolves the deployer key for `chain`, most specific first:
+///
+/// 1. `<NETWORK>_PRIVATE_KEY`, to point one network at its own account.
+/// 2. `TESTNET_DEPLOYER_PRIVATE_KEY`, the shared throwaway deployer these tests fund.
+/// 3. `TEST_PRIVATE_KEY`, kept for existing local setups.
+///
+/// Prefer the dedicated name over `TEST_PRIVATE_KEY`: it is generic enough that an unrelated value
+/// left in the environment would otherwise deploy from an account the caller did not intend.
 pub fn network_private_key(chain: &str) -> Option<String> {
     let key = format!("{}_PRIVATE_KEY", chain.to_uppercase().replace('-', "_"));
-    std::env::var(key).or_else(|_| std::env::var("TEST_PRIVATE_KEY")).ok()
+    std::env::var(key)
+        .or_else(|_| std::env::var("TESTNET_DEPLOYER_PRIVATE_KEY"))
+        .or_else(|_| std::env::var("TEST_PRIVATE_KEY"))
+        .ok()
 }
 
 /// Represents external input required for executing verification requests

--- a/crates/forge/tests/cli/utils.rs
+++ b/crates/forge/tests/cli/utils.rs
@@ -42,12 +42,38 @@ pub struct EnvExternalities {
     pub pk: String,
     pub etherscan: String,
     pub verifier: String,
+    pub verifier_url: Option<String>,
 }
 
 impl EnvExternalities {
     pub fn address(&self) -> Option<Address> {
         let pk: PrivateKeySigner = self.pk.parse().ok()?;
         Some(pk.address())
+    }
+
+    /// Externalities for a deploy + verify run of `chain` against `verifier`.
+    ///
+    /// `network` is the name used to look up `<NETWORK>_RPC_URL` and `<NETWORK>_PRIVATE_KEY`, and
+    /// matches the canonical `NamedChain::as_str` spelling. Blockscout instances have no shared
+    /// registry, so they must be given an explicit `verifier_url`.
+    ///
+    /// Returns `None` when the network is not configured, which is how these tests stay inert
+    /// outside of the nightly workflow that supplies the funded deployer key.
+    pub fn deploy_verify(
+        chain: NamedChain,
+        network: &str,
+        verifier: &str,
+        verifier_url: Option<&str>,
+    ) -> Option<Self> {
+        Some(Self {
+            chain,
+            rpc: network_rpc_key(network)?,
+            pk: network_private_key(network)?,
+            // Only Etherscan authenticates; Sourcify and Blockscout take no key.
+            etherscan: if verifier == "etherscan" { etherscan_key(chain)? } else { String::new() },
+            verifier: verifier.to_string(),
+            verifier_url: verifier_url.map(str::to_string),
+        })
     }
 
     pub fn goerli() -> Option<Self> {
@@ -57,6 +83,7 @@ impl EnvExternalities {
             pk: network_private_key("goerli")?,
             etherscan: etherscan_key(NamedChain::Goerli)?,
             verifier: "etherscan".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -67,6 +94,7 @@ impl EnvExternalities {
             pk: network_private_key("ftm_testnet")?,
             etherscan: etherscan_key(NamedChain::FantomTestnet)?,
             verifier: "etherscan".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -77,6 +105,7 @@ impl EnvExternalities {
             pk: network_private_key("op_kovan")?,
             etherscan: etherscan_key(NamedChain::OptimismKovan)?,
             verifier: "etherscan".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -87,6 +116,7 @@ impl EnvExternalities {
             pk: network_private_key("arbitrum-goerli")?,
             etherscan: etherscan_key(NamedChain::ArbitrumGoerli)?,
             verifier: "blockscout".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -97,6 +127,7 @@ impl EnvExternalities {
             pk: network_private_key("amoy")?,
             etherscan: etherscan_key(NamedChain::PolygonAmoy)?,
             verifier: "etherscan".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -107,6 +138,7 @@ impl EnvExternalities {
             pk: network_private_key("sepolia")?,
             etherscan: etherscan_key(NamedChain::Sepolia)?,
             verifier: "etherscan".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -117,6 +149,7 @@ impl EnvExternalities {
             pk: network_private_key("sepolia")?,
             etherscan: String::new(),
             verifier: "sourcify".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -127,6 +160,7 @@ impl EnvExternalities {
             pk: network_private_key("sepolia")?,
             etherscan: etherscan_key(NamedChain::Sepolia)?,
             verifier: "sourcify".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -137,6 +171,7 @@ impl EnvExternalities {
             pk: network_private_key("sepolia")?,
             etherscan: String::new(),
             verifier: "blockscout".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -147,6 +182,7 @@ impl EnvExternalities {
             pk: network_private_key("sepolia")?,
             etherscan: etherscan_key(NamedChain::Sepolia)?,
             verifier: "blockscout".to_string(),
+            verifier_url: None,
         })
     }
 
@@ -157,6 +193,7 @@ impl EnvExternalities {
             pk: network_private_key("sepolia")?,
             etherscan: String::new(),
             verifier: String::new(),
+            verifier_url: None,
         })
     }
 

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -387,7 +387,7 @@ forgetest!(can_verify_contract_sepolia_etherscan_also_runs_sourcify, |prj, cmd| 
 
 // tests `create --verify on Sepolia testnet if correct env vars are set
 // SEPOLIA_RPC_URL=https://rpc.sepolia.org
-// TEST_PRIVATE_KEY=0x...
+// TESTNET_DEPLOYER_PRIVATE_KEY=0x...
 // ETHERSCAN_API_KEY=<API_KEY>
 forgetest!(can_create_verify_random_contract_sepolia_etherscan, |prj, cmd| {
     // Implicitly tests `--verifier etherscan` on Sepolia testnet
@@ -477,9 +477,9 @@ const ROBINHOOD_TESTNET_BLOCKSCOUT_URL: &str = "https://explorer.testnet.chain.r
 
 /// End-to-end `create` + `verify-contract` coverage across the testnets we support.
 ///
-/// Each test is inert unless `<NETWORK>_RPC_URL` and a deployer key are configured, and they are
-/// wired up by the nightly `test-deploy-verify` workflow rather than by PR CI: they spend testnet
-/// funds and depend on three external verifier services.
+/// Each test is inert unless `<NETWORK>_RPC_URL` and `TESTNET_DEPLOYER_PRIVATE_KEY` are set, and
+/// they are wired up by the nightly `test-deploy-verify` workflow rather than by PR CI: they spend
+/// testnet funds and depend on three external verifier services.
 ///
 /// Etherscan v2 covers Hoodi, Sepolia, Base Sepolia and Monad testnet. Robinhood testnet is not on
 /// the v2 chainlist, so it is covered by Sourcify and its own Blockscout instance instead.

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -2,6 +2,7 @@
 //! and Sourcify.
 
 use crate::utils::{self, EnvExternalities};
+use alloy_chains::NamedChain;
 use alloy_network::Ethereum;
 use alloy_primitives::{Address, U256, hex};
 use anvil::{NodeConfig, spawn};
@@ -94,7 +95,10 @@ fn parse_verification_result(cmd: &mut TestCommand, retries: u32) -> eyre::Resul
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         test_debug!("stdout: {stdout}\nstderr: {stderr}");
-        if stderr.contains("Contract successfully verified") {
+        // A retried attempt can land on a submission that already succeeded, which reports the
+        // contract as verified rather than verifying it again.
+        if stderr.contains("Contract successfully verified") || stderr.contains("already verified")
+        {
             return Ok(());
         }
         eyre::bail!("Failed to get verification, stdout: {stdout}, stderr: {stderr}");
@@ -257,6 +261,64 @@ fn create_verify_on_chain(info: Option<EnvExternalities>, prj: TestProject, mut 
     }
 }
 
+/// Deploys a freshly stamped contract and verifies it, as two separate commands.
+///
+/// Deploy and verify are kept apart on purpose: Sourcify indexes from its own node, and submitting
+/// straight after the broadcast fails the job outright with `contract_not_deployed` rather than
+/// leaving it pending, so the retry has to re-run the whole `verify-contract` command.
+fn deploy_and_verify_on_chain(
+    info: Option<EnvExternalities>,
+    prj: TestProject,
+    mut cmd: TestCommand,
+) {
+    // only execute if the network is configured
+    let Some(info) = info else { return };
+
+    test_debug!("deploying on {} for verification via {}", info.chain, info.verifier);
+    add_single_verify_target_file(&prj);
+
+    let contract_path = "src/Verify.sol:Verify";
+    let output = cmd
+        .forge_fuse()
+        .arg("create")
+        .args(info.create_args())
+        .args([contract_path, "--broadcast"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let address = utils::parse_deployed_address(output.as_str())
+        .unwrap_or_else(|| panic!("Failed to parse deployer {output}"));
+
+    let mut args = vec![
+        "--chain-id".to_string(),
+        (info.chain as u64).to_string(),
+        address,
+        contract_path.to_string(),
+        "--watch".to_string(),
+    ];
+
+    if !info.etherscan.is_empty() {
+        args.push("--etherscan-api-key".to_string());
+        args.push(info.etherscan.clone());
+    }
+
+    if !info.verifier.is_empty() {
+        args.push("--verifier".to_string());
+        args.push(info.verifier.clone());
+    }
+
+    // Blockscout instances share no registry, so the URL has to be passed explicitly.
+    if let Some(verifier_url) = &info.verifier_url {
+        args.push("--verifier-url".to_string());
+        args.push(verifier_url.clone());
+    }
+
+    cmd.forge_fuse().arg("verify-contract").root_arg().args(args);
+
+    parse_verification_result(&mut cmd, 6)
+        .unwrap_or_else(|err| panic!("Failed to verify on {}: {err}", info.chain));
+}
+
 // tests `create && contract-verify && verify-check` on Fantom testnet if correct env vars are set
 forgetest!(can_verify_random_contract_fantom_testnet, |prj, cmd| {
     verify_on_chain(EnvExternalities::ftm_testnet(), prj, cmd);
@@ -407,6 +469,57 @@ forgetest!(can_guess_constructor_args, |prj, cmd| {
 forgetest!(can_verify_random_contract_sepolia_default_sourcify, |prj, cmd| {
     verify_on_chain(EnvExternalities::sepolia_empty_verifier(), prj, cmd);
 });
+
+// Blockscout instances are per-chain deployments with no shared registry, so `--verifier
+// blockscout` has to be given the URL explicitly.
+const SEPOLIA_BLOCKSCOUT_URL: &str = "https://eth-sepolia.blockscout.com/api";
+const ROBINHOOD_TESTNET_BLOCKSCOUT_URL: &str = "https://explorer.testnet.chain.robinhood.com/api";
+
+/// End-to-end `create` + `verify-contract` coverage across the testnets we support.
+///
+/// Each test is inert unless `<NETWORK>_RPC_URL` and a deployer key are configured, and they are
+/// wired up by the nightly `test-deploy-verify` workflow rather than by PR CI: they spend testnet
+/// funds and depend on three external verifier services.
+///
+/// Etherscan v2 covers Hoodi, Sepolia, Base Sepolia and Monad testnet. Robinhood testnet is not on
+/// the v2 chainlist, so it is covered by Sourcify and its own Blockscout instance instead.
+macro_rules! deploy_verify_tests {
+    ($($name:ident: $chain:expr, $network:literal, $verifier:literal, $url:expr;)*) => {$(
+        forgetest!($name, |prj, cmd| {
+            deploy_and_verify_on_chain(
+                EnvExternalities::deploy_verify($chain, $network, $verifier, $url),
+                prj,
+                cmd,
+            );
+        });
+    )*};
+}
+
+deploy_verify_tests! {
+    deploy_verify_hoodi_etherscan: NamedChain::Hoodi, "hoodi", "etherscan", None;
+    deploy_verify_hoodi_sourcify: NamedChain::Hoodi, "hoodi", "sourcify", None;
+
+    deploy_verify_sepolia_etherscan: NamedChain::Sepolia, "sepolia", "etherscan", None;
+    deploy_verify_sepolia_sourcify: NamedChain::Sepolia, "sepolia", "sourcify", None;
+    deploy_verify_sepolia_blockscout:
+        NamedChain::Sepolia, "sepolia", "blockscout", Some(SEPOLIA_BLOCKSCOUT_URL);
+
+    deploy_verify_base_sepolia_etherscan:
+        NamedChain::BaseSepolia, "base-sepolia", "etherscan", None;
+    deploy_verify_base_sepolia_sourcify:
+        NamedChain::BaseSepolia, "base-sepolia", "sourcify", None;
+
+    deploy_verify_monad_testnet_etherscan:
+        NamedChain::MonadTestnet, "monad-testnet", "etherscan", None;
+    deploy_verify_monad_testnet_sourcify:
+        NamedChain::MonadTestnet, "monad-testnet", "sourcify", None;
+
+    deploy_verify_robinhood_testnet_sourcify:
+        NamedChain::RobinhoodTestnet, "robinhood-testnet", "sourcify", None;
+    deploy_verify_robinhood_testnet_blockscout:
+        NamedChain::RobinhoodTestnet, "robinhood-testnet", "blockscout",
+        Some(ROBINHOOD_TESTNET_BLOCKSCOUT_URL);
+}
 
 // Tests that verify properly validates verifier arguments.
 // <https://github.com/foundry-rs/foundry/issues/11430>

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -481,8 +481,9 @@ const ROBINHOOD_TESTNET_BLOCKSCOUT_URL: &str = "https://explorer.testnet.chain.r
 /// they are wired up by the nightly `test-deploy-verify` workflow rather than by PR CI: they spend
 /// testnet funds and depend on three external verifier services.
 ///
-/// Etherscan v2 covers Hoodi, Sepolia, Base Sepolia and Monad testnet. Robinhood testnet is not on
-/// the v2 chainlist, so it is covered by Sourcify and its own Blockscout instance instead.
+/// Etherscan v2 covers Hoodi, Sepolia, Base Sepolia, Arbitrum Sepolia and Monad testnet. Robinhood
+/// testnet is not on the v2 chainlist, so it is covered by Sourcify and its own Blockscout instance
+/// instead.
 macro_rules! deploy_verify_tests {
     ($($name:ident: $chain:expr, $network:literal, $verifier:literal, $url:expr;)*) => {$(
         forgetest!($name, |prj, cmd| {
@@ -508,6 +509,11 @@ deploy_verify_tests! {
         NamedChain::BaseSepolia, "base-sepolia", "etherscan", None;
     deploy_verify_base_sepolia_sourcify:
         NamedChain::BaseSepolia, "base-sepolia", "sourcify", None;
+
+    deploy_verify_arbitrum_sepolia_etherscan:
+        NamedChain::ArbitrumSepolia, "arbitrum-sepolia", "etherscan", None;
+    deploy_verify_arbitrum_sepolia_sourcify:
+        NamedChain::ArbitrumSepolia, "arbitrum-sepolia", "sourcify", None;
 
     deploy_verify_monad_testnet_etherscan:
         NamedChain::MonadTestnet, "monad-testnet", "etherscan", None;


### PR DESCRIPTION
Verification against a real explorer was never exercised for a standard EVM chain. The Sepolia deploy+verify tests are gated on `EnvExternalities`, which needs `SEPOLIA_RPC_URL`, a deployer key and `ETHERSCAN_API_KEY`, and no workflow supplies any of them, so they pass as no-ops. That left the Etherscan, Sourcify and Blockscout submission paths covered only by the mock HTTP servers in `verify.rs`, with Tempo the sole network doing a real deploy to verified round trip.

This adds thirteen tests covering Hoodi, Sepolia, Base Sepolia, Arbitrum Sepolia, Monad testnet and Robinhood testnet. Etherscan v2 covers the first five. Robinhood is not on the v2 chainlist, so it is covered by Sourcify and its own Blockscout instance instead; `--verifier blockscout` requires an explicit URL, so `EnvExternalities` grew a `verifier_url` field.

Deploy and verify are issued as separate commands rather than through `create --verify`. Sourcify indexes from its own node, and a submission made immediately after the broadcast fails the job outright with `contract_not_deployed` instead of leaving it pending, so the retry has to re-run the whole `verify-contract` command.

The tests run in a nightly workflow rather than on pull requests, since they spend testnet funds and depend on three external services. They are excluded from the default nextest profile and serialized through a test group: they share one deployer account per network and one Etherscan key, so running them concurrently collides on the account nonce and trips Etherscan's 3 calls/sec limit.

Two failure modes get their own issue. A failed run opens one as the other nightlies do, and separately, the balance of each network is compared against a threshold worth roughly twenty more runs, so a dedicated refund issue naming the deployer and the low networks is raised while the tests are still passing rather than once the account has already run dry.

All thirteen pass against the live testnets:

```
PASS [ 14.045s] deploy_verify_arbitrum_sepolia_etherscan
PASS [  7.034s] deploy_verify_arbitrum_sepolia_sourcify
PASS [ 12.903s] deploy_verify_base_sepolia_etherscan
PASS [  6.923s] deploy_verify_base_sepolia_sourcify
PASS [ 43.724s] deploy_verify_hoodi_etherscan
PASS [ 14.931s] deploy_verify_hoodi_sourcify
PASS [ 12.030s] deploy_verify_monad_testnet_etherscan
PASS [  5.919s] deploy_verify_monad_testnet_sourcify
PASS [ 13.674s] deploy_verify_robinhood_testnet_blockscout
PASS [  7.086s] deploy_verify_robinhood_testnet_sourcify
PASS [ 43.768s] deploy_verify_sepolia_blockscout
PASS [ 32.736s] deploy_verify_sepolia_etherscan
PASS [ 21.684s] deploy_verify_sepolia_sourcify
Summary [236.467s] 13 tests run: 13 passed
```

The deployer is funded on every network. `ARBITRUM_SEPOLIA_RPC_URL` is deliberately distinct from the existing `ARBITRUM_RPC` secret, which points at mainnet for the fork tests. Remaining RPC URLs default to public endpoints and only need secrets if a network has to be repointed.

Written with assistance from Claude Code.
