### PR TITLE
fix(cheatcodes): preserve isolated refund snapshots

### DIFF
--- a/.changelog/cheatcode-state-gas.md
+++ b/.changelog/cheatcode-state-gas.md
@@ -2,4 +2,4 @@
 forge: minor
 ---
 
-Added `gasStateUsed` to the `Vm.Gas` values returned by `lastCallGas` and `lastFrameGas` while preserving existing gas snapshot totals.
+Added `gasStateUsed` to the `Vm.Gas` values returned by `lastCallGas` and `lastFrameGas` while preserving existing gas snapshot totals, including refund-adjusted isolated snapshots.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -953,10 +953,10 @@ impl Cheatcode for snapshotValue_1Call {
 impl Cheatcode for snapshotGasLastCall_0Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { name } = self;
-        let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
+        if ccx.state.gas_metering.last_call_gas.is_none() {
             bail!("no external call was made yet");
-        };
-        let gas_used = snapshot_gas_used(last_call_gas);
+        }
+        let gas_used = ccx.state.gas_metering.last_call_snapshot_gas_used;
         inner_last_gas_snapshot(ccx, None, Some(name.clone()), gas_used)
     }
 }
@@ -964,10 +964,10 @@ impl Cheatcode for snapshotGasLastCall_0Call {
 impl Cheatcode for snapshotGasLastCall_1Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { name, group } = self;
-        let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
+        if ccx.state.gas_metering.last_call_gas.is_none() {
             bail!("no external call was made yet");
-        };
-        let gas_used = snapshot_gas_used(last_call_gas);
+        }
+        let gas_used = ccx.state.gas_metering.last_call_snapshot_gas_used;
         inner_last_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()), gas_used)
     }
 }
@@ -975,10 +975,10 @@ impl Cheatcode for snapshotGasLastCall_1Call {
 impl Cheatcode for snapshotGasLastFrame_0Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { name } = self;
-        let Some(last_frame_gas) = &ccx.state.gas_metering.last_frame_gas else {
+        if ccx.state.gas_metering.last_frame_gas.is_none() {
             bail!("no external call or create was made yet");
-        };
-        let gas_used = snapshot_gas_used(last_frame_gas);
+        }
+        let gas_used = ccx.state.gas_metering.last_frame_snapshot_gas_used;
         inner_last_gas_snapshot(ccx, None, Some(name.clone()), gas_used)
     }
 }
@@ -986,10 +986,10 @@ impl Cheatcode for snapshotGasLastFrame_0Call {
 impl Cheatcode for snapshotGasLastFrame_1Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { name, group } = self;
-        let Some(last_frame_gas) = &ccx.state.gas_metering.last_frame_gas else {
+        if ccx.state.gas_metering.last_frame_gas.is_none() {
             bail!("no external call or create was made yet");
-        };
-        let gas_used = snapshot_gas_used(last_frame_gas);
+        }
+        let gas_used = ccx.state.gas_metering.last_frame_snapshot_gas_used;
         inner_last_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()), gas_used)
     }
 }
@@ -1753,10 +1753,6 @@ fn inner_value_snapshot<FEN: FoundryEvmNetwork>(
     Ok(Default::default())
 }
 
-const fn snapshot_gas_used(gas: &Gas) -> u64 {
-    gas.gasLimit.saturating_sub(gas.gasRemaining)
-}
-
 fn inner_last_gas_snapshot<FEN: FoundryEvmNetwork>(
     ccx: &mut CheatsCtxt<'_, '_, FEN>,
     group: Option<String>,
@@ -2361,31 +2357,5 @@ fn set_cold_slot<FEN: FoundryEvmNetwork>(
         && let Some(storage_slot) = account.storage.get_mut(&slot)
     {
         storage_slot.is_cold = cold;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn snapshot_gas_preserves_total_used() {
-        for (case, gas_total_used, gas_remaining, gas_refunded, gas_state_used, expected) in [
-            ("state gas spill", 1_000, 79_000, 5_000, 20_000, 21_000),
-            ("state gas reservoir", 1_000, 99_000, 0, 20_000, 1_000),
-            ("reverted frame", 1_000, 99_000, 0, 0, 1_000),
-            ("halted frame", 100_000, 0, 0, 0, 100_000),
-            ("nested state gas refund", 0, 100_000, 0, -20_000, 0),
-        ] {
-            let gas = Gas {
-                gasLimit: 100_000,
-                gasTotalUsed: gas_total_used,
-                gasMemoryUsed: 0,
-                gasRefunded: gas_refunded,
-                gasRemaining: gas_remaining,
-                gasStateUsed: gas_state_used,
-            };
-            assert_eq!(snapshot_gas_used(&gas), expected, "{case}");
-        }
     }
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -452,10 +452,17 @@ pub struct GasMetering {
     /// Cache of the amount of gas used in previous call.
     /// This is used by the `lastCallGas` cheatcode.
     pub last_call_gas: Option<crate::Vm::Gas>,
+    /// Gas used by `snapshotGasLastCall`.
+    pub(crate) last_call_snapshot_gas_used: u64,
 
     /// Cache of the amount of gas used in previous call or create frame.
     /// This is used by the `lastFrameGas` cheatcode.
     pub last_frame_gas: Option<crate::Vm::Gas>,
+    /// Gas used by `snapshotGasLastFrame`.
+    pub(crate) last_frame_snapshot_gas_used: u64,
+
+    /// Post-refund gas used by the isolated transaction wrapping the current frame.
+    isolated_snapshot_gas_used: Option<u64>,
 
     /// True if gas recording is enabled.
     pub recording: bool,
@@ -491,6 +498,11 @@ impl GasMetering {
         self.touched = true;
         self.reset = true;
         self.paused_frames.clear();
+    }
+
+    /// Preserves the historical gas snapshot value for an isolated transaction.
+    pub const fn set_isolated_snapshot_gas_used(&mut self, gas_used: u64) {
+        self.isolated_snapshot_gas_used = Some(gas_used);
     }
 }
 
@@ -2377,6 +2389,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         call: &CallInputs,
         outcome: &mut CallOutcome,
     ) {
+        let isolated_snapshot_gas_used = self.gas_metering.isolated_snapshot_gas_used.take();
         if self.finish_storage_hook_call(ecx, call, outcome) {
             return;
         }
@@ -2570,8 +2583,12 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         // Record the gas usage of the call, this allows the `lastFrameGas` cheatcode to
         // retrieve the gas usage of the last call or create.
         let frame_gas = frame_gas(&outcome.result);
+        let snapshot_gas_used =
+            isolated_snapshot_gas_used.unwrap_or_else(|| outcome.result.gas.total_gas_spent());
         self.gas_metering.last_call_gas = Some(frame_gas.clone());
         self.gas_metering.last_frame_gas = Some(frame_gas);
+        self.gas_metering.last_call_snapshot_gas_used = snapshot_gas_used;
+        self.gas_metering.last_frame_snapshot_gas_used = snapshot_gas_used;
 
         // If `startStateDiffRecording` has been called, update the `reverted` status of the
         // previous call depth's recorded accesses, if any
@@ -2981,6 +2998,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         call: &CreateInputs,
         outcome: &mut CreateOutcome,
     ) {
+        let isolated_snapshot_gas_used = self.gas_metering.isolated_snapshot_gas_used.take();
         let call = Some(call);
         let curr_depth = ecx.journal().depth();
 
@@ -3073,6 +3091,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             // Record the gas usage of the create frame, this allows the `lastFrameGas` cheatcode to
             // retrieve the gas usage of the last call or create.
             self.gas_metering.last_frame_gas = Some(frame_gas(&outcome.result));
+            self.gas_metering.last_frame_snapshot_gas_used =
+                isolated_snapshot_gas_used.unwrap_or_else(|| outcome.result.gas.total_gas_spent());
         }
 
         // If `startStateDiffRecording` has been called, update the `reverted` status of the

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1120,6 +1120,13 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
 
         let transaction_gas = res.result.gas();
         let state_gas_used = transaction_gas.block_state_gas_used();
+        if state_gas_used == 0 {
+            let mut snapshot_gas = Gas::new(gas_limit);
+            let _ = snapshot_gas.record_regular_cost(transaction_gas.tx_gas_used());
+            if let Some(cheats) = self.cheatcodes.as_deref_mut() {
+                cheats.gas_metering.set_isolated_snapshot_gas_used(snapshot_gas.total_gas_spent());
+            }
+        }
         gas.set_state_gas_spent(
             i64::try_from(state_gas_used)
                 .expect("transaction state gas originates from a signed gas tracker"),

--- a/testdata/paris/cheats/LastCallGas.t.sol
+++ b/testdata/paris/cheats/LastCallGas.t.sol
@@ -24,6 +24,12 @@ contract Target {
         slot0 = 0;
     }
 
+    function failWithInvalid() public pure {
+        assembly {
+            invalid()
+        }
+    }
+
     fallback() external {}
 }
 
@@ -276,6 +282,16 @@ contract LastCallGasIsolatedTest is LastCallGasFixture {
         _setup();
         _performRefund();
         _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 26180, gasMemoryUsed: 0, gasRefunded: 4800}));
+        assertEq(vm.snapshotGasLastCall("isolated refund call"), 21380);
+        assertEq(vm.snapshotGasLastFrame("isolated refund frame"), 21380);
+    }
+
+    function testSnapshotGasForFailedCharge() public {
+        _setup();
+        (bool success,) = address(target).call{gas: 100_000}(abi.encodeCall(target.failWithInvalid, ()));
+        assertEq(success, false);
+        assertEq(vm.snapshotGasLastCall("isolated failed charge call"), 0);
+        assertEq(vm.snapshotGasLastFrame("isolated failed charge frame"), 0);
     }
 
     function testStateDiffRecordingDoesNotWarmStorageReads() public {
@@ -397,5 +413,7 @@ contract LastCallGasDefaultTest is LastCallGasFixture {
         _setup();
         _performRefund();
         _assertGas(vm.lastCallGas(), Gas({gasTotalUsed: 216, gasMemoryUsed: 0, gasRefunded: 19900}));
+        assertEq(vm.snapshotGasLastCall("refund call"), 216);
+        assertEq(vm.snapshotGasLastFrame("refund frame"), 216);
     }
 }


### PR DESCRIPTION
## Motivation

The state-gas split changed isolated `snapshotGasLastCall` and `snapshotGasLastFrame` values for regular Ethereum calls with refunds. Snapshots began reporting the pre-refund transaction charge instead of the historical post-refund total.

Follow-up to #16442.
