### PR TITLE
refactor(cast): isolate Monad replay in run

### DIFF
--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -10,11 +10,12 @@ use crate::{
         apply_chain_specific_tx_replay_env_changes_for_chain, block_env_from_header,
     },
 };
+use alloy_chains::Chain;
 use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
 use alloy_eips::BlockNumHash;
 use alloy_network::{
-    AnyNetwork, AnyTxEnvelope, BlockResponse, Network, ReceiptResponse, TransactionResponse,
-    primitives::HeaderResponse,
+    AnyNetwork, AnyRpcBlock, AnyRpcTransaction, AnyTxEnvelope, BlockResponse, Network,
+    ReceiptResponse, TransactionResponse, primitives::HeaderResponse,
 };
 use alloy_primitives::{
     Address, B256, Bytes, U256,
@@ -32,7 +33,9 @@ use foundry_cli::{
     utils::{TraceResult, init_progress},
 };
 use foundry_common::{
-    SYSTEM_TRANSACTION_TYPE, is_known_system_sender, provider::ProviderBuilder, shell,
+    SYSTEM_TRANSACTION_TYPE, is_known_system_sender,
+    provider::{ProviderBuilder, RetryProvider},
+    shell,
 };
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::{
@@ -44,13 +47,13 @@ use foundry_config::{
 };
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
+#[cfg(feature = "monad")]
+use foundry_evm::core::evm::{BlockContext, MonadEvmNetwork};
 use foundry_evm::{
     core::{
-        FoundryBlock as _, FoundryChain,
+        FoundryBlock as _, FoundryChain as _,
         env::FromAnyRpcTransaction as _,
-        evm::{
-            BlockContext, ChainFor, EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor,
-        },
+        evm::{ChainFor, EthEvmNetwork, EvmEnvFor, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
     },
     executors::{EvmError, Executor, TracingExecutor},
     hardforks::FoundryHardfork,
@@ -144,6 +147,42 @@ pub struct RunArgs {
     pub enable_tx_gas_limit: bool,
 }
 
+/// Target transaction resolved up front by [`RunArgs::fetch_target`], before any per-network
+/// preparation.
+struct TargetFetch {
+    tx: AnyRpcTransaction,
+    provider: RetryProvider,
+    compute_units_per_second: Option<u64>,
+    target_is_system: bool,
+}
+
+/// Fields only needed by the Monad-specific `execute_monad`/`execute_monad_target` path.
+#[cfg(feature = "monad")]
+struct MonadPrepared {
+    target_is_system: bool,
+    tx_block_number: u64,
+    compute_units_per_second: Option<u64>,
+}
+
+/// State assembled by [`RunArgs::prepare`] and consumed by the network-specific `execute_*`
+/// methods below.
+struct PreparedRun<FEN: FoundryEvmNetwork> {
+    args: RunArgs,
+    config: Box<Config>,
+    tracing: TracingConfig,
+    tx: AnyRpcTransaction,
+    block: Option<AnyRpcBlock>,
+    evm_env: EvmEnvFor<FEN>,
+    executor: TracingExecutor<FEN>,
+    chain: Chain,
+    networks: NetworkConfigs,
+    resolved_hardfork: Option<FoundryHardfork>,
+    verbosity: u8,
+    prestate_applied: bool,
+    #[cfg(feature = "monad")]
+    monad: MonadPrepared,
+}
+
 impl RunArgs {
     fn resolve_tracing(&self, config: &TracingConfig, verbosity: u8) -> TracingConfig {
         if self.debug_trace_transaction {
@@ -172,9 +211,7 @@ impl RunArgs {
 
         #[cfg(feature = "monad")]
         if evm_opts.networks.is_monad() {
-            return self
-                .run_with_evm::<foundry_evm::core::evm::MonadEvmNetwork>(config, evm_opts)
-                .await;
+            return self.run_with_monad(config, evm_opts).await;
         }
 
         #[cfg(feature = "optimism")]
@@ -186,42 +223,79 @@ impl RunArgs {
     }
 
     async fn run_with_evm<FEN: FoundryEvmNetwork>(
+        self,
+        config: Box<Config>,
+        evm_opts: EvmOpts,
+    ) -> Result<()> {
+        let target = self.fetch_target(&config).await?;
+        if target.target_is_system && !self.replay_system_txes && !self.debug_trace_transaction {
+            eyre::bail!(
+                "{:?} is a system transaction.\nReplaying system transactions is currently not supported.",
+                target.tx.tx_hash()
+            );
+        }
+        let Some(mut run) = self.prepare::<FEN>(config, evm_opts, target).await? else {
+            return Ok(());
+        };
+        let result = run.execute_ordinary()?;
+        run.finish(result).await
+    }
+
+    #[cfg(feature = "monad")]
+    async fn run_with_monad(self, config: Box<Config>, evm_opts: EvmOpts) -> Result<()> {
+        let target = self.fetch_target(&config).await?;
+        let Some(mut run) = self.prepare::<MonadEvmNetwork>(config, evm_opts, target).await? else {
+            return Ok(());
+        };
+        let result = run.execute_monad().await?;
+        run.finish(result).await
+    }
+
+    /// `AnyNetwork` rather than `FEN::Network`: chains such as Arbitrum, Celo and the OP-stack
+    /// forks Foundry does not route to a dedicated network put transaction types the strict
+    /// Ethereum envelope cannot decode into every block, which would fail the full block fetch in
+    /// `prepare` for the whole chain. Execution still uses `FEN`.
+    async fn fetch_target(&self, config: &Config) -> Result<TargetFetch> {
+        let compute_units_per_second = if self.rpc.common.no_rpc_rate_limit {
+            Some(u64::MAX)
+        } else {
+            self.rpc.common.compute_units_per_second
+        };
+        let provider = ProviderBuilder::<AnyNetwork>::from_config(config)?
+            .compute_units_per_second_opt(compute_units_per_second)
+            .build()?;
+        let tx_hash = self.tx_hash.parse().wrap_err("invalid tx hash")?;
+        let tx = provider
+            .get_transaction_by_hash(tx_hash)
+            .await
+            .wrap_err_with(|| format!("tx not found: {tx_hash:?}"))?
+            .ok_or_else(|| eyre::eyre!("tx not found: {tx_hash:?}"))?;
+        let target_is_system = is_known_system_sender(tx.from())
+            || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
+        Ok(TargetFetch { tx, provider, compute_units_per_second, target_is_system })
+    }
+
+    async fn prepare<FEN: FoundryEvmNetwork>(
         mut self,
         mut config: Box<Config>,
         evm_opts: EvmOpts,
-    ) -> Result<()> {
+        target: TargetFetch,
+    ) -> Result<Option<PreparedRun<FEN>>> {
+        #[cfg_attr(not(feature = "monad"), allow(unused_variables))]
+        let TargetFetch { tx, provider, compute_units_per_second, target_is_system } = target;
+        let tx_hash = tx.tx_hash();
         config.networks = evm_opts.networks;
         self.tracing.labels.append(&mut self.legacy_labels);
         config.tracing = self.resolve_tracing(&config.tracing, shell::verbosity());
         let tracing = config.tracing.clone();
 
         let with_local_artifacts = self.with_local_artifacts;
-        let debug = self.debug;
-        let compute_units_per_second = if self.rpc.common.no_rpc_rate_limit {
-            Some(u64::MAX)
-        } else {
-            self.rpc.common.compute_units_per_second
-        };
 
-        // `AnyNetwork` rather than `FEN::Network`: chains such as Arbitrum, Celo and the
-        // OP-stack forks Foundry does not route to a dedicated network put transaction types the
-        // strict Ethereum envelope cannot decode into every block, which would fail the full
-        // block fetch below for the whole chain. Execution still uses `FEN`.
-        let provider = ProviderBuilder::<AnyNetwork>::from_config(&config)?
-            .compute_units_per_second_opt(compute_units_per_second)
-            .build()?;
-
-        let tx_hash = self.tx_hash.parse().wrap_err("invalid tx hash")?;
         let endpoint_identity = if self.debug_trace_transaction {
             Some(evm_opts.discover_fork_endpoint().await?)
         } else {
             None
         };
-        let tx = provider
-            .get_transaction_by_hash(tx_hash)
-            .await
-            .wrap_err_with(|| format!("tx not found: {tx_hash:?}"))?
-            .ok_or_else(|| eyre::eyre!("tx not found: {:?}", tx_hash))?;
 
         // Fetch the trace from the node via `debug_traceTransaction` (callTracer) instead of
         // re-executing the transaction locally. The node already holds the transaction's exact
@@ -279,12 +353,14 @@ impl RunArgs {
             )?;
 
             let Some(transaction_block) = provider.get_block_by_hash(tx_block_hash).await? else {
-                return ensure_remote_transaction_inclusion(
+                // `actual: None` always errors; this call exists to reuse its error message.
+                ensure_remote_transaction_inclusion(
                     tx_hash,
                     tx_inclusion,
                     None,
                     "block fetched by hash",
-                );
+                )?;
+                unreachable!("ensure_remote_transaction_inclusion errors when actual is None");
             };
             ensure_remote_transaction_inclusion(
                 tx_hash,
@@ -377,20 +453,8 @@ impl RunArgs {
             )
             .await?;
 
-            return Ok(());
+            return Ok(None);
         }
-
-        let target_is_system = is_known_system_sender(tx.from())
-            || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
-        // Report an unsupported system transaction before decoding it: the envelopes a chain
-        // reserves for itself, such as Arbitrum's internal transaction, are exactly the ones this
-        // build may not be able to decode.
-        if target_is_system && !self.replay_system_txes && !evm_opts.networks.is_monad() {
-            return Err(eyre::eyre!(
-                "{tx_hash:?} is a system transaction.\nReplaying system transactions is currently not supported."
-            ));
-        }
-        let target_tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(&tx)?;
 
         let tx_block_number = tx
             .block_number()
@@ -457,24 +521,6 @@ impl RunArgs {
         );
         TracingExecutor::<FEN>::extend_precompile_labels(&mut config, networks, resolved_hardfork);
 
-        let block_context = if networks.is_monad() {
-            // `BlockContext` is typed to `FEN::Network`. Monad blocks only carry standard
-            // envelopes, so a typed provider can serve this path while the rest of the command
-            // stays on `AnyNetwork`.
-            let typed_provider = ProviderBuilder::<FEN::Network>::from_config(&config)?
-                .compute_units_per_second_opt(compute_units_per_second)
-                .build()?;
-            let block = typed_provider.get_block(tx_block_number.into()).full().await?.ok_or_else(
-                || {
-                    eyre::eyre!(
-                        "block {tx_block_number} is required to reconstruct transaction context"
-                    )
-                },
-            )?;
-            Some(BlockContext::<FEN>::fetch(&typed_provider, &block).await?)
-        } else {
-            None
-        };
         apply_chain_specific_tx_replay_env_changes_for_chain(&mut evm_env, chain.id());
 
         let mut executor = TracingExecutor::<FEN>::new(
@@ -529,216 +575,299 @@ impl RunArgs {
             }
         }
 
-        // Fall back to replaying previous transactions if prestate trace wasn't applied.
-        if !self.quick && !prestate_applied {
+        Ok(Some(PreparedRun {
+            args: self,
+            config,
+            tracing,
+            tx,
+            block,
+            evm_env,
+            executor,
+            chain,
+            networks,
+            resolved_hardfork,
+            verbosity,
+            prestate_applied,
+            #[cfg(feature = "monad")]
+            monad: MonadPrepared { target_is_system, tx_block_number, compute_units_per_second },
+        }))
+    }
+}
+
+impl<FEN: FoundryEvmNetwork> PreparedRun<FEN> {
+    fn enable_target_tracing(&mut self) {
+        let requirements = TraceRequirements::none()
+            .with_calls(true)
+            .with_debug(self.args.debug)
+            .with_decode_internal(if self.tracing.decode_internal {
+                InternalTraceMode::Full
+            } else {
+                InternalTraceMode::None
+            })
+            .with_state_changes(self.verbosity > 4);
+        self.executor.set_trace_requirements(requirements);
+        self.executor.set_trace_printer(self.args.trace_printer);
+    }
+
+    fn disable_balance_check_for_forged_sender(&mut self) {
+        let sender_is_forged = match &*self.tx.inner.inner {
+            AnyTxEnvelope::Ethereum(inner) => {
+                inner.recover_signer().is_ok_and(|signer| signer != self.tx.from())
+            }
+            AnyTxEnvelope::Unknown(_) => true,
+        };
+        if sender_is_forged {
+            self.evm_env.cfg_env.disable_balance_check = true;
+        }
+    }
+
+    fn execute_ordinary(&mut self) -> Result<TraceResult> {
+        // Decode the target transaction before replaying the block: an envelope this build
+        // can't decode should fail fast.
+        let target_tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(&self.tx)?;
+
+        if !self.args.quick && !self.prestate_applied {
             sh_status!("Executing previous transactions from the block.")?;
-
-            if let Some(block) = &block {
+            if let Some(block) = &self.block {
                 let pb = init_progress(block.transactions().len() as u64, "tx");
-                pb.set_position(0);
-
-                let BlockTransactions::Full(ref txs) = *block.transactions() else {
-                    return Err(eyre::eyre!("Could not get block txs"));
+                let BlockTransactions::Full(txs) = block.transactions() else {
+                    eyre::bail!("Could not get block txs");
                 };
-
                 for (index, tx) in txs.iter().enumerate() {
-                    if tx.tx_hash() == tx_hash {
+                    if tx.tx_hash() == self.tx.tx_hash() {
                         break;
                     }
-
                     let is_system = is_known_system_sender(tx.from())
                         || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
-                    // Classify before converting: a chain's own system envelopes are exactly the
-                    // ones this build may not be able to decode, and they are skipped below.
-                    if is_system && !self.replay_system_txes && !networks.is_monad() {
+                    if is_system && !self.args.replay_system_txes {
                         pb.set_position((index + 1) as u64);
                         continue;
                     }
                     let tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(tx)?;
-                    let chain_context = block_context.as_ref().map_or_else(
-                        || ChainFor::<FEN>::for_transaction(&tx_env),
-                        |context| context.transaction(index),
-                    );
-
-                    evm_env.cfg_env.disable_balance_check = true;
-
-                    if is_system {
-                        #[cfg(feature = "monad")]
-                        if executor
-                            .try_transact_system_replay_with_env_and_context(
-                                evm_env.clone(),
-                                tx_env.clone(),
-                                chain_context.clone(),
-                            )
-                            .wrap_err_with(|| {
-                                format!(
-                                    "Failed to replay system transaction: {:?} in block {}",
-                                    tx.tx_hash(),
-                                    evm_env.block_env.number()
-                                )
-                            })?
-                            .is_some()
-                        {
-                            trace!(tx=?tx.tx_hash(), "executed previous canonical system transaction");
-                            pb.set_position((index + 1) as u64);
-                            continue;
-                        }
-                        if !self.replay_system_txes {
-                            pb.set_position((index + 1) as u64);
-                            continue;
-                        }
-                    }
-
-                    if let Some(to) = Transaction::to(tx) {
-                        trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
-                        executor
-                            .transact_with_env_and_context(
-                                evm_env.clone(),
-                                tx_env.clone(),
-                                chain_context,
-                            )
-                            .wrap_err_with(|| {
-                                format!(
-                                    "Failed to execute transaction: {:?} in block {}",
-                                    tx.tx_hash(),
-                                    evm_env.block_env.number()
-                                )
-                            })?;
-                    } else {
-                        trace!(tx=?tx.tx_hash(), "executing previous create transaction");
-                        if let Err(error) = executor.deploy_with_env_and_context(
-                            evm_env.clone(),
-                            tx_env.clone(),
-                            chain_context,
-                            None,
-                        ) {
-                            match error {
-                                // Reverted transactions should be skipped
-                                EvmError::Execution(_) => (),
-                                error => {
-                                    return Err(error).wrap_err_with(|| {
-                                        format!(
-                                            "Failed to deploy transaction: {:?} in block {}",
-                                            tx.tx_hash(),
-                                            evm_env.block_env.number()
-                                        )
-                                    });
-                                }
-                            }
-                        }
-                    }
-
+                    self.evm_env.cfg_env.disable_balance_check = true;
+                    let chain_context = ChainFor::<FEN>::for_transaction(&tx_env);
+                    execute_previous_transaction(
+                        &mut self.executor,
+                        &self.evm_env,
+                        tx,
+                        tx_env,
+                        chain_context,
+                    )?;
                     pb.set_position((index + 1) as u64);
                 }
             }
         }
 
-        // Execute our transaction
-        let result = {
-            // Enable tracing only for the target transaction; the prefix replay above ran with
-            // tracing disabled.
-            let target_trace_requirements = TraceRequirements::none()
-                .with_calls(true)
-                .with_debug(self.debug)
-                .with_decode_internal(if tracing.decode_internal {
-                    InternalTraceMode::Full
-                } else {
-                    InternalTraceMode::None
-                })
-                .with_state_changes(verbosity > 4);
-            executor.set_trace_requirements(target_trace_requirements);
-            executor.set_trace_printer(self.trace_printer);
-
-            let tx_env = target_tx_env;
-            let target_index = if let Some(block) = &block {
-                let BlockTransactions::Full(transactions) = block.transactions() else {
-                    return Err(eyre::eyre!("Could not get block txs"));
-                };
-                transactions
-                    .iter()
-                    .position(|candidate| candidate.tx_hash() == tx_hash)
-                    .ok_or_else(|| {
-                        eyre::eyre!("transaction {tx_hash:?} is missing from its block")
-                    })?
-            } else {
-                0
+        if let Some(block) = &self.block {
+            let BlockTransactions::Full(txs) = block.transactions() else {
+                eyre::bail!("Could not get block txs");
             };
-            let chain_context = block_context.as_ref().map_or_else(
-                || ChainFor::<FEN>::for_transaction(&tx_env),
-                |context| context.transaction(target_index),
-            );
-
-            // A recovered signer that disagrees with the `from` the node reports marks a
-            // transaction the chain injected rather than one a key signed, such as a HyperCore
-            // credit. Envelopes this build cannot decode are in the same category.
-            let sender_is_forged = match &*tx.inner.inner {
-                AnyTxEnvelope::Ethereum(inner) => {
-                    inner.recover_signer().is_ok_and(|signer| signer != tx.from())
-                }
-                AnyTxEnvelope::Unknown(_) => true,
-            };
-            if sender_is_forged {
-                evm_env.cfg_env.disable_balance_check = true;
+            if !txs.iter().any(|candidate| candidate.tx_hash() == self.tx.tx_hash()) {
+                eyre::bail!("transaction {:?} is missing from its block", self.tx.tx_hash());
             }
+        }
 
-            #[cfg(feature = "monad")]
-            let replay_result = if target_is_system {
-                executor.try_transact_system_replay_with_env_and_context(
-                    evm_env.clone(),
-                    tx_env.clone(),
-                    chain_context.clone(),
-                )?
-            } else {
-                None
-            };
-            #[cfg(not(feature = "monad"))]
-            let replay_result: Option<foundry_evm::executors::RawCallResult<FEN>> = None;
+        self.enable_target_tracing();
+        self.disable_balance_check_for_forged_sender();
+        if let Some(to) = Transaction::to(&self.tx) {
+            trace!(tx=?self.tx.tx_hash(), ?to, "executing call transaction");
+            Ok(TraceResult::from(
+                self.executor.transact_with_env(self.evm_env.clone(), target_tx_env)?,
+            ))
+        } else {
+            trace!(tx=?self.tx.tx_hash(), "executing create transaction");
+            Ok(TraceResult::try_from(self.executor.deploy_with_env(
+                self.evm_env.clone(),
+                target_tx_env,
+                None,
+            ))?)
+        }
+    }
 
-            if let Some(result) = replay_result {
-                trace!(tx=?tx.tx_hash(), "executed canonical system transaction");
-                TraceResult::from(result)
-            } else {
-                if target_is_system && !self.replay_system_txes {
-                    return Err(eyre::eyre!(
-                        "{:?} is a system transaction.\nReplaying system transactions is currently not supported.",
-                        tx.tx_hash()
-                    ));
-                }
-
-                if let Some(to) = Transaction::to(&tx) {
-                    trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
-                    TraceResult::from(executor.transact_with_env_and_context(
-                        evm_env,
-                        tx_env,
-                        chain_context,
-                    )?)
-                } else {
-                    trace!(tx=?tx.tx_hash(), "executing create transaction");
-                    TraceResult::try_from(executor.deploy_with_env_and_context(
-                        evm_env,
-                        tx_env,
-                        chain_context,
-                        None,
-                    ))?
-                }
-            }
-        };
-
-        let contracts_bytecode = fetch_contracts_bytecode_from_trace(&executor, &result)?;
+    async fn finish(self, result: TraceResult) -> Result<()> {
+        let contracts_bytecode = fetch_contracts_bytecode_from_trace(&self.executor, &result)?;
         handle_traces(
             result,
-            &config,
-            chain,
+            &self.config,
+            self.chain,
             &contracts_bytecode,
-            &tracing,
-            with_local_artifacts,
-            debug,
-            resolved_hardfork,
-            networks,
+            &self.tracing,
+            self.args.with_local_artifacts,
+            self.args.debug,
+            self.resolved_hardfork,
+            self.networks,
         )
-        .await?;
+        .await
+    }
+}
 
-        Ok(())
+fn execute_previous_transaction<FEN: FoundryEvmNetwork>(
+    executor: &mut TracingExecutor<FEN>,
+    evm_env: &EvmEnvFor<FEN>,
+    tx: &AnyRpcTransaction,
+    tx_env: TxEnvFor<FEN>,
+    chain_context: ChainFor<FEN>,
+) -> Result<()> {
+    if let Some(to) = Transaction::to(tx) {
+        trace!(tx=?tx.tx_hash(), ?to, "executing previous call transaction");
+        executor
+            .transact_with_env_and_context(evm_env.clone(), tx_env, chain_context)
+            .wrap_err_with(|| {
+                format!(
+                    "Failed to execute transaction: {:?} in block {}",
+                    tx.tx_hash(),
+                    evm_env.block_env.number()
+                )
+            })?;
+    } else {
+        trace!(tx=?tx.tx_hash(), "executing previous create transaction");
+        if let Err(error) =
+            executor.deploy_with_env_and_context(evm_env.clone(), tx_env, chain_context, None)
+        {
+            match error {
+                EvmError::Execution(_) => (),
+                error => {
+                    return Err(error).wrap_err_with(|| {
+                        format!(
+                            "Failed to deploy transaction: {:?} in block {}",
+                            tx.tx_hash(),
+                            evm_env.block_env.number()
+                        )
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "monad")]
+impl PreparedRun<MonadEvmNetwork> {
+    async fn execute_monad(&mut self) -> Result<TraceResult> {
+        // `BlockContext` is typed to `MonadEvmNetwork::Network` (`Ethereum`). Monad blocks only
+        // carry standard envelopes, so a typed provider can serve this path while the rest of the
+        // command stays on `AnyNetwork`.
+        let provider = ProviderBuilder::<alloy_network::Ethereum>::from_config(&self.config)?
+            .compute_units_per_second_opt(self.monad.compute_units_per_second)
+            .build()?;
+        let block =
+            provider.get_block(self.monad.tx_block_number.into()).full().await?.ok_or_else(
+                || {
+                    eyre::eyre!(
+                        "block {} is required to reconstruct transaction context",
+                        self.monad.tx_block_number
+                    )
+                },
+            )?;
+        let block_context = BlockContext::fetch(&provider, &block).await?;
+        // Decode the target transaction before replaying the block: an envelope this build
+        // can't decode should fail fast, not after paying for the entire prior-transaction
+        // replay.
+        let target_tx_env = TxEnvFor::<MonadEvmNetwork>::from_any_rpc_transaction(&self.tx)?;
+
+        if !self.args.quick && !self.prestate_applied {
+            sh_status!("Executing previous transactions from the block.")?;
+            let Some(any_block) = &self.block else {
+                return self.execute_monad_target(&block_context, 0, target_tx_env);
+            };
+            let BlockTransactions::Full(txs) = any_block.transactions() else {
+                eyre::bail!("Could not get block txs");
+            };
+            let pb = init_progress(txs.len() as u64, "tx");
+            for (index, tx) in txs.iter().enumerate() {
+                if tx.tx_hash() == self.tx.tx_hash() {
+                    break;
+                }
+                let tx_env = TxEnvFor::<MonadEvmNetwork>::from_any_rpc_transaction(tx)?;
+                let chain_context = block_context.transaction(index);
+                self.evm_env.cfg_env.disable_balance_check = true;
+                let is_system = is_known_system_sender(tx.from())
+                    || tx.transaction_type() == Some(SYSTEM_TRANSACTION_TYPE);
+                if is_system
+                    && self
+                        .executor
+                        .try_transact_system_replay_with_env_and_context(
+                            self.evm_env.clone(),
+                            tx_env.clone(),
+                            chain_context.clone(),
+                        )
+                        .wrap_err_with(|| {
+                            format!(
+                                "Failed to replay system transaction: {:?} in block {}",
+                                tx.tx_hash(),
+                                self.evm_env.block_env.number()
+                            )
+                        })?
+                        .is_some()
+                {
+                    trace!(tx=?tx.tx_hash(), "executed previous canonical system transaction");
+                } else if !is_system || self.args.replay_system_txes {
+                    execute_previous_transaction(
+                        &mut self.executor,
+                        &self.evm_env,
+                        tx,
+                        tx_env,
+                        chain_context,
+                    )?;
+                }
+                pb.set_position((index + 1) as u64);
+            }
+        }
+
+        let target_index = if let Some(block) = &self.block {
+            let BlockTransactions::Full(txs) = block.transactions() else {
+                eyre::bail!("Could not get block txs");
+            };
+            txs.iter().position(|candidate| candidate.tx_hash() == self.tx.tx_hash()).ok_or_else(
+                || eyre::eyre!("transaction {:?} is missing from its block", self.tx.tx_hash()),
+            )?
+        } else {
+            0
+        };
+        self.execute_monad_target(&block_context, target_index, target_tx_env)
+    }
+
+    fn execute_monad_target(
+        &mut self,
+        block_context: &BlockContext<MonadEvmNetwork>,
+        index: usize,
+        tx_env: TxEnvFor<MonadEvmNetwork>,
+    ) -> Result<TraceResult> {
+        self.enable_target_tracing();
+        let chain_context = block_context.transaction(index);
+        self.disable_balance_check_for_forged_sender();
+        if self.monad.target_is_system
+            && let Some(result) = self.executor.try_transact_system_replay_with_env_and_context(
+                self.evm_env.clone(),
+                tx_env.clone(),
+                chain_context.clone(),
+            )?
+        {
+            trace!(tx=?self.tx.tx_hash(), "executed canonical system transaction");
+            return Ok(TraceResult::from(result));
+        }
+        if self.monad.target_is_system && !self.args.replay_system_txes {
+            eyre::bail!(
+                "{:?} is a system transaction.\nReplaying system transactions is currently not supported.",
+                self.tx.tx_hash()
+            );
+        }
+        if let Some(to) = Transaction::to(&self.tx) {
+            trace!(tx=?self.tx.tx_hash(), ?to, "executing call transaction");
+            Ok(TraceResult::from(self.executor.transact_with_env_and_context(
+                self.evm_env.clone(),
+                tx_env,
+                chain_context,
+            )?))
+        } else {
+            trace!(tx=?self.tx.tx_hash(), "executing create transaction");
+            Ok(TraceResult::try_from(self.executor.deploy_with_env_and_context(
+                self.evm_env.clone(),
+                tx_env,
+                chain_context,
+                None,
+            ))?)
+        }
     }
 }
 

--- a/crates/cast/tests/cli/remote_trace.rs
+++ b/crates/cast/tests/cli/remote_trace.rs
@@ -31,6 +31,9 @@ enum ResponseMutation {
     MissingTransactionBlock {
         block_hash: String,
     },
+    MissingTransactionFromFullBlock {
+        tx_hash: String,
+    },
     CanonicalBlockHash {
         block_number: String,
         replacement: String,
@@ -103,6 +106,21 @@ fn mutate_rpc_result(request: &Value, response: &mut Value, mutation: &ResponseM
         && requested_target.is_some_and(|target| target.eq_ignore_ascii_case(block_hash))
     {
         response["result"] = Value::Null;
+        return;
+    }
+
+    if let ResponseMutation::MissingTransactionFromFullBlock { tx_hash } = mutation
+        && method == "eth_getBlockByNumber"
+        && request.pointer("/params/1").and_then(Value::as_bool) == Some(true)
+        && let Some(transactions) =
+            response.pointer_mut("/result/transactions").and_then(Value::as_array_mut)
+    {
+        transactions.retain(|transaction| {
+            transaction
+                .get("hash")
+                .and_then(Value::as_str)
+                .is_none_or(|hash| !hash.eq_ignore_ascii_case(tx_hash))
+        });
         return;
     }
 
@@ -372,4 +390,25 @@ casttest!(cast_run_remote_trace_rejects_canonical_block_mismatch, async |_prj, c
         .stderr_lossy();
     assert!(output.contains("canonical block lookup reported block"), "{output}");
     assert!(output.contains("changed inclusion"), "{output}");
+});
+
+casttest!(cast_run_rejects_target_missing_from_replay_block, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let (tx_hash, _, _) = send_identity_transaction(&handle).await;
+    let (endpoint, _) = spawn_recording_rpc_proxy(
+        handle.http_endpoint(),
+        ResponseMutation::MissingTransactionFromFullBlock { tx_hash: tx_hash.to_string() },
+    )
+    .await;
+
+    let tx_hash = tx_hash.to_string();
+    let output = cmd
+        .args(["run", &tx_hash, "--rpc-url", &endpoint])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+    assert!(
+        output.contains(&format!("transaction {tx_hash} is missing from its block")),
+        "{output}"
+    );
 });


### PR DESCRIPTION
`cast run` currently mixes Monad block-context reconstruction and canonical system-transaction handling into its generic replay flow. This refactor separates shared target fetching, preparation, and trace rendering from execution, keeping ordinary replay on its existing transaction-derived context while moving Monad replay behind a concrete `MonadEvmNetwork` boundary.

The Monad path now owns its typed block-context fetch and system-transaction handling without adding generic policy abstractions. RPC decoding remains based on `AnyNetwork` for compatibility with non-standard transaction envelopes, and ordinary replay continues to reject inconsistent full-block responses that omit the target transaction.

AI assistance was used for the implementation, regression coverage, and PR text.
