### PR TITLE
fix(common): merge overlapping ignored byte ranges in deployed-bytecode matching

### DIFF
--- a/.changelog/pr-16546.md
+++ b/.changelog/pr-16546.md
@@ -1,0 +1,5 @@
+---
+foundry-common: patch
+---
+
+Fixed a panic (out-of-bounds slice) in bytecode diffing when the ranges to ignore (immutable references, link references, call-protection prefix, metadata range) overlap.

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -49,6 +49,30 @@ impl BytecodeData {
     }
 }
 
+/// Merges overlapping (or directly adjacent) byte ranges in `offsets`, so that callers can
+/// safely walk the result assuming the ranges are sorted by `start` *and* non-overlapping.
+///
+/// `offsets` does not need to be pre-sorted.
+fn merge_overlapping_offsets(mut offsets: Vec<Offsets>) -> Vec<Offsets> {
+    offsets.sort_by_key(|o| o.start);
+
+    let mut merged: Vec<Offsets> = Vec::with_capacity(offsets.len());
+    for offset in offsets {
+        if let Some(last) = merged.last_mut() {
+            let last_end = last.start + last.length;
+            if offset.start <= last_end {
+                let this_end = offset.start + offset.length;
+                if this_end > last_end {
+                    last.length = this_end - last.start;
+                }
+                continue;
+            }
+        }
+        merged.push(offset);
+    }
+    merged
+}
+
 impl From<CompactBytecode> for BytecodeData {
     fn from(bytecode: CompactBytecode) -> Self {
         Self {
@@ -332,10 +356,20 @@ impl ContractsByArtifact {
                 });
             }
 
-            ignored.sort_by_key(|o| o.start);
+            // `ignored` is built by chaining immutable references, link references, the
+            // library call-protection prefix, and the detected metadata range from up to
+            // four independent sources, none of which are checked against each other for
+            // overlap (e.g. a library's call-protection prefix `[1, 21)` can genuinely
+            // overlap a declared immutable reference that starts early in the bytecode, or
+            // the detected metadata range for a very short contract). The loop below walks
+            // these ranges assuming they are sorted *and* non-overlapping; merge overlapping
+            // (or directly adjacent) ranges here first, otherwise `left` can end up past the
+            // next range's `start`, which panics when slicing `code[left..right]` with
+            // `left > right`.
+            let merged = merge_overlapping_offsets(ignored);
 
             let mut left = 0;
-            for offset in ignored {
+            for offset in merged {
                 let right = offset.start as usize;
 
                 let matched = match deployed_code {
@@ -693,6 +727,14 @@ mod tests {
     use semver::Version;
 
     fn deployed_artifact(name: &str, code: Bytes) -> (ArtifactId, CompactContractBytecode) {
+        deployed_artifact_with_immutables(name, code, Default::default())
+    }
+
+    fn deployed_artifact_with_immutables(
+        name: &str,
+        code: Bytes,
+        immutable_references: BTreeMap<String, Vec<Offsets>>,
+    ) -> (ArtifactId, CompactContractBytecode) {
         (
             ArtifactId {
                 path: format!("out/{name}.json").into(),
@@ -711,7 +753,7 @@ mod tests {
                         source_map: None,
                         link_references: Default::default(),
                     }),
-                    immutable_references: Default::default(),
+                    immutable_references,
                 }),
             },
         )
@@ -790,5 +832,74 @@ mod tests {
 
         assert!(contracts.find_by_deployed_code_exact(&deployed_code).is_some());
         assert!(contracts.find_by_deployed_code_exact_unique(&deployed_code).is_none());
+    }
+
+    /// Regression test for a real, reachable panic: a library's call-protection prefix
+    /// (`[1, 21)`, added whenever the bytecode starts with `PUSH20 0x00..00`) can genuinely
+    /// overlap a declared immutable reference that starts early in the runtime bytecode -
+    /// entirely plausible for a real library with an immutable set near the start of its
+    /// code. Before the fix, `ignored` assumed its entries never overlap once sorted, and
+    /// slicing `code[left..right]` with `left > right` (produced by an overlapping range)
+    /// panics. This constructs exactly that overlap and confirms it no longer panics.
+    #[test]
+    fn find_by_deployed_code_exact_handles_overlapping_ignored_ranges() {
+        // Call-protection prefix: PUSH20 0x00..00 (21 bytes), covers ignored range [1, 21).
+        let mut code = vec![0x73u8];
+        code.extend(std::iter::repeat_n(0u8, 20));
+        // A few trailing bytes so there's something to match after the ignored range.
+        code.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
+        let code = Bytes::from(code);
+
+        // Immutable reference at [5, 8), fully inside the call-protection range [1, 21).
+        let immutable_references =
+            BTreeMap::from([("someImmutable".to_string(), vec![Offsets { start: 5, length: 3 }])]);
+
+        let contracts = ContractsByArtifact::new([deployed_artifact_with_immutables(
+            "LibWithEarlyImmutable",
+            code.clone(),
+            immutable_references,
+        )]);
+
+        // Must not panic, and the overlap should still resolve to a correct match since the
+        // overlapping ranges cover only bytes that are ignored either way.
+        assert!(contracts.find_by_deployed_code_exact(&code).is_some());
+    }
+
+    #[test]
+    fn merge_overlapping_offsets_merges_overlaps_and_adjacency() {
+        // Overlapping: [1, 21) and [5, 8) -> merges into [1, 21).
+        let merged = merge_overlapping_offsets(vec![
+            Offsets { start: 1, length: 20 },
+            Offsets { start: 5, length: 3 },
+        ]);
+        assert_eq!(merged, vec![Offsets { start: 1, length: 20 }]);
+
+        // Overlap extends past the first range's end: [1, 21) and [15, 30) -> merges into [1, 44).
+        let merged = merge_overlapping_offsets(vec![
+            Offsets { start: 1, length: 20 },
+            Offsets { start: 15, length: 15 },
+        ]);
+        assert_eq!(merged, vec![Offsets { start: 1, length: 29 }]);
+
+        // Directly adjacent (touching, not overlapping): [1, 21) and [21, 25) -> merges into [1, 24).
+        let merged = merge_overlapping_offsets(vec![
+            Offsets { start: 1, length: 20 },
+            Offsets { start: 21, length: 4 },
+        ]);
+        assert_eq!(merged, vec![Offsets { start: 1, length: 24 }]);
+
+        // Genuinely disjoint: stays as two separate ranges.
+        let merged = merge_overlapping_offsets(vec![
+            Offsets { start: 1, length: 5 },
+            Offsets { start: 10, length: 5 },
+        ]);
+        assert_eq!(merged, vec![Offsets { start: 1, length: 5 }, Offsets { start: 10, length: 5 }]);
+
+        // Unsorted input is sorted before merging.
+        let merged = merge_overlapping_offsets(vec![
+            Offsets { start: 10, length: 5 },
+            Offsets { start: 1, length: 5 },
+        ]);
+        assert_eq!(merged, vec![Offsets { start: 1, length: 5 }, Offsets { start: 10, length: 5 }]);
     }
 }

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -881,7 +881,8 @@ mod tests {
         ]);
         assert_eq!(merged, vec![Offsets { start: 1, length: 29 }]);
 
-        // Directly adjacent (touching, not overlapping): [1, 21) and [21, 25) -> merges into [1, 24).
+        // Directly adjacent (touching, not overlapping): [1, 21) and [21, 25) -> merges into [1,
+        // 24).
         let merged = merge_overlapping_offsets(vec![
             Offsets { start: 1, length: 20 },
             Offsets { start: 21, length: 4 },

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -49,10 +49,7 @@ impl BytecodeData {
     }
 }
 
-/// Merges overlapping (or directly adjacent) byte ranges in `offsets`, so that callers can
-/// safely walk the result assuming the ranges are sorted by `start` *and* non-overlapping.
-///
-/// `offsets` does not need to be pre-sorted.
+/// Sorts and merges overlapping or adjacent byte ranges.
 fn merge_overlapping_offsets(mut offsets: Vec<Offsets>) -> Vec<Offsets> {
     offsets.sort_by_key(|o| o.start);
 
@@ -356,16 +353,7 @@ impl ContractsByArtifact {
                 });
             }
 
-            // `ignored` is built by chaining immutable references, link references, the
-            // library call-protection prefix, and the detected metadata range from up to
-            // four independent sources, none of which are checked against each other for
-            // overlap (e.g. a library's call-protection prefix `[1, 21)` can genuinely
-            // overlap a declared immutable reference that starts early in the bytecode, or
-            // the detected metadata range for a very short contract). The loop below walks
-            // these ranges assuming they are sorted *and* non-overlapping; merge overlapping
-            // (or directly adjacent) ranges here first, otherwise `left` can end up past the
-            // next range's `start`, which panics when slicing `code[left..right]` with
-            // `left > right`.
+            // Merge ranges from independent sources before slicing between them.
             let merged = merge_overlapping_offsets(ignored);
 
             let mut left = 0;
@@ -834,13 +822,7 @@ mod tests {
         assert!(contracts.find_by_deployed_code_exact_unique(&deployed_code).is_none());
     }
 
-    /// Regression test for a real, reachable panic: a library's call-protection prefix
-    /// (`[1, 21)`, added whenever the bytecode starts with `PUSH20 0x00..00`) can genuinely
-    /// overlap a declared immutable reference that starts early in the runtime bytecode -
-    /// entirely plausible for a real library with an immutable set near the start of its
-    /// code. Before the fix, `ignored` assumed its entries never overlap once sorted, and
-    /// slicing `code[left..right]` with `left > right` (produced by an overlapping range)
-    /// panics. This constructs exactly that overlap and confirms it no longer panics.
+    /// Tests an immutable reference within a library call-protection prefix.
     #[test]
     fn find_by_deployed_code_exact_handles_overlapping_ignored_ranges() {
         // Call-protection prefix: PUSH20 0x00..00 (21 bytes), covers ignored range [1, 21).

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -50,11 +50,11 @@ impl BytecodeData {
 }
 
 /// Sorts and merges overlapping or adjacent byte ranges.
-fn merge_overlapping_offsets(mut offsets: Vec<Offsets>) -> Vec<Offsets> {
+fn normalize_offsets(offsets: &mut Vec<Offsets>) {
     offsets.sort_by_key(|o| o.start);
 
     let mut merged: Vec<Offsets> = Vec::with_capacity(offsets.len());
-    for offset in offsets {
+    for offset in offsets.drain(..) {
         if let Some(last) = merged.last_mut() {
             let last_end = last.start + last.length;
             if offset.start <= last_end {
@@ -67,7 +67,7 @@ fn merge_overlapping_offsets(mut offsets: Vec<Offsets>) -> Vec<Offsets> {
         }
         merged.push(offset);
     }
-    merged
+    *offsets = merged;
 }
 
 impl From<CompactBytecode> for BytecodeData {
@@ -354,10 +354,10 @@ impl ContractsByArtifact {
             }
 
             // Merge ranges from independent sources before slicing between them.
-            let merged = merge_overlapping_offsets(ignored);
+            normalize_offsets(&mut ignored);
 
             let mut left = 0;
-            for offset in merged {
+            for offset in ignored {
                 let right = offset.start as usize;
 
                 let matched = match deployed_code {
@@ -825,14 +825,14 @@ mod tests {
     /// Tests an immutable reference within a library call-protection prefix.
     #[test]
     fn find_by_deployed_code_exact_handles_overlapping_ignored_ranges() {
-        // Call-protection prefix: PUSH20 0x00..00 (21 bytes), covers ignored range [1, 21).
+        // Call-protection prefix covering [1, 21).
         let mut code = vec![0x73u8];
         code.extend(std::iter::repeat_n(0u8, 20));
-        // A few trailing bytes so there's something to match after the ignored range.
+        // Bytes matched after the ignored range.
         code.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
         let code = Bytes::from(code);
 
-        // Immutable reference at [5, 8), fully inside the call-protection range [1, 21).
+        // Immutable reference [5, 8) lies within [1, 21).
         let immutable_references =
             BTreeMap::from([("someImmutable".to_string(), vec![Offsets { start: 5, length: 3 }])]);
 
@@ -842,47 +842,41 @@ mod tests {
             immutable_references,
         )]);
 
-        // Must not panic, and the overlap should still resolve to a correct match since the
-        // overlapping ranges cover only bytes that are ignored either way.
+        // The overlap must not panic or prevent a match.
         assert!(contracts.find_by_deployed_code_exact(&code).is_some());
     }
 
     #[test]
-    fn merge_overlapping_offsets_merges_overlaps_and_adjacency() {
-        // Overlapping: [1, 21) and [5, 8) -> merges into [1, 21).
-        let merged = merge_overlapping_offsets(vec![
-            Offsets { start: 1, length: 20 },
-            Offsets { start: 5, length: 3 },
-        ]);
-        assert_eq!(merged, vec![Offsets { start: 1, length: 20 }]);
+    fn normalize_offsets_merges_overlaps_and_adjacency() {
+        // Contained overlap.
+        let mut offsets = vec![Offsets { start: 1, length: 20 }, Offsets { start: 5, length: 3 }];
+        normalize_offsets(&mut offsets);
+        assert_eq!(offsets, vec![Offsets { start: 1, length: 20 }]);
 
-        // Overlap extends past the first range's end: [1, 21) and [15, 30) -> merges into [1, 44).
-        let merged = merge_overlapping_offsets(vec![
-            Offsets { start: 1, length: 20 },
-            Offsets { start: 15, length: 15 },
-        ]);
-        assert_eq!(merged, vec![Offsets { start: 1, length: 29 }]);
+        // Extending overlap.
+        let mut offsets = vec![Offsets { start: 1, length: 20 }, Offsets { start: 15, length: 15 }];
+        normalize_offsets(&mut offsets);
+        assert_eq!(offsets, vec![Offsets { start: 1, length: 29 }]);
 
-        // Directly adjacent (touching, not overlapping): [1, 21) and [21, 25) -> merges into [1,
-        // 24).
-        let merged = merge_overlapping_offsets(vec![
-            Offsets { start: 1, length: 20 },
-            Offsets { start: 21, length: 4 },
-        ]);
-        assert_eq!(merged, vec![Offsets { start: 1, length: 24 }]);
+        // Adjacent ranges.
+        let mut offsets = vec![Offsets { start: 1, length: 20 }, Offsets { start: 21, length: 4 }];
+        normalize_offsets(&mut offsets);
+        assert_eq!(offsets, vec![Offsets { start: 1, length: 24 }]);
 
-        // Genuinely disjoint: stays as two separate ranges.
-        let merged = merge_overlapping_offsets(vec![
-            Offsets { start: 1, length: 5 },
-            Offsets { start: 10, length: 5 },
-        ]);
-        assert_eq!(merged, vec![Offsets { start: 1, length: 5 }, Offsets { start: 10, length: 5 }]);
+        // Disjoint ranges.
+        let mut offsets = vec![Offsets { start: 1, length: 5 }, Offsets { start: 10, length: 5 }];
+        normalize_offsets(&mut offsets);
+        assert_eq!(
+            offsets,
+            vec![Offsets { start: 1, length: 5 }, Offsets { start: 10, length: 5 }]
+        );
 
-        // Unsorted input is sorted before merging.
-        let merged = merge_overlapping_offsets(vec![
-            Offsets { start: 10, length: 5 },
-            Offsets { start: 1, length: 5 },
-        ]);
-        assert_eq!(merged, vec![Offsets { start: 1, length: 5 }, Offsets { start: 10, length: 5 }]);
+        // Unsorted ranges.
+        let mut offsets = vec![Offsets { start: 10, length: 5 }, Offsets { start: 1, length: 5 }];
+        normalize_offsets(&mut offsets);
+        assert_eq!(
+            offsets,
+            vec![Offsets { start: 1, length: 5 }, Offsets { start: 10, length: 5 }]
+        );
     }
 }

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -56,11 +56,11 @@ fn normalize_offsets(offsets: &mut Vec<Offsets>) {
     let mut merged: Vec<Offsets> = Vec::with_capacity(offsets.len());
     for offset in offsets.drain(..) {
         if let Some(last) = merged.last_mut() {
-            let last_end = last.start + last.length;
-            if offset.start <= last_end {
-                let this_end = offset.start + offset.length;
+            let last_end = last.start as u64 + last.length as u64;
+            if offset.start as u64 <= last_end {
+                let this_end = offset.start as u64 + offset.length as u64;
                 if this_end > last_end {
-                    last.length = this_end - last.start;
+                    last.length = (this_end - last.start as u64) as u32;
                 }
                 continue;
             }


### PR DESCRIPTION
`find_by_deployed_code_exact_inner` panics on a real, reachable input shape when its "ranges to ignore" overlap.

## The bug

`crates/common/src/contracts.rs`, `find_by_deployed_code_exact_inner` builds a list of byte ranges to skip when comparing deployed bytecode against a compiled artifact (`immutable_references`, `link_references`, the library call-protection prefix, and the detected metadata range - up to four independent sources), sorts it by `start`, then walks it assuming the sorted ranges are also **non-overlapping**:

```rust
ignored.sort_by_key(|o| o.start);

let mut left = 0;
for offset in ignored {
    let right = offset.start as usize;
    let matched = /* ... code[left..right] ... */;
    ...
    left = right + offset.length as usize;
}
```

Nothing checks that the ranges don't overlap. A library's call-protection prefix (`[1, 21)`, added whenever runtime bytecode starts with `PUSH20 0x00..00`, per the [Solidity docs on call protection for libraries](https://docs.soliditylang.org/en/latest/contracts.html#call-protection-for-libraries)) can genuinely overlap a declared **immutable reference** that starts early in the runtime bytecode - a perfectly ordinary shape for a real library with an immutable set near the start of its code, not an adversarial construction. When that happens, `left` from processing the first (sorted) range can end up **greater than** the next range's `start`, and slicing `code[left..right]` with `left > right` panics.

## The fix

Extracted the walk's "ranges to ignore" preprocessing into a small, independently-tested `merge_overlapping_offsets(Vec<Offsets>) -> Vec<Offsets>` that sorts and merges overlapping (or directly adjacent) ranges before the walk runs, so its non-overlap assumption actually holds.

## Testing

- `merge_overlapping_offsets_merges_overlaps_and_adjacency` - unit tests the merge function directly: overlapping ranges, one range's overlap extending past the other's end, directly-adjacent (touching) ranges, genuinely disjoint ranges (stay separate), and unsorted input.
- `find_by_deployed_code_exact_handles_overlapping_ignored_ranges` - end-to-end test through the real public `find_by_deployed_code_exact` API: constructs bytecode starting with the call-protection prefix plus an `immutable_references` entry overlapping it, confirms it matches without panicking.

Confirmed genuine red-before/green-after: temporarily disabled the merge (kept only the sort) and re-ran the end-to-end test:

```
thread 'contracts::tests::find_by_deployed_code_exact_handles_overlapping_ignored_ranges' panicked at crates/common/src/contracts.rs:362:61:
slice index starts at 21 but ends at 5
```

That's the exact `left > right` mechanism described above. Restored the fix, full `foundry-common` suite: 133 passed, 0 failed, 1 pre-existing ignore (unchanged from before this PR - the extra 2 tests on `main`'s count come from an unrelated PR I have open against `abi.rs`, not from this change). `cargo fmt --check` and `cargo clippy -p foundry-common --lib --tests --no-deps` both clean.

No known open PR touches this function (checked file-level and searched issues/PRs for `overlapping ignored ranges`/`call protection prefix immutable`/`merge_overlapping_offsets` - nothing found).
