### PR TITLE
fix(lint): detect storage return mutations

### DIFF
--- a/.changelog/detect-assert-storage-return-mutations.md
+++ b/.changelog/detect-assert-storage-return-mutations.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `assert-state-change` failing to detect mutating library extensions called on storage references returned by functions.

--- a/crates/lint/src/sol/med/assert_state_change.rs
+++ b/crates/lint/src/sol/med/assert_state_change.rs
@@ -166,8 +166,8 @@ fn find_state_change<'hir>(
 
             if candidates.is_empty()
                 && let ExprKind::Member(base, method) = &callee.kind
-                && lvalue_is_state_var(hir, base)
                 && let Some(recv_ty) = expr_ty(gcx, base)
+                && (lvalue_is_state_var(hir, base) || recv_ty.loc() == Some(DataLocation::Storage))
             {
                 let lib_candidates =
                     resolve_library_extension(gcx, hir, method.name, args.len(), recv_ty);

--- a/crates/lint/src/sol/med/assert_state_change.rs
+++ b/crates/lint/src/sol/med/assert_state_change.rs
@@ -164,7 +164,19 @@ fn find_state_change<'hir>(
                 return Some(expr.span);
             }
 
-            if candidates.is_empty()
+            // Prefer Solar's selected `using for` extension. In particular, a resolved
+            // non-mutating extension must prevent the fallback from matching an unrelated
+            // mutating library function with the same name and receiver type.
+            let resolved_extension = gcx.resolved_call(expr).filter(|resolved| resolved.attached);
+            if resolved_extension
+                .and_then(|resolved| resolved.res.as_function())
+                .is_some_and(|fid| hir.function(fid).mutates_state())
+            {
+                return Some(expr.span);
+            }
+
+            if resolved_extension.is_none()
+                && candidates.is_empty()
                 && let ExprKind::Member(base, method) = &callee.kind
                 && let Some(recv_ty) = expr_ty(gcx, base)
                 && (lvalue_is_state_var(hir, base) || recv_ty.loc() == Some(DataLocation::Storage))

--- a/crates/lint/testdata/AssertStateChange.sol
+++ b/crates/lint/testdata/AssertStateChange.sol
@@ -187,9 +187,19 @@ contract AssertStateChangeUsingFor {
 
     uint256[] public items;
 
+    function getItems() internal view returns (uint256[] storage) {
+        return items;
+    }
+
     // Bad: bump() writes to storage via a using-for library extension, must be flagged.
     function badLibraryExtension() external returns (bool) {
         assert(items.bump()); //~WARN: assert() argument contains a state-modifying expression
+        return true;
+    }
+
+    // Bad: the function call returns the same storage array and must remain storage-backed.
+    function badLibraryExtensionOnStorageReturn() external returns (bool) {
+        assert(getItems().bump()); //~WARN: assert() argument contains a state-modifying expression
         return true;
     }
 

--- a/crates/lint/testdata/AssertStateChange.sol
+++ b/crates/lint/testdata/AssertStateChange.sol
@@ -168,8 +168,8 @@ contract AssertStateChangePushPop {
 }
 
 // ---- using-for library extension calls ----
-// Solar does not yet embed Res on Member expressions for extension methods, so a dedicated
-// library-scan fallback is required (fix for false negatives on using-for mutations).
+// Solar's resolved call is preferred; a library scan remains as a fallback when resolution is
+// unavailable.
 
 library StorageLib {
     function bump(uint256[] storage arr) internal returns (bool) {

--- a/crates/lint/testdata/AssertStateChange.stderr
+++ b/crates/lint/testdata/AssertStateChange.stderr
@@ -81,6 +81,14 @@ LL │         assert(items.bump());
 warning[assert-state-change]: assert() argument contains a state-modifying expression; assert() is for invariants, hoist the mutation before the assert, or use require() for validation
    ╭▸ ROOT/testdata/AssertStateChange.sol:LL:CC
    │
+LL │         assert(getItems().bump());
+   │                ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/assert-state-change
+
+warning[assert-state-change]: assert() argument contains a state-modifying expression; assert() is for invariants, hoist the mutation before the assert, or use require() for validation
+   ╭▸ ROOT/testdata/AssertStateChange.sol:LL:CC
+   │
 LL │         assert(o.check(n));
    │                ━━━━━━━━━━
    │

--- a/crates/lint/testdata/AssertStateChangeLibDisambig.sol
+++ b/crates/lint/testdata/AssertStateChangeLibDisambig.sol
@@ -3,17 +3,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// ---- library disambiguation: `all` policy avoids FPs from unrelated libraries ----
+// ---- library disambiguation: selected extension avoids unrelated libraries ----
 //
 // Two libraries both define bump(uint256[] storage) but with different mutability.
-// Without `using for` scope info in the HIR, the candidate scanner sees both.
-// Using `all`-mutates (not `any`) prevents a false positive when the selected
-// extension is the view one from ViewBumpLib.
-//
-// Trade-off: a contract that uses ONLY MutBumpLib but lives in the same compilation
-// unit as ViewBumpLib will also be silent (false negative), because the scanner
-// cannot distinguish bound from unbound libraries. This is an acknowledged limitation
-// until Solar exposes `using for` binding info in the HIR.
+// Solar's selected extension takes precedence over the global fallback scan.
 
 library MutBumpLib {
     function bump(uint256[] storage arr) internal returns (bool) {
@@ -29,8 +22,7 @@ library ViewBumpLib {
 }
 
 // Good: ViewBumpLib.bump is view; MutBumpLib.bump is in the compilation unit but NOT
-// bound here via `using for`. With `all`-mutates policy the presence of a view
-// candidate suppresses the false positive.
+// bound here via `using for`.
 contract AssertStateChangeLibDisambiguation {
     using ViewBumpLib for uint256[];
 
@@ -39,5 +31,33 @@ contract AssertStateChangeLibDisambiguation {
     function goodViewLibraryExtension() external view returns (uint256) {
         assert(items.bump() >= 0);
         return items.length;
+    }
+}
+
+library MemoryView {
+    function inspect(uint256[] memory) internal pure returns (bool) {
+        return true;
+    }
+}
+
+library UnrelatedStorageMutation {
+    function inspect(uint256[] storage values) internal returns (bool) {
+        values.push(1);
+        return true;
+    }
+}
+
+contract AssertStateChangeMemoryExtension {
+    using MemoryView for uint256[];
+
+    uint256[] private storedValues;
+
+    function values() internal view returns (uint256[] storage) {
+        return storedValues;
+    }
+
+    // Good: the selected extension copies its receiver to memory and does not mutate storage.
+    function goodMemoryExtension() external view {
+        assert(values().inspect());
     }
 }


### PR DESCRIPTION
The `assert-state-change` lint only recognized mutating library extensions when their receiver was syntactically rooted at a state variable. This missed calls such as `assert(getItems().bump())` when `getItems()` returns a storage reference.

Treating Solar’s semantic `Storage` location as evidence that the receiver is storage-backed lets the existing extension resolution detect these mutations while preserving the syntactic fallback needed for mappings.