### PR TITLE
fix(anvil): restore snapshot time offset

### DIFF
--- a/.changelog/anvil-revert-time-offset.md
+++ b/.changelog/anvil-revert-time-offset.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed `evm_revert` discarding time offsets captured by `evm_snapshot`.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -893,6 +893,7 @@ struct StateSnapshot {
     block_number: u64,
     block_hash: B256,
     fees: FeeSnapshot,
+    time_offset: i128,
 }
 
 /// Gives access to the [revm::Database]
@@ -1598,7 +1599,12 @@ impl<N: Network> Backend<N> {
         trace!(target: "backend", "creating snapshot {} at {}", id, num);
         self.active_state_snapshots.lock().insert(
             id,
-            StateSnapshot { block_number: num, block_hash: hash, fees: self.fees.snapshot() },
+            StateSnapshot {
+                block_number: num,
+                block_hash: hash,
+                fees: self.fees.snapshot(),
+                time_offset: self.time.offset(),
+            },
         );
         id
     }
@@ -4697,11 +4703,10 @@ impl<N: Network> Backend<N> {
 
     /// Reverts the state to the state snapshot identified by the given `id`.
     pub async fn revert_state_snapshot(&self, id: U256) -> Result<bool, BlockchainError> {
-        let Some((num, hash, fees)) = self
-            .active_state_snapshots
-            .lock()
-            .get(&id)
-            .map(|snapshot| (snapshot.block_number, snapshot.block_hash, snapshot.fees))
+        let Some((num, hash, fees, time_offset)) =
+            self.active_state_snapshots.lock().get(&id).map(|snapshot| {
+                (snapshot.block_number, snapshot.block_hash, snapshot.fees, snapshot.time_offset)
+            })
         else {
             return Ok(false);
         };
@@ -4718,7 +4723,7 @@ impl<N: Network> Backend<N> {
         self.blockchain.storage.write().unwind_to(num, hash);
 
         let reset_time = block.header.timestamp();
-        self.time.reset(reset_time);
+        self.time.reset_with_offset(reset_time, time_offset);
         // drop any pending next-block prevrandao override so it does not leak into a block
         self.cheats.clear_next_block_prevrandao();
 

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -56,22 +56,28 @@ impl TimeManager {
     /// Resets the current time manager to the given timestamp, resetting the offsets and
     /// next block timestamp option
     pub fn reset(&self, start_timestamp: u64) {
-        self.reset_timestamp(start_timestamp, true);
+        self.reset_timestamp(start_timestamp, true, None);
     }
 
     /// Sets the current timestamp without changing when the current head was installed.
     pub fn set_time(&self, timestamp: u64) {
-        self.reset_timestamp(timestamp, false);
+        self.reset_timestamp(timestamp, false, None);
     }
 
-    fn reset_timestamp(&self, start_timestamp: u64, mark_new_head: bool) {
+    /// Restores the timestamp and offset captured by a state snapshot.
+    pub(crate) fn reset_with_offset(&self, start_timestamp: u64, offset: i128) {
+        self.reset_timestamp(start_timestamp, true, Some(offset));
+    }
+
+    fn reset_timestamp(&self, start_timestamp: u64, mark_new_head: bool, offset: Option<i128>) {
         let current = duration_since_unix_epoch();
         let mut state = self.state.write();
         state.last_timestamp = start_timestamp;
         if mark_new_head {
             state.last_block_wall_time = current.as_millis().try_into().unwrap_or(u64::MAX);
         }
-        state.offset = (start_timestamp as i128) - current.as_secs() as i128;
+        state.offset =
+            offset.unwrap_or_else(|| (start_timestamp as i128) - current.as_secs() as i128);
         state.offset_reset_generation = state.offset_reset_generation.wrapping_add(1);
         state.next_exact_timestamp = None;
         state.next_override_generation = state.next_override_generation.wrapping_add(1);

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -765,6 +765,22 @@ async fn test_revert_invalidates_newer_snapshots() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_revert_restores_time_offset() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    let initial = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+
+    api.evm_increase_time(U256::from(100)).await.unwrap();
+    let snapshot = api.evm_snapshot().await.unwrap();
+    api.evm_increase_time(U256::from(200)).await.unwrap();
+    assert!(api.evm_revert(snapshot).await.unwrap());
+    api.mine_one().await.unwrap();
+
+    let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert!(block.header.timestamp >= initial.header.timestamp + 100);
+    assert!(block.header.timestamp < initial.header.timestamp + 200);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_revert_restores_next_block_base_fee() {
     let (api, _handle) = spawn(NodeConfig::test()).await;
     let base_fee = api.base_fee().unwrap();


### PR DESCRIPTION
Restores the time offset captured by `evm_snapshot` when `evm_revert` is called, preserving pre-snapshot time increases while discarding later changes.