### PR TITLE
feat(forge): add reinit command for submodules

### DIFF
--- a/.changelog/forge-reinit-submodules.md
+++ b/.changelog/forge-reinit-submodules.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added `forge reinit` to discard local submodule changes and restore the revisions recorded by the project.

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -97,6 +97,7 @@ pub fn run_command(args: Forge) -> Result<()> {
         ForgeSubcommand::Create(cmd) => global.block_on(cmd.run()),
         ForgeSubcommand::Update(cmd) => cmd.run(),
         ForgeSubcommand::Install(cmd) => global.block_on(cmd.run()),
+        ForgeSubcommand::Reinit(cmd) => cmd.run(),
         ForgeSubcommand::Remove(cmd) => cmd.run(),
         ForgeSubcommand::Remappings(cmd) => cmd.run(),
         ForgeSubcommand::Init(cmd) => global.block_on(cmd.run()),

--- a/crates/forge/src/cmd/mod.rs
+++ b/crates/forge/src/cmd/mod.rs
@@ -25,6 +25,7 @@ pub mod inspect;
 pub mod install;
 pub mod lint;
 pub mod lsp;
+pub mod reinit;
 pub mod remappings;
 pub mod remove;
 pub mod selectors;

--- a/crates/forge/src/cmd/reinit.rs
+++ b/crates/forge/src/cmd/reinit.rs
@@ -1,0 +1,31 @@
+use clap::{Parser, ValueHint};
+use eyre::Result;
+use foundry_cli::utils::{CommandUtils, Git, LoadConfig};
+use foundry_config::impl_figment_convert_basic;
+use std::{path::PathBuf, process::Command};
+
+/// CLI arguments for `forge reinit`.
+#[derive(Clone, Debug, Parser)]
+pub struct ReinitArgs {
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    root: Option<PathBuf>,
+}
+impl_figment_convert_basic!(ReinitArgs);
+
+impl ReinitArgs {
+    pub fn run(self) -> Result<()> {
+        let config = self.load_config()?;
+        let root = Git::root_of(&config.root)?;
+        let git = Git::new(&root);
+
+        Command::new("git")
+            .current_dir(&root)
+            .args(["submodule", "deinit", "--force", "."])
+            .exec()?;
+        git.submodule_update(false, false, false, true, std::iter::empty::<PathBuf>())
+    }
+}

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -2,8 +2,8 @@ use crate::cmd::{
     bind::BindArgs, bind_json, build::BuildArgs, cache::CacheArgs, clone::CloneArgs,
     compiler::CompilerArgs, config, coverage, create::CreateArgs, doc::DocArgs, eip712, flatten,
     fmt::FmtArgs, fuzz::FuzzArgs, geiger, init::InitArgs, inspect, install::InstallArgs,
-    lint::LintArgs, lsp::LspArgs, remappings::RemappingArgs, remove::RemoveArgs,
-    selectors::SelectorsSubcommands, snapshot, soldeer, test, tree, update,
+    lint::LintArgs, lsp::LspArgs, reinit::ReinitArgs, remappings::RemappingArgs,
+    remove::RemoveArgs, selectors::SelectorsSubcommands, snapshot, soldeer, test, tree, update,
 };
 use clap::{Parser, Subcommand, ValueHint};
 use forge_script::ScriptArgs;
@@ -105,6 +105,9 @@ pub enum ForgeSubcommand {
     /// - forge install openzeppelin/openzeppelin-contracts@v5.0.2 (pin a version)
     #[command(verbatim_doc_comment, visible_aliases = ["i", "add"])]
     Install(InstallArgs),
+
+    /// Reinitialize the project's Git submodules, discarding local changes.
+    Reinit(ReinitArgs),
 
     /// Remove one or multiple dependencies.
     #[command(visible_alias = "rm")]

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -571,6 +571,52 @@ Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag:
     assert!(matches!(forge_std_lock, DepIdentifier::Tag { .. }));
 });
 
+// https://github.com/foundry-rs/foundry/issues/4353
+forgetest!(can_reinit_submodules, |prj, cmd| {
+    cmd.git_init();
+
+    let source = tempfile::tempdir().unwrap();
+    let source_git = Git::new(source.path());
+    source_git.init().unwrap();
+    fs::write(source.path().join("source.txt"), "first revision\n").unwrap();
+    source_git.add(["source.txt"]).unwrap();
+    source_git.commit("first revision").unwrap();
+    let first_rev = source_git.head().unwrap();
+
+    fs::write(source.path().join("source.txt"), "second revision\n").unwrap();
+    source_git.add(["source.txt"]).unwrap();
+    source_git.commit("second revision").unwrap();
+    let second_rev = source_git.head().unwrap();
+
+    let output = Command::new("git")
+        .current_dir(prj.root())
+        .args(["-c", "protocol.file.allow=always", "submodule", "add", "--"])
+        .arg(source.path())
+        .arg("lib/dep")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+
+    let dependency = prj.root().join("lib/dep");
+    let dependency_git = Git::new(&dependency);
+    dependency_git.checkout(false, &first_rev).unwrap();
+    cmd.git_add();
+    cmd.git_commit("add dependency");
+
+    dependency_git.checkout(false, &second_rev).unwrap();
+    Git::new(prj.root()).add(["lib/dep"]).unwrap();
+    cmd.git_commit("advance dependency");
+
+    dependency_git.checkout(false, &first_rev).unwrap();
+    fs::write(dependency.join("source.txt"), "local edit\n").unwrap();
+
+    cmd.forge_fuse();
+    cmd.env("GIT_ALLOW_PROTOCOL", "file");
+    cmd.arg("reinit").assert_success();
+    assert_eq!(dependency_git.head().unwrap(), second_rev);
+    assert_eq!(read_string(dependency.join("source.txt")), "second revision\n");
+});
+
 // test that we can repeatedly install the same dependency without changes
 forgetest!(can_install_repeatedly, |_prj, cmd| {
     cmd.git_init();


### PR DESCRIPTION
## Motivation

Switching branches can leave dependency submodules at stale checkouts with local changes that prevent Forge from restoring the revisions recorded by the project.

Closes #4353.

## Solution

Add `forge reinit`, which force-deinitializes all project submodules and then initializes and updates them recursively. The command help calls out that local submodule changes are discarded.

Add an integration test that creates a local submodule with two revisions, leaves its checkout stale and dirty, and verifies that `forge reinit` restores the recorded revision and contents.

## Compatibility

The command is opt-in and does not change existing install or update behavior. A public GitHub code search found one external direct consumer of `ForgeSubcommand`; its match includes a wildcard arm and remains compatible with the additive variant.
