### PR TITLE
refactor(cast): reuse EVM for block replay

### DIFF
--- a/.changelog/cast-run-single-evm-replay.md
+++ b/.changelog/cast-run-single-evm-replay.md
@@ -1,0 +1,7 @@
+---
+cast: patch
+foundry-evm: patch
+foundry-evm-core: patch
+---
+
+Reused one EVM instance while replaying a block in `cast run`.

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -159,7 +159,6 @@ struct TargetFetch {
 /// Fields only needed by the Monad-specific `execute_monad`/`execute_monad_target` path.
 #[cfg(feature = "monad")]
 struct MonadPrepared {
-    target_is_system: bool,
     tx_block_number: u64,
     compute_units_per_second: Option<u64>,
 }
@@ -282,7 +281,7 @@ impl RunArgs {
         target: TargetFetch,
     ) -> Result<Option<PreparedRun<FEN>>> {
         #[cfg_attr(not(feature = "monad"), allow(unused_variables))]
-        let TargetFetch { tx, provider, compute_units_per_second, target_is_system } = target;
+        let TargetFetch { tx, provider, compute_units_per_second, .. } = target;
         let tx_hash = tx.tx_hash();
         config.networks = evm_opts.networks;
         self.tracing.labels.append(&mut self.legacy_labels);
@@ -589,7 +588,7 @@ impl RunArgs {
             verbosity,
             prestate_applied,
             #[cfg(feature = "monad")]
-            monad: MonadPrepared { target_is_system, tx_block_number, compute_units_per_second },
+            monad: MonadPrepared { tx_block_number, compute_units_per_second },
         }))
     }
 }
@@ -665,14 +664,19 @@ impl<FEN: FoundryEvmNetwork> PreparedRun<FEN> {
                                     block_number
                                 )
                             })?;
+                        if let Some(to) = Transaction::to(tx) {
+                            trace!(tx=?tx.tx_hash(), ?to, "preparing previous call transaction");
+                        } else {
+                            trace!(tx=?tx.tx_hash(), "preparing previous create transaction");
+                        }
                         let chain_context = ChainFor::<FEN>::for_transaction(&tx_env);
-                        replay.push((tx_env, chain_context));
+                        replay.push((tx.tx_hash(), tx_env, chain_context));
                     }
                     pb.set_position((index + 1) as u64);
                 }
             }
         }
-        let result = self.executor.transact_with_block_replay(
+        let result = self.executor.transact_with_ordinary_block_replay(
             self.evm_env.clone(),
             target_tx_env,
             target_chain_context,
@@ -755,10 +759,13 @@ impl PreparedRun<MonadEvmNetwork> {
                 let pb = init_progress(txs.len() as u64, "tx");
                 for (index, tx) in txs.iter().take(target_index).enumerate() {
                     let tx_env = TxEnvFor::<MonadEvmNetwork>::from_any_rpc_transaction(tx)?;
+                    if let Some(to) = Transaction::to(tx) {
+                        trace!(tx=?tx.tx_hash(), ?to, "preparing previous call transaction");
+                    } else {
+                        trace!(tx=?tx.tx_hash(), "preparing previous create transaction");
+                    }
                     let chain_context: ChainFor<MonadEvmNetwork> = block_context.transaction(index);
-                    let is_system = is_known_system_sender(tx.from())
-                        || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
-                    replay.push((tx_env, chain_context, is_system));
+                    replay.push((tx.tx_hash(), tx_env, chain_context));
                     pb.set_position((index + 1) as u64);
                 }
             }
@@ -768,7 +775,6 @@ impl PreparedRun<MonadEvmNetwork> {
             target_tx_env,
             block_context.transaction(target_index),
             replay,
-            self.monad.target_is_system,
             replay_system_txes,
         )?;
         let Some((result, used_system_replay)) = result else {

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -55,7 +55,7 @@ use foundry_evm::{
         env::FromAnyRpcTransaction as _,
         evm::{ChainFor, EthEvmNetwork, EvmEnvFor, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
     },
-    executors::{EvmError, Executor, TracingExecutor},
+    executors::{Executor, TracingExecutor},
     hardforks::FoundryHardfork,
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
@@ -626,62 +626,67 @@ impl<FEN: FoundryEvmNetwork> PreparedRun<FEN> {
         // can't decode should fail fast.
         let target_tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(&self.tx)?;
 
-        if !self.args.quick && !self.prestate_applied {
+        let target_index = if let Some(block) = &self.block {
+            let BlockTransactions::Full(txs) = block.transactions() else {
+                eyre::bail!("Could not get block txs");
+            };
+            txs.iter().position(|candidate| candidate.tx_hash() == self.tx.tx_hash()).ok_or_else(
+                || eyre::eyre!("transaction {:?} is missing from its block", self.tx.tx_hash()),
+            )?
+        } else {
+            0
+        };
+
+        self.enable_target_tracing();
+        self.disable_balance_check_for_forged_sender();
+        let replay_prefix = !self.args.quick && !self.prestate_applied;
+        let block_number = self.evm_env.block_env.number();
+        let tx_hash = self.tx.tx_hash();
+        let block = &self.block;
+        let replay_system_txes = self.args.replay_system_txes;
+        let target_chain_context = ChainFor::<FEN>::for_transaction(&target_tx_env);
+        let mut replay = Vec::new();
+        if replay_prefix {
             sh_status!("Executing previous transactions from the block.")?;
-            if let Some(block) = &self.block {
-                let pb = init_progress(block.transactions().len() as u64, "tx");
+            if let Some(block) = block {
                 let BlockTransactions::Full(txs) = block.transactions() else {
                     eyre::bail!("Could not get block txs");
                 };
-                for (index, tx) in txs.iter().enumerate() {
-                    if tx.tx_hash() == self.tx.tx_hash() {
-                        break;
-                    }
+                let pb = init_progress(txs.len() as u64, "tx");
+                for (index, tx) in txs.iter().take(target_index).enumerate() {
                     let is_system = is_known_system_sender(tx.from())
                         || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
-                    if is_system && !self.args.replay_system_txes {
-                        pb.set_position((index + 1) as u64);
-                        continue;
+                    if !is_system || replay_system_txes {
+                        let tx_env =
+                            TxEnvFor::<FEN>::from_any_rpc_transaction(tx).wrap_err_with(|| {
+                                format!(
+                                    "Failed to prepare transaction: {:?} in block {}",
+                                    tx.tx_hash(),
+                                    block_number
+                                )
+                            })?;
+                        let chain_context = ChainFor::<FEN>::for_transaction(&tx_env);
+                        replay.push((tx_env, chain_context));
                     }
-                    let tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(tx)?;
-                    self.evm_env.cfg_env.disable_balance_check = true;
-                    let chain_context = ChainFor::<FEN>::for_transaction(&tx_env);
-                    execute_previous_transaction(
-                        &mut self.executor,
-                        &self.evm_env,
-                        tx,
-                        tx_env,
-                        chain_context,
-                    )?;
                     pb.set_position((index + 1) as u64);
                 }
             }
         }
-
-        if let Some(block) = &self.block {
-            let BlockTransactions::Full(txs) = block.transactions() else {
-                eyre::bail!("Could not get block txs");
-            };
-            if !txs.iter().any(|candidate| candidate.tx_hash() == self.tx.tx_hash()) {
-                eyre::bail!("transaction {:?} is missing from its block", self.tx.tx_hash());
-            }
-        }
-
-        self.enable_target_tracing();
-        self.disable_balance_check_for_forged_sender();
-        if let Some(to) = Transaction::to(&self.tx) {
+        let result = self.executor.transact_with_block_replay(
+            self.evm_env.clone(),
+            target_tx_env,
+            target_chain_context,
+            replay,
+        )?;
+        let trace_kind = if let Some(to) = Transaction::to(&self.tx) {
             trace!(tx=?self.tx.tx_hash(), ?to, "executing call transaction");
-            Ok(TraceResult::from(
-                self.executor.transact_with_env(self.evm_env.clone(), target_tx_env)?,
-            ))
+            TraceKind::Execution
         } else {
             trace!(tx=?self.tx.tx_hash(), "executing create transaction");
-            Ok(TraceResult::try_from(self.executor.deploy_with_env(
-                self.evm_env.clone(),
-                target_tx_env,
-                None,
-            ))?)
-        }
+            TraceKind::Deployment
+        };
+        trace!(?tx_hash, "completed block replay");
+        Ok(TraceResult::from_raw(result, trace_kind))
     }
 
     async fn finish(self, result: TraceResult) -> Result<()> {
@@ -699,46 +704,6 @@ impl<FEN: FoundryEvmNetwork> PreparedRun<FEN> {
         )
         .await
     }
-}
-
-fn execute_previous_transaction<FEN: FoundryEvmNetwork>(
-    executor: &mut TracingExecutor<FEN>,
-    evm_env: &EvmEnvFor<FEN>,
-    tx: &AnyRpcTransaction,
-    tx_env: TxEnvFor<FEN>,
-    chain_context: ChainFor<FEN>,
-) -> Result<()> {
-    if let Some(to) = Transaction::to(tx) {
-        trace!(tx=?tx.tx_hash(), ?to, "executing previous call transaction");
-        executor
-            .transact_with_env_and_context(evm_env.clone(), tx_env, chain_context)
-            .wrap_err_with(|| {
-                format!(
-                    "Failed to execute transaction: {:?} in block {}",
-                    tx.tx_hash(),
-                    evm_env.block_env.number()
-                )
-            })?;
-    } else {
-        trace!(tx=?tx.tx_hash(), "executing previous create transaction");
-        if let Err(error) =
-            executor.deploy_with_env_and_context(evm_env.clone(), tx_env, chain_context, None)
-        {
-            match error {
-                EvmError::Execution(_) => (),
-                error => {
-                    return Err(error).wrap_err_with(|| {
-                        format!(
-                            "Failed to deploy transaction: {:?} in block {}",
-                            tx.tx_hash(),
-                            evm_env.block_env.number()
-                        )
-                    });
-                }
-            }
-        }
-    }
-    Ok(())
 }
 
 #[cfg(feature = "monad")]
@@ -759,60 +724,11 @@ impl PreparedRun<MonadEvmNetwork> {
                     )
                 },
             )?;
-        let block_context = BlockContext::fetch(&provider, &block).await?;
+        let block_context = BlockContext::<MonadEvmNetwork>::fetch(&provider, &block).await?;
         // Decode the target transaction before replaying the block: an envelope this build
         // can't decode should fail fast, not after paying for the entire prior-transaction
         // replay.
         let target_tx_env = TxEnvFor::<MonadEvmNetwork>::from_any_rpc_transaction(&self.tx)?;
-
-        if !self.args.quick && !self.prestate_applied {
-            sh_status!("Executing previous transactions from the block.")?;
-            let Some(any_block) = &self.block else {
-                return self.execute_monad_target(&block_context, 0, target_tx_env);
-            };
-            let BlockTransactions::Full(txs) = any_block.transactions() else {
-                eyre::bail!("Could not get block txs");
-            };
-            let pb = init_progress(txs.len() as u64, "tx");
-            for (index, tx) in txs.iter().enumerate() {
-                if tx.tx_hash() == self.tx.tx_hash() {
-                    break;
-                }
-                let tx_env = TxEnvFor::<MonadEvmNetwork>::from_any_rpc_transaction(tx)?;
-                let chain_context = block_context.transaction(index);
-                self.evm_env.cfg_env.disable_balance_check = true;
-                let is_system = is_known_system_sender(tx.from())
-                    || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
-                if is_system
-                    && self
-                        .executor
-                        .try_transact_system_replay_with_env_and_context(
-                            self.evm_env.clone(),
-                            tx_env.clone(),
-                            chain_context.clone(),
-                        )
-                        .wrap_err_with(|| {
-                            format!(
-                                "Failed to replay system transaction: {:?} in block {}",
-                                tx.tx_hash(),
-                                self.evm_env.block_env.number()
-                            )
-                        })?
-                        .is_some()
-                {
-                    trace!(tx=?tx.tx_hash(), "executed previous canonical system transaction");
-                } else if !is_system || self.args.replay_system_txes {
-                    execute_previous_transaction(
-                        &mut self.executor,
-                        &self.evm_env,
-                        tx,
-                        tx_env,
-                        chain_context,
-                    )?;
-                }
-                pb.set_position((index + 1) as u64);
-            }
-        }
 
         let target_index = if let Some(block) = &self.block {
             let BlockTransactions::Full(txs) = block.transactions() else {
@@ -824,50 +740,54 @@ impl PreparedRun<MonadEvmNetwork> {
         } else {
             0
         };
-        self.execute_monad_target(&block_context, target_index, target_tx_env)
-    }
-
-    fn execute_monad_target(
-        &mut self,
-        block_context: &BlockContext<MonadEvmNetwork>,
-        index: usize,
-        tx_env: TxEnvFor<MonadEvmNetwork>,
-    ) -> Result<TraceResult> {
         self.enable_target_tracing();
-        let chain_context = block_context.transaction(index);
         self.disable_balance_check_for_forged_sender();
-        if self.monad.target_is_system
-            && let Some(result) = self.executor.try_transact_system_replay_with_env_and_context(
-                self.evm_env.clone(),
-                tx_env.clone(),
-                chain_context.clone(),
-            )?
-        {
-            trace!(tx=?self.tx.tx_hash(), "executed canonical system transaction");
-            return Ok(TraceResult::from(result));
+        let replay_prefix = !self.args.quick && !self.prestate_applied;
+        let replay_system_txes = self.args.replay_system_txes;
+        let block = &self.block;
+        let mut replay = Vec::new();
+        if replay_prefix {
+            sh_status!("Executing previous transactions from the block.")?;
+            if let Some(block) = block {
+                let BlockTransactions::Full(txs) = block.transactions() else {
+                    eyre::bail!("Could not get block txs");
+                };
+                let pb = init_progress(txs.len() as u64, "tx");
+                for (index, tx) in txs.iter().take(target_index).enumerate() {
+                    let tx_env = TxEnvFor::<MonadEvmNetwork>::from_any_rpc_transaction(tx)?;
+                    let chain_context: ChainFor<MonadEvmNetwork> = block_context.transaction(index);
+                    let is_system = is_known_system_sender(tx.from())
+                        || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
+                    replay.push((tx_env, chain_context, is_system));
+                    pb.set_position((index + 1) as u64);
+                }
+            }
         }
-        if self.monad.target_is_system && !self.args.replay_system_txes {
+        let result = self.executor.transact_with_monad_block_replay(
+            self.evm_env.clone(),
+            target_tx_env,
+            block_context.transaction(target_index),
+            replay,
+            self.monad.target_is_system,
+            replay_system_txes,
+        )?;
+        let Some((result, used_system_replay)) = result else {
             eyre::bail!(
                 "{:?} is a system transaction.\nReplaying system transactions is currently not supported.",
                 self.tx.tx_hash()
             );
+        };
+        if used_system_replay {
+            trace!(tx=?self.tx.tx_hash(), "executed canonical system transaction");
         }
-        if let Some(to) = Transaction::to(&self.tx) {
+        let trace_kind = if let Some(to) = Transaction::to(&self.tx) {
             trace!(tx=?self.tx.tx_hash(), ?to, "executing call transaction");
-            Ok(TraceResult::from(self.executor.transact_with_env_and_context(
-                self.evm_env.clone(),
-                tx_env,
-                chain_context,
-            )?))
+            TraceKind::Execution
         } else {
             trace!(tx=?self.tx.tx_hash(), "executing create transaction");
-            Ok(TraceResult::try_from(self.executor.deploy_with_env_and_context(
-                self.evm_env.clone(),
-                tx_env,
-                chain_context,
-                None,
-            ))?)
-        }
+            TraceKind::Deployment
+        };
+        Ok(TraceResult::from_raw(result, trace_kind))
     }
 }
 

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -48,12 +48,12 @@ use foundry_config::{
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 #[cfg(feature = "monad")]
-use foundry_evm::core::evm::{BlockContext, MonadEvmNetwork};
+use foundry_evm::core::evm::{BlockContext, ChainFor, MonadEvmNetwork};
 use foundry_evm::{
     core::{
-        FoundryBlock as _, FoundryChain as _,
+        FoundryBlock as _,
         env::FromAnyRpcTransaction as _,
-        evm::{ChainFor, EthEvmNetwork, EvmEnvFor, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
+        evm::{EthEvmNetwork, EvmEnvFor, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
     },
     executors::{Executor, TracingExecutor},
     hardforks::FoundryHardfork,
@@ -643,7 +643,6 @@ impl<FEN: FoundryEvmNetwork> PreparedRun<FEN> {
         let tx_hash = self.tx.tx_hash();
         let block = &self.block;
         let replay_system_txes = self.args.replay_system_txes;
-        let target_chain_context = ChainFor::<FEN>::for_transaction(&target_tx_env);
         let mut replay = Vec::new();
         if replay_prefix {
             sh_status!("Executing previous transactions from the block.")?;
@@ -669,8 +668,7 @@ impl<FEN: FoundryEvmNetwork> PreparedRun<FEN> {
                         } else {
                             trace!(tx=?tx.tx_hash(), "preparing previous create transaction");
                         }
-                        let chain_context = ChainFor::<FEN>::for_transaction(&tx_env);
-                        replay.push((tx.tx_hash(), tx_env, chain_context));
+                        replay.push((tx.tx_hash(), tx_env));
                     }
                     pb.set_position((index + 1) as u64);
                 }
@@ -679,7 +677,6 @@ impl<FEN: FoundryEvmNetwork> PreparedRun<FEN> {
         let result = self.executor.transact_with_ordinary_block_replay(
             self.evm_env.clone(),
             target_tx_env,
-            target_chain_context,
             replay,
         )?;
         let trace_kind = if let Some(to) = Transaction::to(&self.tx) {

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::Debug,
-    ops::{Deref, DerefMut},
-};
+use std::{fmt::Debug, ops::Deref};
 
 use crate::{
     FoundryBlock, FoundryChain, FoundryContextExt, FoundryInspectorExt, FoundryJournal,
@@ -160,7 +157,6 @@ pub trait FoundryEvmFactory:
             Spec = Self::Spec,
             HaltReason = Self::HaltReason,
         > + Deref<Target = Self::FoundryContext<'db>>
-        + DerefMut<Target = Self::FoundryContext<'db>>
     where
         Self: 'db;
 

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Debug, ops::Deref};
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 use crate::{
     FoundryBlock, FoundryChain, FoundryContextExt, FoundryInspectorExt, FoundryJournal,
@@ -157,6 +160,7 @@ pub trait FoundryEvmFactory:
             Spec = Self::Spec,
             HaltReason = Self::HaltReason,
         > + Deref<Target = Self::FoundryContext<'db>>
+        + DerefMut<Target = Self::FoundryContext<'db>>
     where
         Self: 'db;
 

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -326,7 +326,8 @@ fn finish_protocol_system_call<H>(
     Ok(result)
 }
 
-fn try_transact_monad_system_replay<DB, I>(
+/// Tries to execute a canonical Monad system transaction on an existing Monad EVM.
+pub fn try_transact_monad_system_replay<DB, I>(
     evm: &mut MonadEvm<DB, I>,
     tx: &TxEnv,
 ) -> eyre::Result<Option<ResultAndState>>

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -19,8 +19,11 @@ use alloy_primitives::{
     map::{AddressHashMap, HashMap},
 };
 use alloy_sol_types::{SolCall, sol};
+use eyre::WrapErr;
+#[cfg(feature = "monad")]
+use foundry_evm_core::evm::{MonadEvmNetwork, try_transact_monad_system_replay};
 use foundry_evm_core::{
-    EvmEnv, FoundryBlock, FoundryChain, FoundryTransaction,
+    EvmEnv, FoundryBlock, FoundryChain, FoundryContextExt, FoundryTransaction,
     backend::{
         Backend, BackendError, BackendResult, CowBackend, DatabaseError, DatabaseExt,
         GLOBAL_FAIL_SLOT,
@@ -38,6 +41,7 @@ use foundry_evm_core::{
         BlockContext, ChainFor, EthEvmNetwork, EvmEnvFor, FoundryEvmFactory, FoundryEvmNetwork,
         IntoInstructionResult, SpecFor, TxEnvFor,
     },
+    refresh_chain_journal,
     utils::StateChangeset,
 };
 use foundry_evm_coverage::HitMaps;
@@ -46,7 +50,7 @@ use foundry_evm_networks::NetworkConfigs;
 use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     bytecode::Bytecode,
-    context::{Block, Cfg, Transaction},
+    context::{Block, Cfg, ContextTr, Transaction},
     context_interface::{
         cfg::gas_params::Eip2780TxInfo,
         result::{ExecutionResult, Output, ResultAndState},
@@ -140,6 +144,105 @@ pub struct Executor<FEN: FoundryEvmNetwork> {
     legacy_assertions: bool,
     /// Opt-in cursor for transactions simulated sequentially against one fork.
     block_context: Option<BlockContext<FEN>>,
+}
+
+#[cfg(feature = "monad")]
+impl Executor<MonadEvmNetwork> {
+    /// Replays Monad transactions and executes the target against one EVM instance.
+    #[instrument(name = "transact_monad_block_replay", level = "debug", skip_all)]
+    pub fn transact_with_monad_block_replay(
+        &mut self,
+        evm_env: EvmEnvFor<MonadEvmNetwork>,
+        target_tx_env: TxEnvFor<MonadEvmNetwork>,
+        target_chain_context: ChainFor<MonadEvmNetwork>,
+        replay: Vec<(TxEnvFor<MonadEvmNetwork>, ChainFor<MonadEvmNetwork>, bool)>,
+        target_is_system: bool,
+        replay_system_txes: bool,
+    ) -> eyre::Result<Option<(RawCallResult<MonadEvmNetwork>, bool)>> {
+        let mut stack = self.inspector().clone();
+        let sancov_edges = stack.inner.sancov_edges;
+        let sancov_trace_cmp = stack.inner.sancov_trace_cmp;
+        let sancov_active = sancov_edges || sancov_trace_cmp;
+        let backend = self.backend_mut();
+
+        let (result, evm_env, tx_env, used_system_replay) = {
+            let caller = target_tx_env.caller();
+            backend.set_caller(caller).set_spec_id(evm_env.cfg_env.spec);
+            let target_contract = match target_tx_env.kind() {
+                TxKind::Call(to) => to,
+                TxKind::Create => caller.create(target_tx_env.nonce()),
+            };
+            backend.set_test_contract(target_contract);
+            let mut evm = <MonadEvmNetwork as FoundryEvmNetwork>::EvmFactory::default()
+                .create_foundry_evm_with_inspector(
+                    backend,
+                    evm_env,
+                    target_chain_context.clone(),
+                    &mut stack,
+                );
+            evm.disable_inspector();
+            for (tx_env, chain_context, is_system) in replay {
+                let context = std::ops::DerefMut::deref_mut(&mut evm);
+                *context.chain_mut() = chain_context;
+                refresh_chain_journal(context);
+                context.cfg_env_mut().disable_balance_check = true;
+                let result = if is_system {
+                    try_transact_monad_system_replay(&mut evm, &tx_env)?
+                } else {
+                    None
+                };
+                if let Some(result) = result {
+                    evm.db_mut().commit(result.state);
+                } else if !is_system || replay_system_txes {
+                    let result = evm.transact(tx_env).wrap_err("EVM error")?;
+                    evm.db_mut().commit(result.state);
+                }
+            }
+
+            evm.enable_inspector();
+            let context = std::ops::DerefMut::deref_mut(&mut evm);
+            *context.chain_mut() = target_chain_context;
+            refresh_chain_journal(context);
+            let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
+            let system_result = if target_is_system {
+                try_transact_monad_system_replay(&mut evm, &target_tx_env)?
+            } else {
+                None
+            };
+            let (result, used_system_replay) = if let Some(result) = system_result {
+                (result, true)
+            } else if target_is_system && !replay_system_txes {
+                return Ok(None);
+            } else {
+                (evm.transact(target_tx_env.clone()).wrap_err("EVM error")?, false)
+            };
+            let tx_env = if used_system_replay { target_tx_env } else { evm.tx().clone() };
+            let evm_env = evm.finish().1;
+            (result, evm_env, tx_env, used_system_replay)
+        };
+
+        let has_state_snapshot_failure = backend.has_state_snapshot_failure();
+        let fork_block_number = backend.active_fork_block_number();
+        let mut result = convert_executed_result(
+            evm_env,
+            tx_env,
+            stack,
+            result,
+            &*backend,
+            has_state_snapshot_failure,
+            fork_block_number,
+        )?;
+        if sancov_edges {
+            SancovGuard::append_edges_into(&mut result);
+        }
+        if sancov_trace_cmp {
+            SancovGuard::drain_cmp_into(&mut result);
+        }
+        let committed_tx = result.tx_env.clone();
+        self.commit(&mut result);
+        self.record_block_transaction(committed_tx);
+        Ok(Some((result, used_system_replay)))
+    }
 }
 
 impl<FEN: FoundryEvmNetwork> Executor<FEN> {
@@ -819,6 +922,82 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
             backend.inspect_with_context(&mut evm_env, &mut tx_env, chain_context, &mut stack)?
         };
+        let has_state_snapshot_failure = backend.has_state_snapshot_failure();
+        let fork_block_number = backend.active_fork_block_number();
+        let mut result = convert_executed_result(
+            evm_env,
+            tx_env,
+            stack,
+            result,
+            &*backend,
+            has_state_snapshot_failure,
+            fork_block_number,
+        )?;
+        if sancov_edges {
+            SancovGuard::append_edges_into(&mut result);
+        }
+        if sancov_trace_cmp {
+            SancovGuard::drain_cmp_into(&mut result);
+        }
+        let committed_tx = result.tx_env.clone();
+        self.commit(&mut result);
+        self.record_block_transaction(committed_tx);
+        Ok(result)
+    }
+
+    /// Replays ordinary transactions and executes the target against one EVM instance.
+    #[instrument(name = "transact_block_replay", level = "debug", skip_all)]
+    pub fn transact_with_block_replay(
+        &mut self,
+        evm_env: EvmEnvFor<FEN>,
+        target_tx_env: TxEnvFor<FEN>,
+        target_chain_context: ChainFor<FEN>,
+        replay: Vec<(TxEnvFor<FEN>, ChainFor<FEN>)>,
+    ) -> eyre::Result<RawCallResult<FEN>> {
+        let mut stack = self.inspector().clone();
+        let sancov_edges = stack.inner.sancov_edges;
+        let sancov_trace_cmp = stack.inner.sancov_trace_cmp;
+        let sancov_active = sancov_edges || sancov_trace_cmp;
+        let backend = self.backend_mut();
+
+        let (result, evm_env, tx_env) = {
+            let caller = target_tx_env.caller();
+            backend.set_caller(caller).set_spec_id(evm_env.cfg_env.spec);
+            let target_contract = match target_tx_env.kind() {
+                TxKind::Call(to) => to,
+                // The prefix has not run yet, so use the canonical target nonce rather than the
+                // current database nonce.
+                TxKind::Create => caller.create(target_tx_env.nonce()),
+            };
+            backend.set_test_contract(target_contract);
+            let evm = FEN::EvmFactory::default().create_foundry_evm_with_inspector(
+                backend,
+                evm_env,
+                target_chain_context.clone(),
+                &mut stack,
+            );
+            let mut evm = evm;
+            evm.disable_inspector();
+            for (tx_env, chain_context) in replay {
+                let context = std::ops::DerefMut::deref_mut(&mut evm);
+                *context.chain_mut() = chain_context;
+                refresh_chain_journal(context);
+                context.cfg_env_mut().disable_balance_check = true;
+                let result = evm.transact(tx_env).wrap_err("EVM error")?;
+                evm.db_mut().commit(result.state);
+            }
+
+            evm.enable_inspector();
+            let context = std::ops::DerefMut::deref_mut(&mut evm);
+            *context.chain_mut() = target_chain_context;
+            refresh_chain_journal(context);
+            let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
+            let result = evm.transact(target_tx_env).wrap_err("EVM error")?;
+            let tx_env = evm.tx().clone();
+            let evm_env = evm.finish().1;
+            (result, evm_env, tx_env)
+        };
+
         let has_state_snapshot_failure = backend.has_state_snapshot_failure();
         let fork_block_number = backend.active_fork_block_number();
         let mut result = convert_executed_result(
@@ -1952,6 +2131,147 @@ mod tests {
 
         let err = raw.into_evm_error(None);
         assert!(matches!(err, EvmError::Execution(_)));
+    }
+
+    #[test]
+    fn block_replay_commits_prefix_and_traces_only_target() {
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(1 << 20).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+            NetworkConfigs::default(),
+        );
+        executor.set_balance(CALLER, U256::MAX).unwrap();
+        executor.set_trace_requirements(TraceRequirements::none().with_calls(true));
+
+        let address = Address::repeat_byte(0x11);
+        // Increment slot zero and return its new value.
+        executor
+            .set_code(
+                address,
+                Bytecode::new_raw(Bytes::from_static(&[
+                    0x60, 0x00, 0x54, 0x60, 0x01, 0x01, 0x80, 0x60, 0x00, 0x55, 0x60, 0x00, 0x52,
+                    0x60, 0x20, 0x60, 0x00, 0xf3,
+                ])),
+            )
+            .unwrap();
+        let prefix = TxEnv {
+            caller: CALLER,
+            gas_limit: 100_000,
+            kind: TxKind::Call(address),
+            ..Default::default()
+        };
+        let reverted_create = TxEnv {
+            nonce: 1,
+            kind: TxKind::Create,
+            data: Bytes::from_static(&[0x5f, 0x5f, 0xfd]),
+            ..prefix.clone()
+        };
+        let target = TxEnv { nonce: 2, ..prefix.clone() };
+
+        let result = executor
+            .transact_with_block_replay(
+                EvmEnv::default(),
+                target,
+                (),
+                vec![(prefix, ()), (reverted_create, ())],
+            )
+            .unwrap();
+
+        assert_eq!(result.result, Bytes::from(U256::from(2).to_be_bytes::<32>()));
+        assert_eq!(result.tx_env.nonce, 2);
+        assert_eq!(executor.get_nonce(CALLER).unwrap(), 3);
+        assert_eq!(executor.backend().storage_ref(address, U256::ZERO).unwrap(), U256::from(2));
+        assert_eq!(result.traces.unwrap().arena.nodes().len(), 1);
+    }
+
+    #[test]
+    fn block_replay_initializes_create_target_from_canonical_nonce() {
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(1 << 20).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+            NetworkConfigs::default(),
+        );
+        executor.set_balance(CALLER, U256::MAX).unwrap();
+
+        let prefix = TxEnv {
+            caller: CALLER,
+            gas_limit: 100_000,
+            kind: TxKind::Call(Address::repeat_byte(0x11)),
+            ..Default::default()
+        };
+        let target = TxEnv {
+            nonce: 1,
+            kind: TxKind::Create,
+            data: Bytes::from_static(&[0x00]),
+            ..prefix.clone()
+        };
+        let expected = CALLER.create(1);
+
+        let result = executor
+            .transact_with_block_replay(EvmEnv::default(), target, (), vec![(prefix, ())])
+            .unwrap();
+
+        assert!(
+            matches!(result.out, Some(Output::Create(_, Some(address))) if address == expected)
+        );
+        assert!(executor.backend().is_persistent(&expected));
+        assert!(executor.backend().has_cheatcode_access(&expected));
+    }
+
+    #[cfg(feature = "monad")]
+    #[test]
+    fn block_replay_executes_monad_system_prefix() {
+        use foundry_evm_core::evm::MonadEvmNetwork;
+
+        let backend = Backend::<MonadEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::<MonadEvmNetwork>::default().gas_limit(1 << 20).build(
+            EvmEnvFor::<MonadEvmNetwork>::default(),
+            TxEnvFor::<MonadEvmNetwork>::default(),
+            backend,
+            NetworkConfigs::with_monad(),
+        );
+        executor.set_balance(CALLER, U256::MAX).unwrap();
+
+        let system_address = alloy_primitives::address!("6f49a8f621353f12378d0046e7d7e4b9b249dc9e");
+        let staking_address =
+            alloy_primitives::address!("0000000000000000000000000000000000001000");
+        let selector = keccak256("syscallSnapshot()");
+        let system = TxEnv {
+            caller: system_address,
+            gas_limit: 0,
+            kind: TxKind::Call(staking_address),
+            data: Bytes::copy_from_slice(&selector[..4]),
+            chain_id: None,
+            ..Default::default()
+        };
+        let target = TxEnv {
+            caller: CALLER,
+            gas_limit: 100_000,
+            kind: TxKind::Call(Address::repeat_byte(0x11)),
+            ..Default::default()
+        };
+        let system_chain = ChainFor::<MonadEvmNetwork>::for_transaction(&system);
+        let target_chain = ChainFor::<MonadEvmNetwork>::for_transaction(&target);
+
+        let (result, used_system_replay) = executor
+            .transact_with_monad_block_replay(
+                EvmEnvFor::<MonadEvmNetwork>::default(),
+                target,
+                target_chain,
+                vec![(system, system_chain, true)],
+                false,
+                false,
+            )
+            .unwrap()
+            .unwrap();
+
+        assert!(!used_system_replay);
+        assert!(!result.reverted);
+        assert_eq!(executor.get_nonce(system_address).unwrap(), 1);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -24,8 +24,10 @@ use eyre::WrapErr;
 use foundry_common::{SYSTEM_TRANSACTION_TYPE, is_known_system_sender};
 #[cfg(feature = "monad")]
 use foundry_evm_core::evm::{MonadEvmNetwork, try_transact_monad_system_replay};
+#[cfg(feature = "monad")]
+use foundry_evm_core::refresh_chain_journal;
 use foundry_evm_core::{
-    EvmEnv, FoundryBlock, FoundryChain, FoundryContextExt, FoundryTransaction,
+    EvmEnv, FoundryBlock, FoundryChain, FoundryTransaction,
     backend::{
         Backend, BackendError, BackendResult, CowBackend, DatabaseError, DatabaseExt,
         GLOBAL_FAIL_SLOT,
@@ -43,7 +45,6 @@ use foundry_evm_core::{
         BlockContext, ChainFor, EthEvmNetwork, EvmEnvFor, FoundryEvmFactory, FoundryEvmNetwork,
         IntoInstructionResult, SpecFor, TxEnvFor,
     },
-    refresh_chain_journal,
     utils::StateChangeset,
 };
 use foundry_evm_coverage::HitMaps;
@@ -184,10 +185,9 @@ impl Executor<MonadEvmNetwork> {
                 );
             evm.disable_inspector();
             for (tx_hash, tx_env, chain_context) in replay {
-                let context = std::ops::DerefMut::deref_mut(&mut evm);
-                *context.chain_mut() = chain_context;
-                refresh_chain_journal(context);
-                context.cfg_env_mut().disable_balance_check = true;
+                evm.ctx_mut().chain = chain_context;
+                refresh_chain_journal(evm.ctx_mut());
+                evm.ctx_mut().cfg.disable_balance_check = true;
                 let is_system = is_known_system_sender(tx_env.caller())
                     || tx_env.tx_type() == SYSTEM_TRANSACTION_TYPE;
                 let result = if is_system {
@@ -221,9 +221,8 @@ impl Executor<MonadEvmNetwork> {
             }
 
             evm.enable_inspector();
-            let context = std::ops::DerefMut::deref_mut(&mut evm);
-            *context.chain_mut() = target_chain_context;
-            refresh_chain_journal(context);
+            evm.ctx_mut().chain = target_chain_context;
+            refresh_chain_journal(evm.ctx_mut());
             let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
             let target_is_system = is_known_system_sender(target_tx_env.caller())
                 || target_tx_env.tx_type() == SYSTEM_TRANSACTION_TYPE;
@@ -261,9 +260,7 @@ impl Executor<MonadEvmNetwork> {
         if sancov_trace_cmp {
             SancovGuard::drain_cmp_into(&mut result);
         }
-        let committed_tx = result.tx_env.clone();
         self.commit(&mut result);
-        self.record_block_transaction(committed_tx);
         Ok(Some((result, used_system_replay)))
     }
 }
@@ -972,10 +969,9 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
     #[instrument(name = "transact_block_replay", level = "debug", skip_all)]
     pub fn transact_with_ordinary_block_replay(
         &mut self,
-        evm_env: EvmEnvFor<FEN>,
+        mut evm_env: EvmEnvFor<FEN>,
         target_tx_env: TxEnvFor<FEN>,
-        target_chain_context: ChainFor<FEN>,
-        replay: Vec<(B256, TxEnvFor<FEN>, ChainFor<FEN>)>,
+        replay: Vec<(B256, TxEnvFor<FEN>)>,
     ) -> eyre::Result<RawCallResult<FEN>> {
         let block_number = evm_env.block_env.number();
         let mut stack = self.inspector().clone();
@@ -994,19 +990,19 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
                 TxKind::Create => caller.create(target_tx_env.nonce()),
             };
             backend.set_test_contract(target_contract);
+            let target_chain_context = ChainFor::<FEN>::for_transaction(&target_tx_env);
+            if !replay.is_empty() {
+                evm_env.cfg_env.disable_balance_check = true;
+            }
             let evm = FEN::EvmFactory::default().create_foundry_evm_with_inspector(
                 backend,
                 evm_env,
-                target_chain_context.clone(),
+                target_chain_context,
                 &mut stack,
             );
             let mut evm = evm;
             evm.disable_inspector();
-            for (tx_hash, tx_env, chain_context) in replay {
-                let context = std::ops::DerefMut::deref_mut(&mut evm);
-                *context.chain_mut() = chain_context;
-                refresh_chain_journal(context);
-                context.cfg_env_mut().disable_balance_check = true;
+            for (tx_hash, tx_env) in replay {
                 let created = match tx_env.kind() {
                     TxKind::Create => Some(tx_env.caller().create(tx_env.nonce())),
                     TxKind::Call(_) => None,
@@ -1023,9 +1019,6 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             }
 
             evm.enable_inspector();
-            let context = std::ops::DerefMut::deref_mut(&mut evm);
-            *context.chain_mut() = target_chain_context;
-            refresh_chain_journal(context);
             let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
             let result = evm.transact(target_tx_env).wrap_err("EVM error")?;
             let tx_env = evm.tx().clone();
@@ -1050,9 +1043,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         if sancov_trace_cmp {
             SancovGuard::drain_cmp_into(&mut result);
         }
-        let committed_tx = result.tx_env.clone();
         self.commit(&mut result);
-        self.record_block_transaction(committed_tx);
         Ok(result)
     }
 
@@ -2208,11 +2199,7 @@ mod tests {
             .transact_with_ordinary_block_replay(
                 EvmEnv::default(),
                 target,
-                (),
-                vec![
-                    (B256::repeat_byte(1), prefix, ()),
-                    (B256::repeat_byte(2), reverted_create, ()),
-                ],
+                vec![(B256::repeat_byte(1), prefix), (B256::repeat_byte(2), reverted_create)],
             )
             .unwrap();
 
@@ -2252,8 +2239,7 @@ mod tests {
             .transact_with_ordinary_block_replay(
                 EvmEnv::default(),
                 target,
-                (),
-                vec![(B256::repeat_byte(1), prefix, ())],
+                vec![(B256::repeat_byte(1), prefix)],
             )
             .unwrap();
 
@@ -2289,8 +2275,7 @@ mod tests {
             .transact_with_ordinary_block_replay(
                 EvmEnv::default(),
                 target,
-                (),
-                vec![(B256::repeat_byte(1), prefix, ())],
+                vec![(B256::repeat_byte(1), prefix)],
             )
             .unwrap();
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -15,11 +15,13 @@ use alloy_eips::eip4788::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS};
 use alloy_evm::Evm;
 use alloy_json_abi::Function;
 use alloy_primitives::{
-    Address, Bytes, Log, TxKind, U256, keccak256,
+    Address, B256, Bytes, Log, TxKind, U256, keccak256,
     map::{AddressHashMap, HashMap},
 };
 use alloy_sol_types::{SolCall, sol};
 use eyre::WrapErr;
+#[cfg(feature = "monad")]
+use foundry_common::{SYSTEM_TRANSACTION_TYPE, is_known_system_sender};
 #[cfg(feature = "monad")]
 use foundry_evm_core::evm::{MonadEvmNetwork, try_transact_monad_system_replay};
 use foundry_evm_core::{
@@ -155,10 +157,10 @@ impl Executor<MonadEvmNetwork> {
         evm_env: EvmEnvFor<MonadEvmNetwork>,
         target_tx_env: TxEnvFor<MonadEvmNetwork>,
         target_chain_context: ChainFor<MonadEvmNetwork>,
-        replay: Vec<(TxEnvFor<MonadEvmNetwork>, ChainFor<MonadEvmNetwork>, bool)>,
-        target_is_system: bool,
+        replay: Vec<(B256, TxEnvFor<MonadEvmNetwork>, ChainFor<MonadEvmNetwork>)>,
         replay_system_txes: bool,
     ) -> eyre::Result<Option<(RawCallResult<MonadEvmNetwork>, bool)>> {
+        let block_number = evm_env.block_env.number();
         let mut stack = self.inspector().clone();
         let sancov_edges = stack.inner.sancov_edges;
         let sancov_trace_cmp = stack.inner.sancov_trace_cmp;
@@ -181,20 +183,39 @@ impl Executor<MonadEvmNetwork> {
                     &mut stack,
                 );
             evm.disable_inspector();
-            for (tx_env, chain_context, is_system) in replay {
+            for (tx_hash, tx_env, chain_context) in replay {
                 let context = std::ops::DerefMut::deref_mut(&mut evm);
                 *context.chain_mut() = chain_context;
                 refresh_chain_journal(context);
                 context.cfg_env_mut().disable_balance_check = true;
+                let is_system = is_known_system_sender(tx_env.caller())
+                    || tx_env.tx_type() == SYSTEM_TRANSACTION_TYPE;
                 let result = if is_system {
-                    try_transact_monad_system_replay(&mut evm, &tx_env)?
+                    try_transact_monad_system_replay(&mut evm, &tx_env).wrap_err_with(|| {
+                        format!(
+                            "Failed to replay system transaction: {tx_hash:?} in block {block_number}"
+                        )
+                    })?
                 } else {
                     None
                 };
                 if let Some(result) = result {
                     evm.db_mut().commit(result.state);
                 } else if !is_system || replay_system_txes {
-                    let result = evm.transact(tx_env).wrap_err("EVM error")?;
+                    let created = match tx_env.kind() {
+                        TxKind::Create => Some(tx_env.caller().create(tx_env.nonce())),
+                        TxKind::Call(_) => None,
+                    };
+                    let result = evm.transact(tx_env).wrap_err_with(|| {
+                        format!(
+                            "Failed to execute transaction: {tx_hash:?} in block {block_number}"
+                        )
+                    })?;
+                    if result.result.is_success()
+                        && let Some(address) = created
+                    {
+                        evm.db_mut().add_persistent_account(address);
+                    }
                     evm.db_mut().commit(result.state);
                 }
             }
@@ -204,6 +225,8 @@ impl Executor<MonadEvmNetwork> {
             *context.chain_mut() = target_chain_context;
             refresh_chain_journal(context);
             let _guard = sancov_active.then(|| SancovGuard::new(sancov_edges, sancov_trace_cmp));
+            let target_is_system = is_known_system_sender(target_tx_env.caller())
+                || target_tx_env.tx_type() == SYSTEM_TRANSACTION_TYPE;
             let system_result = if target_is_system {
                 try_transact_monad_system_replay(&mut evm, &target_tx_env)?
             } else {
@@ -947,13 +970,14 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
 
     /// Replays ordinary transactions and executes the target against one EVM instance.
     #[instrument(name = "transact_block_replay", level = "debug", skip_all)]
-    pub fn transact_with_block_replay(
+    pub fn transact_with_ordinary_block_replay(
         &mut self,
         evm_env: EvmEnvFor<FEN>,
         target_tx_env: TxEnvFor<FEN>,
         target_chain_context: ChainFor<FEN>,
-        replay: Vec<(TxEnvFor<FEN>, ChainFor<FEN>)>,
+        replay: Vec<(B256, TxEnvFor<FEN>, ChainFor<FEN>)>,
     ) -> eyre::Result<RawCallResult<FEN>> {
+        let block_number = evm_env.block_env.number();
         let mut stack = self.inspector().clone();
         let sancov_edges = stack.inner.sancov_edges;
         let sancov_trace_cmp = stack.inner.sancov_trace_cmp;
@@ -978,12 +1002,23 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             );
             let mut evm = evm;
             evm.disable_inspector();
-            for (tx_env, chain_context) in replay {
+            for (tx_hash, tx_env, chain_context) in replay {
                 let context = std::ops::DerefMut::deref_mut(&mut evm);
                 *context.chain_mut() = chain_context;
                 refresh_chain_journal(context);
                 context.cfg_env_mut().disable_balance_check = true;
-                let result = evm.transact(tx_env).wrap_err("EVM error")?;
+                let created = match tx_env.kind() {
+                    TxKind::Create => Some(tx_env.caller().create(tx_env.nonce())),
+                    TxKind::Call(_) => None,
+                };
+                let result = evm.transact(tx_env).wrap_err_with(|| {
+                    format!("Failed to execute transaction: {tx_hash:?} in block {block_number}")
+                })?;
+                if result.result.is_success()
+                    && let Some(address) = created
+                {
+                    evm.db_mut().add_persistent_account(address);
+                }
                 evm.db_mut().commit(result.state);
             }
 
@@ -1981,7 +2016,6 @@ pub fn should_ignore_revert(
 mod tests {
     use super::*;
     use crate::inspectors::{EdgeCovHit, EdgeKey};
-    use alloy_primitives::B256;
     use foundry_cheatcodes::{
         CheatsConfig,
         Vm::{blobhashesCall, mockCallRevert_1Call, revertToStateCall, snapshotStateCall},
@@ -2171,11 +2205,14 @@ mod tests {
         let target = TxEnv { nonce: 2, ..prefix.clone() };
 
         let result = executor
-            .transact_with_block_replay(
+            .transact_with_ordinary_block_replay(
                 EvmEnv::default(),
                 target,
                 (),
-                vec![(prefix, ()), (reverted_create, ())],
+                vec![
+                    (B256::repeat_byte(1), prefix, ()),
+                    (B256::repeat_byte(2), reverted_create, ()),
+                ],
             )
             .unwrap();
 
@@ -2212,7 +2249,12 @@ mod tests {
         let expected = CALLER.create(1);
 
         let result = executor
-            .transact_with_block_replay(EvmEnv::default(), target, (), vec![(prefix, ())])
+            .transact_with_ordinary_block_replay(
+                EvmEnv::default(),
+                target,
+                (),
+                vec![(B256::repeat_byte(1), prefix, ())],
+            )
             .unwrap();
 
         assert!(
@@ -2220,6 +2262,39 @@ mod tests {
         );
         assert!(executor.backend().is_persistent(&expected));
         assert!(executor.backend().has_cheatcode_access(&expected));
+    }
+
+    #[test]
+    fn block_replay_preserves_successful_prefix_deployment() {
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(1 << 20).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+            NetworkConfigs::default(),
+        );
+        executor.set_balance(CALLER, U256::MAX).unwrap();
+
+        let deployed = CALLER.create(0);
+        let prefix = TxEnv {
+            caller: CALLER,
+            gas_limit: 100_000,
+            kind: TxKind::Create,
+            data: Bytes::from_static(&[0x00]),
+            ..Default::default()
+        };
+        let target = TxEnv { nonce: 1, kind: TxKind::Call(deployed), ..prefix.clone() };
+
+        executor
+            .transact_with_ordinary_block_replay(
+                EvmEnv::default(),
+                target,
+                (),
+                vec![(B256::repeat_byte(1), prefix, ())],
+            )
+            .unwrap();
+
+        assert!(executor.backend().is_persistent(&deployed));
     }
 
     #[cfg(feature = "monad")]
@@ -2262,14 +2337,56 @@ mod tests {
                 EvmEnvFor::<MonadEvmNetwork>::default(),
                 target,
                 target_chain,
-                vec![(system, system_chain, true)],
-                false,
+                vec![(B256::repeat_byte(1), system, system_chain)],
                 false,
             )
             .unwrap()
             .unwrap();
 
         assert!(!used_system_replay);
+        assert!(!result.reverted);
+        assert_eq!(executor.get_nonce(system_address).unwrap(), 1);
+    }
+
+    #[cfg(feature = "monad")]
+    #[test]
+    fn block_replay_executes_monad_system_target() {
+        use foundry_evm_core::evm::MonadEvmNetwork;
+
+        let backend = Backend::<MonadEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::<MonadEvmNetwork>::default().gas_limit(1 << 20).build(
+            EvmEnvFor::<MonadEvmNetwork>::default(),
+            TxEnvFor::<MonadEvmNetwork>::default(),
+            backend,
+            NetworkConfigs::with_monad(),
+        );
+
+        let system_address = alloy_primitives::address!("6f49a8f621353f12378d0046e7d7e4b9b249dc9e");
+        let staking_address =
+            alloy_primitives::address!("0000000000000000000000000000000000001000");
+        let selector = keccak256("syscallSnapshot()");
+        let target = TxEnv {
+            caller: system_address,
+            gas_limit: 0,
+            kind: TxKind::Call(staking_address),
+            data: Bytes::copy_from_slice(&selector[..4]),
+            chain_id: None,
+            ..Default::default()
+        };
+        let target_chain = ChainFor::<MonadEvmNetwork>::for_transaction(&target);
+
+        let (result, used_system_replay) = executor
+            .transact_with_monad_block_replay(
+                EvmEnvFor::<MonadEvmNetwork>::default(),
+                target,
+                target_chain,
+                Vec::new(),
+                false,
+            )
+            .unwrap()
+            .unwrap();
+
+        assert!(used_system_replay);
         assert!(!result.reverted);
         assert_eq!(executor.get_nonce(system_address).unwrap(), 1);
     }


### PR DESCRIPTION
`cast run` previously constructed a fresh EVM for every transaction in a block prefix and another for the target. This moves block replay into the executor so the prefix and target execute against one EVM instance. Prefix state is committed between transactions, successful deployments remain persistent, per-transaction context is refreshed, and inspection stays limited to the target.

Monad replay remains on a concrete Monad executor path, where canonical system transactions and their chain context are handled without adding Monad-specific replay state to the generic execution path.

This PR was written with Codex assistance.
