### PR TITLE
fix(forge): retain unchecked artifact lookup

### DIFF
--- a/.changelog/unchecked-artifact-dynamic-linking.md
+++ b/.changelog/unchecked-artifact-dynamic-linking.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-cheatcodes: patch
+---
+
+Fixed dynamically linked contract creation when `unchecked_cheatcode_artifacts` is enabled.

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -54,6 +54,9 @@ pub struct CheatsConfig {
     /// If Some, `vm.getDeployedCode` invocations are validated to be in scope of this list.
     /// If None, no validation is performed.
     pub available_artifacts: Option<ContractsByArtifact>,
+    /// Artifacts used to resolve cheatcode artifact references.
+    /// Unlike `available_artifacts`, this is retained when artifact safety checks are disabled.
+    pub artifact_lookup: Option<ContractsByArtifact>,
     /// Currently running artifact.
     pub running_artifact: Option<ArtifactId>,
     /// Whether to enable legacy (non-reverting) assertions.
@@ -76,7 +79,8 @@ impl CheatsConfig {
         let rpc_endpoints = config.rpc_endpoints.clone().resolved();
         trace!(?rpc_endpoints, "using resolved rpc endpoints");
 
-        // If user explicitly disabled safety checks, do not set available_artifacts
+        let artifact_lookup = available_artifacts.clone();
+        // If user explicitly disabled safety checks, do not set available_artifacts.
         let available_artifacts =
             if config.unchecked_cheatcode_artifacts { None } else { available_artifacts };
         let mut labels = config.labels.clone();
@@ -100,6 +104,7 @@ impl CheatsConfig {
             evm_opts,
             labels,
             available_artifacts,
+            artifact_lookup,
             running_artifact,
             assertions_revert: config.assertions_revert,
             seed: config.fuzz.seed,
@@ -112,7 +117,7 @@ impl CheatsConfig {
         let mut cloned = Self::new(
             config,
             evm_opts,
-            self.available_artifacts.clone(),
+            self.artifact_lookup.clone(),
             self.running_artifact.clone(),
             self.batch_rewrite_creates,
         );
@@ -244,6 +249,7 @@ impl Default for CheatsConfig {
             evm_opts: Default::default(),
             labels: Default::default(),
             available_artifacts: Default::default(),
+            artifact_lookup: Default::default(),
             running_artifact: Default::default(),
             assertions_revert: true,
             seed: None,
@@ -311,6 +317,25 @@ mod tests {
 
         let cloned = on.clone_with(&Config::default(), Default::default());
         assert!(cloned.batch_rewrite_creates);
+    }
+
+    #[test]
+    fn unchecked_artifacts_retain_lookup_without_validation() {
+        let config = Config { unchecked_cheatcode_artifacts: true, ..Default::default() };
+        let cheats = CheatsConfig::new(
+            &config,
+            Default::default(),
+            Some(ContractsByArtifact::default()),
+            None,
+            false,
+        );
+
+        assert!(cheats.available_artifacts.is_none());
+        assert!(cheats.artifact_lookup.is_some());
+
+        let cloned = cheats.clone_with(&config, Default::default());
+        assert!(cloned.available_artifacts.is_none());
+        assert!(cloned.artifact_lookup.is_some());
     }
 
     #[test]

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -117,7 +117,7 @@ impl CheatsConfig {
         let mut cloned = Self::new(
             config,
             evm_opts,
-            self.artifact_lookup.clone(),
+            self.artifact_lookup.clone().or_else(|| self.available_artifacts.clone()),
             self.running_artifact.clone(),
             self.batch_rewrite_creates,
         );
@@ -335,6 +335,18 @@ mod tests {
 
         let cloned = cheats.clone_with(&config, Default::default());
         assert!(cloned.available_artifacts.is_none());
+        assert!(cloned.artifact_lookup.is_some());
+    }
+
+    #[test]
+    fn clone_with_preserves_available_artifacts_without_lookup() {
+        let cheats = CheatsConfig {
+            available_artifacts: Some(ContractsByArtifact::default()),
+            ..Default::default()
+        };
+
+        let cloned = cheats.clone_with(&Config::default(), Default::default());
+        assert!(cloned.available_artifacts.is_some());
         assert!(cloned.artifact_lookup.is_some());
     }
 

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -628,8 +628,10 @@ fn get_artifact_source<'a, FEN: FoundryEvmNetwork>(
         }
     });
 
-    // Use available artifacts list if present
-    if let Some(artifacts) = &state.config.available_artifacts {
+    // Use the artifact lookup if present.
+    if let Some(artifacts) =
+        state.config.available_artifacts.as_ref().or(state.config.artifact_lookup.as_ref())
+    {
         let ambiguous_file_profile =
             file.is_some() && version.is_none() && profile.is_none() && contract_name.is_some();
         let filter_artifacts = |treat_ambiguous_as_profile: bool| -> Vec<_> {

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -266,6 +266,77 @@ Compiling 21 files with [..]
 "#]]);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/16468>
+forgetest_init!(unchecked_artifacts_support_dynamic_linking, |prj, cmd| {
+    prj.update_config(|config| {
+        config.dynamic_test_linking = true;
+        config.unchecked_cheatcode_artifacts = true;
+    });
+    prj.add_source(
+        "Counter.sol",
+        r#"
+library Math {
+    function double(uint256 x) public pure returns (uint256) {
+        return x * 2;
+    }
+}
+
+contract Counter {
+    uint256 public number;
+
+    constructor(uint256 number_) {
+        number = Math.double(number_);
+    }
+}
+"#,
+    );
+    prj.add_source(
+        "nested/Counter.sol",
+        r#"
+library Math {
+    function triple(uint256 x) public pure returns (uint256) {
+        return x * 3;
+    }
+}
+
+contract Counter {
+    uint256 public number;
+
+    constructor(uint256 number_) {
+        number = Math.triple(number_);
+    }
+}
+"#,
+    );
+    prj.add_test(
+        "Counter.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {Counter as DoubleCounter} from "../src/Counter.sol";
+import {Counter as TripleCounter} from "../src/nested/Counter.sol";
+
+contract CounterTest is Test {
+    function testNew() public {
+        DoubleCounter doubleCounter = new DoubleCounter(21);
+        TripleCounter tripleCounter = new TripleCounter(21);
+        assertEq(doubleCounter.number(), 42);
+        assertEq(tripleCounter.number(), 63);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--match-test", "testNew"]).assert_success().stdout_eq(str![[r#"
+...
+Ran 1 test for test/Counter.t.sol:CounterTest
+[PASS] testNew() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+});
+
 // Counter contract without interface instantiated in CounterTest
 //
 // ├── src


### PR DESCRIPTION
`unchecked_cheatcode_artifacts` currently disables safety checks by dropping `available_artifacts`, but that also discards the exact source-to-artifact mapping. With dynamic test linking, a linked `CREATE` is rewritten to `vm.deployCode("src/...")`; the disk fallback then tries `out/src/...` instead of the artifact's actual collision-safe path.

Keep a separate Arc-backed artifact lookup while leaving `available_artifacts` unset when safety checks are disabled. This preserves unchecked access semantics while allowing freshly compiled, dynamically linked contracts to resolve from exact artifact data. The regression covers linked same-named contracts in different source directories so artifact path disambiguation is exercised.

Closes #16468.

This PR was written with Codex, including root-cause analysis, implementation, and tests.
