### PR TITLE
refactor(evm): centralize network dispatch

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -47,13 +47,12 @@ use foundry_config::{
         value::{Dict, Map},
     },
 };
-#[cfg(feature = "optimism")]
-use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
     core::{
         FoundryBlock, FoundryTransaction,
-        evm::{EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, context_for_child_transaction},
+        evm::{FoundryEvmNetwork, context_for_child_transaction},
     },
+    dispatch_evm_network,
     executors::TracingExecutor,
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements},
@@ -272,31 +271,9 @@ impl CallArgs {
             config.chain = Some(chain);
         }
 
-        if evm_opts.networks.is_tempo() {
-            return self
-                .run_with_network_and_opts::<TempoEvmNetwork>(config, evm_opts, auth_preflight)
-                .await;
-        }
-
-        #[cfg(feature = "monad")]
-        if evm_opts.networks.is_monad() {
-            return self
-                .run_with_network_and_opts::<foundry_evm::core::evm::MonadEvmNetwork>(
-                    config,
-                    evm_opts,
-                    auth_preflight,
-                )
-                .await;
-        }
-
-        #[cfg(feature = "optimism")]
-        if evm_opts.networks.is_optimism() {
-            return self
-                .run_with_network_and_opts::<OpEvmNetwork>(config, evm_opts, auth_preflight)
-                .await;
-        }
-
-        self.run_with_network_and_opts::<EthEvmNetwork>(config, evm_opts, auth_preflight).await
+        dispatch_evm_network!(evm_opts.networks, |Network| self
+            .run_with_network_and_opts::<Network>(config, evm_opts, auth_preflight)
+            .await)
     }
 
     /// Returns whether resolving this call can disclose an authorization before the transaction

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -42,16 +42,13 @@ use foundry_config::{
         value::{Dict, Map},
     },
 };
-#[cfg(feature = "optimism")]
-use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
     core::{
         FoundryBlock as _, FoundryChain,
         env::FromAnyRpcTransaction as _,
-        evm::{
-            BlockContext, ChainFor, EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor,
-        },
+        evm::{BlockContext, ChainFor, FoundryEvmNetwork, TxEnvFor},
     },
+    dispatch_evm_network,
     executors::{EvmError, Executor, TracingExecutor},
     hardforks::FoundryHardfork,
     opts::EvmOpts,
@@ -166,23 +163,9 @@ impl RunArgs {
         // Auto-detect network from fork chain ID when not explicitly configured.
         evm_opts.infer_network_from_fork().await?;
 
-        if evm_opts.networks.is_tempo() {
-            return self.run_with_evm::<TempoEvmNetwork>(config, evm_opts).await;
-        }
-
-        #[cfg(feature = "monad")]
-        if evm_opts.networks.is_monad() {
-            return self
-                .run_with_evm::<foundry_evm::core::evm::MonadEvmNetwork>(config, evm_opts)
-                .await;
-        }
-
-        #[cfg(feature = "optimism")]
-        if evm_opts.networks.is_optimism() {
-            return self.run_with_evm::<OpEvmNetwork>(config, evm_opts).await;
-        }
-
-        self.run_with_evm::<EthEvmNetwork>(config, evm_opts).await
+        dispatch_evm_network!(evm_opts.networks, |Network| self
+            .run_with_evm::<Network>(config, evm_opts)
+            .await)
     }
 
     async fn run_with_evm<FEN: FoundryEvmNetwork>(

--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -7,12 +7,7 @@ use eyre::{Context, Result};
 use foundry_cli::utils::{self, LoadConfig};
 use foundry_common::fs;
 use foundry_config::Config;
-#[cfg(feature = "optimism")]
-use foundry_evm::core::evm::OpEvmNetwork;
-use foundry_evm::{
-    core::evm::{EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork},
-    opts::EvmOpts,
-};
+use foundry_evm::{core::evm::FoundryEvmNetwork, dispatch_evm_network, opts::EvmOpts};
 use foundry_evm_networks::NetworkConfigs;
 use rustyline::{Editor, config::Configurer, error::ReadlineError};
 use std::{ops::ControlFlow, path::PathBuf};
@@ -59,49 +54,10 @@ pub async fn run_command(args: Chisel) -> Result<()> {
     let local_networks = evm_opts.networks;
     let local_chain_id = evm_opts.env.chain_id.or(config.chain.map(|chain| chain.id()));
 
-    if evm_opts.networks.is_tempo() {
-        return Box::pin(run_command_with_network::<TempoEvmNetwork>(
-            args,
-            config,
-            evm_opts,
-            local_networks,
-            local_chain_id,
-        ))
-        .await;
-    }
-
-    #[cfg(feature = "monad")]
-    if evm_opts.networks.is_monad() {
-        return Box::pin(run_command_with_network::<foundry_evm::core::evm::MonadEvmNetwork>(
-            args,
-            config,
-            evm_opts,
-            local_networks,
-            local_chain_id,
-        ))
-        .await;
-    }
-
-    #[cfg(feature = "optimism")]
-    if evm_opts.networks.is_optimism() {
-        return Box::pin(run_command_with_network::<OpEvmNetwork>(
-            args,
-            config,
-            evm_opts,
-            local_networks,
-            local_chain_id,
-        ))
-        .await;
-    }
-
-    Box::pin(run_command_with_network::<EthEvmNetwork>(
-        args,
-        config,
-        evm_opts,
-        local_networks,
-        local_chain_id,
-    ))
-    .await
+    dispatch_evm_network!(evm_opts.networks, |Network| Box::pin(
+        run_command_with_network::<Network>(args, config, evm_opts, local_networks, local_chain_id,)
+    )
+    .await)
 }
 
 fn infer_network_from_chain_id(

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -21,6 +21,40 @@ pub use foundry_evm_fuzz as fuzz;
 pub use foundry_evm_hardforks as hardforks;
 pub use foundry_evm_traces as traces;
 
+/// Dispatches an expression to the EVM network selected by a [`NetworkConfigs`]-like value.
+///
+/// The identifier between pipes is bound to the selected [`FoundryEvmNetwork`] type within the
+/// expression.
+///
+/// [`FoundryEvmNetwork`]: core::evm::FoundryEvmNetwork
+/// [`NetworkConfigs`]: foundry_evm_networks::NetworkConfigs
+#[macro_export]
+macro_rules! dispatch_evm_network {
+    ($networks:expr, | $network:ident | $body:expr) => {{
+        let networks = &$networks;
+        match () {
+            _ if networks.is_tempo() => {
+                type $network = $crate::core::evm::TempoEvmNetwork;
+                $body
+            }
+            #[cfg(feature = "monad")]
+            _ if networks.is_monad() => {
+                type $network = $crate::core::evm::MonadEvmNetwork;
+                $body
+            }
+            #[cfg(feature = "optimism")]
+            _ if networks.is_optimism() => {
+                type $network = $crate::core::evm::OpEvmNetwork;
+                $body
+            }
+            _ => {
+                type $network = $crate::core::evm::EthEvmNetwork;
+                $body
+            }
+        }
+    }};
+}
+
 // TODO: We should probably remove these, but it's a pretty big breaking change.
 #[doc(hidden)]
 pub use revm;

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -59,12 +59,9 @@ use foundry_config::{
     fs_permissions::FsAccessPermission,
 };
 use foundry_debugger::{Debugger, DebuggerLayout};
-#[cfg(feature = "optimism")]
-use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
-    core::evm::{
-        BlockEnvFor, EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor,
-    },
+    core::evm::{BlockEnvFor, FoundryEvmNetwork, SpecFor, TxEnvFor},
+    dispatch_evm_network,
     executors::ShowmapDomain,
     fork::ResolvedFork,
     fuzz::{BaseCounterExample, BasicTxDetails, CounterExample},
@@ -267,34 +264,6 @@ fn count_fuzz_minimize_targets<FEN: FoundryEvmNetwork>(
             fuzz_targets + invariant_targets
         })
         .sum()
-}
-
-#[derive(Clone, Copy)]
-enum NetworkDispatchKind {
-    Tempo,
-    #[cfg(feature = "monad")]
-    Monad,
-    #[cfg(feature = "optimism")]
-    Optimism,
-    Eth,
-}
-
-const fn network_dispatch_kind(evm_opts: &EvmOpts) -> NetworkDispatchKind {
-    if evm_opts.networks.is_tempo() {
-        return NetworkDispatchKind::Tempo;
-    }
-
-    #[cfg(feature = "monad")]
-    if evm_opts.networks.is_monad() {
-        return NetworkDispatchKind::Monad;
-    }
-
-    #[cfg(feature = "optimism")]
-    if evm_opts.networks.is_optimism() {
-        return NetworkDispatchKind::Optimism;
-    }
-
-    NetworkDispatchKind::Eth
 }
 
 /// Output format for EVM execution profiles.
@@ -2694,54 +2663,16 @@ impl TestArgs {
         execution: TestExecutionOptions,
         resolved_fork: Option<&ResolvedFork>,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
-        match network_dispatch_kind(dispatch_opts) {
-            NetworkDispatchKind::Tempo => {
-                self.build_and_run_tests::<TempoEvmNetwork>(
-                    config,
-                    evm_opts,
-                    output,
-                    filter,
-                    execution,
-                    resolved_fork,
-                )
-                .await
-            }
-            #[cfg(feature = "monad")]
-            NetworkDispatchKind::Monad => {
-                self.build_and_run_tests::<foundry_evm::core::evm::MonadEvmNetwork>(
-                    config,
-                    evm_opts,
-                    output,
-                    filter,
-                    execution,
-                    resolved_fork,
-                )
-                .await
-            }
-            #[cfg(feature = "optimism")]
-            NetworkDispatchKind::Optimism => {
-                self.build_and_run_tests::<OpEvmNetwork>(
-                    config,
-                    evm_opts,
-                    output,
-                    filter,
-                    execution,
-                    resolved_fork,
-                )
-                .await
-            }
-            NetworkDispatchKind::Eth => {
-                self.build_and_run_tests::<EthEvmNetwork>(
-                    config,
-                    evm_opts,
-                    output,
-                    filter,
-                    execution,
-                    resolved_fork,
-                )
-                .await
-            }
-        }
+        dispatch_evm_network!(dispatch_opts.networks, |Network| self
+            .build_and_run_tests::<Network>(
+                config,
+                evm_opts,
+                output,
+                filter,
+                execution,
+                resolved_fork,
+            )
+            .await)
     }
 
     async fn dispatch_fuzz_minimize_network(
@@ -2753,28 +2684,10 @@ impl TestArgs {
         options: FuzzMinimizeNetworkPassOptions,
         filter: &ProjectPathsAwareFilter,
     ) -> eyre::Result<FuzzMinimizeReplayPass> {
-        match network_dispatch_kind(dispatch_opts) {
-            NetworkDispatchKind::Tempo => self
-                .build_fuzz_minimize_runner::<TempoEvmNetwork>(config, evm_opts, output, options)
-                .await
-                .map(|runner| fuzz_minimize_replay(runner, filter)),
-            #[cfg(feature = "monad")]
-            NetworkDispatchKind::Monad => self
-                .build_fuzz_minimize_runner::<foundry_evm::core::evm::MonadEvmNetwork>(
-                    config, evm_opts, output, options,
-                )
-                .await
-                .map(|runner| fuzz_minimize_replay(runner, filter)),
-            #[cfg(feature = "optimism")]
-            NetworkDispatchKind::Optimism => self
-                .build_fuzz_minimize_runner::<OpEvmNetwork>(config, evm_opts, output, options)
-                .await
-                .map(|runner| fuzz_minimize_replay(runner, filter)),
-            NetworkDispatchKind::Eth => self
-                .build_fuzz_minimize_runner::<EthEvmNetwork>(config, evm_opts, output, options)
-                .await
-                .map(|runner| fuzz_minimize_replay(runner, filter)),
-        }
+        dispatch_evm_network!(dispatch_opts.networks, |Network| self
+            .build_fuzz_minimize_runner::<Network>(config, evm_opts, output, options)
+            .await
+            .map(|runner| fuzz_minimize_replay(runner, filter)))
     }
 
     fn symbolic_regression_config(&self, config: &Config) -> Option<SymbolicRegressionConfig> {

--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -21,12 +21,9 @@ use eyre::Result;
 use foundry_common::{compile::ProjectCompiler, sh_eprintln, sh_println};
 use foundry_compilers::compilers::multi::MultiCompiler;
 use foundry_config::{Config, InlineConfig};
-#[cfg(feature = "optimism")]
-use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
-    core::evm::{
-        BlockEnvFor, EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor,
-    },
+    core::evm::{BlockEnvFor, FoundryEvmNetwork, SpecFor, TxEnvFor},
+    dispatch_evm_network,
     fork::ResolvedFork,
     opts::EvmOpts,
 };
@@ -624,47 +621,14 @@ fn compile_and_test(
     selected_sources_relative: &[PathBuf],
     isolate: bool,
 ) -> Result<bool> {
-    if evm.opts.networks.is_tempo() {
-        compile_and_test_inner::<TempoEvmNetwork>(
-            config,
-            evm,
-            filter_args,
-            rerun_failures,
-            selected_sources_relative,
-            isolate,
-        )
-    } else {
-        #[cfg(feature = "monad")]
-        if evm.opts.networks.is_monad() {
-            return compile_and_test_inner::<foundry_evm::core::evm::MonadEvmNetwork>(
-                config,
-                evm,
-                filter_args,
-                rerun_failures,
-                selected_sources_relative,
-                isolate,
-            );
-        }
-        #[cfg(feature = "optimism")]
-        if evm.opts.networks.is_optimism() {
-            return compile_and_test_inner::<OpEvmNetwork>(
-                config,
-                evm,
-                filter_args,
-                rerun_failures,
-                selected_sources_relative,
-                isolate,
-            );
-        }
-        compile_and_test_inner::<EthEvmNetwork>(
-            config,
-            evm,
-            filter_args,
-            rerun_failures,
-            selected_sources_relative,
-            isolate,
-        )
-    }
+    dispatch_evm_network!(evm.opts.networks, |Network| compile_and_test_inner::<Network>(
+        config,
+        evm,
+        filter_args,
+        rerun_failures,
+        selected_sources_relative,
+        isolate,
+    ))
 }
 
 fn compile_and_test_inner<FEN: FoundryEvmNetwork>(

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -1147,6 +1147,7 @@ mod tests {
     };
     use foundry_config::UnresolvedEnvVarError;
     use foundry_evm::{
+        core::evm::EthEvmNetwork,
         revm::context::Block as _,
         traces::{
             CallKind, CallTrace, CallTraceArena, CallTraceNode, SparsedTraceArena, TraceKind,

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -46,15 +46,14 @@ use foundry_config::{
     },
 };
 use foundry_debugger::DebuggerLayout;
-#[cfg(feature = "optimism")]
-use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
     backend::Backend,
     core::{
         Breakpoints, FoundryTransaction,
-        evm::{EthEvmNetwork, EvmEnvFor, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor},
+        evm::{EvmEnvFor, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor},
         fork::ResolvedFork,
     },
+    dispatch_evm_network,
     executors::ExecutorBuilder,
     inspectors::{
         CheatsConfig,
@@ -409,22 +408,10 @@ impl ScriptArgs {
             .await;
         }
 
-        #[cfg(feature = "monad")]
-        if evm_opts.networks.is_monad() {
-            return Box::pin(
-                self.run_generic_script::<foundry_evm::core::evm::MonadEvmNetwork>(
-                    config, evm_opts,
-                ),
-            )
-            .await;
-        }
-
-        #[cfg(feature = "optimism")]
-        if evm_opts.networks.is_optimism() {
-            return Box::pin(self.run_generic_script::<OpEvmNetwork>(config, evm_opts)).await;
-        }
-
-        Box::pin(self.run_generic_script::<EthEvmNetwork>(config, evm_opts)).await
+        dispatch_evm_network!(evm_opts.networks, |Network| Box::pin(
+            self.run_generic_script::<Network>(config, evm_opts)
+        )
+        .await)
     }
 
     /// Prepares the bundled state (compile, simulate, bundle) and returns it


### PR DESCRIPTION
Cast, Chisel, Forge and Script independently repeat the same runtime network checks to select a concrete `FoundryEvmNetwork`. This adds `dispatch_evm_network!` and uses it across those call sites, also removing Forge’s local `NetworkDispatchKind`.

The execution bodies remain visible at each call site, while network ordering, feature gates, and concrete type selection live in one place. This removes repeated dispatch boilerplate without changing behavior.

Base can add its network type once to the shared macro instead of repeating the same dispatch branch across these paths.