### PR TITLE
fix(anvil): use dynamic OP base fee params

### DIFF
--- a/.changelog/anvil-op-dynamic-base-fee.md
+++ b/.changelog/anvil-op-dynamic-base-fee.md
@@ -2,4 +2,5 @@
 anvil: patch
 ---
 
-Fixed locally mined OP-family blocks using stale EIP-1559 parameters after Holocene and Jovian.
+Fixed OP-family mining and simulation using stale header fee parameters, and populated Jovian's
+DA footprint in `blobGasUsed`.

--- a/.changelog/anvil-op-dynamic-base-fee.md
+++ b/.changelog/anvil-op-dynamic-base-fee.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed locally mined OP-family blocks using stale EIP-1559 parameters after Holocene and Jovian.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1968,6 +1968,10 @@ latest block number: {latest_block}"
             self.networks.base_fee_params(block.header.timestamp()),
             self.networks.is_tempo().then(|| TempoHardfork::from(effective_hardfork)),
         );
+        #[cfg(feature = "optimism")]
+        if self.networks.is_optimism() {
+            fees.set_optimism_base_fee_rules(block.header.extra_data());
+        }
 
         // if not set explicitly we use the base fee of the latest block
         self.base_fee = fork_overrides.base_fee.or_else(|| block.header.base_fee_per_gas());
@@ -1977,8 +1981,7 @@ latest block number: {latest_block}"
             // This is the base fee of the current block, but we need the base fee of the next
             // block.
             fees.set_base_fee(base_fee);
-            let next_block_base_fee =
-                fees.get_next_block_base_fee_per_gas(block.header.gas_used(), gas_limit, base_fee);
+            let next_block_base_fee = fees.get_next_block_base_fee_from_header(&block.header);
             fees.set_base_fee(next_block_base_fee);
         } else {
             fees.set_base_fee(self.get_base_fee());

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -239,21 +239,26 @@ pub struct AnvilBlockExecutor<E> {
     gas_used: u64,
     /// Blob gas used by the block.
     blob_gas_used: u64,
+    /// Whether OP Jovian repurposes `blobGasUsed` for the DA footprint.
+    #[cfg(feature = "optimism")]
+    optimism_jovian: bool,
     /// State changes captured for deferred publication.
     state_changes: Option<Vec<EvmState>>,
 }
 
 impl<E: fmt::Debug> fmt::Debug for AnvilBlockExecutor<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AnvilBlockExecutor")
+        let mut debug = f.debug_struct("AnvilBlockExecutor");
+        debug
             .field("evm", &self.evm)
             .field("parent_hash", &self.parent_hash)
             .field("spec_id", &self.spec_id)
             .field("ethereum_transitions", &self.ethereum_transitions)
             .field("gas_used", &self.gas_used)
-            .field("blob_gas_used", &self.blob_gas_used)
-            .field("receipts", &self.receipts.len())
-            .finish_non_exhaustive()
+            .field("blob_gas_used", &self.blob_gas_used);
+        #[cfg(feature = "optimism")]
+        debug.field("optimism_jovian", &self.optimism_jovian);
+        debug.field("receipts", &self.receipts.len()).finish_non_exhaustive()
     }
 }
 
@@ -274,6 +279,8 @@ impl<E> AnvilBlockExecutor<E> {
             receipts: Vec::new(),
             gas_used: 0,
             blob_gas_used: 0,
+            #[cfg(feature = "optimism")]
+            optimism_jovian: false,
             state_changes: None,
         }
     }
@@ -325,14 +332,18 @@ where
 
         let sender = *tx.signer();
         let transaction_hash = tx.tx().trie_hash();
+        #[cfg(feature = "optimism")]
+        let blob_gas_used = if self.optimism_jovian && tx.tx().tx_type() != FoundryTxType::Deposit {
+            optimism::jovian_da_footprint(self.evm.db_mut(), tx.tx())?
+        } else {
+            tx.tx().blob_gas_used().unwrap_or_default()
+        };
+        #[cfg(not(feature = "optimism"))]
+        let blob_gas_used = tx.tx().blob_gas_used().unwrap_or_default();
         let result = transact(&mut self.evm, tx_env, transaction_hash)?;
 
         Ok(AnvilTxResult {
-            inner: EthTxResult {
-                result,
-                blob_gas_used: tx.tx().blob_gas_used().unwrap_or_default(),
-                tx_type: tx.tx().tx_type(),
-            },
+            inner: EthTxResult { result, blob_gas_used, tx_type: tx.tx().tx_type() },
             sender,
         })
     }

--- a/crates/anvil/src/eth/backend/executor/optimism.rs
+++ b/crates/anvil/src/eth/backend/executor/optimism.rs
@@ -1,11 +1,34 @@
 //! OP-stack receipt construction for the Anvil block executor.
 
 use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom};
+use alloy_eips::Encodable2718;
 use alloy_primitives::{Address, Log};
 use foundry_evm::hardfork::{FoundryHardfork, OpHardfork};
-use foundry_primitives::FoundryReceiptEnvelope;
+use foundry_primitives::{FoundryReceiptEnvelope, FoundryTxEnvelope};
 use op_alloy_consensus::{OpDepositReceipt, OpDepositReceiptWithBloom};
-use revm::{context_interface::result::ExecutionResult, state::EvmState};
+use op_revm::{L1BlockInfo, constants::L1_BLOCK_CONTRACT, estimate_tx_compressed_size};
+use revm::{Database, context_interface::result::ExecutionResult, state::EvmState};
+
+use super::AnvilBlockExecutor;
+
+impl<E> AnvilBlockExecutor<E> {
+    /// Configures OP-specific block accounting without changing the shared constructor.
+    pub(crate) fn set_optimism_hardfork(&mut self, hardfork: FoundryHardfork) {
+        self.optimism_jovian = OpHardfork::from(hardfork) >= OpHardfork::Jovian;
+    }
+}
+
+/// Calculates the Jovian DA footprint exactly as the upstream OP block executor does.
+pub(crate) fn jovian_da_footprint<DB: Database>(
+    db: &mut DB,
+    tx: &FoundryTxEnvelope,
+) -> Result<u64, alloy_evm::block::BlockExecutionError> {
+    let encoded = estimate_tx_compressed_size(tx.encoded_2718().as_ref()).saturating_div(1_000_000);
+    db.basic(L1_BLOCK_CONTRACT).map_err(alloy_evm::block::BlockExecutionError::other)?;
+    let scalar = L1BlockInfo::fetch_da_footprint_gas_scalar(db)
+        .map_err(alloy_evm::block::BlockExecutionError::other)?;
+    Ok(encoded.saturating_mul(u64::from(scalar)))
+}
 
 /// Builds a mined OP deposit receipt and derives its fork-specific metadata.
 pub(crate) fn build_mined_deposit_receipt<H>(

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -120,6 +120,8 @@ use anvil_rpc::error::{ErrorCode, RpcError};
 use chrono::Datelike;
 use eyre::{Context, Result};
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
+#[cfg(feature = "optimism")]
+use foundry_evm::hardfork::OpHardfork;
 use foundry_evm::{
     backend::{BlockchainDb, DatabaseError, DatabaseResult, RevertStateSnapshotAction},
     constants::{DEFAULT_CREATE2_DEPLOYER, DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE},
@@ -1424,6 +1426,23 @@ impl<N: Network> Backend<N> {
         get_blob_params_by_hardfork(configured_hardfork)
     }
 
+    #[cfg(feature = "optimism")]
+    fn is_optimism_jovian_at_header<H: BlockHeader>(&self, header: &H) -> bool {
+        if !self.is_optimism() {
+            return false;
+        }
+        if !header.extra_data().is_empty() {
+            return self.fees.is_optimism_jovian_header(header);
+        }
+        let hardfork = if self.get_fork().is_some() {
+            FoundryHardfork::from_chain_and_timestamp(self.protocol_chain_id(), header.timestamp())
+                .unwrap_or_else(|| self.hardfork())
+        } else {
+            self.hardfork()
+        };
+        OpHardfork::from(hardfork) >= OpHardfork::Jovian
+    }
+
     /// Returns an error if EIP1559 is not active (pre Berlin)
     pub fn ensure_eip1559_active(&self) -> Result<(), BlockchainError> {
         if self.is_eip1559() {
@@ -2628,6 +2647,10 @@ impl<N: Network> Backend<N> {
                 self.inject_precompiles($evm.precompiles_mut(), evm_env);
                 let mut executor =
                     AnvilBlockExecutor::new($evm, parent_hash, spec_id, ethereum_transitions);
+                #[cfg(feature = "optimism")]
+                if self.is_optimism() {
+                    executor.set_optimism_hardfork(hardfork);
+                }
                 executor
                     .apply_pre_execution_changes()
                     .map_err(|err| BlockchainError::Internal(err.to_string()))?;
@@ -5152,6 +5175,10 @@ where
         self.time.reset(timestamp);
         self.time.set_next_block_timestamp(next_timestamp)?;
 
+        #[cfg(feature = "optimism")]
+        if self.is_optimism() {
+            self.fees.set_optimism_base_fee_rules(header.extra_data());
+        }
         let next_block_base_fee = self.fees.get_next_block_base_fee_from_header(&header);
         let next_block_excess_blob_gas = self.networks.next_block_blob_excess_gas(
             self.fees.blob_params(),
@@ -5227,6 +5254,10 @@ where
                     ethereum_transitions,
                 )
                 .with_state_changes();
+                #[cfg(feature = "optimism")]
+                if self.is_optimism() {
+                    executor.set_optimism_hardfork(hardfork);
+                }
                 executor
                     .apply_pre_execution_changes()
                     .wrap_err("failed to apply replay block-start transitions")?;
@@ -7479,7 +7510,8 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
                     header.timestamp,
                 ),
             );
-            (next_block_base_fee, blob_excess_gas_and_price)
+            let base_fee_extra_data = self.fees.base_fee_extra_data_from_header(header);
+            (next_block_base_fee, blob_excess_gas_and_price, base_fee_extra_data)
         });
 
         let historical_states = state.historical_states.take();
@@ -7511,7 +7543,15 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         if let Some(block_env) = block_env {
             self.evm_env.write().block_env = block_env;
         }
-        if let Some((next_block_base_fee, blob_excess_gas_and_price)) = next_fees {
+        if let Some((next_block_base_fee, blob_excess_gas_and_price, base_fee_extra_data)) =
+            next_fees
+        {
+            #[cfg(not(feature = "optimism"))]
+            let _ = base_fee_extra_data;
+            #[cfg(feature = "optimism")]
+            if self.is_optimism() {
+                self.fees.set_optimism_base_fee_rules(&base_fee_extra_data);
+            }
             self.fees.set_base_fee(next_block_base_fee);
             self.fees.set_blob_excess_gas_and_price(blob_excess_gas_and_price);
         }
@@ -7792,7 +7832,9 @@ impl Backend<FoundryNetwork> {
                            mut monad_context: Option<MonadReplayContext>,
                            base_base_fee_per_gas,
                            base_excess_blob_gas,
-                           base_blob_gas_used| {
+                           base_blob_gas_used,
+                           base_fee_extra_data: Bytes,
+                           optimism_jovian: bool| {
             let SimulatePayload {
                 block_state_calls,
                 trace_transfers,
@@ -7935,7 +7977,7 @@ impl Backend<FoundryNetwork> {
                         request.trim_conflicting_keys();
                         request.populate_blob_hashes();
                     }
-                    let request_blob_gas_used = if is_ethereum_request {
+                    let request_blob_gas_used = if is_ethereum_request && !optimism_jovian {
                         u64::try_from(request.blob_versioned_hashes.as_ref().map_or(0, Vec::len))
                             .unwrap_or(u64::MAX)
                             .saturating_mul(DATA_GAS_PER_BLOB)
@@ -7943,7 +7985,9 @@ impl Backend<FoundryNetwork> {
                         0
                     };
                     let max_blob_gas = blob_params.max_blob_gas_per_block();
-                    if block_blob_gas_used.saturating_add(request_blob_gas_used) > max_blob_gas {
+                    if !optimism_jovian
+                        && block_blob_gas_used.saturating_add(request_blob_gas_used) > max_blob_gas
+                    {
                         return Err(BlockchainError::RpcError(RpcError::invalid_params(format!(
                             "blob gas usage exceeds the limit of {max_blob_gas} gas per block."
                         ))));
@@ -8135,9 +8179,6 @@ impl Backend<FoundryNetwork> {
                         state.keys().copied(),
                     );
 
-                    // commit the transaction
-                    cache_db.commit(state);
-                    preserve_deleted_storage(&mut cache_db.cache.accounts, previously_deleted);
                     rpc_gas_budget = rpc_gas_budget.saturating_sub(result.tx_gas_used());
                     cumulative_gas_used = cumulative_gas_used.saturating_add(result.tx_gas_used());
                     block_regular_gas_used = block_regular_gas_used
@@ -8165,6 +8206,21 @@ impl Backend<FoundryNetwork> {
                         )
                     };
                     let tx_hash = tx.as_ref().hash();
+                    #[cfg(feature = "optimism")]
+                    if optimism_jovian && !matches!(tx.as_ref(), FoundryTxEnvelope::Deposit(_)) {
+                        let da_footprint =
+                            crate::eth::backend::executor::optimism::jovian_da_footprint(
+                                &mut cache_db,
+                                tx.as_ref(),
+                            )
+                            .map_err(|err| BlockchainError::Internal(err.to_string()))?;
+                        block_blob_gas_used = block_blob_gas_used.saturating_add(da_footprint);
+                    }
+
+                    // Commit after calculating the footprint so the scalar comes from pre-tx
+                    // state, matching the upstream OP block executor.
+                    cache_db.commit(state);
+                    preserve_deleted_storage(&mut cache_db.cache.accounts, previously_deleted);
                     #[cfg(feature = "optimism")]
                     let receipt = if matches!(tx.as_ref(), FoundryTxEnvelope::Deposit(_)) {
                         crate::eth::backend::executor::optimism::build_simulated_deposit_receipt(
@@ -8293,7 +8349,7 @@ impl Backend<FoundryNetwork> {
                     gas_limit: block_env.gas_limit,
                     gas_used,
                     timestamp: block_env.timestamp.saturating_to(),
-                    extra_data: self.fees.base_fee_extra_data(),
+                    extra_data: base_fee_extra_data.clone(),
                     mix_hash: block_env.prevrandao.unwrap_or_default(),
                     nonce: Default::default(),
                     base_fee_per_gas: (spec_id >= SpecId::LONDON).then_some(block_env.basefee),
@@ -8369,6 +8425,11 @@ impl Backend<FoundryNetwork> {
                 self.with_pending_block(pool_transactions, |state, block| {
                     let header = &block.block.header;
                     let base_fee = self.fees.calculate_next_block_base_fee_from_header(header);
+                    let base_fee_extra_data = self.fees.base_fee_extra_data_from_header(header);
+                    #[cfg(feature = "optimism")]
+                    let optimism_jovian = self.is_optimism_jovian_at_header(header);
+                    #[cfg(not(feature = "optimism"))]
+                    let optimism_jovian = false;
                     let monad_context = self.active_monad_context_before_mined_transaction(
                         &block.block,
                         block.block.body.transactions.len(),
@@ -8390,6 +8451,8 @@ impl Backend<FoundryNetwork> {
                         header.base_fee_per_gas().unwrap_or_default(),
                         header.excess_blob_gas().unwrap_or_default(),
                         header.blob_gas_used().unwrap_or_default(),
+                        base_fee_extra_data,
+                        optimism_jovian,
                     )
                 })
                 .await
@@ -8409,6 +8472,12 @@ impl Backend<FoundryNetwork> {
                 let base_hash = base_block.header.hash;
                 let base_fee =
                     self.fees.calculate_next_block_base_fee_from_header(&base_block.header.inner);
+                let base_fee_extra_data =
+                    self.fees.base_fee_extra_data_from_header(&base_block.header.inner);
+                #[cfg(feature = "optimism")]
+                let optimism_jovian = self.is_optimism_jovian_at_header(&base_block.header.inner);
+                #[cfg(not(feature = "optimism"))]
+                let optimism_jovian = false;
 
                 #[cfg(feature = "monad")]
                 let monad_context = if self.is_monad() {
@@ -8431,6 +8500,8 @@ impl Backend<FoundryNetwork> {
                         base_block.header.base_fee_per_gas().unwrap_or_default(),
                         base_block.header.excess_blob_gas().unwrap_or_default(),
                         base_block.header.blob_gas_used().unwrap_or_default(),
+                        base_fee_extra_data,
+                        optimism_jovian,
                     )
                 })
                 .await?

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5152,11 +5152,7 @@ where
         self.time.reset(timestamp);
         self.time.set_next_block_timestamp(next_timestamp)?;
 
-        let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
-            header.gas_used,
-            header.gas_limit,
-            header.base_fee_per_gas.unwrap_or_default(),
-        );
+        let next_block_base_fee = self.fees.get_next_block_base_fee_from_header(&header);
         let next_block_excess_blob_gas = self.fees.get_next_block_blob_excess_gas(
             header.excess_blob_gas.unwrap_or_default(),
             header.blob_gas_used.unwrap_or_default(),
@@ -5307,7 +5303,7 @@ where
             gas_limit: evm_env.block_env.gas_limit,
             gas_used: block_result.gas_used,
             timestamp: evm_env.block_env.timestamp.saturating_to(),
-            extra_data: Default::default(),
+            extra_data: self.fees.base_fee_extra_data(),
             mix_hash: evm_env.block_env.prevrandao.unwrap_or_default(),
             nonce: Default::default(),
             base_fee_per_gas: (spec_id >= SpecId::LONDON).then_some(evm_env.block_env.basefee),
@@ -5553,11 +5549,7 @@ where
 
             (outcome, header, block_hash)
         };
-        let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
-            header.gas_used,
-            header.gas_limit,
-            header.base_fee_per_gas.unwrap_or_default(),
-        );
+        let next_block_base_fee = self.fees.get_next_block_base_fee_from_header(&header);
         let next_block_excess_blob_gas = self.fees.get_next_block_blob_excess_gas(
             header.excess_blob_gas.unwrap_or_default(),
             header.blob_gas_used.unwrap_or_default(),
@@ -7469,11 +7461,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         }
 
         let next_fees = selected_header.as_ref().map(|header| {
-            let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
-                header.gas_used(),
-                header.gas_limit(),
-                header.base_fee_per_gas().unwrap_or_default(),
-            );
+            let next_block_base_fee = self.fees.get_next_block_base_fee_from_header(header);
             let next_block_excess_blob_gas =
                 self.fees.blob_params().next_block_excess_blob_gas_osaka(
                     header.excess_blob_gas().unwrap_or_default(),
@@ -8300,7 +8288,7 @@ impl Backend<FoundryNetwork> {
                     gas_limit: block_env.gas_limit,
                     gas_used,
                     timestamp: block_env.timestamp.saturating_to(),
-                    extra_data: Default::default(),
+                    extra_data: self.fees.base_fee_extra_data(),
                     mix_hash: block_env.prevrandao.unwrap_or_default(),
                     nonce: Default::default(),
                     base_fee_per_gas: (spec_id >= SpecId::LONDON).then_some(block_env.basefee),
@@ -8358,11 +8346,7 @@ impl Backend<FoundryNetwork> {
                 inherited_block_env.gas_limit = block_env.gas_limit;
                 // Route through the fee manager so Tempo chains use their own base fee rules.
                 let header = &simulated_block.inner.header;
-                next_base_fee = self.fees.calculate_next_block_base_fee_per_gas(
-                    header.gas_used(),
-                    header.gas_limit(),
-                    header.base_fee_per_gas().unwrap_or_default(),
-                );
+                next_base_fee = self.fees.calculate_next_block_base_fee_from_header(&header.inner);
                 parent_base_fee_per_gas = header.base_fee_per_gas().unwrap_or_default();
                 parent_excess_blob_gas = header.excess_blob_gas().unwrap_or_default();
                 parent_blob_gas_used = header.blob_gas_used().unwrap_or_default();
@@ -8379,11 +8363,7 @@ impl Backend<FoundryNetwork> {
             Some(BlockRequest::Pending(pool_transactions)) => {
                 self.with_pending_block(pool_transactions, |state, block| {
                     let header = &block.block.header;
-                    let base_fee = self.fees.calculate_next_block_base_fee_per_gas(
-                        header.gas_used(),
-                        header.gas_limit(),
-                        header.base_fee_per_gas().unwrap_or_default(),
-                    );
+                    let base_fee = self.fees.calculate_next_block_base_fee_from_header(header);
                     let monad_context = self.active_monad_context_before_mined_transaction(
                         &block.block,
                         block.block.body.transactions.len(),
@@ -8422,11 +8402,8 @@ impl Backend<FoundryNetwork> {
                 let base_number = base_block.header.number();
                 let base_timestamp = base_block.header.timestamp();
                 let base_hash = base_block.header.hash;
-                let base_fee = self.fees.calculate_next_block_base_fee_per_gas(
-                    base_block.header.gas_used(),
-                    base_block.header.gas_limit(),
-                    base_block.header.base_fee_per_gas().unwrap_or_default(),
-                );
+                let base_fee =
+                    self.fees.calculate_next_block_base_fee_from_header(&base_block.header.inner);
 
                 #[cfg(feature = "monad")]
                 let monad_context = if self.is_monad() {

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -59,7 +59,10 @@ struct FeeRules {
 enum BaseFeeRules {
     Standard(BaseFeeParams),
     #[cfg(feature = "optimism")]
-    Optimism(optimism::OptimismBaseFeeRules),
+    Optimism {
+        inherited: Option<optimism::OptimismBaseFeeRules>,
+        fallback: BaseFeeParams,
+    },
 }
 
 impl BaseFeeRules {
@@ -67,7 +70,13 @@ impl BaseFeeRules {
         match self {
             Self::Standard(params) => params,
             #[cfg(feature = "optimism")]
-            Self::Optimism(rules) => rules.params(),
+            Self::Optimism { inherited, fallback } => {
+                if let Some(rules) = inherited {
+                    rules.params()
+                } else {
+                    fallback
+                }
+            }
         }
     }
 
@@ -75,7 +84,21 @@ impl BaseFeeRules {
         match self {
             Self::Standard(_) => Bytes::new(),
             #[cfg(feature = "optimism")]
-            Self::Optimism(rules) => rules.extra_data(),
+            Self::Optimism { inherited, .. } => {
+                inherited.map_or_else(Bytes::new, optimism::OptimismBaseFeeRules::extra_data)
+            }
+        }
+    }
+
+    fn extra_data_from_header<H: BlockHeader>(
+        self,
+        #[cfg_attr(not(feature = "optimism"), allow(unused_variables))] header: &H,
+    ) -> Bytes {
+        match self {
+            Self::Standard(_) => Bytes::new(),
+            #[cfg(feature = "optimism")]
+            Self::Optimism { .. } => optimism::OptimismBaseFeeRules::decode(header.extra_data())
+                .map_or_else(Bytes::new, optimism::OptimismBaseFeeRules::extra_data),
         }
     }
 
@@ -88,7 +111,18 @@ impl BaseFeeRules {
                 params,
             ),
             #[cfg(feature = "optimism")]
-            Self::Optimism(rules) => rules.next_block_base_fee(header),
+            Self::Optimism { fallback, .. } => {
+                if let Some(rules) = optimism::OptimismBaseFeeRules::decode(header.extra_data()) {
+                    rules.next_block_base_fee(header)
+                } else {
+                    calc_next_block_base_fee(
+                        header.gas_used(),
+                        header.gas_limit(),
+                        header.base_fee_per_gas().unwrap_or_default(),
+                        fallback,
+                    )
+                }
+            }
         }
     }
 }
@@ -188,15 +222,34 @@ impl FeeManager {
     /// Applies the dynamic EIP-1559 parameters encoded in an Optimism-family parent header.
     #[cfg(feature = "optimism")]
     pub(crate) fn set_optimism_base_fee_rules(&self, extra_data: &[u8]) {
-        let Some(rules) = optimism::OptimismBaseFeeRules::decode(extra_data) else {
-            return;
+        let mut state = self.state.write();
+        let fallback = match state.rules.base_fee {
+            BaseFeeRules::Standard(params) | BaseFeeRules::Optimism { fallback: params, .. } => {
+                params
+            }
         };
-        self.state.write().rules.base_fee = BaseFeeRules::Optimism(rules);
+        state.rules.base_fee = BaseFeeRules::Optimism {
+            inherited: optimism::OptimismBaseFeeRules::decode(extra_data),
+            fallback,
+        };
     }
 
     /// Returns the Optimism-family EIP-1559 parameters inherited by locally built blocks.
     pub(crate) fn base_fee_extra_data(&self) -> Bytes {
         self.state.read().rules.base_fee.extra_data()
+    }
+
+    /// Returns the dynamic Optimism-family fee parameters encoded by `header`, if any.
+    pub(crate) fn base_fee_extra_data_from_header<H: BlockHeader>(&self, header: &H) -> Bytes {
+        self.state.read().rules.base_fee.extra_data_from_header(header)
+    }
+
+    /// Returns whether `header` activates Jovian's DA-footprint base fee accounting.
+    #[cfg(feature = "optimism")]
+    pub(crate) fn is_optimism_jovian_header<H: BlockHeader>(&self, header: &H) -> bool {
+        matches!(self.state.read().rules.base_fee, BaseFeeRules::Optimism { .. })
+            && optimism::OptimismBaseFeeRules::decode(header.extra_data())
+                .is_some_and(optimism::OptimismBaseFeeRules::is_jovian)
     }
 
     pub fn elasticity(&self) -> f64 {

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -22,8 +22,6 @@ use crate::eth::{
 
 #[cfg(feature = "optimism")]
 mod optimism;
-#[cfg(feature = "optimism")]
-use optimism::OptimismBaseFeeRules;
 
 /// Maximum number of entries in the fee history cache
 pub const MAX_FEE_HISTORY_CACHE_SIZE: u64 = 2048u64;
@@ -61,7 +59,7 @@ struct FeeRules {
 enum BaseFeeRules {
     Standard(BaseFeeParams),
     #[cfg(feature = "optimism")]
-    Optimism(OptimismBaseFeeRules),
+    Optimism(optimism::OptimismBaseFeeRules),
 }
 
 impl BaseFeeRules {
@@ -190,7 +188,7 @@ impl FeeManager {
     /// Applies the dynamic EIP-1559 parameters encoded in an Optimism-family parent header.
     #[cfg(feature = "optimism")]
     pub(crate) fn set_optimism_base_fee_rules(&self, extra_data: &[u8]) {
-        let Some(rules) = OptimismBaseFeeRules::decode(extra_data) else {
+        let Some(rules) = optimism::OptimismBaseFeeRules::decode(extra_data) else {
             return;
         };
         self.state.write().rules.base_fee = BaseFeeRules::Optimism(rules);

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -9,7 +9,7 @@ use std::{
 use alloy_consensus::{BlockHeader, Transaction, TxReceipt};
 use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_network::Network;
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Bytes};
 use futures::StreamExt;
 use parking_lot::{Mutex, RwLock};
 use revm::{context_interface::block::BlobExcessGasAndPrice, primitives::hardfork::SpecId};
@@ -19,6 +19,11 @@ use crate::eth::{
     backend::{info::StorageInfo, notifications::ChainNotifications},
     error::BlockchainError,
 };
+
+#[cfg(feature = "optimism")]
+mod optimism;
+#[cfg(feature = "optimism")]
+use optimism::OptimismBaseFeeRules;
 
 /// Maximum number of entries in the fee history cache
 pub const MAX_FEE_HISTORY_CACHE_SIZE: u64 = 2048u64;
@@ -47,9 +52,47 @@ pub struct FeeManager {
 #[derive(Clone, Copy, Debug)]
 struct FeeRules {
     spec_id: SpecId,
-    base_fee_params: BaseFeeParams,
+    base_fee: BaseFeeRules,
     /// The active Tempo hardfork, set only when running a Tempo chain.
     tempo_hardfork: Option<TempoHardfork>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum BaseFeeRules {
+    Standard(BaseFeeParams),
+    #[cfg(feature = "optimism")]
+    Optimism(OptimismBaseFeeRules),
+}
+
+impl BaseFeeRules {
+    const fn params(self) -> BaseFeeParams {
+        match self {
+            Self::Standard(params) => params,
+            #[cfg(feature = "optimism")]
+            Self::Optimism(rules) => rules.params(),
+        }
+    }
+
+    fn extra_data(self) -> Bytes {
+        match self {
+            Self::Standard(_) => Bytes::new(),
+            #[cfg(feature = "optimism")]
+            Self::Optimism(rules) => rules.extra_data(),
+        }
+    }
+
+    fn next_block_base_fee<H: BlockHeader>(self, header: &H) -> u64 {
+        match self {
+            Self::Standard(params) => calc_next_block_base_fee(
+                header.gas_used(),
+                header.gas_limit(),
+                header.base_fee_per_gas().unwrap_or_default(),
+                params,
+            ),
+            #[cfg(feature = "optimism")]
+            Self::Optimism(rules) => rules.next_block_base_fee(header),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -85,7 +128,11 @@ impl FeeManager {
     ) -> Self {
         Self {
             state: Arc::new(RwLock::new(FeeState {
-                rules: FeeRules { spec_id, base_fee_params, tempo_hardfork },
+                rules: FeeRules {
+                    spec_id,
+                    base_fee: BaseFeeRules::Standard(base_fee_params),
+                    tempo_hardfork,
+                },
                 blob_params,
                 base_fee,
                 blob_excess_gas_and_price,
@@ -97,17 +144,10 @@ impl FeeManager {
 
     /// Creates an independent copy suitable for staging a fork reset.
     pub(crate) fn detached(&self) -> Self {
-        let state = *self.state.read();
-        Self::new(
-            state.rules.spec_id,
-            state.base_fee,
-            self.is_min_priority_fee_enforced,
-            state.gas_price,
-            state.blob_excess_gas_and_price,
-            state.blob_params,
-            state.rules.base_fee_params,
-            state.rules.tempo_hardfork,
-        )
+        Self {
+            state: Arc::new(RwLock::new(*self.state.read())),
+            is_min_priority_fee_enforced: self.is_min_priority_fee_enforced,
+        }
     }
 
     /// Replaces all mutable fee state with a staged manager's values.
@@ -143,11 +183,26 @@ impl FeeManager {
         base_fee_params: BaseFeeParams,
         tempo_hardfork: Option<TempoHardfork>,
     ) {
-        self.state.write().rules = FeeRules { spec_id, base_fee_params, tempo_hardfork };
+        self.state.write().rules =
+            FeeRules { spec_id, base_fee: BaseFeeRules::Standard(base_fee_params), tempo_hardfork };
+    }
+
+    /// Applies the dynamic EIP-1559 parameters encoded in an Optimism-family parent header.
+    #[cfg(feature = "optimism")]
+    pub(crate) fn set_optimism_base_fee_rules(&self, extra_data: &[u8]) {
+        let Some(rules) = OptimismBaseFeeRules::decode(extra_data) else {
+            return;
+        };
+        self.state.write().rules.base_fee = BaseFeeRules::Optimism(rules);
+    }
+
+    /// Returns the Optimism-family EIP-1559 parameters inherited by locally built blocks.
+    pub(crate) fn base_fee_extra_data(&self) -> Bytes {
+        self.state.read().rules.base_fee.extra_data()
     }
 
     pub fn elasticity(&self) -> f64 {
-        1f64 / self.state.read().rules.base_fee_params.elasticity_multiplier as f64
+        1f64 / self.state.read().rules.base_fee.params().elasticity_multiplier as f64
     }
 
     /// Returns true for post London
@@ -234,6 +289,7 @@ impl FeeManager {
 
     /// Calculates the next block base fee from the parent block without applying the configured
     /// zero-fee sentinel.
+    #[cfg(test)]
     pub(crate) fn calculate_next_block_base_fee_per_gas(
         &self,
         gas_used: u64,
@@ -245,6 +301,28 @@ impl FeeManager {
             return 0;
         }
         calculate_next_block_base_fee_per_gas(rules, gas_used, gas_limit, last_fee_per_gas)
+    }
+
+    /// Calculates the next block base fee from a complete parent header.
+    pub(crate) fn get_next_block_base_fee_from_header<H: BlockHeader>(&self, header: &H) -> u64 {
+        let state = self.state.read();
+        if (state.rules.spec_id as u8) < (SpecId::LONDON as u8) || state.base_fee == 0 {
+            return 0;
+        }
+        calculate_next_block_base_fee_from_header(state.rules, header)
+    }
+
+    /// Calculates the next block base fee from a complete parent header without applying the
+    /// configured zero-fee sentinel.
+    pub(crate) fn calculate_next_block_base_fee_from_header<H: BlockHeader>(
+        &self,
+        header: &H,
+    ) -> u64 {
+        let rules = self.state.read().rules;
+        if (rules.spec_id as u8) < (SpecId::LONDON as u8) {
+            return 0;
+        }
+        calculate_next_block_base_fee_from_header(rules, header)
     }
 
     /// Calculates the next block blob base fee.
@@ -283,7 +361,18 @@ fn calculate_next_block_base_fee_per_gas(
     if let Some(hardfork) = rules.tempo_hardfork {
         return tempo_next_block_base_fee(hardfork, gas_used, last_fee_per_gas);
     }
-    calc_next_block_base_fee(gas_used, gas_limit, last_fee_per_gas, rules.base_fee_params)
+    calc_next_block_base_fee(gas_used, gas_limit, last_fee_per_gas, rules.base_fee.params())
+}
+
+fn calculate_next_block_base_fee_from_header<H: BlockHeader>(rules: FeeRules, header: &H) -> u64 {
+    if let Some(hardfork) = rules.tempo_hardfork {
+        return tempo_next_block_base_fee(
+            hardfork,
+            header.gas_used(),
+            header.base_fee_per_gas().unwrap_or_default(),
+        );
+    }
+    rules.base_fee.next_block_base_fee(header)
 }
 
 /// Computes the next block's base fee for a Tempo chain.

--- a/crates/anvil/src/eth/fees/optimism.rs
+++ b/crates/anvil/src/eth/fees/optimism.rs
@@ -1,0 +1,158 @@
+//! Optimism-specific dynamic EIP-1559 fee rules.
+
+use alloy_consensus::BlockHeader;
+use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams};
+use alloy_primitives::Bytes;
+use op_alloy_consensus::{decode_holocene_extra_data, decode_jovian_extra_data};
+
+/// Header-derived EIP-1559 rules introduced by the Optimism Holocene and Jovian upgrades.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum OptimismBaseFeeRules {
+    Holocene { extra_data: [u8; 9], params: BaseFeeParams },
+    Jovian { extra_data: [u8; 17], params: BaseFeeParams, min_base_fee: u64 },
+}
+
+impl OptimismBaseFeeRules {
+    pub(super) fn decode(extra_data: &[u8]) -> Option<Self> {
+        if let Ok((elasticity, denominator, min_base_fee)) = decode_jovian_extra_data(extra_data) {
+            let mut encoded = [0; 17];
+            encoded.copy_from_slice(extra_data);
+            return Some(Self::Jovian {
+                extra_data: encoded,
+                params: BaseFeeParams::new(denominator as u128, elasticity as u128),
+                min_base_fee,
+            });
+        }
+        if let Ok((elasticity, denominator)) = decode_holocene_extra_data(extra_data) {
+            let mut encoded = [0; 9];
+            encoded.copy_from_slice(extra_data);
+            return Some(Self::Holocene {
+                extra_data: encoded,
+                params: BaseFeeParams::new(denominator as u128, elasticity as u128),
+            });
+        }
+        None
+    }
+
+    pub(super) const fn params(self) -> BaseFeeParams {
+        match self {
+            Self::Holocene { params, .. } | Self::Jovian { params, .. } => params,
+        }
+    }
+
+    pub(super) fn extra_data(self) -> Bytes {
+        match self {
+            Self::Holocene { extra_data, .. } => Bytes::copy_from_slice(&extra_data),
+            Self::Jovian { extra_data, .. } => Bytes::copy_from_slice(&extra_data),
+        }
+    }
+
+    pub(super) fn next_block_base_fee<H: BlockHeader>(self, header: &H) -> u64 {
+        let gas_used = match self {
+            Self::Holocene { .. } => header.gas_used(),
+            Self::Jovian { .. } => {
+                header.gas_used().max(header.blob_gas_used().unwrap_or_default())
+            }
+        };
+        let next_base_fee = calc_next_block_base_fee(
+            gas_used,
+            header.gas_limit(),
+            header.base_fee_per_gas().unwrap_or_default(),
+            self.params(),
+        );
+        match self {
+            Self::Jovian { min_base_fee, .. } => next_base_fee.max(min_base_fee),
+            Self::Holocene { .. } => next_base_fee,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::Header;
+
+    use super::*;
+
+    #[test]
+    fn header_base_fee_rules_match_upstream_blocks() {
+        struct Case {
+            extra_data: &'static [u8],
+            gas_limit: u64,
+            gas_used: u64,
+            blob_gas_used: u64,
+            base_fee: u64,
+            expected: u64,
+        }
+
+        // Captured parent/child pairs from Base and OP Mainnet across Holocene and Jovian.
+        let cases = [
+            Case {
+                extra_data: &[1, 0, 0, 0, 100, 0, 0, 0, 5, 0, 0, 0, 0, 0, 76, 75, 64],
+                gas_limit: 0x17d7_8400,
+                gas_used: 0x132_0096,
+                blob_gas_used: 0x37_5b00,
+                base_fee: 0x4c_4b40,
+                expected: 0x4c_4b40,
+            },
+            Case {
+                extra_data: &[1, 0, 0, 0, 250, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+                gas_limit: 0x262_5a00,
+                gas_used: 0xa5_646d,
+                blob_gas_used: 0x22_cd60,
+                base_fee: 0x196,
+                expected: 0x196,
+            },
+            Case {
+                extra_data: &[0, 0, 0, 0, 50, 0, 0, 0, 2],
+                gas_limit: 0x858_3b00,
+                gas_used: 0x311_2ab9,
+                blob_gas_used: 0,
+                base_fee: 0xc_bdf6,
+                expected: 0xc_acae,
+            },
+            Case {
+                extra_data: &[0, 0, 0, 0, 250, 0, 0, 0, 2],
+                gas_limit: 0x262_5a00,
+                gas_used: 0xe6_2170,
+                blob_gas_used: 0,
+                base_fee: 0xd87,
+                expected: 0xd84,
+            },
+        ];
+
+        for case in cases {
+            let rules = OptimismBaseFeeRules::decode(case.extra_data).unwrap();
+            let header = Header {
+                gas_limit: case.gas_limit,
+                gas_used: case.gas_used,
+                blob_gas_used: Some(case.blob_gas_used),
+                base_fee_per_gas: Some(case.base_fee),
+                ..Default::default()
+            };
+
+            assert_eq!(rules.next_block_base_fee(&header), case.expected);
+            assert_eq!(rules.extra_data().as_ref(), case.extra_data);
+        }
+    }
+
+    #[test]
+    fn jovian_base_fee_uses_blob_gas_when_greater() {
+        let extra_data = [1, 0, 0, 0, 250, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0];
+        let rules = OptimismBaseFeeRules::decode(&extra_data).unwrap();
+        let header = Header {
+            gas_limit: 10_000_000_000,
+            gas_used: 1_000_000_000,
+            blob_gas_used: Some(5_000_000_000),
+            base_fee_per_gas: Some(super::super::INITIAL_BASE_FEE),
+            ..Default::default()
+        };
+
+        let expected = calc_next_block_base_fee(
+            header.blob_gas_used.unwrap(),
+            header.gas_limit,
+            header.base_fee_per_gas.unwrap(),
+            BaseFeeParams::new(250, 2),
+        );
+        assert_eq!(rules.next_block_base_fee(&header), expected);
+    }
+}

--- a/crates/anvil/src/eth/fees/optimism.rs
+++ b/crates/anvil/src/eth/fees/optimism.rs
@@ -47,6 +47,10 @@ impl OptimismBaseFeeRules {
         }
     }
 
+    pub(super) const fn is_jovian(self) -> bool {
+        matches!(self, Self::Jovian { .. })
+    }
+
     pub(super) fn next_block_base_fee<H: BlockHeader>(self, header: &H) -> u64 {
         let gas_used = match self {
             Self::Holocene { .. } => header.gas_used(),
@@ -154,5 +158,35 @@ mod tests {
             BaseFeeParams::new(250, 2),
         );
         assert_eq!(rules.next_block_base_fee(&header), expected);
+    }
+
+    #[test]
+    fn supplied_header_overrides_cached_optimism_rules() {
+        let holocene = [0, 0, 0, 0, 50, 0, 0, 0, 2];
+        let jovian = [1, 0, 0, 0, 250, 0, 0, 0, 2, 0, 0, 0, 0, 0, 76, 75, 64];
+        let fallback = BaseFeeParams::ethereum();
+
+        for (cached, supplied) in
+            [(jovian.as_slice(), holocene.as_slice()), (holocene.as_slice(), jovian.as_slice())]
+        {
+            let supplied_rules = OptimismBaseFeeRules::decode(supplied).unwrap();
+            let header = Header {
+                gas_limit: 10_000_000_000,
+                gas_used: 1_000_000_000,
+                blob_gas_used: Some(5_000_000_000),
+                base_fee_per_gas: Some(super::super::INITIAL_BASE_FEE),
+                extra_data: Bytes::copy_from_slice(supplied),
+                ..Default::default()
+            };
+            let rules = super::super::BaseFeeRules::Optimism {
+                inherited: Some(OptimismBaseFeeRules::decode(cached).unwrap()),
+                fallback,
+            };
+
+            assert_eq!(
+                rules.next_block_base_fee(&header),
+                supplied_rules.next_block_base_fee(&header)
+            );
+        }
     }
 }

--- a/crates/anvil/tests/it/optimism.rs
+++ b/crates/anvil/tests/it/optimism.rs
@@ -9,6 +9,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, TransactionRequest, anvil::Forking};
 use alloy_serde::{OtherFields, WithOtherFields};
 use anvil::{NodeConfig, eth::fees::INITIAL_BASE_FEE, spawn};
+use axum::{Json, Router, routing::post};
 use foundry_evm::hardfork::OpHardfork;
 use foundry_evm_networks::NetworkConfigs;
 use foundry_primitives::FoundryReceiptEnvelope;
@@ -455,6 +456,113 @@ fn preserves_op_fields_in_convert_to_anvil_receipt() {
 }
 
 const GAS_TRANSFER: u64 = 21_000;
+
+async fn spawn_rpc_proxy_with_extra_data(endpoint: String, extra_data: &'static str) -> String {
+    let client = reqwest::Client::new();
+    let router = Router::new().route(
+        "/",
+        post(move |Json(request): Json<Value>| {
+            let client = client.clone();
+            let endpoint = endpoint.clone();
+            async move {
+                let mut response = client
+                    .post(endpoint)
+                    .json(&request)
+                    .send()
+                    .await
+                    .unwrap()
+                    .json::<Value>()
+                    .await
+                    .unwrap();
+                if matches!(
+                    request.get("method").and_then(Value::as_str),
+                    Some("eth_getBlockByHash" | "eth_getBlockByNumber")
+                ) && let Some(block) = response.get_mut("result").and_then(Value::as_object_mut)
+                {
+                    block.insert("extraData".to_string(), Value::String(extra_data.to_string()));
+                }
+                Json(response)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    format!("http://{address}")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn jovian_mining_and_simulation_use_da_footprint() {
+    const DA_FOOTPRINT_SCALAR: u16 = 6_000;
+    const EXPECTED_DA_FOOTPRINT: u64 = 100 * DA_FOOTPRINT_SCALAR as u64;
+    const JOVIAN_EXTRA_DATA: &str = "0x01000000fa000000020000000000000000";
+
+    let (origin_api, origin) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(8453u64))
+            .with_networks(NetworkConfigs::with_optimism())
+            .with_hardfork(Some(OpHardfork::Jovian.into()))
+            .with_gas_limit(Some(1_000_000)),
+    )
+    .await;
+    let l1_block = address!("0x4200000000000000000000000000000000000015");
+    let mut scalar_slot = [0u8; 32];
+    scalar_slot[18..20].copy_from_slice(&DA_FOOTPRINT_SCALAR.to_be_bytes());
+    origin_api
+        .anvil_set_storage_at(l1_block, U256::from(8), B256::from(scalar_slot))
+        .await
+        .unwrap();
+
+    let fork_url = spawn_rpc_proxy_with_extra_data(origin.http_endpoint(), JOVIAN_EXTRA_DATA).await;
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_no_storage_caching(true)
+            .with_eth_rpc_url(Some(fork_url))
+            .with_fork_block_number(Some(0u64)),
+    )
+    .await;
+    let wallet = handle.dev_wallets().next().unwrap();
+    let to = Address::random();
+    let provider = http_provider_with_signer(&handle.http_endpoint(), wallet.clone().into());
+
+    let simulated = provider
+        .raw_request::<_, Value>(
+            "eth_simulateV1".into(),
+            (json!({
+                "blockStateCalls": [{
+                    "calls": [{
+                        "from": wallet.address(),
+                        "to": to,
+                        "gas": "0x5208",
+                    }]
+                }]
+            }),),
+        )
+        .await
+        .unwrap();
+    assert_eq!(simulated[0]["blobGasUsed"], json!(format!("0x{EXPECTED_DA_FOOTPRINT:x}")));
+    assert_eq!(simulated[0]["excessBlobGas"], "0x0");
+
+    provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default().with_to(to).with_value(U256::ONE),
+        ))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let transaction_block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(transaction_block.header.blob_gas_used, Some(EXPECTED_DA_FOOTPRINT));
+    assert_eq!(transaction_block.header.excess_blob_gas, Some(0));
+
+    api.mine_one().await.unwrap();
+    let next_block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert!(
+        next_block.header.base_fee_per_gas > transaction_block.header.base_fee_per_gas,
+        "Jovian should price the next block from its DA footprint"
+    );
+}
 
 /// Test that Optimism uses Canyon base fee params instead of Ethereum params.
 ///


### PR DESCRIPTION
## Summary

- derive Holocene and Jovian EIP-1559 parameters from the fork parent header for every OP-family network
- apply Jovian's blob-gas input and minimum base-fee clamp, matching the pinned OP-Reth implementation
- preserve the encoded fee parameters in locally mined and simulated headers, and use header-aware calculation in replay, mining, state-load, pending, and simulation paths

## Reproduction

```sh
anvil --fork-url https://mainnet.base.org --fork-block-number 50727122
cast rpc --rpc-url http://127.0.0.1:8545 evm_mine
cast block latest --rpc-url http://127.0.0.1:8545
cast block 50727123 --rpc-url https://mainnet.base.org
```

Before this change, Anvil mined `baseFeePerGas=0x4c14a1` with empty `extraData`; Base returned `0x4c4b40` and `extraData=0x01000000640000000500000000004c4b40`. After the change, the local block matches both fields.

The same differential reproduced on Optimism at parent block 156322413 (`0x197` locally versus `0x196` upstream). Captured historical Holocene vectors for Base and Optimism and current Jovian vectors for both chains are covered by deterministic tests.

Upstream behavior:

- [OP-Reth Holocene/Jovian calculation](https://github.com/foundry-rs/optimism/blob/566d19ee21aef0b1235c028bd1a4a98eacb95753/rust/op-reth/crates/chainspec/src/basefee.rs#L15-L59)
- [OP-Reth fork dispatch](https://github.com/foundry-rs/optimism/blob/566d19ee21aef0b1235c028bd1a4a98eacb95753/rust/op-reth/crates/chainspec/src/lib.rs#L294-L301)
- [Holocene execution-engine specification](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#base-fee-computation)
- [Jovian execution-engine specification](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/exec-engine.md#base-fee-computation)

## Tests

- `cargo test -p anvil --locked` (705 integration tests and 5 doctests passed)
- `cargo test -p anvil --test it --features monad --locked 'optimism::'` (12 passed)
- `cargo test -p anvil --test it --features monad --locked 'fork_chains::'` (8 passed across all CI fork chains)
- `cargo clippy -p anvil --all-targets --features monad --locked -- -D warnings`
- `cargo check -p anvil --no-default-features --locked`
