### PR TITLE
fix(cheatcodes): guard vm.removeDir against deleting foundry.toml

### DIFF
--- a/.changelog/removedir-foundry-toml-guard.md
+++ b/.changelog/removedir-foundry-toml-guard.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+`vm.removeDir` now refuses to target `foundry.toml` (or a directory containing it), matching the existing protection on `vm.writeFile`, `vm.writeFileBinary`, `vm.writeLine`, `vm.copyFile`, and `vm.removeFile`.

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -288,6 +288,8 @@ impl Cheatcode for removeDirCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
         let Self { path, recursive } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
+        // deleting foundry.toml (or a directory containing it) is not allowed
+        state.config.ensure_not_foundry_toml(&path)?;
         if *recursive { fs::remove_dir_all(path) } else { fs::remove_dir(path) }?;
         Ok(Default::default())
     }

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -288,7 +288,6 @@ impl Cheatcode for removeDirCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
         let Self { path, recursive } = self;
         let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
-        // deleting foundry.toml (or a directory containing it) is not allowed
         state.config.ensure_not_foundry_toml(&path)?;
         if *recursive { fs::remove_dir_all(path) } else { fs::remove_dir(path) }?;
         Ok(Default::default())

--- a/testdata/default/cheats/Fs.t.sol
+++ b/testdata/default/cheats/Fs.t.sol
@@ -139,6 +139,19 @@ contract FsTest is Test {
         vm.writeFile("./Foundry.toml", "\nffi = true\n");
     }
 
+    function testRemoveDirFoundrytoml() public {
+        string memory root = vm.projectRoot();
+
+        vm._expectCheatcodeRevert();
+        vm.removeDir(root, true);
+
+        vm._expectCheatcodeRevert();
+        vm.removeDir(".", true);
+
+        vm._expectCheatcodeRevert();
+        vm.removeDir("./", true);
+    }
+
     function testReadDir() public {
         string memory path = "fixtures/Dir";
 


### PR DESCRIPTION
## Summary

`vm.removeDir(path, true)` is the one destructive filesystem cheatcode missing the `foundry.toml` guard its five siblings (`copyFile`, `writeFile`, `writeFileBinary`, `writeLine`, `removeFile`) already have.

```rust
impl Cheatcode for removeDirCall {
    fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
        let Self { path, recursive } = self;
        let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
        if *recursive { fs::remove_dir_all(path) } else { fs::remove_dir(path) }?;   // no ensure_not_foundry_toml
        Ok(Default::default())
    }
}
```

vs. `removeFile`, right above it:

```rust
impl Cheatcode for removeFileCall {
    fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
        let Self { path } = self;
        let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
        state.config.ensure_not_foundry_toml(&path)?;   // <- the missing call
        ...
```

Since `recursive: true` deletes the whole directory tree, this is the most destructive of the six write cheatcodes — and the only one left unguarded.

## Reproduction

Standalone project, `fs_permissions = [{ access = "read-write", path = "./" }]`. Real `forge test` output, unmodified `fs.rs`:

```
Ran 4 tests for test/RemoveDirRepro.t.sol:RemoveDirRepro
[FAIL: vm.removeDir: failed to remove dir ".../repro-project": Directory not empty (os error 66)] test_removeDir_recursive_deletes_foundry_toml()
[PASS] test_siblingGuardsHold_copyFile()
[FAIL: vm.removeFile: access to `foundry.toml` is not allowed] test_siblingGuardsHold_removeFile()
[FAIL: vm.writeFile: access to `foundry.toml` is not allowed] test_siblingGuardsHold_writeFile()
```

(`test_siblingGuardsHold_copyFile` "passing" is correct, unrelated behavior — the guard only checks `copyFile`'s destination, and that test copies *from* `foundry.toml` to an unrelated path, which is a safe read, not a write to `foundry.toml`.)

The first run above happened to target `removeDir(".", true)` — the CWD, which macOS/Linux itself refuses to unlink out from under the running process ("Directory not empty" is an OS quirk of deleting your own CWD, not the guard). Retargeting the exact same call at `vm.projectRoot()` (an absolute path, no CWD quirk) shows the real, unguarded behavior:

```
$ forge test --match-test test_removeDir_recursive_deletes_foundry_toml -vvv
[PASS] test_removeDir_recursive_deletes_foundry_toml() (gas: 4613)

$ ls -la repro-project/
ls: repro-project: No such file or directory
```

`foundry.toml`, `src/`, `test/`, and the unrelated `victim/` directory — the entire project — are gone. Confirmed genuine red-before/green-after: after applying the one-line fix and rebuilding, the identical call reverts with `access to \`foundry.toml\` is not allowed` (byte-identical message to the sibling cheatcodes), and the directory survives fully intact.

## Additional verification

- **Non-recursive arm** (`removeDir(path, false)`): the guard runs before the recursive/non-recursive branch, so both are covered. Confirmed live: `removeDir(projectRoot(), false)` now reverts with the same message; `removeDir("emptydir", false)` on an unrelated, non-foundry.toml-containing directory still succeeds — the guard doesn't false-positive on ordinary directory removal.
- **Swept the rest of the crate** for the same bug class: `createDir` also lacks the guard, but it's not the same defect — `fs::create_dir("foundry.toml", false)` against an existing `foundry.toml` fails at the OS level (`File exists`, confirmed live) before ever touching the file, so it can't destroy an existing config. No other cheatcode in `fs.rs` writes/deletes without either calling `ensure_not_foundry_toml` directly or (like `createDir`) being unable to clobber an existing file by construction.
- **Symlink/path-traversal escape**: not applicable to this fix specifically — `ensure_path_allowed` (which already runs, unchanged) canonicalizes via a real filesystem `canonicalize()` call before any permission check, so `removeDir` can't be used to escape the permitted roots regardless of this guard.

## Severity — read this before triaging

This is a **guard-consistency bug, not a sandbox escape**. `ensure_path_allowed` runs first and canonicalizes the path via a real filesystem `canonicalize()` call (confirmed by reading `CheatsConfig::normalized_path`), so `removeDir` cannot be used to escape the permitted roots even without this fix.

The realistic exposure requires write permission granted at-or-above `foundry.toml`'s directory — the default `fs_permissions` is empty. The exposure is the documented `path = "./"` + `read-write` pattern: under that (common) configuration, an untrusted dependency's test suite — or a buggy test of your own — can currently wipe the whole project, despite Foundry explicitly protecting `foundry.toml` from every *other* write cheatcode in the same configuration.

`ensure_not_foundry_toml` already returns an error both when the target path *is* `foundry.toml` and when it's an *ancestor directory containing it* (`Path::starts_with`), so one call covers both "delete the config file directly" and "delete a directory that contains it."

## Fix

One line, matching the five siblings exactly:

```rust
let path = state.config.ensure_path_allowed(path, FsAccessKind::Write)?;
state.config.ensure_not_foundry_toml(&path)?;
if *recursive { fs::remove_dir_all(path) } else { fs::remove_dir(path) }?;
```

## Testing

Added `testRemoveDirFoundrytoml` to `testdata/default/cheats/Fs.t.sol`, matching the existing `testWriteFoundrytoml`/`testWriteLineFoundrytoml` pattern.

**Honest caveat on that checked-in test**: this project's own `testdata/foundry.toml` scopes `fs_permissions` to `out/` and `fixtures/` only, not the project root — so `testRemoveDirFoundrytoml` (like its two siblings it's modeled on) is actually blocked by `ensure_path_allowed` before it ever reaches the new `ensure_not_foundry_toml` check. It's a safe, non-destructive regression test consistent with repo convention, but it doesn't *in isolation* prove this specific fix — the standalone repro above (a project with `fs_permissions: "./"`) is what isolates and proves the fix itself.

Full suite, real output (`--skip .vy` to exclude Vyper sources, which need a compiler this environment doesn't have installed; unrelated to this change):

```
$ forge test --match-contract FsTest --skip ".vy" --threads 1
Ran 16 tests for default/cheats/Fs.t.sol:FsTest
[PASS] testCloseFile() ... [PASS] testRemoveDirFoundrytoml() (gas: 6261) ... (16/16 pass)
```

One pre-existing, unrelated flake worth disclosing: with the default parallel thread pool (no `--threads 1`), `testReadDir` occasionally fails on an entry-count mismatch — it races against `testCreateRemoveDir` over the same shared `fixtures/Dir` fixture path. Confirmed this reproduces identically on unmodified upstream `fs.rs` (3 runs: FAIL, PASS, FAIL) — it's a pre-existing test-isolation issue in the shared fixture, unrelated to this change.

`cargo fmt --check` and `cargo clippy -p foundry-cheatcodes --lib` both clean on the changed crate.

## Provenance

`removeDir` was introduced in #4803 (Apr 2023) — the same PR that (re-)added `ensure_not_foundry_toml` to three other cheatcodes. It was overlooked at the exact moment the pattern was being established elsewhere in that diff.

## AI disclosure

This PR was written primarily by Claude Code, per [CONTRIBUTING.md](https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md#contributions-assisted-by-ai) — the fix, tests, and this description were AI-generated. Every claim above (the bug, the fix, the sibling-guard comparison, the non-recursive-arm coverage, the `createDir` ruled-out check, and the `testReadDir` flake) was independently verified against real `forge test`/`cargo` runs, not just reasoned about, before opening.
