### PR TITLE
chore(cast): remove stale wallet JSON comment

### DIFF
--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -379,8 +379,6 @@ pub enum WalletSubcommands {
 }
 
 impl WalletSubcommands {
-    // NOTE: wallet subcommands use custom shell::is_json() branches with local output shapes.
-    // TODO: Full JsonEnvelope migration is deferred to a follow-up pass.
     pub async fn run(self) -> Result<()> {
         match self {
             Self::New {


### PR DESCRIPTION
## Summary

- remove the stale note claiming the wallet JsonEnvelope migration is deferred
- reflect the existing wallet JSON envelope behavior without changing runtime behavior

## Testing

- git diff --check (comment-only change)