### PR TITLE
fix(evm): replay Celo CIP-64 transactions

### DIFF
--- a/.changelog/celo-dynamic-fee-replay.md
+++ b/.changelog/celo-dynamic-fee-replay.md
@@ -1,0 +1,6 @@
+---
+cast: patch
+forge: patch
+---
+
+Allowed Celo CIP-64 transactions to be converted for local EVM replay.

--- a/crates/cast/tests/cli/run_networks.rs
+++ b/crates/cast/tests/cli/run_networks.rs
@@ -9,6 +9,7 @@
 //! `flaky` profile runs it with retries. These endpoints are free, unauthenticated, and rate
 //! limited, so an outage must not fail a normal CI run.
 
+use foundry_evm_networks::celo::CELO_DYNAMIC_FEE_TX_TYPE;
 use foundry_test_utils::{TestCommand, util::OutputExt};
 
 /// How closely a replay is expected to reproduce the receipt's `gasUsed`.
@@ -42,6 +43,7 @@ struct Network {
     name: &'static str,
     rpc_url: &'static str,
     gas: GasExpectation,
+    transaction_type: Option<u8>,
 }
 
 /// Replays a recent transaction from `network` and checks it against its receipt.
@@ -140,7 +142,7 @@ fn find_replayable_transaction(
 
     for number in (latest.saturating_sub(BLOCK_SCAN_DEPTH)..=latest).rev() {
         let Some(block) = full_block(cmd, network, number) else { continue };
-        let mut candidates = replayable_transactions(&block);
+        let mut candidates = replayable_transactions(&block, network.transaction_type);
         match candidates.len() {
             1 => single_candidate = single_candidate.or_else(|| candidates.pop()),
             len if len > 1 => {
@@ -158,11 +160,11 @@ fn find_replayable_transaction(
 ///
 /// System transactions are excluded: chains inject them outside normal execution, and `cast run`
 /// deliberately refuses to replay them.
-fn replayable_transactions(block: &serde_json::Value) -> Vec<String> {
-    const SYSTEM_TX_TYPES: [&str; 2] = [
+fn replayable_transactions(block: &serde_json::Value, transaction_type: Option<u8>) -> Vec<String> {
+    const SYSTEM_TX_TYPES: [u8; 2] = [
         // OP-stack deposit.
-        "0x7e", // Arbitrum internal.
-        "0x6a",
+        0x7e, // Arbitrum internal.
+        0x6a,
     ];
 
     let Some(transactions) = block.get("transactions").and_then(|txs| txs.as_array()) else {
@@ -171,13 +173,18 @@ fn replayable_transactions(block: &serde_json::Value) -> Vec<String> {
 
     transactions
         .iter()
+        .filter(|tx| rpc_transaction_type(tx).is_none_or(|ty| !SYSTEM_TX_TYPES.contains(&ty)))
         .filter(|tx| {
-            tx.get("type")
-                .and_then(|ty| ty.as_str())
-                .is_none_or(|ty| !SYSTEM_TX_TYPES.contains(&ty))
+            transaction_type.is_none_or(|expected| rpc_transaction_type(tx) == Some(expected))
         })
         .filter_map(|tx| Some(tx.get("hash")?.as_str()?.to_string()))
         .collect()
+}
+
+/// Reads a transaction type quantity from a JSON-RPC transaction.
+fn rpc_transaction_type(tx: &serde_json::Value) -> Option<u8> {
+    let raw = tx.get("type")?.as_str()?;
+    u8::from_str_radix(raw.strip_prefix("0x").unwrap_or(raw), 16).ok()
 }
 
 /// Runs a `cast` subcommand with `--json` and parses its output, returning `None` on any failure.
@@ -216,6 +223,7 @@ macro_rules! network_replay_tests {
                         name: $name,
                         rpc_url: $rpc_url,
                         gas: GasExpectation::$gas,
+                        transaction_type: None,
                     },
                 );
             });
@@ -255,3 +263,15 @@ network_replay_tests! {
     // the official one ignores the block tag and answers every state read at latest.
     flaky_run_hyperevm => ("hyperevm", "https://rpc.purroofgroup.com", ReplaysOnly),
 }
+
+casttest!(flaky_run_celo_cip64, |_prj, cmd| {
+    assert_replays_recent_transaction(
+        &mut cmd,
+        &Network {
+            name: "celo",
+            rpc_url: "https://forno.celo.org",
+            gas: GasExpectation::ReplaysOnly,
+            transaction_type: Some(CELO_DYNAMIC_FEE_TX_TYPE),
+        },
+    );
+});

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,10 +1,12 @@
 use std::fmt::Debug;
 
-use alloy_consensus::Typed2718;
+use alloy_chains::NamedChain;
+use alloy_consensus::{Transaction as _, Typed2718};
 pub use alloy_evm::EvmEnv;
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
 use alloy_primitives::{Address, B256, Bytes, U256};
+use foundry_evm_networks::celo::CELO_DYNAMIC_FEE_TX_TYPE;
 #[cfg(feature = "optimism")]
 use op_revm::transaction::deposit::DEPOSIT_TRANSACTION_TYPE;
 use revm::{
@@ -668,9 +670,8 @@ impl<DB: Database> FoundryContextExt
 
 /// Trait for converting an [`AnyRpcTransaction`] into a specific `TxEnv`.
 ///
-/// Implementations extract the inner [`alloy_consensus::TxEnvelope`] via
-/// [`as_envelope()`](alloy_network::AnyTxEnvelope::as_envelope) then delegate to
-/// [`FromRecoveredTx`].
+/// Ethereum envelopes delegate to [`FromRecoveredTx`]. Implementations may also explicitly
+/// project compatible network-specific envelopes into their execution environment.
 pub trait FromAnyRpcTransaction: Sized {
     /// Tries to convert an [`AnyRpcTransaction`] into `Self`.
     fn from_any_rpc_transaction(tx: &AnyRpcTransaction) -> eyre::Result<Self>;
@@ -679,16 +680,43 @@ pub trait FromAnyRpcTransaction: Sized {
 impl FromAnyRpcTransaction for TxEnv {
     fn from_any_rpc_transaction(tx: &AnyRpcTransaction) -> eyre::Result<Self> {
         if let Some(envelope) = tx.as_envelope() {
-            Ok(Self::from_recovered_tx(envelope, tx.from()))
-        } else {
-            eyre::bail!("cannot convert unknown transaction type to TxEnv");
+            return Ok(Self::from_recovered_tx(envelope, tx.from()));
         }
+
+        // CIP-64 transactions have EIP-1559 execution fields plus a Celo-specific fee currency.
+        // Foundry does not model fee payment in TxEnv, but can replay their EVM payload. Preserve
+        // the custom type so revm does not compare the fee-currency price with the native-CELO
+        // base fee. Keep this projection restricted to active Celo chains so an unrelated network
+        // cannot silently acquire semantics for its own type 0x7b envelope.
+        if let AnyTxEnvelope::Unknown(unknown) = &*tx.inner.inner
+            && unknown.ty() == CELO_DYNAMIC_FEE_TX_TYPE
+            && matches!(
+                unknown.chain_id().and_then(NamedChain::from_chain_id),
+                Some(NamedChain::Celo | NamedChain::CeloSepolia)
+            )
+        {
+            return Ok(Self {
+                tx_type: CELO_DYNAMIC_FEE_TX_TYPE,
+                caller: tx.from(),
+                gas_limit: unknown.gas_limit(),
+                gas_price: unknown.max_fee_per_gas(),
+                gas_priority_fee: unknown.max_priority_fee_per_gas(),
+                kind: unknown.kind(),
+                value: unknown.value(),
+                data: unknown.input().clone(),
+                nonce: unknown.nonce(),
+                chain_id: unknown.chain_id(),
+                access_list: unknown.access_list().cloned().unwrap_or_default(),
+                ..Default::default()
+            });
+        }
+
+        eyre::bail!("cannot convert unknown transaction type to TxEnv");
     }
 }
 
 impl FromAnyRpcTransaction for TempoTxEnv {
     fn from_any_rpc_transaction(tx: &AnyRpcTransaction) -> eyre::Result<Self> {
-        use alloy_consensus::Transaction as _;
         if let Some(envelope) = tx.as_envelope() {
             return Ok(TxEnv::from_recovered_tx(envelope, tx.from()).into());
         }
@@ -1149,6 +1177,55 @@ mod tests {
 
         let result = TxEnv::from_any_rpc_transaction(&any_tx).unwrap_err();
         assert!(result.to_string().contains("unknown transaction type"));
+    }
+
+    #[test]
+    fn from_any_rpc_transaction_for_celo_dynamic_fee() {
+        let from = Address::with_last_byte(0xAA);
+        let to = Address::with_last_byte(0xBB);
+        let fee_currency = Address::with_last_byte(0xCC);
+        let json = serde_json::json!({
+            "accessList": [],
+            "blockHash": B256::ZERO,
+            "blockNumber": "0x1",
+            "chainId": "0xa4ec",
+            "feeCurrency": fee_currency,
+            "from": from,
+            "gas": "0x5208",
+            "gasPrice": "0x3",
+            "hash": B256::ZERO,
+            "input": "0x1234",
+            "maxFeePerGas": "0x3",
+            "maxPriorityFeePerGas": "0x1",
+            "nonce": "0x2a",
+            "r": B256::ZERO,
+            "s": B256::ZERO,
+            "to": to,
+            "transactionIndex": "0x0",
+            "type": "0x7b",
+            "v": "0x0",
+            "value": "0x65",
+            "yParity": "0x0"
+        });
+        let mut non_celo_json = json.clone();
+        non_celo_json["chainId"] = serde_json::json!("0x1");
+        let non_celo_tx: AnyRpcTransaction = serde_json::from_value(non_celo_json).unwrap();
+        assert!(TxEnv::from_any_rpc_transaction(&non_celo_tx).is_err());
+
+        let any_tx: AnyRpcTransaction = serde_json::from_value(json).unwrap();
+
+        let tx_env = TxEnv::from_any_rpc_transaction(&any_tx).unwrap();
+
+        assert_eq!(tx_env.tx_type, CELO_DYNAMIC_FEE_TX_TYPE);
+        assert_eq!(tx_env.caller, from);
+        assert_eq!(tx_env.nonce, 42);
+        assert_eq!(tx_env.gas_limit, 21000);
+        assert_eq!(tx_env.gas_price, 3);
+        assert_eq!(tx_env.gas_priority_fee, Some(1));
+        assert_eq!(tx_env.kind, TxKind::Call(to));
+        assert_eq!(tx_env.value, U256::from(101));
+        assert_eq!(tx_env.data, Bytes::from_static(&[0x12, 0x34]));
+        assert_eq!(tx_env.chain_id, Some(42_220));
     }
 
     #[test]

--- a/crates/evm/networks/src/celo/mod.rs
+++ b/crates/evm/networks/src/celo/mod.rs
@@ -1,6 +1,6 @@
 //! Celo-specific execution support.
 
+pub mod transfer;
+
 /// Celo dynamic fee transaction type introduced by CIP-64.
 pub const CELO_DYNAMIC_FEE_TX_TYPE: u8 = 0x7b;
-
-pub mod transfer;

--- a/crates/evm/networks/src/celo/mod.rs
+++ b/crates/evm/networks/src/celo/mod.rs
@@ -1,1 +1,6 @@
+//! Celo-specific execution support.
+
+/// Celo dynamic fee transaction type introduced by CIP-64.
+pub const CELO_DYNAMIC_FEE_TX_TYPE: u8 = 0x7b;
+
 pub mod transfer;


### PR DESCRIPTION
Celo CIP-64 transactions use type `0x7b`, which `AnyNetwork` decodes as an unknown envelope. This explicitly converts those envelopes on Celo and Celo Sepolia into `TxEnv`, preserving the custom transaction type so fee-currency prices are not validated against the native-CELO base fee. It restores `cast run` for real CIP-64 transactions while continuing to reject unrelated unknown types.

This supersedes #16462 with a narrower conversion-boundary fix instead of introducing a catch-all execution network. It replays the transaction’s EVM payload but does not model Celo fee-currency settlement or reproduce its additional gas accounting; complete Celo execution support remains separate work.

Prepared with assistance from Codex.