### PR TITLE
fix(config): expand directory ignore globs to their contained files

### DIFF
--- a/.changelog/pr-16489.md
+++ b/.changelog/pr-16489.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+forge-doc: patch
+foundry-config: patch
+---
+
+Fixed lint, build-time lint, and doc `ignore` globs ending in `**` (e.g. `src/**`) silently ignoring nothing: directory-matching patterns now also exclude the files they contain, and plain directory entries are honored.

--- a/crates/config/src/filter.rs
+++ b/crates/config/src/filter.rs
@@ -185,10 +185,9 @@ impl FromStr for SkipBuildFilter {
 
 /// Expand globs with a root path.
 ///
-/// A pattern ending in `**`, like `src/**`, only matches directories: the glob crate yields the
-/// matched directories themselves but never the files they contain, and yields nothing at all
-/// when the directory has no subdirectories. Such patterns are additionally expanded with a
-/// trailing `/*` so the files inside the matched directories are included.
+/// A trailing recursive component, like `src/**`, only matches subdirectories. Such patterns also
+/// expand their parent so directory-aware consumers cover direct files and every descendant
+/// without enumerating the entire tree.
 pub fn expand_globs(
     root: &Path,
     patterns: impl IntoIterator<Item = impl AsRef<str>>,
@@ -196,16 +195,15 @@ pub fn expand_globs(
     let mut expanded = Vec::new();
     for pattern in patterns {
         let pattern = pattern.as_ref();
-        let mut globs = vec![root.join(pattern)];
-        if pattern.ends_with("**") {
-            globs.push(root.join(format!("{pattern}/*")));
-        }
+        let path = Path::new(pattern);
+        let recursive_parent = path
+            .file_name()
+            .is_some_and(|component| component == "**")
+            .then(|| root.join(path.parent().unwrap_or_else(|| Path::new(""))));
+        let globs = recursive_parent.into_iter().chain([root.join(path)]);
         for glob in globs {
             for path in glob::glob(&glob.display().to_string())? {
-                let path = path?;
-                if !expanded.contains(&path) {
-                    expanded.push(path);
-                }
+                expanded.push(path?);
             }
         }
     }
@@ -226,6 +224,24 @@ pub fn is_ignored_path(file: &Path, paths: &[PathBuf], base: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_expand_trailing_recursive_glob() {
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let sub = src.join("sub");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(src.join("A.sol"), []).unwrap();
+        fs::write(sub.join("B.sol"), []).unwrap();
+
+        let expanded = expand_globs(root.path(), ["src/**"]).unwrap();
+
+        assert_eq!(expanded.first(), Some(&src));
+        assert!(expanded.contains(&sub));
+        assert!(!expanded.iter().any(|path| path.is_file()));
+    }
 
     #[test]
     fn test_is_ignored_path() {

--- a/crates/config/src/filter.rs
+++ b/crates/config/src/filter.rs
@@ -185,26 +185,20 @@ impl FromStr for SkipBuildFilter {
 
 /// Expand globs with a root path.
 ///
-/// A trailing recursive component, like `src/**`, only matches subdirectories. Such patterns also
-/// expand their parent so directory-aware consumers cover direct files and every descendant
-/// without enumerating the entire tree.
+/// A trailing recursive component, like `src/**`, only matches subdirectories. Replace it with its
+/// parent so directory-aware consumers cover every descendant without enumerating the tree.
 pub fn expand_globs(
     root: &Path,
     patterns: impl IntoIterator<Item = impl AsRef<str>>,
 ) -> eyre::Result<Vec<PathBuf>> {
     let mut expanded = Vec::new();
     for pattern in patterns {
-        let pattern = pattern.as_ref();
-        let path = Path::new(pattern);
-        let recursive_parent = path
-            .file_name()
-            .is_some_and(|component| component == "**")
-            .then(|| root.join(path.parent().unwrap_or_else(|| Path::new(""))));
-        let globs = recursive_parent.into_iter().chain([root.join(path)]);
-        for glob in globs {
-            for path in glob::glob(&glob.display().to_string())? {
-                expanded.push(path?);
-            }
+        let mut pattern = Path::new(pattern.as_ref());
+        if pattern.ends_with("**") {
+            pattern = pattern.parent().unwrap_or_else(|| Path::new(""));
+        }
+        for path in glob::glob(&root.join(pattern).display().to_string())? {
+            expanded.push(path?);
         }
     }
     Ok(expanded)
@@ -231,16 +225,9 @@ mod tests {
     fn test_expand_trailing_recursive_glob() {
         let root = tempdir().unwrap();
         let src = root.path().join("src");
-        let sub = src.join("sub");
-        fs::create_dir_all(&sub).unwrap();
-        fs::write(src.join("A.sol"), []).unwrap();
-        fs::write(sub.join("B.sol"), []).unwrap();
+        fs::create_dir(&src).unwrap();
 
-        let expanded = expand_globs(root.path(), ["src/**"]).unwrap();
-
-        assert_eq!(expanded.first(), Some(&src));
-        assert!(expanded.contains(&sub));
-        assert!(!expanded.iter().any(|path| path.is_file()));
+        assert_eq!(expand_globs(root.path(), ["src/**"]).unwrap(), vec![src]);
     }
 
     #[test]

--- a/crates/config/src/filter.rs
+++ b/crates/config/src/filter.rs
@@ -184,22 +184,66 @@ impl FromStr for SkipBuildFilter {
 }
 
 /// Expand globs with a root path.
+///
+/// A pattern ending in `**`, like `src/**`, only matches directories: the glob crate yields the
+/// matched directories themselves but never the files they contain, and yields nothing at all
+/// when the directory has no subdirectories. Such patterns are additionally expanded with a
+/// trailing `/*` so the files inside the matched directories are included.
 pub fn expand_globs(
     root: &Path,
     patterns: impl IntoIterator<Item = impl AsRef<str>>,
 ) -> eyre::Result<Vec<PathBuf>> {
     let mut expanded = Vec::new();
     for pattern in patterns {
-        for paths in glob::glob(&root.join(pattern.as_ref()).display().to_string())? {
-            expanded.push(paths?);
+        let pattern = pattern.as_ref();
+        let mut globs = vec![root.join(pattern)];
+        if pattern.ends_with("**") {
+            globs.push(root.join(format!("{pattern}/*")));
+        }
+        for glob in globs {
+            for path in glob::glob(&glob.display().to_string())? {
+                let path = path?;
+                if !expanded.contains(&path) {
+                    expanded.push(path);
+                }
+            }
         }
     }
     Ok(expanded)
 }
 
+/// Returns whether `file` is contained in `paths`, or lies underneath a directory contained in
+/// `paths`.
+///
+/// Expanded ignore globs can contain directories, e.g. `test/**` yields the directories under
+/// `test`, so an ignore check must also match the files below every entry. `base` is used to
+/// resolve `file` when it is relative.
+pub fn is_ignored_path(file: &Path, paths: &[PathBuf], base: &Path) -> bool {
+    let joined = base.join(file);
+    paths.iter().any(|path| file.starts_with(path) || joined.starts_with(path))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_is_ignored_path() {
+        let base = Path::new("/root");
+        let ignored = [PathBuf::from("/root/test"), PathBuf::from("/root/src/A.sol")];
+
+        // Exact file matches, absolute and relative.
+        assert!(is_ignored_path(Path::new("/root/src/A.sol"), &ignored, base));
+        assert!(is_ignored_path(Path::new("src/A.sol"), &ignored, base));
+
+        // Files under an ignored directory.
+        assert!(is_ignored_path(Path::new("/root/test/B.t.sol"), &ignored, base));
+        assert!(is_ignored_path(Path::new("test/sub/C.t.sol"), &ignored, base));
+
+        // A directory prefix only matches whole path components.
+        assert!(!is_ignored_path(Path::new("/root/testOther.sol"), &ignored, base));
+        assert!(!is_ignored_path(Path::new("/root/src/B.sol"), &ignored, base));
+    }
 
     #[test]
     fn test_build_filter() {

--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -5,7 +5,10 @@ use crate::{
 };
 use eyre::Result;
 use foundry_compilers::{compilers::solc::SOLC_EXTENSIONS, utils::source_files_iter};
-use foundry_config::{DocConfig, filter::expand_globs};
+use foundry_config::{
+    DocConfig,
+    filter::{expand_globs, is_ignored_path},
+};
 use rayon::prelude::*;
 use solar::{config::CompilerStage, sema::Compiler};
 use std::{
@@ -94,14 +97,14 @@ impl DocBuilder {
         });
 
         let mut sources: Vec<(PathBuf, bool)> = source_files_iter(&self.sources, SOLC_EXTENSIONS)
-            .filter(|p| !ignored.contains(p) && !ignored.contains(&self.root.join(p)))
+            .filter(|p| !is_ignored_path(p, &ignored, &self.root))
             .map(|p| (p, false))
             .collect();
 
         if self.include_libraries {
             for lib_dir in &self.libraries {
                 let lib_sources = source_files_iter(lib_dir, SOLC_EXTENSIONS)
-                    .filter(|p| !ignored.contains(p) && !ignored.contains(&self.root.join(p)))
+                    .filter(|p| !is_ignored_path(p, &ignored, &self.root))
                     .map(|p| (p, true));
                 sources.extend(lib_sources);
             }

--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -318,6 +318,7 @@ impl DocBuilder {
                 let mut manifest_lines: Vec<String> =
                     all_rel.iter().map(|p| p.to_string_lossy().into_owned()).collect();
                 manifest_lines.sort();
+                fs::create_dir_all(&pages_dir)?;
                 fs::write(&manifest_path, manifest_lines.join("\n") + "\n")?;
             }
 

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -27,7 +27,7 @@ use foundry_config::{
         error::Kind::InvalidType,
         value::{Dict, Map, Value},
     },
-    filter::expand_globs,
+    filter::{expand_globs, is_ignored_path},
 };
 use serde::Serialize;
 use solar::{
@@ -205,8 +205,7 @@ impl BuildArgs {
                     if let Some(files) = files {
                         return files.iter().any(|file| &curr_dir.join(file) == p);
                     }
-                    skip.is_match(p)
-                        && !(ignored.contains(p) || ignored.contains(&curr_dir.join(p)))
+                    skip.is_match(p) && !is_ignored_path(p, &ignored, &curr_dir)
                 })
                 .collect::<Vec<_>>();
 

--- a/crates/forge/src/cmd/lint.rs
+++ b/crates/forge/src/cmd/lint.rs
@@ -11,7 +11,11 @@ use foundry_cli::{
 };
 use foundry_common::shell;
 use foundry_compilers::{FileFilter, solc::SolcLanguage, utils::SOLC_EXTENSIONS};
-use foundry_config::{SkipBuildFilters, filter::expand_globs, lint::Severity};
+use foundry_config::{
+    SkipBuildFilters,
+    filter::{expand_globs, is_ignored_path},
+    lint::Severity,
+};
 use std::path::PathBuf;
 
 /// CLI arguments for `forge lint`.
@@ -65,7 +69,7 @@ impl LintArgs {
                 config
                     .project_paths::<SolcLanguage>()
                     .input_files_iter()
-                    .filter(|p| !(ignored.contains(p) || ignored.contains(&cwd.join(p))))
+                    .filter(|p| !is_ignored_path(p, &ignored, &cwd))
                     .collect()
             }
             paths => {

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -45,6 +45,14 @@ forgetest_init!(doc_supports_empty_projects, |_prj, cmd| {
     cmd.arg("doc").assert_success();
 });
 
+forgetest_init!(doc_supports_ignoring_all_sources, |prj, cmd| {
+    prj.add_source("Ignored.sol", "contract Ignored {}");
+    prj.update_config(|config| config.doc.ignore = vec!["src/**".to_string()]);
+
+    cmd.arg("doc").assert_success();
+    assert!(prj.root().join("docs/src/pages/.forge-doc-manifest").exists());
+});
+
 forgetest_init!(doc_uses_configured_commit_for_source_links, |prj, cmd| {
     prj.add_source(
         "Revision.sol",

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -286,6 +286,36 @@ note[mixed-case-function]: function names should use mixedCase
 nothing to lint
 
 "#]]);
+
+    // Check config again, ignoring a directory via the documented `dir/**` glob form
+    prj.update_config(|config| {
+        config.lint = LinterConfig {
+            severity: vec![],
+            exclude_lints: vec![],
+            ignore: vec!["src/**".into()],
+            lint_on_build: true,
+            ..Default::default()
+        };
+    });
+    cmd.forge_fuse().arg("lint").assert_success().stderr_eq(str![[r#"
+nothing to lint
+
+"#]]);
+
+    // Check config again, ignoring a bare directory path
+    prj.update_config(|config| {
+        config.lint = LinterConfig {
+            severity: vec![],
+            exclude_lints: vec![],
+            ignore: vec!["src".into()],
+            lint_on_build: true,
+            ..Default::default()
+        };
+    });
+    cmd.forge_fuse().arg("lint").assert_success().stderr_eq(str![[r#"
+nothing to lint
+
+"#]]);
 });
 
 forgetest!(inline_config_suppresses_lint_in_inherited_source, |prj, cmd| {


### PR DESCRIPTION
## Problem

The documented form of the `[lint]` / `[doc]` `ignore` config silently ignores nothing. Per https://getfoundry.sh/config/reference/linter:

```toml
[lint]
ignore = ["src/legacy/**", "test/mocks/*.sol"]
```

Any pattern **ending in `**`** matches no files at all — `forge lint`, the build-time lint, and `forge doc` all keep reporting on files the user asked to ignore.

Repro (forge 1.8.1):

```
src/A.sol            # has a lint finding
src/sub/B.sol        # has a lint finding
```
```toml
[lint]
ignore = ["src/**"]
```
→ both files are still linted.

## Root cause (two independent layers)

**1. glob 0.3.4 trailing `**` semantics** — a trailing `**` only yields *directories*, never the files inside them, and yields nothing when the directory has no subdirectories. Verified directly against glob 0.3.4 on this fixture (`src/A.sol`, `src/sub/B.sol`):

| pattern       | glob 0.3.4 yields        |
|---------------|--------------------------|
| `src/**`      | `src/sub` (dir only)     |
| `src/*`       | `src/A.sol`, `src/sub`   |
| `src/**/*`    | all files + dirs         |

**2. Exact-membership ignore checks** — `forge lint`, build-time lint, and `forge doc` filter with `ignored.contains(p) || ignored.contains(&cwd.join(p))`, so a directory entry can never match the file paths being filtered. `forge fmt` does not have this bug because it already treats ignore entries as path prefixes (`path.starts_with(ignored)`).

## Fix

- `expand_globs` additionally expands a trailing `**` pattern with `/*` (`src/**` → also `src/**/*`) so the files inside matched directories are included. Existing matches are untouched — the expansion is a strict superset.
- New `foundry_config::filter::is_ignored_path(file, paths, base)`: exact match or component-wise directory prefix (`Path::starts_with`), used by `forge lint`, the build-time lint, and `forge doc`. This mirrors fmt's existing prefix semantics and also makes plain directory entries (`ignore = ["test"]`) and `test/*`-style patterns work for nested files.

`forge fmt` call sites are unchanged: they already prefix-match, so the extra file entries produced by the expansion yield identical ignore sets.

## Testing

- `test_is_ignored_path` unit test (exact file match, directory prefix, partial-component negative).
- Extended `can_use_config_ignore` with `ignore = ["src/**"]` and `ignore = ["src"]` rounds asserting `nothing to lint`; verified the new rounds **fail on master** and pass with this change.
- `cargo +nightly fmt --check` clean; `cargo +nightly clippy` clean on `foundry-config`, `forge`, `forge-doc`.
