### PR TITLE
perf(symbolic): speed up checked-add constraints

### DIFF
--- a/.changelog/symbolic-checked-add-normalization.md
+++ b/.changelog/symbolic-checked-add-normalization.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Sped up symbolic tests by canonicalizing checked-add overflow constraints before SMT solving.

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -680,6 +680,14 @@ fn normalize_bool_node_for_solver(cx: &mut SymCx, expr: SymBoolExpr) -> SymBoolE
     }
 
     match expr.kind() {
+        SymBoolExprKind::Not(value) => match value.kind() {
+            SymBoolExprKind::Cmp(SymCmpOp::Ult, left, right)
+                if matches!(left.kind(), SymExprKind::Not(_)) =>
+            {
+                SymBoolExpr::cmp(cx, SymCmpOp::Ule, right.clone(), left.clone())
+            }
+            _ => expr,
+        },
         SymBoolExprKind::Cmp(op, left, right) => {
             let left = normalize_expr_for_solver(cx, left.clone());
             let right = normalize_expr_for_solver(cx, right.clone());
@@ -1538,13 +1546,38 @@ impl SymBoolExpr {
         left: &SymExpr,
         right: &SymExpr,
     ) -> Option<Self> {
-        match op {
-            // `a + b > a => false` when `a + b` cannot overflow.
-            SymCmpOp::Ugt if left.add_overflow_check(right) => Some(Self::constant(cx, false)),
-            // `a < a + b => false` when `a + b` cannot overflow.
-            SymCmpOp::Ult if right.add_overflow_check(left) => Some(Self::constant(cx, false)),
-            _ => None,
+        // Strict forms test overflow and non-strict forms its complement; addition wraps iff the
+        // increment exceeds `~base`.
+        let (base, increment, overflow) = match op {
+            SymCmpOp::Ugt => {
+                right.add_with_operand(left).map(|(_, increment)| (left, increment, true))
+            }
+            SymCmpOp::Ult => {
+                left.add_with_operand(right).map(|(_, increment)| (right, increment, true))
+            }
+            SymCmpOp::Uge => {
+                left.add_with_operand(right).map(|(_, increment)| (right, increment, false))
+            }
+            SymCmpOp::Ule => {
+                right.add_with_operand(left).map(|(_, increment)| (left, increment, false))
+            }
+            SymCmpOp::Eq | SymCmpOp::Slt | SymCmpOp::Sgt => None,
+        }?;
+        if base.add_cannot_overflow_256(increment) {
+            return Some(Self::constant(cx, !overflow));
         }
+
+        let limit = match base.kind() {
+            SymExprKind::BinOp(SymBinOp::Sub, max, value) if max.as_const() == Some(U256::MAX) => {
+                value.clone()
+            }
+            _ => SymExpr::not(cx, base.clone()),
+        };
+        Some(if overflow {
+            Self::cmp(cx, SymCmpOp::Ult, limit, increment.clone())
+        } else {
+            Self::cmp(cx, SymCmpOp::Ule, increment.clone(), limit)
+        })
     }
 
     fn normalize_udiv_eq_zero(cx: &mut SymCx, left: &SymExpr, right: &SymExpr) -> Option<Self> {
@@ -1623,11 +1656,6 @@ impl SymExpr {
         self.strip_low_byte_mask()
             .bool_word_condition()
             .map(|condition| normalize_bool_for_solver(cx, condition))
-    }
-
-    fn add_overflow_check(&self, right: &Self) -> bool {
-        let Some((base, increment)) = right.add_with_operand(self) else { return false };
-        base == self && base.add_cannot_overflow_256(increment)
     }
 
     fn add_with_operand<'a>(&'a self, operand: &Self) -> Option<(&'a Self, &'a Self)> {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -4181,20 +4181,31 @@ fn solver_normalizes_checked_add_overflow_guard_for_bounded_operands() {
 }
 
 #[test]
-fn solver_does_not_normalize_unbounded_checked_add_overflow_guard() {
+fn solver_normalizes_unbounded_checked_add_overflow_guard() {
     let mut cx = SymCx::new();
     let a = SymExpr::var(&mut cx, "a");
     let b = SymExpr::var(&mut cx, "b");
-    let sum = SymExpr::binop(&mut cx, SymBinOp::Add, a.clone(), b);
-    let original = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a, sum);
-    let normalized = normalize_bool_for_solver(&mut cx, original.clone());
+    let sum = SymExpr::binop(&mut cx, SymBinOp::Add, a.clone(), b.clone());
+    let limit = SymExpr::not(&mut cx, a.clone());
+    let overflow = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, limit.clone(), b.clone());
+    let no_overflow = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, b, limit);
+    let cases = [
+        (SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a.clone(), sum.clone()), overflow.clone()),
+        (SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, sum.clone(), a.clone()), overflow),
+        (SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, a.clone(), sum.clone()), no_overflow.clone()),
+        (SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, sum.clone(), a.clone()), no_overflow.clone()),
+        (SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, sum, a).not(&mut cx), no_overflow),
+    ];
+    for (original, expected) in &cases {
+        assert_eq!(normalize_bool_for_solver(&mut cx, original.clone()), *expected);
+    }
 
-    assert_ne!(normalized, SymBoolExpr::constant(&mut cx, false));
-
-    let model =
-        symbolic_model(&mut cx, [("a".to_string(), U256::MAX), ("b".to_string(), U256::from(1))]);
-    assert!(original.eval_model(&model).unwrap());
-    assert_eq!(original.eval_model(&model).unwrap(), normalized.eval_model(&model).unwrap());
+    for (a, b) in [(U256::MAX, U256::ZERO), (U256::MAX, U256::ONE)] {
+        let model = symbolic_model(&mut cx, [("a".to_string(), a), ("b".to_string(), b)]);
+        for (original, expected) in &cases {
+            assert_eq!(original.eval_model(&model).unwrap(), expected.eval_model(&model).unwrap());
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Canonicalize Solidity checked-add overflow guards into direct increment bounds before SMT solving.
- Reuse the existing add-overflow normalizer and restrict complement canonicalization to the `~base` shape produced by checked addition, preserving unrelated solver optimizations.
- Cover strict and non-strict comparison orientations plus `uint256` overflow boundaries.
- Validated with all 315 symbolic unit tests in parallel and serial, `cargo +nightly fmt --all -- --check`, `git diff --check`, and `cargo +1.96.0 check -p forge`. The focused Angstrom benchmark retained identical path and query behavior.

This PR was developed with Codex assistance for profiling, implementation, tests, benchmarking, and drafting. I reviewed the change and results.

## Benchmarks

Command: `forge test --symbolic --json --match-contract WETHInvariants` in Vectorized/solady v0.1.26.

| Metric | master | this PR | Change |
| --- | ---: | ---: | ---: |
| Wall time | 19.83s | 3.78s | 5.25x faster |
| Solver time | 18.411s | 1.508s | 12.2x faster |
| Maximum query time | 12.084s | 99ms | 122x faster |
| SMT queries | 335 | 297 | -11.3% |
| SAT cache hits | 0 | 64 | +64 |
| SMT input | 196,584 bytes | 161,560 bytes | -17.8% |

Both runs completed the same 1,024 bounded paths. A Samply comparison reduced Z3 CPU time from 37.09s to 3.08s.