### PR TITLE
fix(anvil): initialize blob env for Nitro forks

### DIFF
--- a/.changelog/anvil-nitro-blob-env.md
+++ b/.changelog/anvil-nitro-blob-env.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed forked Arbitrum Nitro chains failing ordinary calls when upstream headers omit blob gas fields.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1993,7 +1993,9 @@ latest block number: {latest_block}"
         let blob_excess_gas = block.header.excess_blob_gas().or_else(|| {
             // Pre-Cancun headers, Polygon Bor headers, and Arbitrum Nitro headers omit the blob
             // fields. REVM still requires a valid blob environment when executing with the Cancun
-            // spec; zero is the neutral excess-gas value.
+            // spec; zero is the neutral excess-gas value. On Nitro this makes `BLOBBASEFEE` return
+            // `1`, although Nitro rejects the opcode; matching that requires Arbitrum-specific EVM
+            // handling.
             (effective_spec >= SpecId::CANCUN
                 && ((source_may_omit_blob_fields && block.header.blob_gas_used().is_none())
                     || Chain::from_id(source_chain_id).is_polygon()

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1991,12 +1991,13 @@ latest block number: {latest_block}"
         fees.set_blob_params(blob_params);
         let blob_update_fraction = blob_params.update_fraction as u64;
         let blob_excess_gas = block.header.excess_blob_gas().or_else(|| {
-            // Pre-Cancun headers and Polygon Bor headers omit the blob fields. REVM still requires
-            // a valid blob environment when executing with the Cancun spec; zero is the neutral
-            // excess-gas value.
+            // Pre-Cancun headers, Polygon Bor headers, and Arbitrum Nitro headers omit the blob
+            // fields. REVM still requires a valid blob environment when executing with the Cancun
+            // spec; zero is the neutral excess-gas value.
             (effective_spec >= SpecId::CANCUN
                 && ((source_may_omit_blob_fields && block.header.blob_gas_used().is_none())
-                    || Chain::from_id(source_chain_id).is_polygon()))
+                    || Chain::from_id(source_chain_id).is_polygon()
+                    || Chain::from_id(source_chain_id).is_arbitrum()))
             .then_some(0)
         });
         evm_env.block_env.blob_excess_gas_and_price =

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -3369,6 +3369,53 @@ async fn spawn_rpc_proxy_with_blob_header_fields(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_arbitrum_forks_accept_nitro_headers_without_blob_fields() {
+    // Nitro omits Ethereum's EIP-4844 header fields, including on post-Cancun chains. Hide Anvil
+    // metadata so these deterministic local origins have the same observable shape as public RPCs.
+    for chain in [NamedChain::Arbitrum, NamedChain::Robinhood] {
+        let target = Address::random();
+        let (origin_api, origin) = spawn(
+            NodeConfig::test()
+                .with_chain_id(Some(chain as u64))
+                .with_hardfork(Some(EthereumHardfork::Prague.into()))
+                .with_genesis_timestamp(EthereumHardfork::Prague.arbitrum_activation_timestamp()),
+        )
+        .await;
+        origin_api.anvil_set_code(target, bytes!("600060005260206000f3")).await.unwrap();
+        let fork_url =
+            spawn_rpc_proxy_with_blob_header_fields(origin.http_endpoint(), None, None).await;
+        let fork_url = spawn_rpc_proxy_rejecting_method_after(fork_url, "anvil_nodeInfo", 0).await;
+
+        let (api, handle) = spawn(
+            NodeConfig::test()
+                .with_no_storage_caching(true)
+                .with_eth_rpc_url(Some(fork_url))
+                .with_fork_block_number(Some(0u64)),
+        )
+        .await;
+
+        assert!(api.backend.spec_id() >= SpecId::CANCUN);
+        assert_eq!(
+            api.backend
+                .evm_env()
+                .read()
+                .block_env
+                .blob_excess_gas_and_price
+                .as_ref()
+                .map(|blob| blob.excess_blob_gas),
+            Some(0),
+            "{chain}"
+        );
+        let request = TransactionRequest { to: Some(TxKind::Call(target)), ..Default::default() };
+        assert_eq!(
+            handle.http_provider().call(request.into()).await.unwrap(),
+            Bytes::from(vec![0; 32]),
+            "{chain}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_polygon_fork_missing_blob_fields_is_chain_scoped_across_reset() {
     // Polygon's Bor headers omit the EIP-4844 fields even though Anvil executes the fork with a
     // post-Cancun spec. Local origins provide deterministic state while the proxies reproduce that

--- a/crates/anvil/tests/it/fork_chains.rs
+++ b/crates/anvil/tests/it/fork_chains.rs
@@ -10,9 +10,9 @@
 
 use alloy_chains::NamedChain;
 use alloy_eips::Typed2718;
-use alloy_network::{ReceiptResponse, TransactionResponse};
-use alloy_primitives::B256;
-use alloy_rpc_types::BlockNumberOrTag;
+use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
+use alloy_primitives::{Address, B256};
+use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest, state::EvmOverrides};
 use alloy_transport::{RpcError, TransportError};
 use anvil::{
     NodeConfig,
@@ -95,6 +95,17 @@ async fn fork_and_assert(chain: NamedChain) -> Option<()> {
     let (api, handle) = fork_ok(chain, "fork setup", try_spawn(config).await)?;
 
     assert_eq!(api.chain_id(), chain as u64, "{chain:?} fork adopted the wrong chain id");
+
+    fork_ok(
+        chain,
+        "eth_call",
+        api.call(
+            TransactionRequest::default().with_to(Address::ZERO).into(),
+            None,
+            EvmOverrides::default(),
+        )
+        .await,
+    )?;
 
     let fork_block = api.block_number().unwrap().to::<u64>();
     if fork_block == 0 {


### PR DESCRIPTION
## Summary

- initialize a neutral blob environment for post-Cancun Arbitrum Nitro-family forks whose headers omit Ethereum's EIP-4844 fields
- cover both Arbitrum and Robinhood through `Chain::is_arbitrum()`

## Repro

```console
anvil --fork-url https://arb1.arbitrum.io/rpc
cast call 0x0000000000000000000000000000000000000000
```

Before this change, the call fails with `Excess blob gas not set.` The same failure occurs on Robinhood Chain. Both RPCs omit `blobGasUsed` and `excessBlobGas`, as Nitro intentionally constructs L2 headers without those fields.

Nitro also explicitly treats `BLOBBASEFEE` as unsupported, so zero excess blob gas is only the neutral REVM environment needed to execute ordinary calls; it does not claim EIP-4844 support:

- https://github.com/OffchainLabs/nitro/blob/a618155919315241665356fe60f3cd00d66d5e46/arbos/block_processor.go
- https://github.com/OffchainLabs/nitro/blob/a618155919315241665356fe60f3cd00d66d5e46/system_tests/estimation_test.go
- https://docs.robinhood.com/chain/run-a-full-node/

## Tests

- deterministic Arbitrum and Robinhood fork regression test
- `cargo fmt --all --check`
- `cargo clippy --manifest-path crates/anvil/Cargo.toml --tests --features monad --locked -- -D warnings`
- Anvil integration suite (default features and Monad feature coverage)
