### PR TITLE
fix(cast): replay HyperEVM read precompiles

### DIFF
--- a/.changelog/cast-hyperevm-read-precompiles.md
+++ b/.changelog/cast-hyperevm-read-precompiles.md
@@ -1,0 +1,8 @@
+---
+cast: patch
+foundry-evm-core: patch
+foundry-evm: patch
+foundry-evm-networks: patch
+---
+
+Added exact historical replay of HyperEVM read precompiles when the archive RPC exposes block precompile data.

--- a/.changelog/cast-run-single-evm-replay.md
+++ b/.changelog/cast-run-single-evm-replay.md
@@ -1,0 +1,7 @@
+---
+cast: patch
+foundry-evm: patch
+foundry-evm-core: patch
+---
+
+Reused one EVM instance while replaying a block in `cast run`.

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -52,7 +52,7 @@ use foundry_evm::{
             BlockContext, ChainFor, EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor,
         },
     },
-    executors::{EvmError, Executor, TracingExecutor},
+    executors::{Executor, ReplayTarget, TracingExecutor},
     hardforks::FoundryHardfork,
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
@@ -529,200 +529,152 @@ impl RunArgs {
             }
         }
 
-        // Fall back to replaying previous transactions if prestate trace wasn't applied.
-        if !self.quick && !prestate_applied {
-            sh_status!("Executing previous transactions from the block.")?;
+        // Configure the one inspector before creating the replay EVM. The executor disables it
+        // while applying the block prefix and enables it for the target transaction only.
+        let target_trace_requirements = TraceRequirements::none()
+            .with_calls(true)
+            .with_debug(self.debug)
+            .with_decode_internal(if tracing.decode_internal {
+                InternalTraceMode::Full
+            } else {
+                InternalTraceMode::None
+            })
+            .with_state_changes(verbosity > 4);
+        executor.set_trace_requirements(target_trace_requirements);
+        executor.set_trace_printer(self.trace_printer);
 
-            if let Some(block) = &block {
-                let pb = init_progress(block.transactions().len() as u64, "tx");
-                pb.set_position(0);
+        let target_index = if let Some(block) = &block {
+            let BlockTransactions::Full(transactions) = block.transactions() else {
+                return Err(eyre::eyre!("Could not get block txs"));
+            };
+            transactions
+                .iter()
+                .position(|candidate| candidate.tx_hash() == tx_hash)
+                .ok_or_else(|| eyre::eyre!("transaction {tx_hash:?} is missing from its block"))?
+        } else {
+            0
+        };
+        let target_chain_context = block_context.as_ref().map_or_else(
+            || ChainFor::<FEN>::for_transaction(&target_tx_env),
+            |context| context.transaction(target_index),
+        );
 
-                let BlockTransactions::Full(ref txs) = *block.transactions() else {
-                    return Err(eyre::eyre!("Could not get block txs"));
-                };
-
-                for (index, tx) in txs.iter().enumerate() {
-                    if tx.tx_hash() == tx_hash {
-                        break;
-                    }
-
-                    let is_system = is_known_system_sender(tx.from())
-                        || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
-                    // Classify before converting: a chain's own system envelopes are exactly the
-                    // ones this build may not be able to decode, and they are skipped below.
-                    if is_system && !self.replay_system_txes && !networks.is_monad() {
-                        pb.set_position((index + 1) as u64);
-                        continue;
-                    }
-                    let tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(tx)?;
-                    let chain_context = block_context.as_ref().map_or_else(
-                        || ChainFor::<FEN>::for_transaction(&tx_env),
-                        |context| context.transaction(index),
-                    );
-
-                    evm_env.cfg_env.disable_balance_check = true;
-
-                    if is_system {
-                        #[cfg(feature = "monad")]
-                        if executor
-                            .try_transact_system_replay_with_env_and_context(
-                                evm_env.clone(),
-                                tx_env.clone(),
-                                chain_context.clone(),
-                            )
-                            .wrap_err_with(|| {
-                                format!(
-                                    "Failed to replay system transaction: {:?} in block {}",
-                                    tx.tx_hash(),
-                                    evm_env.block_env.number()
-                                )
-                            })?
-                            .is_some()
-                        {
-                            trace!(tx=?tx.tx_hash(), "executed previous canonical system transaction");
-                            pb.set_position((index + 1) as u64);
-                            continue;
-                        }
-                        if !self.replay_system_txes {
-                            pb.set_position((index + 1) as u64);
-                            continue;
-                        }
-                    }
-
-                    if let Some(to) = Transaction::to(tx) {
-                        trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
-                        executor
-                            .transact_with_env_and_context(
-                                evm_env.clone(),
-                                tx_env.clone(),
-                                chain_context,
-                            )
-                            .wrap_err_with(|| {
-                                format!(
-                                    "Failed to execute transaction: {:?} in block {}",
-                                    tx.tx_hash(),
-                                    evm_env.block_env.number()
-                                )
-                            })?;
-                    } else {
-                        trace!(tx=?tx.tx_hash(), "executing previous create transaction");
-                        if let Err(error) = executor.deploy_with_env_and_context(
-                            evm_env.clone(),
-                            tx_env.clone(),
-                            chain_context,
-                            None,
-                        ) {
-                            match error {
-                                // Reverted transactions should be skipped
-                                EvmError::Execution(_) => (),
-                                error => {
-                                    return Err(error).wrap_err_with(|| {
-                                        format!(
-                                            "Failed to deploy transaction: {:?} in block {}",
-                                            tx.tx_hash(),
-                                            evm_env.block_env.number()
-                                        )
-                                    });
-                                }
-                            }
-                        }
-                    }
-
-                    pb.set_position((index + 1) as u64);
-                }
+        // A recovered signer that disagrees with the `from` the node reports marks a transaction
+        // the chain injected rather than one a key signed. Unknown envelopes are in the same
+        // category.
+        let sender_is_forged = match &*tx.inner.inner {
+            AnyTxEnvelope::Ethereum(inner) => {
+                inner.recover_signer().is_ok_and(|signer| signer != tx.from())
             }
+            AnyTxEnvelope::Unknown(_) => true,
+        };
+        if sender_is_forged {
+            evm_env.cfg_env.disable_balance_check = true;
         }
 
-        // Execute our transaction
-        let result = {
-            // Enable tracing only for the target transaction; the prefix replay above ran with
-            // tracing disabled.
-            let target_trace_requirements = TraceRequirements::none()
-                .with_calls(true)
-                .with_debug(self.debug)
-                .with_decode_internal(if tracing.decode_internal {
-                    InternalTraceMode::Full
-                } else {
-                    InternalTraceMode::None
-                })
-                .with_state_changes(verbosity > 4);
-            executor.set_trace_requirements(target_trace_requirements);
-            executor.set_trace_printer(self.trace_printer);
-
-            let tx_env = target_tx_env;
-            let target_index = if let Some(block) = &block {
-                let BlockTransactions::Full(transactions) = block.transactions() else {
-                    return Err(eyre::eyre!("Could not get block txs"));
-                };
-                transactions
-                    .iter()
-                    .position(|candidate| candidate.tx_hash() == tx_hash)
-                    .ok_or_else(|| {
-                        eyre::eyre!("transaction {tx_hash:?} is missing from its block")
-                    })?
-            } else {
-                0
-            };
-            let chain_context = block_context.as_ref().map_or_else(
-                || ChainFor::<FEN>::for_transaction(&tx_env),
-                |context| context.transaction(target_index),
-            );
-
-            // A recovered signer that disagrees with the `from` the node reports marks a
-            // transaction the chain injected rather than one a key signed, such as a HyperCore
-            // credit. Envelopes this build cannot decode are in the same category.
-            let sender_is_forged = match &*tx.inner.inner {
-                AnyTxEnvelope::Ethereum(inner) => {
-                    inner.recover_signer().is_ok_and(|signer| signer != tx.from())
-                }
-                AnyTxEnvelope::Unknown(_) => true,
-            };
-            if sender_is_forged {
-                evm_env.cfg_env.disable_balance_check = true;
-            }
-
-            #[cfg(feature = "monad")]
-            let replay_result = if target_is_system {
-                executor.try_transact_system_replay_with_env_and_context(
-                    evm_env.clone(),
-                    tx_env.clone(),
-                    chain_context.clone(),
-                )?
-            } else {
-                None
-            };
-            #[cfg(not(feature = "monad"))]
-            let replay_result: Option<foundry_evm::executors::RawCallResult<FEN>> = None;
-
-            if let Some(result) = replay_result {
-                trace!(tx=?tx.tx_hash(), "executed canonical system transaction");
-                TraceResult::from(result)
-            } else {
-                if target_is_system && !self.replay_system_txes {
-                    return Err(eyre::eyre!(
-                        "{:?} is a system transaction.\nReplaying system transactions is currently not supported.",
-                        tx.tx_hash()
-                    ));
-                }
-
-                if let Some(to) = Transaction::to(&tx) {
-                    trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
-                    TraceResult::from(executor.transact_with_env_and_context(
-                        evm_env,
-                        tx_env,
-                        chain_context,
-                    )?)
-                } else {
-                    trace!(tx=?tx.tx_hash(), "executing create transaction");
-                    TraceResult::try_from(executor.deploy_with_env_and_context(
-                        evm_env,
-                        tx_env,
-                        chain_context,
-                        None,
-                    ))?
-                }
-            }
+        let replay_block_prefix = !self.quick && !prestate_applied;
+        let block_number = evm_env.block_env.number();
+        let replay_target = match (target_is_system, self.replay_system_txes) {
+            (false, _) => ReplayTarget::Transaction,
+            (true, false) => ReplayTarget::System,
+            (true, true) => ReplayTarget::SystemWithFallback,
         };
+        let result = executor
+            .transact_with_block_replay(
+                evm_env,
+                target_tx_env,
+                target_chain_context,
+                replay_target,
+                |replay_evm| {
+                    if !replay_block_prefix {
+                        return Ok(());
+                    }
+
+                    sh_status!("Executing previous transactions from the block.")?;
+                    let Some(block) = &block else { return Ok(()) };
+                    let pb = init_progress(block.transactions().len() as u64, "tx");
+                    pb.set_position(0);
+
+                    let BlockTransactions::Full(ref txs) = *block.transactions() else {
+                        return Err(eyre::eyre!("Could not get block txs"));
+                    };
+                    for (index, tx) in txs.iter().enumerate() {
+                        if tx.tx_hash() == tx_hash {
+                            break;
+                        }
+
+                        let is_system = is_known_system_sender(tx.from())
+                            || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
+                        // Classify before converting: a chain's own system envelopes are exactly
+                        // the ones this build may not be able to decode, and they are skipped.
+                        if is_system && !self.replay_system_txes && !networks.is_monad() {
+                            pb.set_position((index + 1) as u64);
+                            continue;
+                        }
+                        let tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(tx)?;
+                        let chain_context = block_context.as_ref().map_or_else(
+                            || ChainFor::<FEN>::for_transaction(&tx_env),
+                            |context| context.transaction(index),
+                        );
+
+                        if is_system {
+                            if replay_evm
+                                .try_transact_system_replay(
+                                    tx_env.clone(),
+                                    chain_context.clone(),
+                                )
+                                .wrap_err_with(|| {
+                                    format!(
+                                        "Failed to replay system transaction: {:?} in block {}",
+                                        tx.tx_hash(), block_number
+                                    )
+                                })?
+                            {
+                                trace!(tx=?tx.tx_hash(), "executed previous canonical system transaction");
+                                pb.set_position((index + 1) as u64);
+                                continue;
+                            }
+                            if !self.replay_system_txes {
+                                pb.set_position((index + 1) as u64);
+                                continue;
+                            }
+                        }
+
+                        if let Some(to) = Transaction::to(tx) {
+                            trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
+                        } else {
+                            trace!(tx=?tx.tx_hash(), "executing previous create transaction");
+                        }
+                        replay_evm.transact(tx_env, chain_context).wrap_err_with(|| {
+                            format!(
+                                "Failed to execute transaction: {:?} in block {}",
+                                tx.tx_hash(), block_number
+                            )
+                        })?;
+                        pb.set_position((index + 1) as u64);
+                    }
+                    Ok(())
+                },
+            )
+            .wrap_err_with(|| format!("Failed to replay transaction {tx_hash:?}"))?;
+        let Some((result, used_system_replay)) = result else {
+            return Err(eyre::eyre!(
+                "{:?} is a system transaction.\nReplaying system transactions is currently not supported.",
+                tx.tx_hash()
+            ));
+        };
+
+        if used_system_replay {
+            trace!(tx=?tx.tx_hash(), "executed canonical system transaction");
+        }
+        let trace_kind = if let Some(to) = Transaction::to(&tx) {
+            trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
+            TraceKind::Execution
+        } else {
+            trace!(tx=?tx.tx_hash(), "executing create transaction");
+            TraceKind::Deployment
+        };
+        let result = TraceResult::from_raw(result, trace_kind);
 
         let contracts_bytecode = fetch_contracts_bytecode_from_trace(&executor, &result)?;
         handle_traces(

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -57,7 +57,10 @@ use foundry_evm::{
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
 };
-use foundry_evm_networks::NetworkConfigs;
+use foundry_evm_networks::{
+    NetworkConfigs,
+    hyperevm::{HyperEvmBlockPrecompileData, is_hyperevm_chain},
+};
 use futures::{StreamExt, TryFutureExt};
 use revm::{DatabaseRef, context::Block, primitives::hardfork::SpecId};
 
@@ -487,6 +490,28 @@ impl RunArgs {
             None,
         )?;
 
+        let hyperevm_precompile_data = if is_hyperevm_chain(chain.id()) {
+            let block_id = block.as_ref().map_or_else(
+                || BlockId::Number(tx_block_number.into()),
+                |block| BlockId::hash(block.header().hash()),
+            );
+            match provider
+                .raw_request::<_, HyperEvmBlockPrecompileData>(
+                    "eth_blockPrecompileData".into(),
+                    (block_id,),
+                )
+                .await
+            {
+                Ok(data) => Some(data),
+                Err(error) => {
+                    trace!(?error, "HyperEVM block precompile data is unavailable");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         evm_env.cfg_env.set_spec_and_mainnet_gas_params(executor.spec_id());
 
         let spec_id = (*evm_env.cfg_env.spec()).into();
@@ -586,6 +611,9 @@ impl RunArgs {
                 target_chain_context,
                 replay_target,
                 |replay_evm| {
+                    if let Some(data) = &hyperevm_precompile_data {
+                        data.inject(replay_evm.precompiles_mut(), tx_block_number);
+                    }
                     if !replay_block_prefix {
                         return Ok(());
                     }

--- a/crates/cast/tests/cli/run_networks.rs
+++ b/crates/cast/tests/cli/run_networks.rs
@@ -258,11 +258,50 @@ network_replay_tests! {
     flaky_run_berachain => ("berachain", "https://rpc.berachain.com", Exact),
     flaky_run_mantle => ("mantle", "https://rpc.mantle.xyz", ReplaysOnly),
 
-    // HyperCore credits are injected by the chain and read precompiles have no local
-    // implementation, so only some transactions reproduce exactly. Needs an archive endpoint:
-    // the official one ignores the block tag and answers every state read at latest.
+    // HyperCore credits are injected by the chain and can still affect prefix replay, so recent
+    // transactions are only required to replay. Needs an archive endpoint: the official one
+    // ignores the block tag and answers every state read at latest.
     flaky_run_hyperevm => ("hyperevm", "https://rpc.purroofgroup.com", ReplaysOnly),
 }
+
+/// Replays a pinned HyperEVM transaction that calls the BBO read precompile four times.
+#[expect(clippy::disallowed_macros, reason = "skips have to be visible in the nightly test log")]
+fn assert_replays_hyperevm_read_precompile(cmd: &mut TestCommand) {
+    let network = Network {
+        name: "hyperevm-read-precompile",
+        rpc_url: "https://rpc.purroofgroup.com",
+        gas: GasExpectation::Exact,
+        transaction_type: None,
+    };
+    let tx_hash = "0x0ef26f3e00d84d6a5d47271d0f7bbde713f4067e78d61b458727bfc7205017e4";
+    let Some(receipt) = json_output(cmd, &["receipt", tx_hash, "--rpc-url", network.rpc_url])
+    else {
+        eprintln!("skipping {}: endpoint unreachable", network.name);
+        return;
+    };
+
+    let output = cmd
+        .cast_fuse()
+        .args(["run", tx_hash, "--rpc-url", network.rpc_url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let replayed_gas = gas_used(&output).unwrap_or_else(|| {
+        panic!("{}: `cast run` reported no gas for {tx_hash}:\n{output}", network.name)
+    });
+    let receipt_gas = hex_field(&receipt, "gasUsed")
+        .unwrap_or_else(|| panic!("{}: receipt for {tx_hash} has no gasUsed", network.name));
+    assert_eq!(
+        replayed_gas, receipt_gas,
+        "{}: replayed gas does not match the receipt",
+        network.name
+    );
+}
+
+// The block-scoped archive data makes the precompile output and gas exactly reproducible.
+casttest!(flaky_run_hyperevm_read_precompile, |_prj, cmd| {
+    assert_replays_hyperevm_read_precompile(&mut cmd);
+});
 
 casttest!(flaky_run_celo_cip64, |_prj, cmd| {
     assert_replays_recent_transaction(

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Debug, ops::Deref};
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 use crate::{
     FoundryBlock, FoundryChain, FoundryContextExt, FoundryInspectorExt, FoundryJournal,
@@ -157,6 +160,7 @@ pub trait FoundryEvmFactory:
             Spec = Self::Spec,
             HaltReason = Self::HaltReason,
         > + Deref<Target = Self::FoundryContext<'db>>
+        + DerefMut<Target = Self::FoundryContext<'db>>
     where
         Self: 'db;
 
@@ -168,6 +172,23 @@ pub trait FoundryEvmFactory:
         chain_context: Self::Chain,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I>;
+
+    /// Tries to execute a canonical system transaction on a Foundry-wrapped EVM during replay.
+    ///
+    /// Returning `Ok(None)` means the transaction was not recognized. Implementations must not
+    /// mutate the EVM, its database, or inspector before returning `Ok(None)`, because callers may
+    /// fall back to ordinary execution using the same EVM instance.
+    #[cfg(feature = "monad")]
+    fn try_transact_foundry_system_replay<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>>(
+        &self,
+        _evm: &mut Self::FoundryEvm<'db, I>,
+        _tx: &Self::Tx,
+    ) -> eyre::Result<Option<ResultAndState<Self::HaltReason>>>
+    where
+        Self: 'db,
+    {
+        Ok(None)
+    }
 
     /// Tries to execute a canonical system transaction on a regular Alloy EVM during replay.
     ///

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -159,6 +159,7 @@ pub trait FoundryEvmFactory:
             BlockEnv = Self::BlockEnv,
             Spec = Self::Spec,
             HaltReason = Self::HaltReason,
+            Precompiles = Self::Precompiles,
         > + Deref<Target = Self::FoundryContext<'db>>
         + DerefMut<Target = Self::FoundryContext<'db>>
     where

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -403,6 +403,17 @@ impl FoundryEvmFactory for MonadEvmFactory {
         try_transact_monad_system_replay(evm, tx)
     }
 
+    fn try_transact_foundry_system_replay<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>>(
+        &self,
+        evm: &mut Self::FoundryEvm<'db, I>,
+        tx: &Self::Tx,
+    ) -> eyre::Result<Option<ResultAndState<Self::HaltReason>>>
+    where
+        Self: 'db,
+    {
+        try_transact_monad_system_replay(evm, tx)
+    }
+
     fn create_foundry_nested_evm<'db>(
         &self,
         db: &'db mut dyn DatabaseExt<Self>,

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -19,8 +19,9 @@ use alloy_primitives::{
     map::{AddressHashMap, HashMap},
 };
 use alloy_sol_types::{SolCall, sol};
+use eyre::WrapErr;
 use foundry_evm_core::{
-    EvmEnv, FoundryBlock, FoundryChain, FoundryTransaction,
+    EvmEnv, FoundryBlock, FoundryChain, FoundryContextExt, FoundryTransaction,
     backend::{
         Backend, BackendError, BackendResult, CowBackend, DatabaseError, DatabaseExt,
         GLOBAL_FAIL_SLOT,
@@ -36,8 +37,9 @@ use foundry_evm_core::{
     },
     evm::{
         BlockContext, ChainFor, EthEvmNetwork, EvmEnvFor, FoundryEvmFactory, FoundryEvmNetwork,
-        IntoInstructionResult, SpecFor, TxEnvFor,
+        HaltReasonFor, IntoInstructionResult, SpecFor, TxEnvFor,
     },
+    refresh_chain_journal,
     utils::StateChangeset,
 };
 use foundry_evm_coverage::HitMaps;
@@ -46,7 +48,7 @@ use foundry_evm_networks::NetworkConfigs;
 use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     bytecode::Bytecode,
-    context::{Block, Cfg, Transaction},
+    context::{Block, Cfg, ContextTr, Transaction},
     context_interface::{
         cfg::gas_params::Eip2780TxInfo,
         result::{ExecutionResult, Output, ResultAndState},
@@ -140,6 +142,73 @@ pub struct Executor<FEN: FoundryEvmNetwork> {
     legacy_assertions: bool,
     /// Opt-in cursor for transactions simulated sequentially against one fork.
     block_context: Option<BlockContext<FEN>>,
+}
+
+/// A single EVM used to replay transactions before a target transaction.
+pub struct ReplayEvm<'a, FEN: FoundryEvmNetwork> {
+    evm: <FEN::EvmFactory as FoundryEvmFactory>::FoundryEvm<'a, &'a mut InspectorStack<FEN>>,
+}
+
+impl<FEN: FoundryEvmNetwork> ReplayEvm<'_, FEN> {
+    fn prepare(&mut self, chain_context: ChainFor<FEN>, disable_balance_check: bool) {
+        let context = std::ops::DerefMut::deref_mut(&mut self.evm);
+        *context.chain_mut() = chain_context;
+        refresh_chain_journal(context);
+        if disable_balance_check {
+            context.cfg_env_mut().disable_balance_check = true;
+        }
+    }
+
+    #[cfg(feature = "monad")]
+    fn try_transact_system(
+        &mut self,
+        tx_env: &TxEnvFor<FEN>,
+    ) -> eyre::Result<Option<ResultAndState<HaltReasonFor<FEN>>>> {
+        FEN::EvmFactory::default().try_transact_foundry_system_replay(&mut self.evm, tx_env)
+    }
+
+    #[cfg(not(feature = "monad"))]
+    fn try_transact_system(
+        &mut self,
+        _tx_env: &TxEnvFor<FEN>,
+    ) -> eyre::Result<Option<ResultAndState<HaltReasonFor<FEN>>>> {
+        Ok(None)
+    }
+
+    /// Executes and commits an ordinary replay transaction.
+    pub fn transact(
+        &mut self,
+        tx_env: TxEnvFor<FEN>,
+        chain_context: ChainFor<FEN>,
+    ) -> eyre::Result<()> {
+        self.prepare(chain_context, true);
+        let result = self.evm.transact(tx_env).wrap_err("EVM error")?;
+        self.evm.db_mut().commit(result.state);
+        Ok(())
+    }
+
+    /// Tries to execute and commit a canonical system replay transaction.
+    pub fn try_transact_system_replay(
+        &mut self,
+        tx_env: TxEnvFor<FEN>,
+        chain_context: ChainFor<FEN>,
+    ) -> eyre::Result<bool> {
+        self.prepare(chain_context, true);
+        let Some(result) = self.try_transact_system(&tx_env)? else { return Ok(false) };
+        self.evm.db_mut().commit(result.state);
+        Ok(true)
+    }
+}
+
+/// How the target transaction of a block replay should be executed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReplayTarget {
+    /// Execute the target as an ordinary transaction.
+    Transaction,
+    /// Require the target to be recognized as a canonical system transaction.
+    System,
+    /// Prefer canonical system execution and fall back to an ordinary transaction.
+    SystemWithFallback,
 }
 
 impl<FEN: FoundryEvmNetwork> Executor<FEN> {
@@ -840,6 +909,90 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         self.commit(&mut result);
         self.record_block_transaction(committed_tx);
         Ok(result)
+    }
+
+    /// Replays transactions and executes the target transaction against one EVM instance.
+    ///
+    /// The replay callback runs with inspection disabled and commits preceding transactions
+    /// through [`ReplayEvm`]. Inspection is enabled for the target transaction only. Returns
+    /// `None` when a required system target is not recognized by the active network.
+    #[instrument(name = "transact_block_replay", level = "debug", skip_all)]
+    pub fn transact_with_block_replay(
+        &mut self,
+        evm_env: EvmEnvFor<FEN>,
+        target_tx_env: TxEnvFor<FEN>,
+        target_chain_context: ChainFor<FEN>,
+        target: ReplayTarget,
+        replay: impl for<'a> FnOnce(&mut ReplayEvm<'a, FEN>) -> eyre::Result<()>,
+    ) -> eyre::Result<Option<(RawCallResult<FEN>, bool)>> {
+        let mut stack = self.inspector().clone();
+        let sancov_edges = stack.inner.sancov_edges;
+        let sancov_trace_cmp = stack.inner.sancov_trace_cmp;
+        let sancov_active = sancov_edges || sancov_trace_cmp;
+        let backend = self.backend_mut();
+
+        let (result, evm_env, tx_env, used_system_replay) = {
+            let caller = target_tx_env.caller();
+            backend.set_caller(caller).set_spec_id(evm_env.cfg_env.spec);
+            let target_contract = match target_tx_env.kind() {
+                TxKind::Call(to) => to,
+                // The prefix has not run yet, so use the canonical target nonce rather than the
+                // current database nonce.
+                TxKind::Create => caller.create(target_tx_env.nonce()),
+            };
+            backend.set_test_contract(target_contract);
+            let evm = FEN::EvmFactory::default().create_foundry_evm_with_inspector(
+                backend,
+                evm_env,
+                target_chain_context.clone(),
+                &mut stack,
+            );
+            let mut replay_evm: ReplayEvm<'_, FEN> = ReplayEvm { evm };
+            replay_evm.evm.disable_inspector();
+            replay(&mut replay_evm)?;
+
+            replay_evm.evm.enable_inspector();
+            replay_evm.prepare(target_chain_context, false);
+            let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
+            let (result, used_system_replay) = if target == ReplayTarget::Transaction {
+                (replay_evm.evm.transact(target_tx_env.clone()).wrap_err("EVM error")?, false)
+            } else {
+                match replay_evm.try_transact_system(&target_tx_env)? {
+                    Some(result) => (result, true),
+                    None if target == ReplayTarget::System => return Ok(None),
+                    None => (
+                        replay_evm.evm.transact(target_tx_env.clone()).wrap_err("EVM error")?,
+                        false,
+                    ),
+                }
+            };
+            let tx_env =
+                if used_system_replay { target_tx_env } else { replay_evm.evm.tx().clone() };
+            let evm_env = replay_evm.evm.finish().1;
+            (result, evm_env, tx_env, used_system_replay)
+        };
+
+        let has_state_snapshot_failure = backend.has_state_snapshot_failure();
+        let fork_block_number = backend.active_fork_block_number();
+        let mut result = convert_executed_result(
+            evm_env,
+            tx_env,
+            stack,
+            result,
+            &*backend,
+            has_state_snapshot_failure,
+            fork_block_number,
+        )?;
+        if sancov_edges {
+            SancovGuard::append_edges_into(&mut result);
+        }
+        if sancov_trace_cmp {
+            SancovGuard::drain_cmp_into(&mut result);
+        }
+        let committed_tx = result.tx_env.clone();
+        self.commit(&mut result);
+        self.record_block_transaction(committed_tx);
+        Ok(Some((result, used_system_replay)))
     }
 
     /// Tries to execute and commit a canonical system transaction during replay.
@@ -1952,6 +2105,163 @@ mod tests {
 
         let err = raw.into_evm_error(None);
         assert!(matches!(err, EvmError::Execution(_)));
+    }
+
+    #[test]
+    fn block_replay_commits_prefix_and_traces_only_target() {
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(1 << 20).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+            NetworkConfigs::default(),
+        );
+        executor.set_balance(CALLER, U256::MAX).unwrap();
+        executor.set_trace_requirements(TraceRequirements::none().with_calls(true));
+
+        let address = Address::repeat_byte(0x11);
+        // Increment slot zero and return its new value.
+        executor
+            .set_code(
+                address,
+                Bytecode::new_raw(Bytes::from_static(&[
+                    0x60, 0x00, 0x54, 0x60, 0x01, 0x01, 0x80, 0x60, 0x00, 0x55, 0x60, 0x00, 0x52,
+                    0x60, 0x20, 0x60, 0x00, 0xf3,
+                ])),
+            )
+            .unwrap();
+        let prefix = TxEnv {
+            caller: CALLER,
+            gas_limit: 100_000,
+            kind: TxKind::Call(address),
+            ..Default::default()
+        };
+        let reverted_create = TxEnv {
+            nonce: 1,
+            kind: TxKind::Create,
+            data: Bytes::from_static(&[0x5f, 0x5f, 0xfd]),
+            ..prefix.clone()
+        };
+        let target = TxEnv { nonce: 2, ..prefix.clone() };
+
+        let (result, used_system_replay) = executor
+            .transact_with_block_replay(
+                EvmEnv::default(),
+                target,
+                (),
+                ReplayTarget::Transaction,
+                |evm| {
+                    evm.transact(prefix, ())?;
+                    evm.transact(reverted_create, ())
+                },
+            )
+            .unwrap()
+            .unwrap();
+
+        assert!(!used_system_replay);
+        assert_eq!(result.result, Bytes::from(U256::from(2).to_be_bytes::<32>()));
+        assert_eq!(result.tx_env.nonce, 2);
+        assert_eq!(executor.get_nonce(CALLER).unwrap(), 3);
+        assert_eq!(executor.backend().storage_ref(address, U256::ZERO).unwrap(), U256::from(2));
+        assert_eq!(result.traces.unwrap().arena.nodes().len(), 1);
+    }
+
+    #[test]
+    fn block_replay_initializes_create_target_from_canonical_nonce() {
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(1 << 20).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+            NetworkConfigs::default(),
+        );
+        executor.set_balance(CALLER, U256::MAX).unwrap();
+
+        let prefix = TxEnv {
+            caller: CALLER,
+            gas_limit: 100_000,
+            kind: TxKind::Call(Address::repeat_byte(0x11)),
+            ..Default::default()
+        };
+        let target = TxEnv {
+            nonce: 1,
+            kind: TxKind::Create,
+            data: Bytes::from_static(&[0x00]),
+            ..prefix.clone()
+        };
+        let expected = CALLER.create(1);
+
+        let (result, used_system_replay) = executor
+            .transact_with_block_replay(
+                EvmEnv::default(),
+                target,
+                (),
+                ReplayTarget::Transaction,
+                |evm| evm.transact(prefix, ()),
+            )
+            .unwrap()
+            .unwrap();
+
+        assert!(!used_system_replay);
+        assert!(
+            matches!(result.out, Some(Output::Create(_, Some(address))) if address == expected)
+        );
+        assert!(executor.backend().is_persistent(&expected));
+        assert!(executor.backend().has_cheatcode_access(&expected));
+    }
+
+    #[cfg(feature = "monad")]
+    #[test]
+    fn block_replay_executes_monad_system_prefix() {
+        use foundry_evm_core::evm::MonadEvmNetwork;
+
+        let backend = Backend::<MonadEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::<MonadEvmNetwork>::default().gas_limit(1 << 20).build(
+            EvmEnvFor::<MonadEvmNetwork>::default(),
+            TxEnvFor::<MonadEvmNetwork>::default(),
+            backend,
+            NetworkConfigs::with_monad(),
+        );
+        executor.set_balance(CALLER, U256::MAX).unwrap();
+
+        let system_address = alloy_primitives::address!("6f49a8f621353f12378d0046e7d7e4b9b249dc9e");
+        let staking_address =
+            alloy_primitives::address!("0000000000000000000000000000000000001000");
+        let selector = keccak256("syscallSnapshot()");
+        let system = TxEnv {
+            caller: system_address,
+            gas_limit: 0,
+            kind: TxKind::Call(staking_address),
+            data: Bytes::copy_from_slice(&selector[..4]),
+            chain_id: None,
+            ..Default::default()
+        };
+        let target = TxEnv {
+            caller: CALLER,
+            gas_limit: 100_000,
+            kind: TxKind::Call(Address::repeat_byte(0x11)),
+            ..Default::default()
+        };
+        let system_chain = ChainFor::<MonadEvmNetwork>::for_transaction(&system);
+        let target_chain = ChainFor::<MonadEvmNetwork>::for_transaction(&target);
+
+        let (result, used_system_replay) = executor
+            .transact_with_block_replay(
+                EvmEnvFor::<MonadEvmNetwork>::default(),
+                target,
+                target_chain,
+                ReplayTarget::Transaction,
+                |evm| {
+                    assert!(evm.try_transact_system_replay(system, system_chain)?);
+                    Ok(())
+                },
+            )
+            .unwrap()
+            .unwrap();
+
+        assert!(!used_system_replay);
+        assert!(!result.reverted);
+        assert_eq!(executor.get_nonce(system_address).unwrap(), 1);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -12,7 +12,7 @@ use crate::inspectors::{
 };
 use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_eips::eip4788::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS};
-use alloy_evm::Evm;
+use alloy_evm::{Evm, precompiles::PrecompilesMap};
 use alloy_json_abi::Function;
 use alloy_primitives::{
     Address, Bytes, Log, TxKind, U256, keccak256,
@@ -197,6 +197,11 @@ impl<FEN: FoundryEvmNetwork> ReplayEvm<'_, FEN> {
         let Some(result) = self.try_transact_system(&tx_env)? else { return Ok(false) };
         self.evm.db_mut().commit(result.state);
         Ok(true)
+    }
+
+    /// Returns the precompiles used by this replay EVM.
+    pub fn precompiles_mut(&mut self) -> &mut PrecompilesMap {
+        self.evm.precompiles_mut()
     }
 }
 

--- a/crates/evm/networks/src/hyperevm.rs
+++ b/crates/evm/networks/src/hyperevm.rs
@@ -1,0 +1,237 @@
+//! HyperEVM read precompiles reconstructed from archive-node block data.
+//!
+//! HyperEVM's read precompiles expose HyperCore state, so their results cannot be derived from the
+//! EVM state alone. Archive nodes based on `nanoreth` expose the calls made while executing a block
+//! through `eth_blockPrecompileData`. This module installs those recorded calls as exact
+//! `(calldata, gas limit)` lookups for historical replay.
+
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use alloy_primitives::{Address, B256, Bytes, U256};
+use revm::precompile::{PrecompileHalt, PrecompileId, PrecompileOutput, PrecompileResult};
+use serde::{Deserialize, Serialize};
+use std::{borrow::Cow, collections::HashMap};
+
+/// HyperEVM mainnet chain ID.
+pub const HYPEREVM_MAINNET_CHAIN_ID: u64 = 999;
+
+/// HyperEVM testnet chain ID.
+pub const HYPEREVM_TESTNET_CHAIN_ID: u64 = 998;
+
+const READ_PRECOMPILE_START: u16 = 0x800;
+const DEFAULT_READ_PRECOMPILE_END: u16 = 0x80d;
+const READ_PRECOMPILE_PAGE_END: u16 = 0x8ff;
+const WARM_PRECOMPILES_BLOCK_NUMBER: u64 = 8_197_684;
+
+/// Block-scoped HyperEVM precompile inputs returned by `eth_blockPrecompileData`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HyperEvmBlockPrecompileData {
+    /// Calls to HyperEVM read precompiles made while executing the block.
+    pub read_precompile_calls: Option<HyperEvmReadPrecompileCalls>,
+    /// Highest active read precompile address reported by the node.
+    pub highest_precompile_address: Option<Address>,
+}
+
+/// Recorded HyperEVM read precompile calls grouped by address.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct HyperEvmReadPrecompileCalls(
+    pub Vec<(Address, Vec<(HyperEvmReadPrecompileInput, HyperEvmReadPrecompileResult)>)>,
+);
+
+/// The input key for one recorded HyperEVM read precompile call.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct HyperEvmReadPrecompileInput {
+    /// Call data supplied to the precompile.
+    pub input: Bytes,
+    /// Gas supplied to the precompile.
+    pub gas_limit: u64,
+}
+
+/// The recorded outcome of a HyperEVM read precompile call.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HyperEvmReadPrecompileResult {
+    /// The call succeeded with the recorded gas cost and return bytes.
+    Ok { gas_used: u64, bytes: Bytes },
+    /// The call exhausted all supplied gas.
+    OutOfGas,
+    /// The HyperCore query rejected the input.
+    Error,
+    /// The source node encountered an unexpected query error.
+    UnexpectedError,
+}
+
+/// Returns whether the chain ID identifies HyperEVM mainnet or testnet.
+pub const fn is_hyperevm_chain(chain_id: u64) -> bool {
+    matches!(chain_id, HYPEREVM_MAINNET_CHAIN_ID | HYPEREVM_TESTNET_CHAIN_ID)
+}
+
+impl HyperEvmBlockPrecompileData {
+    /// Installs the recorded block's HyperEVM read precompiles.
+    ///
+    /// Inputs absent from the recording halt with out-of-gas, matching HyperEVM's behavior for an
+    /// invalid query and preventing replay from inventing HyperCore state.
+    pub fn inject(&self, precompiles: &mut PrecompilesMap, block_number: u64) {
+        // Clear the complete page first in case the map was reused with older block-scoped data.
+        let addresses = precompiles.addresses().copied().collect::<Vec<_>>();
+        for address in addresses {
+            if read_precompile_number(address).is_some() {
+                precompiles.apply_precompile(&address, |_| None);
+            }
+        }
+
+        for (address, calls) in
+            self.read_precompile_calls.as_ref().map(|calls| calls.0.as_slice()).unwrap_or_default()
+        {
+            if read_precompile_number(*address).is_none() {
+                continue;
+            }
+            let calls = calls.iter().cloned().collect::<HashMap<_, _>>();
+            let id = PrecompileId::Custom(Cow::Owned(format!("HyperEVM read {address}")));
+            precompiles.apply_precompile(address, |_| {
+                Some(DynPrecompile::new_stateful(id, move |input| {
+                    execute_recorded_call(&calls, input.data, input.gas, input.reservoir)
+                }))
+            });
+        }
+
+        if block_number < WARM_PRECOMPILES_BLOCK_NUMBER {
+            return;
+        }
+
+        let highest = self
+            .highest_precompile_address
+            .and_then(read_precompile_number)
+            .unwrap_or(DEFAULT_READ_PRECOMPILE_END)
+            .clamp(READ_PRECOMPILE_START, READ_PRECOMPILE_PAGE_END);
+        for number in READ_PRECOMPILE_START..=highest {
+            let address = read_precompile_address(number);
+            precompiles.apply_precompile(&address, |existing| {
+                existing.or_else(|| {
+                    let id = PrecompileId::Custom(Cow::Owned(format!("HyperEVM read {address}")));
+                    Some(DynPrecompile::new_stateful(id, |input| {
+                        Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, input.reservoir))
+                    }))
+                })
+            });
+        }
+    }
+}
+
+fn execute_recorded_call(
+    calls: &HashMap<HyperEvmReadPrecompileInput, HyperEvmReadPrecompileResult>,
+    data: &[u8],
+    gas_limit: u64,
+    reservoir: u64,
+) -> PrecompileResult {
+    let input = HyperEvmReadPrecompileInput { input: Bytes::copy_from_slice(data), gas_limit };
+    match calls.get(&input) {
+        Some(HyperEvmReadPrecompileResult::Ok { gas_used, bytes }) => {
+            Ok(PrecompileOutput::new(*gas_used, bytes.clone(), reservoir))
+        }
+        Some(
+            HyperEvmReadPrecompileResult::OutOfGas
+            | HyperEvmReadPrecompileResult::Error
+            | HyperEvmReadPrecompileResult::UnexpectedError,
+        )
+        | None => Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, reservoir)),
+    }
+}
+
+fn read_precompile_address(number: u16) -> Address {
+    Address::from_word(B256::from(U256::from(number)))
+}
+
+fn read_precompile_number(address: Address) -> Option<u16> {
+    let bytes = address.as_slice();
+    (bytes[..18] == [0; 18] && bytes[18] == 8).then(|| u16::from_be_bytes([8, bytes[19]]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm::precompile::{PrecompileStatus, Precompiles};
+
+    const FIXTURE: &str = r#"{
+        "read_precompile_calls": [[
+            "0x000000000000000000000000000000000000080e",
+            [[
+                {
+                    "input": "0x000000000000000000000000000000000000000000000000000000000000277b",
+                    "gas_limit": 120530
+                },
+                {
+                    "Ok": {
+                        "gas_used": 4168,
+                        "bytes": "0x0000000000000000000000000000000000000000000000000000000004f8d3c00000000000000000000000000000000000000000000000000000000004f8d7a8"
+                    }
+                }
+            ]]
+        ]],
+        "highest_precompile_address": "0x0000000000000000000000000000000000000814"
+    }"#;
+
+    #[test]
+    fn deserializes_archive_node_response() {
+        let data: HyperEvmBlockPrecompileData = serde_json::from_str(FIXTURE).unwrap();
+        let calls = &data.read_precompile_calls.unwrap().0;
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, read_precompile_address(0x80e));
+        assert_eq!(calls[0].1[0].0.gas_limit, 120_530);
+        assert_eq!(data.highest_precompile_address, Some(read_precompile_address(0x814)));
+    }
+
+    #[test]
+    fn returns_only_exact_recorded_call() {
+        let input =
+            HyperEvmReadPrecompileInput { input: Bytes::from_static(b"input"), gas_limit: 10_000 };
+        let calls = HashMap::from([(
+            input.clone(),
+            HyperEvmReadPrecompileResult::Ok {
+                gas_used: 2_325,
+                bytes: Bytes::from_static(b"output"),
+            },
+        )]);
+
+        let output = execute_recorded_call(&calls, &input.input, input.gas_limit, 7).unwrap();
+        assert_eq!(output.status, PrecompileStatus::Success);
+        assert_eq!(output.gas_used, 2_325);
+        assert_eq!(output.bytes, Bytes::from_static(b"output"));
+        assert_eq!(output.reservoir, 7);
+
+        let output = execute_recorded_call(&calls, &input.input, input.gas_limit + 1, 0).unwrap();
+        assert_eq!(output.status, PrecompileStatus::Halt(PrecompileHalt::OutOfGas));
+    }
+
+    #[test]
+    fn installs_warm_precompile_range_and_rejects_invalid_highest_address() {
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::prague());
+        HyperEvmBlockPrecompileData {
+            read_precompile_calls: None,
+            highest_precompile_address: Some(Address::ZERO),
+        }
+        .inject(&mut precompiles, WARM_PRECOMPILES_BLOCK_NUMBER);
+
+        for number in READ_PRECOMPILE_START..=DEFAULT_READ_PRECOMPILE_END {
+            assert!(
+                precompiles.addresses().any(|address| *address == read_precompile_address(number))
+            );
+        }
+        assert!(!precompiles
+            .addresses()
+            .any(|address| *address == read_precompile_address(DEFAULT_READ_PRECOMPILE_END + 1)));
+    }
+
+    #[test]
+    fn does_not_warm_unrecorded_precompiles_before_activation() {
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::prague());
+        HyperEvmBlockPrecompileData::default()
+            .inject(&mut precompiles, WARM_PRECOMPILES_BLOCK_NUMBER - 1);
+
+        assert!(
+            !precompiles
+                .addresses()
+                .any(|address| *address == read_precompile_address(READ_PRECOMPILE_START))
+        );
+    }
+}

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -52,6 +52,7 @@ const MONAD_CHEATCODE_ADDRESSES: &[Address] = &[MONAD_CHEATCODE_ADDRESS];
 
 pub mod arbitrum;
 pub mod celo;
+pub mod hyperevm;
 
 #[cfg(feature = "optimism")]
 mod optimism;


### PR DESCRIPTION
HyperEVM read precompiles expose HyperCore state, so their results cannot be reconstructed from the EVM database alone. This adds a reusable block-scoped implementation that mirrors Nanoreth's exact `(calldata, gas limit)` lookup semantics, including the active-address warming range and out-of-gas behavior for missing or failed queries.

On HyperEVM mainnet and testnet, `cast run` now opportunistically requests `eth_blockPrecompileData` for the exact transaction block hash. The response remains local to that replay and is injected once into the replay EVM before any prefix or target transaction executes; it is not stored in the executor or backend, and no HyperEVM-specific transaction path is introduced. The RPC extension remains optional, so endpoints that do not expose it retain the existing replay behavior rather than becoming unusable.

This is stacked on #16531, which makes `cast run` reuse one EVM for block replay. A pinned end-to-end case covers a transaction that calls the BBO precompile at `0x080e` four times and reproduces its receipt gas exactly. This advances the HyperEVM portion of #7262.

This contribution was implemented with AI assistance and reviewed and tested by the contributor.
