### PR TITLE
fix(forge): preserve filtered restrictions

### DIFF
--- a/.changelog/forge-filtered-compilation-restrictions.md
+++ b/.changelog/forge-filtered-compilation-restrictions.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Preserve compilation restrictions when filtering Forge tests by path, contract, or test name.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -393,6 +393,7 @@ struct CompiledTestProject {
 fn sources_to_compile_from_artifacts(
     config: &Config,
     test_filter: &ProjectPathsAwareFilter,
+    root_sources: &BTreeSet<PathBuf>,
     artifacts: &ProjectCompileOutput,
     test_matcher: &TestFunctionMatcher<'_>,
 ) -> BTreeSet<PathBuf> {
@@ -411,6 +412,9 @@ fn sources_to_compile_from_artifacts(
     artifacts
         .artifact_ids()
         .filter_map(|(id, artifact)| artifact.abi.as_ref().map(|abi| (id, abi)))
+        // Imported dependencies must remain attached to their roots so compilation restrictions
+        // apply to the entire source graph instead of compiling dependencies with default settings.
+        .filter(|(id, _)| root_sources.contains(&id.source))
         .filter(|(id, abi)| {
             if id.source.starts_with(&paths.sources) {
                 return true;
@@ -1606,9 +1610,9 @@ impl TestArgs {
     /// Returns a list of files that need to be compiled in order to run all the tests that match
     /// the given filter.
     ///
-    /// For filtered runs, this includes all configured source files, non-test artifacts outside
-    /// script-only paths, and runnable tests that match the filter. Non-test artifacts remain
-    /// available because tests may resolve them dynamically through cheatcodes.
+    /// For filtered runs, this includes all configured source roots, non-test fixture roots, and
+    /// runnable tests that match the filter. Imported dependencies remain attached to those roots
+    /// so compiler profiles and restrictions apply to the complete source graph.
     #[instrument(target = "forge::test", skip_all)]
     fn get_sources_to_compile(
         &self,
@@ -1640,7 +1644,7 @@ impl TestArgs {
         let output = compile_abi_project(
             &mut project,
             ProjectCompiler::new()
-                .files(sources)
+                .files(sources.iter().cloned())
                 .dynamic_test_linking(config.dynamic_test_linking)
                 .quiet(true),
         )?;
@@ -1655,7 +1659,13 @@ impl TestArgs {
         };
         let test_matcher =
             TestFunctionMatcher::new(config, &inline_config, symbolic_artifact_replay);
-        let files = sources_to_compile_from_artifacts(config, test_filter, &output, &test_matcher);
+        let files = sources_to_compile_from_artifacts(
+            config,
+            test_filter,
+            &sources,
+            &output,
+            &test_matcher,
+        );
 
         Ok((files, Some(inline_config)))
     }

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -1,5 +1,8 @@
 //! Tests for commands using the preprocessed cache.
 
+use foundry_compilers::artifacts::EvmVersion;
+use foundry_config::{CompilationRestrictions, SettingsOverrides};
+
 #[cfg(unix)]
 forgetest_init!(abi_commands_reuse_preprocessed_cache, |prj, cmd| {
     use foundry_test_utils::util::OutputExt;
@@ -167,6 +170,61 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
 "#
     ]]);
+});
+
+// <https://github.com/foundry-rs/foundry/issues/16529>
+forgetest_init!(filtered_tests_preserve_compilation_restrictions, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.add_lib(
+        "dep/src/Clz.sol",
+        r#"
+library Clz {
+    function msb(uint128 bitmap) internal pure returns (uint256 res) {
+        assembly {
+            res := sub(255, clz(bitmap))
+        }
+    }
+}
+"#,
+    );
+    prj.add_source(
+        "Root.sol",
+        r#"
+import "../lib/dep/src/Clz.sol";
+
+contract Root {
+    function msb(uint128 bitmap) external pure returns (uint256) {
+        return Clz.msb(bitmap);
+    }
+}
+"#,
+    );
+    prj.add_test("RootTest.sol", "contract RootTest { function testFoo() public pure {} }");
+    prj.update_config(|config| {
+        config.evm_version = EvmVersion::Prague;
+        config.additional_compiler_profiles = vec![SettingsOverrides {
+            name: "osaka".to_string(),
+            via_ir: None,
+            evm_version: Some(EvmVersion::Osaka),
+            optimizer: None,
+            optimizer_runs: None,
+            bytecode_hash: None,
+        }];
+        config.compilation_restrictions = vec![CompilationRestrictions {
+            paths: "src/Root.sol".parse().unwrap(),
+            version: None,
+            via_ir: None,
+            bytecode_hash: None,
+            min_optimizer_runs: None,
+            optimizer_runs: None,
+            max_optimizer_runs: None,
+            min_evm_version: None,
+            evm_version: Some(EvmVersion::Osaka),
+            max_evm_version: None,
+        }];
+    });
+
+    cmd.args(["test", "--match-path", "test/RootTest.sol"]).assert_success();
 });
 
 forgetest_init!(filtered_tests_support_overlapping_source_roots, |prj, cmd| {


### PR DESCRIPTION
Filtered test compilation currently promotes every ABI artifact to an independent compile root. Imported dependencies can therefore lose the compiler restrictions inherited from their importing root, as in #16529 where `Clz.sol` is compiled for Prague instead of Osaka whenever a path, contract, or test filter is present.

This keeps the final selection limited to configured source and test roots, leaving imported dependencies attached to their original source graphs so restrictions and compiler profiles continue to apply. The regression test reproduces the reporter's Osaka/Prague split. Fixes #16529.

This is a v1.8 regression introduced by #15794: the official v1.7.1 binary passes the reporter's filtered reproduction from a clean cache, while the official v1.8.0 binary fails with the reported `clz` compiler error.

The implementation, regression test, and pull request description were written with Codex under my direction.
