### PR TITLE
fix(bench): restore nightly benchmark health

### DIFF
--- a/.github/scripts/compare-benchmark-thresholds.py
+++ b/.github/scripts/compare-benchmark-thresholds.py
@@ -79,17 +79,14 @@ def compare(base, candidate, rules):
     print("| Benchmark | Stable | Nightly | Change |")
     print("|-----------|--------:|---------:|--------|")
     has_regression = False
+    has_missing = False
     for key in sorted(base.keys() | candidate.keys()):
         has_base, has_candidate = key in base, key in candidate
         if not has_base or not has_candidate:
+            has_missing = True
             present = duration(mean_of(candidate[key] if not has_base else base[key], key))
             left, right = ("N/A", present) if not has_base else (present, "N/A")
-            if has_base and rules.get(key, {}).get("alert", False):
-                has_regression = True
-                verdict = "❌ Missing nightly result"
-            else:
-                verdict = "⚠️ Inconclusive (missing side)"
-            print(f"| `{key}` | {left} | {right} | {verdict} |")
+            print(f"| `{key}` | {left} | {right} | ⚠️ Incomplete benchmark |")
             continue
 
         baseline = mean_of(base[key], key)
@@ -121,6 +118,8 @@ def compare(base, candidate, rules):
         "\nLegend: ❌ regression, ⚠️ warning/inconclusive, ✅ improvement, "
         "⚪ within threshold or uncalibrated. Advisory results never alert."
     )
+    if has_missing:
+        return 2
     return 1 if has_regression else 0
 
 

--- a/.github/scripts/tests/test_compare_benchmark_thresholds.py
+++ b/.github/scripts/tests/test_compare_benchmark_thresholds.py
@@ -58,23 +58,22 @@ class CompareBenchmarkThresholdsTests(unittest.TestCase):
         self.assertEqual(uncalibrated.returncode, 0)
         self.assertIn("Uncalibrated", uncalibrated.stdout)
 
-    def test_missing_nightly_alerts_but_missing_baseline_does_not(self):
+    def test_missing_results_are_execution_errors(self):
         rules = {
             "alerting": self.rule(5, 10),
             "advisory": self.rule(5, 10, False),
         }
         missing_nightly = self.run_compare({"alerting": 1, "advisory": 1}, {}, rules)
-        self.assertEqual(missing_nightly.returncode, 1)
-        self.assertIn("❌ Missing nightly result", missing_nightly.stdout)
-        self.assertIn("⚠️ Inconclusive (missing side)", missing_nightly.stdout)
+        self.assertEqual(missing_nightly.returncode, 2)
+        self.assertIn("⚠️ Incomplete benchmark", missing_nightly.stdout)
 
         missing_nightly_file = self.run_compare({"alerting": 1}, {}, rules, False)
-        self.assertEqual(missing_nightly_file.returncode, 1)
-        self.assertIn("❌ Missing nightly result", missing_nightly_file.stdout)
+        self.assertEqual(missing_nightly_file.returncode, 2)
+        self.assertIn("⚠️ Incomplete benchmark", missing_nightly_file.stdout)
 
         missing_baseline = self.run_compare({}, {"alerting": 1}, rules)
-        self.assertEqual(missing_baseline.returncode, 0)
-        self.assertIn("⚠️ Inconclusive (missing side)", missing_baseline.stdout)
+        self.assertEqual(missing_baseline.returncode, 2)
+        self.assertIn("⚠️ Incomplete benchmark", missing_baseline.stdout)
 
     def test_malformed_config_and_input_exit_two(self):
         config = self.run_compare({"key": 1}, {"key": 2}, {"key": self.rule(10, 5)})

--- a/benches/scripts/run-benchmark-suite.sh
+++ b/benches/scripts/run-benchmark-suite.sh
@@ -35,6 +35,8 @@ SYMBOLIC_REPOSITORIES=$(join_repositories \
   "farcasterxyz/contracts:3f37e21db8e9c6319b4a3d5f62b1c514ef01c36b")
 
 NIGHTLY_REPOSITORIES="aave/aave-v4:1e8de8630dfeb26ad309d986eaec44c1ceb48a6d"
+# The pinned Aave revision has three malformed expected revert payloads that exact matching rejects.
+NIGHTLY_TEST_REPOSITORIES="${NIGHTLY_REPOSITORIES} --nmt 'test_(updateUser(RiskPremium|DynamicConfig)WithSig_revertsWith_SpokeNotRegistered|repayWithSig_revertsWith_ERC20InsufficientAllowance)'"
 
 SUITE_PROFILES=()
 SUITE_NAMES=()
@@ -73,16 +75,16 @@ define_suite ci symbolic \
 
 # Nightly suites run once for stable and once for nightly.
 define_suite nightly test \
-  "forge_test" "${NIGHTLY_REPOSITORIES}" \
+  "forge_test" "${NIGHTLY_TEST_REPOSITORIES}" \
   "" "{version}-{date}-forge_test.json" true
 define_suite nightly fuzz \
-  "forge_fuzz_test" "${NIGHTLY_REPOSITORIES}" \
+  "forge_fuzz_test" "${NIGHTLY_TEST_REPOSITORIES}" \
   "" "{version}-{date}-forge_fuzz_test.json" false
 define_suite nightly build \
   "forge_build_no_cache,forge_build_with_cache" "${NIGHTLY_REPOSITORIES}" \
   "" "{version}-{date}-forge_build.json" false
 define_suite nightly coverage \
-  "forge_coverage" "${NIGHTLY_REPOSITORIES}" \
+  "forge_coverage" "${NIGHTLY_TEST_REPOSITORIES}" \
   "" "{version}-{date}-forge_coverage.json" false
 define_suite nightly symbolic \
   "forge_symbolic_test" "${SYMBOLIC_REPOSITORIES}" \

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -413,14 +413,11 @@ impl BenchmarkProject {
         runs: u32,
         verbose: bool,
     ) -> Result<HyperfineResult> {
-        // No setup needed, forge coverage builds internally
-        // Use --ir-minimum to avoid "Stack too deep" errors
+        // No setup needed, forge coverage builds internally.
         self.hyperfine(
             "forge_coverage",
             version,
-            &self.cmd(
-                "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_ISOLATE=false forge coverage --ir-minimum",
-            ),
+            &self.cmd("FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_ISOLATE=false forge coverage"),
             runs,
             None,
             None,


### PR DESCRIPTION
Aave's nightly results disappeared because commands failed, not because execution regressed: forcing `forge coverage --ir-minimum` hits a Yul stack limit, while #16428 exposes three malformed revert expectations in the pinned revision. This runs coverage without that workaround, skips only those tests, and treats a missing stable/nightly pair as an execution error instead of a performance regression. Fixes #16517.

This is CI-only maintenance and should receive `L-ignore`.

AI assistance disclosure: Codex assisted with investigation, implementation, validation, and this pull request description.
