### PR TITLE
feat(cast): use chain RPC endpoint

### DIFF
--- a/.changelog/cast-run-chain-rpc-endpoint.md
+++ b/.changelog/cast-run-chain-rpc-endpoint.md
@@ -1,0 +1,5 @@
+---
+cast: minor
+---
+
+Made `cast run --chain` use the matching RPC endpoint configured in `foundry.toml` when no RPC URL is otherwise set.

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -160,7 +160,15 @@ impl RunArgs {
     /// Note: This executes the transaction(s) as is: Cheatcodes are disabled
     pub async fn run(self) -> Result<()> {
         let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
-        let (config, mut evm_opts) = super::load_cast_config_and_evm_opts(figment)?;
+        let (mut config, mut evm_opts) = super::load_cast_config_and_evm_opts(figment)?;
+        if config.eth_rpc_url.is_none()
+            && let Some(chain) = self.etherscan.chain
+        {
+            let alias = chain.to_string();
+            if config.rpc_endpoints.contains_key(&alias) {
+                config.eth_rpc_url = Some(alias);
+            }
+        }
         evm_opts.fork_url = Some(config.get_rpc_url_or_localhost_http()?.into_owned());
 
         // Auto-detect network from fork chain ID when not explicitly configured.

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -6124,6 +6124,42 @@ async fn deploy_counter_and_set_number(
         .tx_hash()
 }
 
+// <https://github.com/foundry-rs/foundry/issues/10699>
+forgetest_async!(cast_run_uses_chain_rpc_endpoint, |prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test().with_chain_id(Some(1u64))).await;
+    let endpoint = handle.http_endpoint();
+    let provider = handle.http_provider();
+    let sender = handle.dev_wallets().next().unwrap().address();
+    let receipt = provider
+        .send_transaction(
+            TransactionRequest::default()
+                .from(sender)
+                .to(address!("000000000000000000000000000000000000dEaD"))
+                .value(U256::from(1))
+                .into(),
+        )
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    fs::write(
+        prj.root().join("foundry.toml"),
+        r#"[rpc_endpoints]
+mainnet = "${CAST_RUN_MAINNET_RPC_URL}"
+"#,
+    )
+    .unwrap();
+
+    cmd.cast_fuse();
+    cmd.set_current_dir(prj.root());
+    cmd.env("CAST_RUN_MAINNET_RPC_URL", endpoint);
+    cmd.unset_env("ETH_RPC_URL");
+    cmd.args(["run", &receipt.transaction_hash.to_string(), "--chain", "mainnet", "--quick"])
+        .assert_success();
+});
+
 // `cast run` must replay a transaction's block prefix without changing the trace requested for the
 // selected transaction. A single block covers a deployment in the first position, a revert in the
 // middle, and an internally traced state change in the last position.


### PR DESCRIPTION
When `cast run` receives `--chain` without another RPC URL, use the matching endpoint from `foundry.toml`. This preserves explicit RPC precedence and supports environment-backed endpoints. Adds end-to-end regression coverage. 

Closes #10699.