### PR TITLE
fix(anvil): handle fractional fee percentiles

### DIFF
--- a/.changelog/anvil-fee-history-fractional-percentiles.md
+++ b/.changelog/anvil-fee-history-fractional-percentiles.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed `eth_feeHistory` rewards for fractional percentiles.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         fees::{
             FeeDetails, FeeHistoryCache, FeeHistoryCacheItem, MIN_SUGGESTED_PRIORITY_FEE,
-            create_fee_history_cache_item,
+            REWARD_PERCENTILE_RESOLUTION, create_fee_history_cache_item,
         },
         macros::node_info,
         miner::FixedBlockTimeMiner,
@@ -1384,11 +1384,8 @@ impl<N: Network> EthApi<N> {
                 // requested percentiles
                 if !reward_percentiles.is_empty() {
                     let mut block_rewards = Vec::new();
-                    let resolution_per_percentile: f64 = 2.0;
                     for p in &reward_percentiles {
-                        let index = ((p.round() / 2f64) * 2f64) * resolution_per_percentile;
-                        let reward = item.rewards.get(index as usize).map_or(0, |r| *r);
-                        block_rewards.push(reward);
+                        block_rewards.push(reward_at_percentile(&item.rewards, *p));
                     }
                     rewards.push(block_rewards);
                 }
@@ -5262,6 +5259,11 @@ fn merge_pre_fork_fee_history(
     response.blob_gas_used_ratio.resize(count, 0.0);
 }
 
+fn reward_at_percentile(rewards: &[u128], percentile: f64) -> u128 {
+    let index = (percentile * REWARD_PERCENTILE_RESOLUTION).round() as usize;
+    rewards.get(index).copied().unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5368,6 +5370,16 @@ mod tests {
         for percentiles in [vec![], vec![0.0, 100.0]] {
             api.fee_history(U256::from(1), BlockNumber::Latest, percentiles).await.unwrap();
         }
+    }
+
+    #[test]
+    fn fractional_reward_percentiles_use_cache_resolution() {
+        let rewards = (0..=200).collect::<Vec<_>>();
+
+        assert_eq!(reward_at_percentile(&rewards, 0.0), 0);
+        assert_eq!(reward_at_percentile(&rewards, 0.5), 1);
+        assert_eq!(reward_at_percentile(&rewards, 1.0), 2);
+        assert_eq!(reward_at_percentile(&rewards, 100.0), 200);
     }
 
     #[test]

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -23,6 +23,16 @@ use crate::eth::{
 /// Maximum number of entries in the fee history cache
 pub const MAX_FEE_HISTORY_CACHE_SIZE: u64 = 2048u64;
 
+/// Number of cached reward samples per percentile.
+pub(crate) const REWARD_PERCENTILE_RESOLUTION: f64 = 2.0;
+
+/// Percentile list from 0.0 to 100.0 with a 0.5 resolution (201 points).
+///
+/// Constant across blocks, so it is computed once instead of being rebuilt on every
+/// `create_fee_history_cache_item` call.
+static REWARD_PERCENTILES: LazyLock<Vec<f64>> =
+    LazyLock::new(|| (0..=200).map(|index| index as f64 / REWARD_PERCENTILE_RESOLUTION).collect());
+
 /// Initial base fee for EIP-1559 blocks.
 pub const INITIAL_BASE_FEE: u64 = 1_000_000_000;
 
@@ -383,21 +393,6 @@ pub(crate) fn insert_fee_history_cache_item(
         }
     }
 }
-
-/// Percentile list from 0.0 to 100.0 with a 0.5 resolution (201 points).
-///
-/// Constant across blocks, so it is computed once instead of being rebuilt on every
-/// `create_fee_history_cache_item` call.
-static REWARD_PERCENTILES: LazyLock<Vec<f64>> = LazyLock::new(|| {
-    let mut percentile: f64 = 0.0;
-    (0..=200)
-        .map(|_| {
-            let val = percentile;
-            percentile += 0.5;
-            val
-        })
-        .collect()
-});
 
 /// Calculates percentile rewards from transactions sorted by effective reward.
 ///


### PR DESCRIPTION
Anvil rounded `eth_feeHistory` reward percentiles to whole percentages before selecting from its 0.5%-resolution cache. This caused fractional requests such as `0.5` to return the reward for `1.0`. Use the cache resolution directly when mapping requested percentiles and share that resolution between cache generation and lookup.