### PR TITLE
fix(forge): skip linking custom layouts

### DIFF
--- a/.changelog/custom-layout-dynamic-linking.md
+++ b/.changelog/custom-layout-dynamic-linking.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed compilation of tests that reference contracts with custom storage layouts and constructor arguments.

--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -213,7 +213,8 @@ impl<'gcx, 'src> BytecodeDependencyCollector<'gcx, 'src> {
             .ctor
             .is_some_and(|ctor_id| !self.gcx.hir.function(ctor_id).parameters.is_empty());
         // Solidity only permits a custom layout on the most-derived contract, so the generated
-        // constructor helper cannot inherit a target that declares one; keep this dependency native.
+        // constructor helper cannot inherit a target that declares one; keep this dependency
+        // native.
         if contract.layout.is_some() && has_constructor_args {
             trace!("skip dependency on custom-layout contract");
             return;

--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -209,6 +209,16 @@ impl<'gcx, 'src> BytecodeDependencyCollector<'gcx, 'src> {
         }
 
         let contract = self.gcx.hir.contract(dependency.referenced_contract);
+        let has_constructor_args = contract
+            .ctor
+            .is_some_and(|ctor_id| !self.gcx.hir.function(ctor_id).parameters.is_empty());
+        // Solidity forbids inheriting contracts with custom storage layouts, so the generated
+        // constructor helper cannot be used and this dependency must retain native semantics.
+        if contract.layout.is_some() && has_constructor_args {
+            trace!("skip dependency on custom-layout contract");
+            return;
+        }
+
         let source = self.gcx.hir.source(contract.source);
         let FileName::Real(path) = &source.file.name else {
             return;

--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -212,8 +212,8 @@ impl<'gcx, 'src> BytecodeDependencyCollector<'gcx, 'src> {
         let has_constructor_args = contract
             .ctor
             .is_some_and(|ctor_id| !self.gcx.hir.function(ctor_id).parameters.is_empty());
-        // Solidity forbids inheriting contracts with custom storage layouts, so the generated
-        // constructor helper cannot be used and this dependency must retain native semantics.
+        // Solidity only permits a custom layout on the most-derived contract, so the generated
+        // constructor helper cannot inherit a target that declares one; keep this dependency native.
         if contract.layout.is_some() && has_constructor_args {
             trace!("skip dependency on custom-layout contract");
             return;

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -2070,6 +2070,48 @@ contract TargetTest is Test {
     cmd.args(["build"]).assert_success();
 });
 
+// <https://github.com/foundry-rs/foundry/issues/16487>
+forgetest_init!(preprocess_custom_layout_contract, |prj, cmd| {
+    prj.update_config(|config| {
+        config.dynamic_test_linking = true;
+        config.solc = Some(foundry_config::SolcReq::Version(semver::Version::new(0, 8, 35)));
+    });
+
+    prj.add_source(
+        "Target.sol",
+        r#"
+contract Target layout at erc7201("test.Target") {
+    uint256 public value;
+
+    constructor(uint256 value_) {
+        value = value_;
+    }
+}
+        "#,
+    );
+
+    prj.add_test(
+        "Target.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {Target} from "../src/Target.sol";
+
+contract TargetTest is Test {
+    function testDirectNew() public {
+        Target target = new Target(42);
+        assertEq(target.value(), 42);
+    }
+
+    function targetCreationCode() public view returns (bytes memory) {
+        return type(Target).creationCode;
+    }
+}
+        "#,
+    );
+
+    cmd.args(["test"]).assert_success();
+});
+
 // Test that `type(Contract).creationCode` keeps native pure semantics when dynamic linking is
 // enabled.
 forgetest_init!(preprocess_creation_code_in_pure_function, |prj, cmd| {


### PR DESCRIPTION
Custom-layout contracts with constructor arguments cannot use dynamic test linking because the generated helper inherits the target, which Solidity forbids. Preserve native compilation for these dependencies while retaining dynamic linking for unaffected contracts.

Fixes #16487.