### PR TITLE
refactor(verify): extract block replay

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -8,10 +8,8 @@ use crate::{
     verify::VerifierArgs,
 };
 use alloy_consensus::Transaction as ConsensusTransaction;
-use alloy_network::AnyNetwork;
-#[cfg(test)]
-use alloy_primitives::B256;
-use alloy_primitives::{Address, Bytes, TxKind, U256, hex};
+use alloy_network::{AnyNetwork, AnyRpcBlock};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex};
 use alloy_provider::{
     Provider,
     ext::TraceApi,
@@ -40,10 +38,11 @@ use foundry_evm::{
         FoundryChain, FoundryTransaction as _,
         env::FromAnyRpcTransaction as _,
         evm::{
-            BlockContext, ChainFor, EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor,
+            BlockContext, ChainFor, EthEvmNetwork, EvmEnvFor, FoundryEvmNetwork, TempoEvmNetwork,
+            TxEnvFor,
         },
     },
-    executors::EvmError,
+    executors::{EvmError, TracingExecutor},
     opts::{EvmOpts, ForkEndpointIdentity},
     utils::apply_chain_specific_tx_replay_env_changes_for_chain,
 };
@@ -780,104 +779,15 @@ impl VerifyBytecodeArgs {
                 provider.get_transaction_count(transaction.from()).block_id(prev_block_id).await?;
 
             apply_chain_specific_tx_replay_env_changes_for_chain(&mut evm_env, chain.id());
-            let mut target_context = None::<ChainFor<FEN>>;
-            if let Some(ref block) = block {
-                let BlockTransactions::Full(txs) = block.transactions() else {
-                    return Err(eyre::eyre!("Could not get block txs"));
-                };
-                let block_context = if config.networks.is_monad() {
-                    Some(monad_block_context::<FEN>(&config, simulation_block).await?)
-                } else {
-                    None
-                };
-                let target_index =
-                    txs.iter().position(|tx| tx.tx_hash() == tx_hash).ok_or_else(|| {
-                        eyre::eyre!("transaction {tx_hash:?} is missing from its block")
-                    })?;
-                let target_tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(&txs[target_index])?;
-                target_context = Some(block_context.as_ref().map_or_else(
-                    || ChainFor::<FEN>::for_transaction(&target_tx_env),
-                    |context| context.transaction(target_index),
-                ));
-
-                // Replay txes in block until the contract creation one.
-                for (index, tx) in txs.iter().enumerate() {
-                    trace!("replay tx::: {}", tx.tx_hash());
-                    if tx.tx_hash() == tx_hash {
-                        break;
-                    }
-
-                    let is_system = is_known_system_sender(tx.from())
-                        || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
-                    // Classify before converting: a chain's own system envelopes are exactly the
-                    // ones this build may not be able to decode.
-                    if is_system && !config.networks.is_monad() {
-                        continue;
-                    }
-                    let tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(tx)?;
-                    let chain_context = block_context.as_ref().map_or_else(
-                        || ChainFor::<FEN>::for_transaction(&tx_env),
-                        |context| context.transaction(index),
-                    );
-
-                    if is_system {
-                        #[cfg(feature = "monad")]
-                        let _ = executor
-                            .try_transact_system_replay_with_env_and_context(
-                                evm_env.clone(),
-                                tx_env.clone(),
-                                chain_context,
-                            )
-                            .wrap_err_with(|| {
-                                format!(
-                                    "Failed to replay system transaction: {:?} in block {}",
-                                    tx.tx_hash(),
-                                    evm_env.block_env.number()
-                                )
-                            })?;
-                        continue;
-                    }
-
-                    if ConsensusTransaction::to(tx).is_some() {
-                        executor
-                            .transact_with_env_and_context(
-                                evm_env.clone(),
-                                tx_env.clone(),
-                                chain_context,
-                            )
-                            .wrap_err_with(|| {
-                                format!(
-                                    "Failed to execute transaction: {:?} in block {}",
-                                    tx.tx_hash(),
-                                    evm_env.block_env.number()
-                                )
-                            })?;
-                    } else if let Err(error) = executor.deploy_with_env_and_context(
-                        evm_env.clone(),
-                        tx_env.clone(),
-                        chain_context,
-                        None,
-                    ) {
-                        match error {
-                            // Reverted transactions should be skipped
-                            EvmError::Execution(_) => (),
-                            error => {
-                                return Err(error).wrap_err_with(|| {
-                                    format!(
-                                        "Failed to deploy transaction: {:?} in block {}",
-                                        tx.tx_hash(),
-                                        evm_env.block_env.number()
-                                    )
-                                });
-                            }
-                        }
-                    }
-                }
-            } else if config.networks.is_monad() {
-                eyre::bail!(
-                    "block {simulation_block} is required to reconstruct transaction context"
-                );
-            }
+            let target_context = replay_block_transactions::<FEN>(
+                &config,
+                block.as_ref(),
+                simulation_block,
+                tx_hash,
+                &mut executor,
+                &evm_env,
+            )
+            .await?;
 
             let kind = ConsensusTransaction::kind(&transaction);
             let mut tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(&transaction)?;
@@ -941,6 +851,111 @@ impl VerifyBytecodeArgs {
         }
         Ok(())
     }
+}
+
+/// Replays the transactions preceding `target_hash` and returns its execution context.
+async fn replay_block_transactions<FEN: FoundryEvmNetwork>(
+    config: &Config,
+    block: Option<&AnyRpcBlock>,
+    block_number: u64,
+    target_hash: B256,
+    executor: &mut TracingExecutor<FEN>,
+    evm_env: &EvmEnvFor<FEN>,
+) -> Result<Option<ChainFor<FEN>>> {
+    let Some(block) = block else {
+        if config.networks.is_monad() {
+            eyre::bail!("block {block_number} is required to reconstruct transaction context");
+        }
+        return Ok(None);
+    };
+    let BlockTransactions::Full(txs) = block.transactions() else {
+        return Err(eyre::eyre!("Could not get block txs"));
+    };
+    let block_context = if config.networks.is_monad() {
+        Some(monad_block_context::<FEN>(config, block_number).await?)
+    } else {
+        None
+    };
+    let target_index = txs
+        .iter()
+        .position(|tx| tx.tx_hash() == target_hash)
+        .ok_or_else(|| eyre::eyre!("transaction {target_hash:?} is missing from its block"))?;
+    let target_tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(&txs[target_index])?;
+    let target_context = block_context.as_ref().map_or_else(
+        || ChainFor::<FEN>::for_transaction(&target_tx_env),
+        |context| context.transaction(target_index),
+    );
+
+    for (index, tx) in txs.iter().enumerate() {
+        trace!("replay tx::: {}", tx.tx_hash());
+        if tx.tx_hash() == target_hash {
+            break;
+        }
+
+        let is_system = is_known_system_sender(tx.from())
+            || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
+        // Classify before converting: a chain's own system envelopes are exactly the ones this
+        // build may not be able to decode.
+        if is_system && !config.networks.is_monad() {
+            continue;
+        }
+        let tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(tx)?;
+        let chain_context = block_context.as_ref().map_or_else(
+            || ChainFor::<FEN>::for_transaction(&tx_env),
+            |context| context.transaction(index),
+        );
+
+        if is_system {
+            #[cfg(feature = "monad")]
+            let _ = executor
+                .try_transact_system_replay_with_env_and_context(
+                    evm_env.clone(),
+                    tx_env.clone(),
+                    chain_context,
+                )
+                .wrap_err_with(|| {
+                    format!(
+                        "Failed to replay system transaction: {:?} in block {}",
+                        tx.tx_hash(),
+                        evm_env.block_env.number()
+                    )
+                })?;
+            continue;
+        }
+
+        if ConsensusTransaction::to(tx).is_some() {
+            executor
+                .transact_with_env_and_context(evm_env.clone(), tx_env.clone(), chain_context)
+                .wrap_err_with(|| {
+                    format!(
+                        "Failed to execute transaction: {:?} in block {}",
+                        tx.tx_hash(),
+                        evm_env.block_env.number()
+                    )
+                })?;
+        } else if let Err(error) = executor.deploy_with_env_and_context(
+            evm_env.clone(),
+            tx_env.clone(),
+            chain_context,
+            None,
+        ) {
+            match error {
+                // Reverted transactions should be skipped.
+                EvmError::Execution(_) => (),
+                error => {
+                    return Err(error).wrap_err_with(|| {
+                        format!(
+                            "Failed to deploy transaction: {:?} in block {}",
+                            tx.tx_hash(),
+                            evm_env.block_env.number()
+                        )
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(Some(target_context))
 }
 
 /// Fetches the block context Monad needs to reconstruct replay ordering.


### PR DESCRIPTION
Extracts `verify-bytecode`'s context-sensitive block replay into a private helper without changing behavior. A follow-up will split ordinary and Monad replay so generic Verify paths no longer dispatch through `NetworkConfigs` or depend on Monad-only `BlockContext` behavior.
