### PR TITLE
fix(config): respect explicitly empty remappings

### DIFF
--- a/.changelog/empty-remappings-disable-fallbacks.md
+++ b/.changelog/empty-remappings-disable-fallbacks.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-config: patch
+---
+
+Treat `remappings = []` as an explicit opt-out of `remappings.txt` and auto-detected remappings.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3670,35 +3670,29 @@ mod tests {
             jail.create_dir("lib/dependency/src")?;
             jail.create_file("lib/dependency/src/Dependency.sol", "contract Dependency {}")?;
             jail.create_file("remappings.txt", "from-file/=lib/from-file/\n")?;
-            jail.create_file(
-                "foundry.toml",
-                r#"
-                [profile.default]
-                libs = ["lib"]
-            "#,
-            )?;
 
-            let config = Config::load().unwrap();
-            assert!(config.remappings.iter().any(|remapping| remapping.name == "from-file/"));
-            assert!(config.remappings.iter().any(|remapping| remapping.name == "dependency/"));
-
-            jail.create_file(
-                "foundry.toml",
-                r#"
-                [profile.default]
-                libs = ["lib"]
-                remappings = []
-            "#,
-            )?;
-
-            let config = Config::load().unwrap();
-            assert!(
-                config
-                    .remappings
-                    .iter()
-                    .all(|remapping| remapping.name != "from-file/"
-                        && remapping.name != "dependency/"),
-            );
+            let cases: [(&str, &[&str]); 3] = [
+                ("", &["from-file/", "dependency/"]),
+                (
+                    r#"remappings = ["from-config/=lib/from-config/"]"#,
+                    &["from-file/", "dependency/", "from-config/"],
+                ),
+                ("remappings = []", &[]),
+            ];
+            for (remappings, expected) in cases {
+                jail.create_file(
+                    "foundry.toml",
+                    &format!("[profile.default]\nlibs = [\"lib\"]\n{remappings}"),
+                )?;
+                let config = Config::load().unwrap();
+                for name in ["from-file/", "dependency/", "from-config/"] {
+                    assert_eq!(
+                        config.remappings.iter().any(|remapping| remapping.name == name),
+                        expected.contains(&name),
+                        "unexpected `{name}` with `{remappings}`",
+                    );
+                }
+            }
             Ok(())
         });
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3663,6 +3663,47 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_toml_remappings_disable_fallbacks() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_dir("lib")?;
+            jail.create_dir("lib/dependency")?;
+            jail.create_dir("lib/dependency/src")?;
+            jail.create_file("lib/dependency/src/Dependency.sol", "contract Dependency {}")?;
+            jail.create_file("remappings.txt", "from-file/=lib/from-file/\n")?;
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                libs = ["lib"]
+            "#,
+            )?;
+
+            let config = Config::load().unwrap();
+            assert!(config.remappings.iter().any(|remapping| remapping.name == "from-file/"));
+            assert!(config.remappings.iter().any(|remapping| remapping.name == "dependency/"));
+
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                libs = ["lib"]
+                remappings = []
+            "#,
+            )?;
+
+            let config = Config::load().unwrap();
+            assert!(
+                config
+                    .remappings
+                    .iter()
+                    .all(|remapping| remapping.name != "from-file/"
+                        && remapping.name != "dependency/"),
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
     fn test_remappings_override() {
         figment::Jail::expect_with(|jail| {
             jail.create_file(

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -208,11 +208,18 @@ impl RemappingsProvider<'_> {
     /// - `remappings.txt`
     /// - Environment variables
     /// - CLI parameters
-    fn get_remappings(
-        &self,
-        remappings: Vec<Remapping>,
-        use_fallbacks: bool,
-    ) -> Result<RemappingsOutput, Error> {
+    fn get_remappings(&self) -> Result<RemappingsOutput, Error> {
+        let (remappings, explicitly_empty) = match &self.remappings {
+            Ok(remappings) => (remappings.clone(), remappings.is_empty()),
+            Err(err) => {
+                if let figment::error::Kind::MissingField(_) = err.kind {
+                    (Vec::new(), false)
+                } else {
+                    return Err(err.clone());
+                }
+            }
+        };
+
         trace!("get all remappings from {:?}", self.root);
         /// Prioritizes remappings by shortest path, then a `src` target, then lexical path.
         ///   - ("a", "1/2") over ("a", "1/2/3")
@@ -255,7 +262,7 @@ impl RemappingsProvider<'_> {
 
         // check remappings.txt file
         let remappings_file = self.root.join("remappings.txt");
-        if use_fallbacks && remappings_file.is_file() {
+        if !explicitly_empty && remappings_file.is_file() {
             let content = fs::read_to_string(remappings_file).map_err(|err| err.to_string())?;
             let remappings_from_file: Result<Vec<_>, _> =
                 remappings_from_newline(&content).collect();
@@ -275,7 +282,7 @@ impl RemappingsProvider<'_> {
         let mut all_remappings = Remappings::new_with_remappings(user_remappings);
 
         // scan all library dirs and autodetect remappings
-        if use_fallbacks && self.auto_detect_remappings {
+        if !explicitly_empty && self.auto_detect_remappings {
             let (nested_foundry_remappings, auto_detected_remappings) = rayon::join(
                 || self.find_nested_foundry_remappings(),
                 || self.auto_detect_remappings(),
@@ -738,16 +745,7 @@ impl Provider for RemappingsProvider<'_> {
     }
 
     fn data(&self) -> Result<Map<Profile, Dict>, Error> {
-        let output = match &self.remappings {
-            Ok(remappings) => self.get_remappings(remappings.clone(), !remappings.is_empty()),
-            Err(err) => {
-                if let figment::error::Kind::MissingField(_) = err.kind {
-                    self.get_remappings(vec![], true)
-                } else {
-                    return Err(err.clone());
-                }
-            }
-        }?;
+        let output = self.get_remappings()?;
 
         // turn the absolute remapping into a relative one by stripping the `root`
         let remappings = output

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -179,6 +179,9 @@ struct CachedNestedConfig {
 ///   - `DAPP_REMAPPINGS` || `FOUNDRY_REMAPPINGS` env var
 ///   - `<root>/remappings.txt` file
 ///   - `Remapping::find_many`.
+///
+/// An explicitly empty remappings list disables the filesystem fallbacks. Environment remappings
+/// remain authoritative.
 pub struct RemappingsProvider<'a> {
     /// Whether to auto detect remappings from the `lib_paths`
     pub auto_detect_remappings: bool,
@@ -205,7 +208,11 @@ impl RemappingsProvider<'_> {
     /// - `remappings.txt`
     /// - Environment variables
     /// - CLI parameters
-    fn get_remappings(&self, remappings: Vec<Remapping>) -> Result<RemappingsOutput, Error> {
+    fn get_remappings(
+        &self,
+        remappings: Vec<Remapping>,
+        use_fallbacks: bool,
+    ) -> Result<RemappingsOutput, Error> {
         trace!("get all remappings from {:?}", self.root);
         /// Prioritizes remappings by shortest path, then a `src` target, then lexical path.
         ///   - ("a", "1/2") over ("a", "1/2/3")
@@ -248,7 +255,7 @@ impl RemappingsProvider<'_> {
 
         // check remappings.txt file
         let remappings_file = self.root.join("remappings.txt");
-        if remappings_file.is_file() {
+        if use_fallbacks && remappings_file.is_file() {
             let content = fs::read_to_string(remappings_file).map_err(|err| err.to_string())?;
             let remappings_from_file: Result<Vec<_>, _> =
                 remappings_from_newline(&content).collect();
@@ -268,7 +275,7 @@ impl RemappingsProvider<'_> {
         let mut all_remappings = Remappings::new_with_remappings(user_remappings);
 
         // scan all library dirs and autodetect remappings
-        if self.auto_detect_remappings {
+        if use_fallbacks && self.auto_detect_remappings {
             let (nested_foundry_remappings, auto_detected_remappings) = rayon::join(
                 || self.find_nested_foundry_remappings(),
                 || self.auto_detect_remappings(),
@@ -732,10 +739,10 @@ impl Provider for RemappingsProvider<'_> {
 
     fn data(&self) -> Result<Map<Profile, Dict>, Error> {
         let output = match &self.remappings {
-            Ok(remappings) => self.get_remappings(remappings.clone()),
+            Ok(remappings) => self.get_remappings(remappings.clone(), !remappings.is_empty()),
             Err(err) => {
                 if let figment::error::Kind::MissingField(_) = err.kind {
-                    self.get_remappings(vec![])
+                    self.get_remappings(vec![], true)
                 } else {
                     return Err(err.clone());
                 }

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use figment::{
     Error, Figment, Metadata, Profile, Provider,
+    error::Kind,
     value::{Dict, Map},
 };
 use foundry_compilers::artifacts::remappings::{RelativeRemapping, Remapping, RemappingDiscovery};
@@ -212,7 +213,7 @@ impl RemappingsProvider<'_> {
         let (remappings, explicitly_empty) = match &self.remappings {
             Ok(remappings) => (remappings.clone(), remappings.is_empty()),
             Err(err) => {
-                if let figment::error::Kind::MissingField(_) = err.kind {
+                if let Kind::MissingField(_) = err.kind {
                     (Vec::new(), false)
                 } else {
                     return Err(err.clone());


### PR DESCRIPTION
## Motivation

An explicit remappings = [] in foundry.toml currently still loads remappings.txt and auto-detected remappings. This prevents profiles that intentionally need no filesystem-derived remappings from expressing that configuration.

Closes #5258

## Solution

Treat an explicitly empty TOML remappings list as an opt-out of filesystem fallbacks. Preserve existing behavior when the field is omitted or contains remappings, and keep environment and CLI remappings authoritative.

Add a regression test covering both remappings.txt and auto-detected remappings.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes