### PR TITLE
fix(anvil): support unknown fork schedules

### DIFF
--- a/.changelog/anvil-unknown-fork-schedules.md
+++ b/.changelog/anvil-unknown-fork-schedules.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed Cancun-or-newer overrides for forks whose source chain has no known hardfork schedule.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1950,24 +1950,15 @@ latest block number: {latest_block}"
         let effective_network =
             self.networks.resolved_network().unwrap_or(NetworkVariant::Ethereum);
         let endpoint_matches_execution = fork_identity.network == Some(effective_network);
-        let inferred_hardfork = if endpoint_matches_execution {
-            fork_identity
-                .hardfork
-                .filter(|hardfork| hardfork.namespace() == effective_network.hardfork_namespace())
-                .or_else(|| {
-                    FoundryHardfork::from_chain_and_timestamp(
-                        source_chain_id,
-                        block.header.timestamp(),
-                    )
-                    .filter(|hardfork| {
-                        hardfork.namespace() == effective_network.hardfork_namespace()
-                    })
-                })
-        } else {
-            None
-        };
-        let source_is_pre_cancun =
-            inferred_hardfork.is_some_and(|hardfork| SpecId::from(hardfork) < SpecId::CANCUN);
+        let source_hardfork = fork_identity.hardfork.or_else(|| {
+            FoundryHardfork::from_chain_and_timestamp(source_chain_id, block.header.timestamp())
+        });
+        let inferred_hardfork = source_hardfork.filter(|hardfork| {
+            endpoint_matches_execution
+                && hardfork.namespace() == effective_network.hardfork_namespace()
+        });
+        let source_may_omit_blob_fields = source_hardfork
+            .map_or(self.hardfork.is_some(), |hardfork| SpecId::from(hardfork) < SpecId::CANCUN);
         let fork_hardfork = self.hardfork.or(inferred_hardfork);
         let effective_hardfork = fork_hardfork.unwrap_or_else(|| self.get_hardfork());
         let effective_spec = SpecId::from(effective_hardfork);
@@ -2004,7 +1995,7 @@ latest block number: {latest_block}"
             // a valid blob environment when executing with the Cancun spec; zero is the neutral
             // excess-gas value.
             (effective_spec >= SpecId::CANCUN
-                && ((source_is_pre_cancun && block.header.blob_gas_used().is_none())
+                && ((source_may_omit_blob_fields && block.header.blob_gas_used().is_none())
                     || Chain::from_id(source_chain_id).is_polygon()))
             .then_some(0)
         });

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -3271,6 +3271,57 @@ async fn test_pre_cancun_fork_with_post_cancun_hardfork() {
     assert!(api.backend.evm_env().read().block_env.blob_excess_gas_and_price.is_none());
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unknown_schedule_fork_with_post_cancun_hardfork() {
+    let target = Address::random();
+    let (origin_api, origin_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(NamedChain::BinanceSmartChain as u64))
+            .with_hardfork(Some(EthereumHardfork::Shanghai.into()))
+            .with_genesis_timestamp(EthereumHardfork::Cancun.mainnet_activation_timestamp()),
+    )
+    .await;
+    origin_api.anvil_set_code(target, bytes!("600060005260206000f3")).await.unwrap();
+    origin_api.mine_one().await.unwrap();
+    let origin_url =
+        spawn_rpc_proxy_with_blob_header_fields(origin_handle.http_endpoint(), None, None).await;
+    let origin_url = spawn_rpc_proxy_rejecting_method_after(origin_url, "anvil_nodeInfo", 0).await;
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_url.clone()))
+            .with_fork_block_number(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::Prague.into())),
+    )
+    .await;
+
+    assert_eq!(
+        api.backend
+            .evm_env()
+            .read()
+            .block_env
+            .blob_excess_gas_and_price
+            .as_ref()
+            .map(|blob| blob.excess_blob_gas),
+        Some(0)
+    );
+    assert_eq!(
+        handle
+            .http_provider()
+            .call(
+                TransactionRequest { to: Some(TxKind::Call(target)), ..Default::default() }.into()
+            )
+            .await
+            .unwrap(),
+        Bytes::from(vec![0; 32])
+    );
+
+    let (api, _) = spawn(
+        NodeConfig::test().with_eth_rpc_url(Some(origin_url)).with_fork_block_number(Some(1u64)),
+    )
+    .await;
+    assert!(api.backend.evm_env().read().block_env.blob_excess_gas_and_price.is_none());
+}
+
 async fn spawn_rpc_proxy_with_blob_header_fields(
     endpoint: String,
     blob_gas_used: Option<u64>,


### PR DESCRIPTION
Chains such as BSC, Linea, and Gnosis lack known timestamp-based hardfork schedules, preventing Anvil from identifying headers that may legitimately omit EIP-4844 fields. Allow a neutral blob environment when the schedule is unknown and the user explicitly selects a Cancun-or-newer hardfork, while preserving strict behavior without an override.

Follow-up to #16505.