### PR TITLE
fix(lint): keep data location when resolving members in initializers

### DIFF
--- a/.changelog/lint-init-member-data-location.md
+++ b/.changelog/lint-init-member-data-location.md
@@ -1,0 +1,5 @@
+---
+forge-lint: patch
+---
+
+Fixed a panic when linting a member access on a struct, array or bytes inside a state variable initializer.

--- a/crates/lint/src/sol/info/function_init_state.rs
+++ b/crates/lint/src/sol/info/function_init_state.rs
@@ -175,13 +175,14 @@ impl ImpureRefFinder<'_> {
     fn judge_member(&mut self, base: &Expr<'_>, member: &solar::ast::Ident) {
         let Some(ty) = self.gcx.type_of_expr(base.peel_parens().id) else { return };
         // A contract name used as the base is a type-namespace item, so its type comes wrapped
-        // as `Type(Contract(..))`, while a contract-typed value comes bare.
-        let ty = ty.peel_refs();
-        let ty = match ty.kind {
+        // as `Type(Contract(..))`, while a contract-typed value comes bare. Peel only to
+        // discriminate: `members_of` needs reference types to keep their data location.
+        let peeled = ty.peel_refs();
+        let peeled = match peeled.kind {
             TyKind::Type(inner) => inner.peel_refs(),
-            _ => ty,
+            _ => peeled,
         };
-        if let TyKind::Contract(contract_id) = ty.kind {
+        if let TyKind::Contract(contract_id) = peeled.kind {
             // Walk the linearization: an inherited function or getter is not among the
             // contract's own items.
             for base_id in self.hir.contract(contract_id).linearized_bases {

--- a/crates/lint/testdata/FunctionInitState.sol
+++ b/crates/lint/testdata/FunctionInitState.sol
@@ -187,3 +187,29 @@ contract InitFromFunction is Base {
         return local;
     }
 }
+
+struct Config {
+    address owner;
+    uint8 decimals;
+}
+
+library Defaults {
+    function config() internal pure returns (Config memory) {
+        return Config(address(0), 18);
+    }
+}
+
+// Member access on a reference type inside an initializer used to abort the linter, because the
+// base type reached `members_of` with its data location peeled off. Reading a state variable is
+// still reported, and a pure library call is still fine.
+contract InitFromReferenceType {
+    Config internal config;
+    uint256[] internal ids;
+    bytes internal payload;
+
+    address public owner = config.owner; //~NOTE: state variable initializer
+    uint256 public idCount = ids.length; //~NOTE: state variable initializer
+    uint256 public payloadSize = payload.length; //~NOTE: state variable initializer
+
+    uint8 public defaultDecimals = Defaults.config().decimals;
+}

--- a/crates/lint/testdata/FunctionInitState.stderr
+++ b/crates/lint/testdata/FunctionInitState.stderr
@@ -142,3 +142,27 @@ LL │     uint256 public immutable fromNonPureImmutable = set();
    │
    ╰ help: https://getfoundry.sh/forge/linting/function-init-state
 
+note[function-init-state]: state variable initializer depends on a non-pure function or another state variable
+   ╭▸ ROOT/testdata/FunctionInitState.sol:LL:CC
+   │
+LL │     address public owner = config.owner;
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/function-init-state
+
+note[function-init-state]: state variable initializer depends on a non-pure function or another state variable
+   ╭▸ ROOT/testdata/FunctionInitState.sol:LL:CC
+   │
+LL │     uint256 public idCount = ids.length;
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/function-init-state
+
+note[function-init-state]: state variable initializer depends on a non-pure function or another state variable
+   ╭▸ ROOT/testdata/FunctionInitState.sol:LL:CC
+   │
+LL │     uint256 public payloadSize = payload.length;
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/function-init-state
+


### PR DESCRIPTION
## Motivation

Fixes #16473.

`forge lint` aborts with an internal panic when a state-variable initializer contains a member access on a reference type:

```solidity
struct S {
    address a;
}

contract C {
    S internal s;
    address internal x = s.a; // native_members: type Struct(StructId(0)) should be wrapped in Ref
}
```

The code is valid Solidity and `solc` accepts it, so this makes `forge lint` (and plain `forge build`, which runs the linter) unusable for any project containing the pattern. `uint256 internal n = arr.length;` trips it too, which is ordinary enough to hit real codebases.

The panic aborts the process, so findings that were not yet flushed are lost. That makes it easy to misread: piping `forge lint` into a counter shows zero warnings, because the abort happens before warnings are printed.

## Solution

`judge_member` in `crates/lint/src/sol/info/function_init_state.rs` took the type of the base expression and unconditionally stripped its data location:

```rust
let Some(ty) = self.gcx.type_of_expr(base.peel_parens().id) else { return };
let ty = ty.peel_refs();
```

The `peel_refs()` is needed to unwrap the `Type(Contract(..))` form so the `TyKind::Contract` check below it works for a contract name used as a base. But the same peeled type was then handed to `gcx.members_of` in the `else` branch, and `members_of` requires reference types to keep their location: `native_members` panics for `Struct`, `Array`, `DynArray` and `Bytes` that are not wrapped in `Ty::Ref`.

`type_of_expr` returns a correctly located `Ref(Struct, Storage)`, so the location only went missing here.

This keeps the peeled type for the contract discrimination and passes the original to `members_of`.

Only `FunctionInitState` walks state-variable initializers, which is why the same member access inside a function body was never affected.

This is the same class of defect as #14845 ("fix(lint): preserve variable locations in loop lints"), in a different lint.

## Test

Added a case to `crates/lint/testdata/FunctionInitState.sol` covering struct member access, `uint256[].length` and `bytes.length` in initializers. All three read a state variable, so they must still be reported rather than crash, plus a pure library call returning a struct that must stay silent.

Verified the fixture panics on `master` and passes with this change.
