### PR TITLE
docs(config): document solc PATH names

### DIFF
--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -29,7 +29,8 @@ The following is an example of what such a file might look like. This can also b
 src = "src"
 out = "out"
 libs = ["lib"]
-solc = "0.8.10" # to use a specific local solc install set the path as `solc = "<path to solc>/solc"`
+# Use a version, a path to a local binary, or an executable name available on `PATH`
+solc = "custom-solc"
 eth-rpc-url = "https://mainnet.infura.io"
 
 ## set only when the `hardhat` profile is selected


### PR DESCRIPTION
Clarifies the crate-level `foundry.toml` example to show that the `solc` setting accepts a strict version, a local binary path, or an executable name resolved from `PATH`. The example uses `solc = "custom-solc"` as a follow-up to #16494 and [the review discussion](https://github.com/foundry-rs/foundry/pull/16494#discussion_r3893156620).

This documentation-only PR is labeled `L-ignore` because it does not need a release note.

This PR was written with Codex assistance.
