### PR TITLE
fix(anvil): skip OP fees for calls

### DIFF
--- a/.changelog/anvil-op-call-operator-fee.md
+++ b/.changelog/anvil-op-call-operator-fee.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed OP-stack calls failing for unfunded senders when the operator fee is non-zero.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2786,11 +2786,6 @@ impl<N: Network> Backend<N> {
         let gas_price = gas_price.or(max_fee_per_gas).unwrap_or_else(|| {
             self.fees().raw_gas_price().saturating_add(MIN_SUGGESTED_PRIORITY_FEE)
         });
-        // Zero-fee calls on OP chains do not charge additional transaction fees.
-        #[cfg(feature = "optimism")]
-        if self.is_optimism() && gas_price == 0 && max_fee_per_blob_gas.unwrap_or_default() == 0 {
-            evm_env.cfg_env.disable_fee_charge = true;
-        }
         let caller = from.unwrap_or_default();
         let to = to.as_ref().and_then(TxKind::to);
         let blob_hashes = blob_versioned_hashes.unwrap_or_default();
@@ -2888,7 +2883,11 @@ impl<N: Network> Backend<N> {
             self.build_call_env_with_base(request, fee_details, block_env, base_evm_env);
         #[cfg(feature = "optimism")]
         let tx_env = if self.is_optimism() {
-            CallTxEnv::Op(OpTransaction { base: tx_env, deposit: op_deposit, ..Default::default() })
+            CallTxEnv::Op(OpTransaction {
+                base: tx_env,
+                deposit: op_deposit,
+                enveloped_tx: Some(Bytes::new()),
+            })
         } else if self.is_tempo() {
             CallTxEnv::Tempo(TempoTxEnv::from(tx_env))
         } else {
@@ -3246,7 +3245,7 @@ impl<N: Network> Backend<N> {
         let mut inspector = self.build_inspector();
         let PreparedCall { mut evm_env, mut tx_env, .. } =
             self.prepare_typed_call_env(state, request, fee_details, block_env)?;
-        evm_env.cfg_env.disable_fee_charge |= overrides.disable_fee_charge;
+        evm_env.cfg_env.disable_fee_charge = overrides.disable_fee_charge;
         if let Some(gas_limit) = overrides.gas_limit {
             tx_env.base_mut().gas_limit = gas_limit;
         }
@@ -8074,7 +8073,6 @@ impl Backend<FoundryNetwork> {
                         evm_env.cfg_env.disable_nonce_check = false;
                         evm_env.cfg_env.disable_base_fee = false;
                         evm_env.cfg_env.disable_block_gas_limit = false;
-                        evm_env.cfg_env.disable_fee_charge = false;
                     }
 
                     let mut inspector = self.build_inspector();

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2783,6 +2783,12 @@ impl<N: Network> Backend<N> {
         // Disable nonce check in revm
         evm_env.cfg_env.disable_nonce_check = true;
 
+        // Calls on OP chains do not charge transaction fees.
+        #[cfg(feature = "optimism")]
+        if self.is_optimism() {
+            evm_env.cfg_env.disable_fee_charge = true;
+        }
+
         let gas_price = gas_price.or(max_fee_per_gas).unwrap_or_else(|| {
             self.fees().raw_gas_price().saturating_add(MIN_SUGGESTED_PRIORITY_FEE)
         });
@@ -3241,7 +3247,7 @@ impl<N: Network> Backend<N> {
         let mut inspector = self.build_inspector();
         let PreparedCall { mut evm_env, mut tx_env, .. } =
             self.prepare_typed_call_env(state, request, fee_details, block_env)?;
-        evm_env.cfg_env.disable_fee_charge = overrides.disable_fee_charge;
+        evm_env.cfg_env.disable_fee_charge |= overrides.disable_fee_charge;
         if let Some(gas_limit) = overrides.gas_limit {
             tx_env.base_mut().gas_limit = gas_limit;
         }
@@ -8069,6 +8075,7 @@ impl Backend<FoundryNetwork> {
                         evm_env.cfg_env.disable_nonce_check = false;
                         evm_env.cfg_env.disable_base_fee = false;
                         evm_env.cfg_env.disable_block_gas_limit = false;
+                        evm_env.cfg_env.disable_fee_charge = false;
                     }
 
                     let mut inspector = self.build_inspector();

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2783,15 +2783,14 @@ impl<N: Network> Backend<N> {
         // Disable nonce check in revm
         evm_env.cfg_env.disable_nonce_check = true;
 
-        // Calls on OP chains do not charge transaction fees.
-        #[cfg(feature = "optimism")]
-        if self.is_optimism() {
-            evm_env.cfg_env.disable_fee_charge = true;
-        }
-
         let gas_price = gas_price.or(max_fee_per_gas).unwrap_or_else(|| {
             self.fees().raw_gas_price().saturating_add(MIN_SUGGESTED_PRIORITY_FEE)
         });
+        // Zero-fee calls on OP chains do not charge additional transaction fees.
+        #[cfg(feature = "optimism")]
+        if self.is_optimism() && gas_price == 0 && max_fee_per_blob_gas.unwrap_or_default() == 0 {
+            evm_env.cfg_env.disable_fee_charge = true;
+        }
         let caller = from.unwrap_or_default();
         let to = to.as_ref().and_then(TxKind::to);
         let blob_hashes = blob_versioned_hashes.unwrap_or_default();

--- a/crates/anvil/tests/it/optimism.rs
+++ b/crates/anvil/tests/it/optimism.rs
@@ -4,7 +4,7 @@ use crate::utils::{http_provider, http_provider_with_signer};
 use alloy_consensus::{Eip658Value, Receipt, proofs::calculate_receipt_root};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::{EthereumWallet, NetworkTransactionBuilder, TransactionBuilder};
-use alloy_primitives::{Address, Bloom, TxHash, TxKind, U256, b256};
+use alloy_primitives::{Address, B256, Bloom, Bytes, TxHash, TxKind, U256, address, b256};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, TransactionRequest, anvil::Forking};
 use alloy_serde::{OtherFields, WithOtherFields};
@@ -159,6 +159,52 @@ async fn test_tempo_fields_do_not_override_op_deposit_classification() {
     };
 
     provider.call(tx).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_call_does_not_charge_operator_fee() {
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_networks(NetworkConfigs::with_optimism())
+            .with_hardfork(Some(OpHardfork::Isthmus.into())),
+    )
+    .await;
+    let provider = handle.http_provider();
+    let caller = Address::random();
+    let target = Address::random();
+    let l1_block = address!("0x4200000000000000000000000000000000000015");
+    let mut operator_fee_params = [0u8; 32];
+    operator_fee_params[24..].copy_from_slice(&1_351_351_351_351u64.to_be_bytes());
+
+    api.anvil_set_storage_at(l1_block, U256::from(8), B256::from(operator_fee_params))
+        .await
+        .unwrap();
+    api.anvil_set_code(target, Bytes::from_static(&[0x00])).await.unwrap();
+
+    let request = WithOtherFields::new(
+        TransactionRequest::default().with_from(caller).with_to(target).with_gas_limit(21_000),
+    );
+    provider.call(request).await.unwrap();
+
+    let err = provider
+        .raw_request::<_, Value>(
+            "eth_simulateV1".into(),
+            (json!({
+                "blockStateCalls": [{
+                    "calls": [{
+                        "from": caller,
+                        "to": target,
+                        "gas": "0x5208",
+                        "maxFeePerGas": "0x3b9aca00",
+                        "maxPriorityFeePerGas": "0x0"
+                    }]
+                }],
+                "validation": true,
+            }),),
+        )
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("Insufficient funds for gas * price + value"), "{err}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/optimism.rs
+++ b/crates/anvil/tests/it/optimism.rs
@@ -191,6 +191,16 @@ async fn test_call_does_not_charge_operator_fee() {
     let err = provider.call(priced_request).await.unwrap_err();
     assert!(err.to_string().contains("Insufficient funds for gas * price + value"), "{err}");
 
+    let value_request = WithOtherFields::new(
+        TransactionRequest::default()
+            .with_from(caller)
+            .with_to(target)
+            .with_gas_limit(21_000)
+            .with_value(U256::ONE),
+    );
+    let err = provider.call(value_request).await.unwrap_err();
+    assert!(err.to_string().contains("Insufficient funds for gas * price + value"), "{err}");
+
     for validation in [false, true] {
         let err = provider
             .raw_request::<_, Value>(

--- a/crates/anvil/tests/it/optimism.rs
+++ b/crates/anvil/tests/it/optimism.rs
@@ -184,27 +184,34 @@ async fn test_call_does_not_charge_operator_fee() {
     let request = WithOtherFields::new(
         TransactionRequest::default().with_from(caller).with_to(target).with_gas_limit(21_000),
     );
-    provider.call(request).await.unwrap();
+    provider.call(request.clone()).await.unwrap();
+    provider.call(WithOtherFields::new(request.inner.clone().with_gas_price(0))).await.unwrap();
 
-    let err = provider
-        .raw_request::<_, Value>(
-            "eth_simulateV1".into(),
-            (json!({
-                "blockStateCalls": [{
-                    "calls": [{
-                        "from": caller,
-                        "to": target,
-                        "gas": "0x5208",
-                        "maxFeePerGas": "0x3b9aca00",
-                        "maxPriorityFeePerGas": "0x0"
-                    }]
-                }],
-                "validation": true,
-            }),),
-        )
-        .await
-        .unwrap_err();
+    let priced_request = WithOtherFields::new(request.inner.with_gas_price(1_000_000_000));
+    let err = provider.call(priced_request).await.unwrap_err();
     assert!(err.to_string().contains("Insufficient funds for gas * price + value"), "{err}");
+
+    for validation in [false, true] {
+        let err = provider
+            .raw_request::<_, Value>(
+                "eth_simulateV1".into(),
+                (json!({
+                    "blockStateCalls": [{
+                        "calls": [{
+                            "from": caller,
+                            "to": target,
+                            "gas": "0x5208",
+                            "maxFeePerGas": "0x3b9aca00",
+                            "maxPriorityFeePerGas": "0x0"
+                        }]
+                    }],
+                    "validation": validation,
+                }),),
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Insufficient funds for gas * price + value"), "{err}");
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Fixes #16506 by disabling transaction fee charging for OP call simulations. Validating simulations and real transactions continue charging fees normally.