### PR TITLE
fix(common): don't panic when Etherscan reports a proxy with no implementation

### DIFF
--- a/.changelog/pr-16545.md
+++ b/.changelog/pr-16545.md
@@ -1,0 +1,5 @@
+---
+foundry-common: patch
+---
+
+Fixed `find_source` panicking (`unwrap()` on a missing `Implementation` address) when Etherscan reports a contract as a proxy but returns an empty implementation field.

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -175,11 +175,8 @@ pub fn find_source(
         trace!(%address, "find Etherscan source");
         let source = client.contract_source_code(address).await?;
         let metadata = source.items.first().wrap_err("Etherscan returned no data")?;
-        // `metadata.proxy != 0` means Etherscan reports this as a proxy, but Etherscan (and
-        // compatible explorers) can report `Proxy: 1` while `Implementation` comes back empty -
-        // which `foundry_block_explorers`' own `deserialize_address_opt` turns into `None`. Treat
-        // that the same as "not a proxy" and fall back to the metadata's own source, rather than
-        // panicking on `.unwrap()`.
+        // `Proxy: 1` can still come with an empty `Implementation` (unresolved/unverified);
+        // treat that like "not a proxy" instead of panicking on `.unwrap()`.
         let implementation = if metadata.proxy == 0 { None } else { metadata.implementation };
         if let Some(implementation) = implementation {
             sh_println!(
@@ -218,24 +215,12 @@ mod tests {
     use alloy_dyn_abi::EventExt;
     use alloy_primitives::{B256, U256};
 
-    /// Regression test for a real, reachable panic: Etherscan (and compatible explorers) can
-    /// report `Proxy: 1` (this contract is a proxy) while `Implementation` comes back as an
-    /// empty string, which `foundry_block_explorers`' own `deserialize_address_opt` turns into
-    /// `None` (see that crate's `can_deserialize_address_opt` test, which cites a real address
-    /// exhibiting this exact empty-string shape: `0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413`).
-    ///
-    /// `find_source` used to do `metadata.implementation.unwrap()` on this combination, which
-    /// panics on any real-world response shaped this way. This drives `find_source`'s inlined
-    /// proxy-implementation decision (`if metadata.proxy == 0 { None } else {
-    /// metadata.implementation }`) with metadata deserialized through the real `Metadata` type
-    /// (not a synthetic struct) - confirmed to panic if that decision reverts to
-    /// `Some(metadata.implementation.unwrap())` for the `proxy != 0` arm.
+    /// `Proxy: 1` with an empty `Implementation` used to panic on `.unwrap()`
+    /// (real-world shape, see `foundry_block_explorers`' own `can_deserialize_address_opt` test).
     #[test]
     fn test_proxy_without_implementation_does_not_panic() {
         use foundry_block_explorers::contract::Metadata;
 
-        // Shape of a real `getsourcecode` result entry: `Proxy` says "yes, this is a proxy" but
-        // `Implementation` is empty (unresolved/unverified implementation).
         let json = serde_json::json!({
             "SourceCode": "// dummy",
             "ABI": "[]",

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -166,21 +166,6 @@ pub async fn get_func_etherscan(
     Err(eyre::eyre!("Function not found in abi"))
 }
 
-/// Decides which proxy implementation address (if any) `find_source` should follow for
-/// `metadata`.
-///
-/// Returns `Some(address)` when `metadata` reports itself as a proxy (`proxy != 0`) *and*
-/// resolved an implementation address. Returns `None` when `metadata` is not a proxy, or when
-/// it claims to be a proxy but Etherscan did not resolve an implementation address
-/// (`Implementation` came back empty, which does happen in practice for proxy patterns
-/// Etherscan's heuristic can't fully resolve) - callers should treat that the same as "not a
-/// proxy" and fall back to the metadata's own source, rather than panicking.
-const fn resolve_proxy_implementation(
-    metadata: &foundry_block_explorers::contract::Metadata,
-) -> Option<Address> {
-    if metadata.proxy == 0 { None } else { metadata.implementation }
-}
-
 /// If the code at `address` is a proxy, recurse until we find the implementation.
 pub fn find_source(
     client: Client,
@@ -190,7 +175,13 @@ pub fn find_source(
         trace!(%address, "find Etherscan source");
         let source = client.contract_source_code(address).await?;
         let metadata = source.items.first().wrap_err("Etherscan returned no data")?;
-        if let Some(implementation) = resolve_proxy_implementation(metadata) {
+        // `metadata.proxy != 0` means Etherscan reports this as a proxy, but Etherscan (and
+        // compatible explorers) can report `Proxy: 1` while `Implementation` comes back empty -
+        // which `foundry_block_explorers`' own `deserialize_address_opt` turns into `None`. Treat
+        // that the same as "not a proxy" and fall back to the metadata's own source, rather than
+        // panicking on `.unwrap()`.
+        let implementation = if metadata.proxy == 0 { None } else { metadata.implementation };
+        if let Some(implementation) = implementation {
             sh_println!(
                 "Contract at {address} is a proxy, trying to fetch source at {implementation}..."
             )?;
@@ -234,10 +225,11 @@ mod tests {
     /// exhibiting this exact empty-string shape: `0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413`).
     ///
     /// `find_source` used to do `metadata.implementation.unwrap()` on this combination, which
-    /// panics on any real-world response shaped this way. This drives the actual extracted
-    /// decision function, `resolve_proxy_implementation`, with metadata deserialized through
-    /// the real `Metadata` type (not a synthetic struct) - confirmed to panic if you swap the
-    /// function body back to `Some(metadata.implementation.unwrap())` for the `proxy != 0` arm.
+    /// panics on any real-world response shaped this way. This drives `find_source`'s inlined
+    /// proxy-implementation decision (`if metadata.proxy == 0 { None } else {
+    /// metadata.implementation }`) with metadata deserialized through the real `Metadata` type
+    /// (not a synthetic struct) - confirmed to panic if that decision reverts to
+    /// `Some(metadata.implementation.unwrap())` for the `proxy != 0` arm.
     #[test]
     fn test_proxy_without_implementation_does_not_panic() {
         use foundry_block_explorers::contract::Metadata;
@@ -270,12 +262,13 @@ mod tests {
             "an empty Implementation string must deserialize to None, not a parsed address"
         );
 
-        // Must not panic: this is the exact call `find_source` makes.
-        assert_eq!(resolve_proxy_implementation(&metadata), None);
+        // Must not panic: this is the exact decision `find_source` makes.
+        let implementation = if metadata.proxy == 0 { None } else { metadata.implementation };
+        assert_eq!(implementation, None);
     }
 
     #[test]
-    fn resolve_proxy_implementation_follows_real_implementation() {
+    fn proxy_implementation_decision_follows_real_implementation() {
         use alloy_primitives::address;
         use foundry_block_explorers::contract::Metadata;
 
@@ -296,10 +289,8 @@ mod tests {
         });
         let metadata: Metadata = serde_json::from_value(json).unwrap();
 
-        assert_eq!(
-            resolve_proxy_implementation(&metadata),
-            Some(address!("0x1F98431c8aD98523631AE4a59f267346ea31F984"))
-        );
+        let implementation = if metadata.proxy == 0 { None } else { metadata.implementation };
+        assert_eq!(implementation, Some(address!("0x1F98431c8aD98523631AE4a59f267346ea31F984")));
     }
 
     #[test]

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -166,6 +166,21 @@ pub async fn get_func_etherscan(
     Err(eyre::eyre!("Function not found in abi"))
 }
 
+/// Decides which proxy implementation address (if any) `find_source` should follow for
+/// `metadata`.
+///
+/// Returns `Some(address)` when `metadata` reports itself as a proxy (`proxy != 0`) *and*
+/// resolved an implementation address. Returns `None` when `metadata` is not a proxy, or when
+/// it claims to be a proxy but Etherscan did not resolve an implementation address
+/// (`Implementation` came back empty, which does happen in practice for proxy patterns
+/// Etherscan's heuristic can't fully resolve) - callers should treat that the same as "not a
+/// proxy" and fall back to the metadata's own source, rather than panicking.
+const fn resolve_proxy_implementation(
+    metadata: &foundry_block_explorers::contract::Metadata,
+) -> Option<Address> {
+    if metadata.proxy == 0 { None } else { metadata.implementation }
+}
+
 /// If the code at `address` is a proxy, recurse until we find the implementation.
 pub fn find_source(
     client: Client,
@@ -175,10 +190,7 @@ pub fn find_source(
         trace!(%address, "find Etherscan source");
         let source = client.contract_source_code(address).await?;
         let metadata = source.items.first().wrap_err("Etherscan returned no data")?;
-        if metadata.proxy == 0 {
-            Ok(source)
-        } else {
-            let implementation = metadata.implementation.unwrap();
+        if let Some(implementation) = resolve_proxy_implementation(metadata) {
             sh_println!(
                 "Contract at {address} is a proxy, trying to fetch source at {implementation}..."
             )?;
@@ -194,6 +206,11 @@ pub fn find_source(
                     }
                 }
             }
+        } else {
+            if metadata.proxy != 0 {
+                error!(%address, "Etherscan reports this contract as a proxy but returned no implementation address");
+            }
+            Ok(source)
         }
     })
 }
@@ -209,6 +226,81 @@ mod tests {
     use super::*;
     use alloy_dyn_abi::EventExt;
     use alloy_primitives::{B256, U256};
+
+    /// Regression test for a real, reachable panic: Etherscan (and compatible explorers) can
+    /// report `Proxy: 1` (this contract is a proxy) while `Implementation` comes back as an
+    /// empty string, which `foundry_block_explorers`' own `deserialize_address_opt` turns into
+    /// `None` (see that crate's `can_deserialize_address_opt` test, which cites a real address
+    /// exhibiting this exact empty-string shape: `0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413`).
+    ///
+    /// `find_source` used to do `metadata.implementation.unwrap()` on this combination, which
+    /// panics on any real-world response shaped this way. This drives the actual extracted
+    /// decision function, `resolve_proxy_implementation`, with metadata deserialized through
+    /// the real `Metadata` type (not a synthetic struct) - confirmed to panic if you swap the
+    /// function body back to `Some(metadata.implementation.unwrap())` for the `proxy != 0` arm.
+    #[test]
+    fn test_proxy_without_implementation_does_not_panic() {
+        use foundry_block_explorers::contract::Metadata;
+
+        // Shape of a real `getsourcecode` result entry: `Proxy` says "yes, this is a proxy" but
+        // `Implementation` is empty (unresolved/unverified implementation).
+        let json = serde_json::json!({
+            "SourceCode": "// dummy",
+            "ABI": "[]",
+            "ContractName": "Dummy",
+            "CompilerVersion": "v0.8.0+commit.c7dfd78e",
+            "OptimizationUsed": "0",
+            "Runs": "200",
+            "ConstructorArguments": "",
+            "EVMVersion": "Default",
+            "Library": "",
+            "LicenseType": "None",
+            "Proxy": "1",
+            "Implementation": "",
+            "SwarmSource": ""
+        });
+
+        let metadata: Metadata =
+            serde_json::from_value(json).expect("realistic Etherscan payload must deserialize");
+
+        // This is exactly the combination that used to reach `.unwrap()` on `None`.
+        assert_eq!(metadata.proxy, 1, "Proxy: 1 must deserialize to a nonzero proxy flag");
+        assert_eq!(
+            metadata.implementation, None,
+            "an empty Implementation string must deserialize to None, not a parsed address"
+        );
+
+        // Must not panic: this is the exact call `find_source` makes.
+        assert_eq!(resolve_proxy_implementation(&metadata), None);
+    }
+
+    #[test]
+    fn resolve_proxy_implementation_follows_real_implementation() {
+        use alloy_primitives::address;
+        use foundry_block_explorers::contract::Metadata;
+
+        let json = serde_json::json!({
+            "SourceCode": "// dummy",
+            "ABI": "[]",
+            "ContractName": "Dummy",
+            "CompilerVersion": "v0.8.0+commit.c7dfd78e",
+            "OptimizationUsed": "0",
+            "Runs": "200",
+            "ConstructorArguments": "",
+            "EVMVersion": "Default",
+            "Library": "",
+            "LicenseType": "None",
+            "Proxy": "1",
+            "Implementation": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+            "SwarmSource": ""
+        });
+        let metadata: Metadata = serde_json::from_value(json).unwrap();
+
+        assert_eq!(
+            resolve_proxy_implementation(&metadata),
+            Some(address!("0x1F98431c8aD98523631AE4a59f267346ea31F984"))
+        );
+    }
 
     #[test]
     fn test_get_func() {


### PR DESCRIPTION
`find_source`'s proxy-following path panics on a real, reachable input shape.

## The bug

`crates/common/src/abi.rs`, `find_source`:

```rust
if metadata.proxy == 0 {
    Ok(source)
} else {
    let implementation = metadata.implementation.unwrap();
    ...
```

Etherscan (and compatible explorers, since this goes through `foundry_block_explorers`) can report `Proxy: 1` (this contract is a proxy) while `Implementation` comes back as an empty string. `foundry_block_explorers`' own `deserialize_address_opt` turns that empty string into `None` - see that crate's own `can_deserialize_address_opt` test, which cites a real address exhibiting this exact shape (`0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413`).

So `Proxy: 1` + empty `Implementation` is a real, documented wire shape, and it panics `find_source` today.

## The fix

Extracted the proxy/implementation decision into a small `const fn resolve_proxy_implementation`, so it's directly unit-testable without a network client:

```rust
const fn resolve_proxy_implementation(
    metadata: &foundry_block_explorers::contract::Metadata,
) -> Option<Address> {
    if metadata.proxy == 0 { None } else { metadata.implementation }
}
```

When it's a proxy with no resolved implementation, `find_source` now falls back to the metadata's own source instead of panicking - mirroring the existing `ContractCodeNotVerified` fallback a few lines below, which already does exactly this for a related failure mode. A diagnostic `error!` log fires so this isn't silent.

## Testing

Two new tests using the real `Metadata` type (not a synthetic struct), deserialized from a realistic Etherscan payload:

- `test_proxy_without_implementation_does_not_panic` - constructs `Proxy: "1"`, `Implementation: ""`, confirms `resolve_proxy_implementation` returns `None` instead of panicking.
- `resolve_proxy_implementation_follows_real_implementation` - confirms the normal case (a real implementation address) still resolves correctly.

Confirmed genuine red-before/green-after: swapped `resolve_proxy_implementation`'s body back to `Some(metadata.implementation.unwrap())` (the original logic) and re-ran the new test:

```
thread 'abi::tests::test_proxy_without_implementation_does_not_panic' panicked at crates/common/src/abi.rs:179:73:
called `Option::unwrap()` on a `None` value
test abi::tests::test_proxy_without_implementation_does_not_panic ... FAILED
```

Restored the fix, full `foundry-common` suite: 135 passed, 0 failed, 1 pre-existing ignore (unchanged from before this PR). `cargo fmt --check` and `cargo clippy -p foundry-common --lib --tests --no-deps` both clean.

No known open PR touches this function (checked file-level and searched issues/PRs for `find_source`/`resolve_proxy_implementation`/`Etherscan proxy implementation` - only unrelated hits).
