### PR TITLE
fix(anvil): avoid blob tx stack overflow

### DIFF
--- a/.changelog/anvil-blob-transaction-stack-overflow.md
+++ b/.changelog/anvil-blob-transaction-stack-overflow.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed a stack overflow when submitting signed EIP-4844 blob transactions.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -41,7 +41,7 @@ use alloy_consensus::{
 };
 use alloy_dyn_abi::TypedData;
 use alloy_eips::{
-    eip2718::Encodable2718,
+    eip2718::{EIP4844_TX_TYPE_ID, Encodable2718},
     eip7910::{EthConfig, EthForkConfig},
 };
 use alloy_evm::overrides::{OverrideBlockHashes, apply_state_overrides};
@@ -2944,11 +2944,21 @@ impl EthApi<FoundryNetwork> {
         } else {
             None
         };
-        let raw = service_encoded.as_deref().unwrap_or(tx.as_ref());
+        let raw = service_encoded.map(Bytes::from).unwrap_or(tx);
 
-        let mut data = raw;
-        let transaction = FoundryTxEnvelope::decode_2718(&mut data)
-            .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?;
+        let transaction = if raw.first() == Some(&EIP4844_TX_TYPE_ID) {
+            // Pooled EIP-4844 decoding uses large stack frames for inline blobs. Isolate it from
+            // the already-large RPC dispatcher without increasing every worker's stack.
+            let raw = raw.clone();
+            tokio::task::spawn_blocking(move || FoundryTxEnvelope::decode_2718(&mut raw.as_ref()))
+                .await
+                .map_err(|_| {
+                    BlockchainError::Internal("transaction decoding task panicked".into())
+                })?
+        } else {
+            FoundryTxEnvelope::decode_2718(&mut raw.as_ref())
+        }
+        .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?;
 
         self.ensure_typed_transaction_supported(&transaction)?;
 
@@ -2963,7 +2973,7 @@ impl EthApi<FoundryNetwork> {
         };
 
         if self.backend.is_tempo() && TempoHardfork::from(self.backend.hardfork()).is_t5() {
-            let classification = classify_payment_lane(raw);
+            let classification = classify_payment_lane(raw.as_ref());
             trace!(target: "node", tx = ?transaction.hash(), ?classification, "classified transaction lane");
         }
 

--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -4,7 +4,7 @@ use alloy_consensus::{
     TxEip4844, proofs::calculate_transaction_root,
 };
 use alloy_eips::{
-    Decodable2718, Typed2718,
+    eip2718::{Decodable2718, EIP4844_TX_TYPE_ID, Typed2718},
     eip4844::{
         BLOB_TX_MIN_BLOB_GASPRICE, DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK_DENCUN,
         TARGET_DATA_GAS_PER_BLOCK_DENCUN,
@@ -416,6 +416,16 @@ async fn can_correctly_estimate_blob_gas_with_recommended_fillers_with_signer() 
         receipt.blob_gas_used.expect("Expected to be EIP-4844 transaction"),
         DATA_GAS_PER_BLOB
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_malformed_eip4844_transaction() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
+    let (_api, handle) = spawn(node_config).await;
+
+    let err = handle.http_provider().send_raw_transaction(&[EIP4844_TX_TYPE_ID]).await.unwrap_err();
+
+    assert!(err.to_string().contains("Failed to decode transaction"));
 }
 
 // <https://github.com/foundry-rs/foundry/issues/9924>


### PR DESCRIPTION
Anvil currently decodes signed EIP-4844 transactions on the Tokio RPC worker. Because the pooled envelope carries inline blobs, Alloy decoding's large transient stack frames combine with the already-large RPC dispatcher frame and can overflow the default worker stack.

This change detects only the EIP-4844 transaction type and performs that decode on the blocking pool. Every other raw transaction type keeps the existing inline path, and malformed blob transactions retain the existing decode error. A focused regression covers that error path, and the changelog records the user-visible fix.

I reproduced the stack overflow on master with the existing signed-blob integration test. With this change, that test passes on the default stack and the full EIP-4844 integration module passes with 23 tests. I also validated signed blob submission over WebSocket, an EIP-7702 raw transaction, and Tempo's sponsored raw-transaction path.

This PR was written with Codex, including code generation and validation.