### PR TITLE
fix(anvil): allow pre-Cancun fork overrides

### DIFF
--- a/.changelog/anvil-pre-cancun-explicit-hardfork.md
+++ b/.changelog/anvil-pre-cancun-explicit-hardfork.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed calls on pre-Cancun forks when explicitly selecting a Cancun-or-newer hardfork.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1966,6 +1966,8 @@ latest block number: {latest_block}"
         } else {
             None
         };
+        let source_is_pre_cancun =
+            inferred_hardfork.is_some_and(|hardfork| SpecId::from(hardfork) < SpecId::CANCUN);
         let fork_hardfork = self.hardfork.or(inferred_hardfork);
         let effective_hardfork = fork_hardfork.unwrap_or_else(|| self.get_hardfork());
         let effective_spec = SpecId::from(effective_hardfork);
@@ -1997,9 +1999,6 @@ latest block number: {latest_block}"
         let blob_params = get_blob_params(source_chain_id, block.header.timestamp());
         fees.set_blob_params(blob_params);
         let blob_update_fraction = blob_params.update_fraction as u64;
-        let source_is_pre_cancun =
-            FoundryHardfork::from_chain_and_timestamp(source_chain_id, block.header.timestamp())
-                .is_some_and(|hardfork| SpecId::from(hardfork) < SpecId::CANCUN);
         let blob_excess_gas = block.header.excess_blob_gas().or_else(|| {
             // Pre-Cancun headers and Polygon Bor headers omit the blob fields. REVM still requires
             // a valid blob environment when executing with the Cancun spec; zero is the neutral

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1997,12 +1997,17 @@ latest block number: {latest_block}"
         let blob_params = get_blob_params(source_chain_id, block.header.timestamp());
         fees.set_blob_params(blob_params);
         let blob_update_fraction = blob_params.update_fraction as u64;
+        let source_is_pre_cancun =
+            FoundryHardfork::from_chain_and_timestamp(source_chain_id, block.header.timestamp())
+                .is_some_and(|hardfork| SpecId::from(hardfork) < SpecId::CANCUN);
         let blob_excess_gas = block.header.excess_blob_gas().or_else(|| {
-            // Polygon enables Cancun EVM features without EIP-4844, so Bor headers omit the blob
-            // fields. REVM still requires a valid blob environment for the Cancun spec; zero is
-            // the neutral excess-gas value.
-            (effective_spec >= SpecId::CANCUN && Chain::from_id(source_chain_id).is_polygon())
-                .then_some(0)
+            // Pre-Cancun headers and Polygon Bor headers omit the blob fields. REVM still requires
+            // a valid blob environment when executing with the Cancun spec; zero is the neutral
+            // excess-gas value.
+            (effective_spec >= SpecId::CANCUN
+                && ((source_is_pre_cancun && block.header.blob_gas_used().is_none())
+                    || Chain::from_id(source_chain_id).is_polygon()))
+            .then_some(0)
         });
         evm_env.block_env.blob_excess_gas_and_price =
             blob_excess_gas.map(|excess| BlobExcessGasAndPrice::new(excess, blob_update_fraction));

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -3217,17 +3217,18 @@ async fn test_pre_cancun_fork_with_post_cancun_hardfork() {
         NodeConfig::test()
             .with_chain_id(Some(NamedChain::Mainnet as u64))
             .with_hardfork(Some(EthereumHardfork::Shanghai.into()))
-            .with_genesis_timestamp(EthereumHardfork::Shanghai.mainnet_activation_timestamp()),
+            .with_genesis_timestamp(EthereumHardfork::Cancun.mainnet_activation_timestamp()),
     )
     .await;
     origin_api.anvil_set_code(target, bytes!("600060005260206000f3")).await.unwrap();
+    origin_api.mine_one().await.unwrap();
     let origin_url = origin_handle.http_endpoint();
 
     for hardfork in [EthereumHardfork::Cancun, EthereumHardfork::Prague] {
         let (api, handle) = spawn(
             NodeConfig::test()
                 .with_eth_rpc_url(Some(origin_url.clone()))
-                .with_fork_block_number(Some(0u64))
+                .with_fork_block_number(Some(1u64))
                 .with_hardfork(Some(hardfork.into())),
         )
         .await;
@@ -3249,7 +3250,7 @@ async fn test_pre_cancun_fork_with_post_cancun_hardfork() {
 
         api.anvil_reset(Some(Forking {
             json_rpc_url: Some(origin_url.clone()),
-            block_number: Some(0),
+            block_number: Some(1),
         }))
         .await
         .unwrap();
@@ -3263,7 +3264,7 @@ async fn test_pre_cancun_fork_with_post_cancun_hardfork() {
     let (api, _) = spawn(
         NodeConfig::test()
             .with_eth_rpc_url(Some(partial_header_url))
-            .with_fork_block_number(Some(0u64))
+            .with_fork_block_number(Some(1u64))
             .with_hardfork(Some(EthereumHardfork::Prague.into())),
     )
     .await;

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -3210,7 +3210,71 @@ async fn test_fork_reset_to_new_url_updates_source_chain_id() {
     assert!(send().await.unwrap().get_receipt().await.unwrap().status());
 }
 
-async fn spawn_rpc_proxy_without_blob_header_fields(endpoint: String) -> String {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pre_cancun_fork_with_post_cancun_hardfork() {
+    let target = Address::random();
+    let (origin_api, origin_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(NamedChain::Mainnet as u64))
+            .with_hardfork(Some(EthereumHardfork::Shanghai.into()))
+            .with_genesis_timestamp(EthereumHardfork::Shanghai.mainnet_activation_timestamp()),
+    )
+    .await;
+    origin_api.anvil_set_code(target, bytes!("600060005260206000f3")).await.unwrap();
+    let origin_url = origin_handle.http_endpoint();
+
+    for hardfork in [EthereumHardfork::Cancun, EthereumHardfork::Prague] {
+        let (api, handle) = spawn(
+            NodeConfig::test()
+                .with_eth_rpc_url(Some(origin_url.clone()))
+                .with_fork_block_number(Some(0u64))
+                .with_hardfork(Some(hardfork.into())),
+        )
+        .await;
+        let provider = handle.http_provider();
+        let request =
+            || TransactionRequest { to: Some(TxKind::Call(target)), ..Default::default() };
+
+        assert_eq!(provider.call(request().into()).await.unwrap(), Bytes::from(vec![0; 32]));
+        assert_eq!(
+            api.backend
+                .evm_env()
+                .read()
+                .block_env
+                .blob_excess_gas_and_price
+                .as_ref()
+                .map(|blob| blob.excess_blob_gas),
+            Some(0)
+        );
+
+        api.anvil_reset(Some(Forking {
+            json_rpc_url: Some(origin_url.clone()),
+            block_number: Some(0),
+        }))
+        .await
+        .unwrap();
+        assert_eq!(provider.call(request().into()).await.unwrap(), Bytes::from(vec![0; 32]));
+    }
+
+    let partial_header_url =
+        spawn_rpc_proxy_with_blob_header_fields(origin_url, Some(0), None).await;
+    let partial_header_url =
+        spawn_rpc_proxy_rejecting_method_after(partial_header_url, "anvil_nodeInfo", 0).await;
+    let (api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(partial_header_url))
+            .with_fork_block_number(Some(0u64))
+            .with_hardfork(Some(EthereumHardfork::Prague.into())),
+    )
+    .await;
+    assert!(api.backend.evm_env().read().block_env.blob_excess_gas_and_price.is_none());
+}
+
+async fn spawn_rpc_proxy_with_blob_header_fields(
+    endpoint: String,
+    blob_gas_used: Option<u64>,
+    excess_blob_gas: Option<u64>,
+) -> String {
     let client = reqwest::Client::new();
     let router = Router::new().route(
         "/",
@@ -3232,8 +3296,15 @@ async fn spawn_rpc_proxy_without_blob_header_fields(endpoint: String) -> String 
                     Some("eth_getBlockByHash" | "eth_getBlockByNumber")
                 ) && let Some(block) = response.get_mut("result").and_then(Value::as_object_mut)
                 {
-                    block.remove("blobGasUsed");
-                    block.remove("excessBlobGas");
+                    for (field, value) in
+                        [("blobGasUsed", blob_gas_used), ("excessBlobGas", excess_blob_gas)]
+                    {
+                        if let Some(value) = value {
+                            block.insert(field.to_string(), Value::String(format!("0x{value:x}")));
+                        } else {
+                            block.remove(field);
+                        }
+                    }
                 }
                 Json(response)
             }
@@ -3261,7 +3332,7 @@ async fn test_polygon_fork_missing_blob_fields_is_chain_scoped_across_reset() {
     .await;
     polygon_api.anvil_set_code(token, return_zero.clone()).await.unwrap();
     let polygon_url =
-        spawn_rpc_proxy_without_blob_header_fields(polygon_origin.http_endpoint()).await;
+        spawn_rpc_proxy_with_blob_header_fields(polygon_origin.http_endpoint(), None, None).await;
     let polygon_url =
         spawn_rpc_proxy_rejecting_method_after(polygon_url, "anvil_nodeInfo", 0).await;
 
@@ -3274,7 +3345,8 @@ async fn test_polygon_fork_missing_blob_fields_is_chain_scoped_across_reset() {
     .await;
     pre_cancun_api.anvil_set_code(token, return_zero.clone()).await.unwrap();
     let pre_cancun_url =
-        spawn_rpc_proxy_without_blob_header_fields(pre_cancun_origin.http_endpoint()).await;
+        spawn_rpc_proxy_with_blob_header_fields(pre_cancun_origin.http_endpoint(), None, None)
+            .await;
     let pre_cancun_url =
         spawn_rpc_proxy_rejecting_method_after(pre_cancun_url, "anvil_nodeInfo", 0).await;
 
@@ -3289,7 +3361,7 @@ async fn test_polygon_fork_missing_blob_fields_is_chain_scoped_across_reset() {
     .await;
     ethereum_api.anvil_set_code(token, return_zero).await.unwrap();
     let ethereum_url =
-        spawn_rpc_proxy_without_blob_header_fields(ethereum_origin.http_endpoint()).await;
+        spawn_rpc_proxy_with_blob_header_fields(ethereum_origin.http_endpoint(), None, None).await;
     let ethereum_url =
         spawn_rpc_proxy_rejecting_method_after(ethereum_url, "anvil_nodeInfo", 0).await;
 


### PR DESCRIPTION
Forking a pre-Cancun block with a Cancun-or-newer hardfork left revm's required blob environment unset because the source header legitimately omitted EIP-4844 fields. Initialize neutral excess blob gas only when the source schedule confirms a pre-Cancun block and both blob fields are absent, while preserving malformed post-Cancun header rejection and Polygon compatibility.

Fixes #16503.