### PR TITLE
fix(anvil): zero post-Merge simulated difficulty

### DIFF
--- a/.changelog/anvil-simulate-post-merge-difficulty.md
+++ b/.changelog/anvil-simulate-post-merge-difficulty.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed forked `eth_simulateV1` blocks inheriting nonzero post-Merge difficulty from their parent.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -7819,9 +7819,10 @@ impl Backend<FoundryNetwork> {
             let mut parent_hash = base_hash;
             let mut next_base_fee = base_fee;
             let mut inherited_block_env = base_block_env;
-            let (is_cancun, is_amsterdam, tx_gas_limit_cap) = {
+            let (is_merge, is_cancun, is_amsterdam, tx_gas_limit_cap) = {
                 let cfg_env = &self.evm_env.read().cfg_env;
                 (
+                    cfg_env.spec >= SpecId::MERGE,
                     cfg_env.spec >= SpecId::CANCUN,
                     cfg_env.spec >= SpecId::AMSTERDAM,
                     cfg_env.tx_gas_limit_cap(),
@@ -7858,6 +7859,9 @@ impl Backend<FoundryNetwork> {
                 }
                 block_env.basefee = if validation { next_base_fee } else { 0 };
                 block_env.prevrandao = Some(B256::ZERO);
+                if is_merge && !is_arbitrum(self.protocol_chain_id()) {
+                    block_env.difficulty = U256::ZERO;
+                }
                 let mut call_res = Vec::with_capacity(calls.len());
                 let mut log_index = 0;
                 let mut cumulative_gas_used = 0;

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -145,6 +145,42 @@ async fn test_fork_simulate_multiple_blocks_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fork_simulate_post_merge_block_context_rpc() {
+    let (source_api, source_handle) =
+        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()))).await;
+    source_api.anvil_set_next_block_prevrandao(B256::repeat_byte(0x42)).await.unwrap();
+    source_api.mine_one().await.unwrap();
+
+    let (_, fork_handle) = spawn(
+        NodeConfig::test()
+            .with_hardfork(Some(EthereumHardfork::Prague.into()))
+            .with_eth_rpc_url(Some(source_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64)),
+    )
+    .await;
+    let contract = "0xc000000000000000000000000000000000000000";
+    let response = rpc_request(
+        &fork_handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {
+                    (contract): {"code": "0x445f5260205ff3"}
+                },
+                "calls": [{"to": contract}]
+            }]
+        }, "latest"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+
+    let block = &response["result"][0];
+    assert_eq!(block["difficulty"], "0x0");
+    assert_eq!(block["mixHash"], B256::ZERO.to_string());
+    assert_eq!(block["calls"][0]["returnData"], format!("0x{}", "00".repeat(32)));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_v1_moves_precompiles_per_block_rpc() {
     let (_, handle) = spawn(NodeConfig::test()).await;
     let endpoint = handle.http_endpoint();


### PR DESCRIPTION
## Summary

- zero `difficulty` for post-Merge blocks produced by forked `eth_simulateV1`
- keep Nitro-family behavior unchanged (`difficulty = 1`)
- cover the inconsistent fork context with a deterministic local regression test

## Repro

Start Anvil on a current mainnet fork, then simulate one empty block:

```sh
anvil --fork-url https://ethereum-rpc.publicnode.com
cast rpc --rpc-url http://127.0.0.1:8545 eth_simulateV1 '{"blockStateCalls":[{}]}' latest
```

Before this change, the simulated header inherited the parent's random `mixHash` as a nonzero `difficulty`, even though the response `mixHash` and the `PREVRANDAO` opcode were both zero. Direct Geth and Base Reth return zero difficulty for the same post-Merge simulation.

The regression test reproduces this without an external RPC: it forks a local Prague node whose parent has a nonzero `prevrandao`, injects code that returns `PREVRANDAO`, and asserts that simulated `difficulty`, `mixHash`, and opcode output are consistently zero.

This matches [EIP-4399](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4399.md), [Geth's post-Merge simulation header construction](https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/simulate.go), and [Base Reth's pinned simulation implementation](https://github.com/base/reth/blob/78658a84600d7d0567f6626f39a76bc7d8e8290c/crates/rpc/rpc-eth-api/src/helpers/call.rs). Nitro is excluded because its clients intentionally expose `difficulty = 1`; see [Nitro's L2 header construction](https://github.com/OffchainLabs/nitro/blob/a618155919315241665356fe60f3cd00d66d5e46/arbos/block_processor.go).

## Tests

- `cargo test --manifest-path crates/anvil/Cargo.toml --test it test_fork_simulate_post_merge_block_context_rpc --locked`
- all 58 `simulate` integration tests with `--features monad`
- full default Anvil integration suite: 705 passed, 3 ignored (external DNS-only reset test excluded)
- full Monad Anvil integration suite: 749 passed, 3 ignored (one unrelated malformed user cache-path test failed)
- `cargo clippy --manifest-path crates/anvil/Cargo.toml --tests --features monad --locked -- -D warnings`
- `cargo fmt --all --check`
- live fork matrix across Ethereum, Arbitrum, Base, BSC, Celo, Gnosis, Hyperliquid, Optimism, Polygon, and Robinhood
- 192 deterministic `eth_simulateV1` state/block-override fuzz cases across the eight CI fork chains

This behavior predates the latest network-dispatch refactor; it was found during the same cross-chain regression audit and is intentionally kept in a separate PR.
