### PR TITLE
refactor(networks): centralize optimism predicates

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1224,18 +1224,11 @@ impl<N: Network> Backend<N> {
         (self.spec_id() as u8) >= (SpecId::PRAGUE as u8)
     }
 
-    /// Returns true if op-stack deposits are active
-    #[cfg(feature = "optimism")]
-    pub const fn is_optimism(&self) -> bool {
-        self.networks.is_optimism()
-    }
-
     /// Returns true if op-stack deposits are active.
     ///
     /// Always `false` when built without the `optimism` feature.
-    #[cfg(not(feature = "optimism"))]
     pub const fn is_optimism(&self) -> bool {
-        false
+        self.networks.is_optimism()
     }
 
     /// Returns true if Tempo network mode is active

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -283,9 +283,15 @@ impl NetworkVariant {
     }
 
     /// Returns `true` if this is the Optimism network variant.
-    #[cfg(feature = "optimism")]
     pub const fn is_optimism(&self) -> bool {
-        matches!(self, Self::Optimism)
+        #[cfg(feature = "optimism")]
+        {
+            matches!(self, Self::Optimism)
+        }
+        #[cfg(not(feature = "optimism"))]
+        {
+            false
+        }
     }
 
     /// Returns `true` if this is the Tempo network variant.
@@ -457,6 +463,13 @@ impl NetworkConfigs {
 
     pub const fn is_tempo(&self) -> bool {
         if let Some(network) = self.resolved_network() { network.is_tempo() } else { false }
+    }
+
+    /// Returns whether Optimism network features are enabled.
+    ///
+    /// Always returns `false` when built without the `optimism` feature.
+    pub const fn is_optimism(&self) -> bool {
+        if let Some(network) = self.resolved_network() { network.is_optimism() } else { false }
     }
 
     #[cfg(feature = "monad")]
@@ -947,9 +960,11 @@ mod tests {
     #[test]
     fn network_variant_predicates() {
         assert!(NetworkVariant::Ethereum.is_ethereum());
+        assert!(!NetworkVariant::Ethereum.is_optimism());
         assert!(!NetworkVariant::Ethereum.is_tempo());
         assert!(NetworkVariant::Tempo.is_tempo());
         assert!(!NetworkVariant::Tempo.is_ethereum());
+        assert!(!NetworkVariant::Tempo.is_optimism());
 
         #[cfg(feature = "monad")]
         {
@@ -957,6 +972,7 @@ mod tests {
             assert!(!NetworkVariant::Tempo.is_monad());
             assert!(NetworkVariant::Monad.is_monad());
             assert!(!NetworkVariant::Monad.is_ethereum());
+            assert!(!NetworkVariant::Monad.is_optimism());
             assert!(!NetworkVariant::Monad.is_tempo());
         }
 
@@ -969,9 +985,6 @@ mod tests {
             #[cfg(feature = "monad")]
             assert!(!NetworkVariant::Optimism.is_monad());
         }
-
-        #[cfg(all(feature = "optimism", feature = "monad"))]
-        assert!(!NetworkVariant::Monad.is_optimism());
     }
 
     #[test]
@@ -1595,6 +1608,7 @@ mod tests {
     fn active_network_name_default_is_none() {
         let cfg = NetworkConfigs::default();
         assert_eq!(cfg.active_network_name(), None);
+        assert!(!cfg.is_optimism());
         assert!(cfg.extra_cheatcode_addresses().is_empty());
     }
 

--- a/crates/evm/networks/src/optimism.rs
+++ b/crates/evm/networks/src/optimism.rs
@@ -9,10 +9,6 @@ impl NetworkConfigs {
         Self { network: Some(NetworkVariant::Optimism), optimism: true, ..Default::default() }
     }
 
-    pub const fn is_optimism(&self) -> bool {
-        if let Some(network) = self.resolved_network() { network.is_optimism() } else { false }
-    }
-
     /// Optimism-specific base fee parameters, picking Canyon vs pre-Canyon based on `timestamp`.
     pub(crate) fn op_base_fee_params(&self, timestamp: u64) -> BaseFeeParams {
         let op_hardforks = OpChainHardforks::op_mainnet();


### PR DESCRIPTION
## Motivation

Feature-gating the Optimism predicates themselves forces feature-independent callers and wrappers to duplicate cfg branches just to obtain false when Optimism support is disabled.

## Solution

- make NetworkVariant::is_optimism and NetworkConfigs::is_optimism available in every feature configuration
- keep the feature-specific match inside the variant predicate and return false without Optimism support
- remove the duplicate predicate from the Optimism extension module
- simplify the Anvil backend wrapper to delegate to NetworkConfigs
- cover the feature-independent false behavior in the existing predicate tests

Optimism-only branch bodies remain feature-gated because they reference optional OP types.

## Testing

- cargo fmt --all -- --check
- cargo test -p foundry-evm-networks --locked
- cargo test -p foundry-evm-networks --no-default-features --locked
- cargo check -p anvil --lib --no-default-features --locked

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes