### PR TITLE
fix(anvil): index pending transactions

### DIFF
--- a/.changelog/anvil-pending-transaction-index.md
+++ b/.changelog/anvil-pending-transaction-index.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed indexed transaction lookups for the pending block.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1116,18 +1116,6 @@ impl<N: Network> EthApi<N> {
         self.backend.transaction_by_block_hash_and_index(hash, index).await
     }
 
-    /// Returns transaction by given block number and index.
-    ///
-    /// Handler for ETH RPC call: `eth_getTransactionByBlockNumberAndIndex`
-    pub async fn transaction_by_block_number_and_index(
-        &self,
-        block: BlockNumber,
-        idx: Index,
-    ) -> Result<Option<AnyRpcTransaction>> {
-        node_info!("eth_getTransactionByBlockNumberAndIndex");
-        self.backend.transaction_by_block_number_and_index(block, idx).await
-    }
-
     /// Returns an uncles at given block and index.
     ///
     /// Handler for ETH RPC call: `eth_getUncleByBlockHashAndIndex`
@@ -1580,6 +1568,25 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> EthApi<N> {
 // == impl EthApi anvil endpoints ==
 
 impl EthApi<FoundryNetwork> {
+    /// Returns transaction by given block number and index.
+    ///
+    /// Handler for ETH RPC call: `eth_getTransactionByBlockNumberAndIndex`
+    pub async fn transaction_by_block_number_and_index(
+        &self,
+        block: BlockNumber,
+        idx: Index,
+    ) -> Result<Option<AnyRpcTransaction>> {
+        node_info!("eth_getTransactionByBlockNumberAndIndex");
+        if block == BlockNumber::Pending {
+            return Ok(self.pending_block_full().await.and_then(|block| {
+                let WithOtherFields { inner: block, .. } = block.0;
+                block.transactions.into_transactions().nth(idx.into())
+            }));
+        }
+
+        self.backend.transaction_by_block_number_and_index(block, idx).await
+    }
+
     /// Create a buffer that represents all state on the chain, which can be loaded to separate
     /// process by calling `anvil_loadState`
     ///
@@ -3855,7 +3862,7 @@ impl EthApi<FoundryNetwork> {
         index: Index,
     ) -> Result<Option<Bytes>> {
         node_info!("eth_getRawTransactionByBlockNumberAndIndex");
-        match self.backend.transaction_by_block_number_and_index(block_number, index).await? {
+        match self.transaction_by_block_number_and_index(block_number, index).await? {
             Some(tx) => self.inner_raw_transaction(tx.tx_hash()).await,
             None => Ok(None),
         }

--- a/crates/anvil/tests/it/block_index.rs
+++ b/crates/anvil/tests/it/block_index.rs
@@ -108,6 +108,54 @@ async fn raw_transaction_by_block_and_index_matches_by_hash() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn pending_transaction_by_block_number_and_index() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let wallet = handle.dev_wallets().next().unwrap();
+    let sender = wallet.address();
+    let signer: EthereumWallet = wallet.into();
+    let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let pending = provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .with_from(sender)
+                .with_to(Address::repeat_byte(0x11))
+                .with_value(U256::from(1)),
+        ))
+        .await
+        .unwrap()
+        .register()
+        .await
+        .unwrap();
+    let tx_hash = *pending.tx_hash();
+
+    let tx: Option<Value> = provider
+        .client()
+        .request(
+            "eth_getTransactionByBlockNumberAndIndex",
+            (BlockNumberOrTag::Pending, Index::from(0)),
+        )
+        .await
+        .unwrap();
+    let tx = tx.expect("expected a pending transaction at index 0");
+    assert_eq!(tx["hash"].as_str().unwrap().parse::<B256>().unwrap(), tx_hash);
+
+    let expected: Option<Bytes> =
+        provider.client().request("eth_getRawTransactionByHash", (tx_hash,)).await.unwrap();
+    let expected = expected.expect("expected a raw pending transaction");
+    let raw: Option<Bytes> = provider
+        .client()
+        .request(
+            "eth_getRawTransactionByBlockNumberAndIndex",
+            (BlockNumberOrTag::Pending, Index::from(0)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(raw, Some(expected));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn uncle_endpoints_report_no_uncles() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
Fixes indexed pending-block transaction lookups returning `null` despite the transaction appearing in the constructed pending block. Both regular and raw RPC variants now use the same pending-block ordering.