### PR TITLE
test(cast): cover T11 allowed call scopes

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -460,6 +460,60 @@ else
   echo -e "\n=== SKIPPING T6 receive-policy/admin-key tests (HARDFORK=$HARDFORK) ==="
 fi
 
+# --- T3+ set-scope tests ---
+if [[ ! "$HARDFORK_UPPER" =~ ^T(0|1|1B|2)$ ]]; then
+  echo -e "\n=== CAST KEYCHAIN: SET-SCOPE ==="
+  if [[ "$DIRECT_KEYCHAIN_AUTH" == "true" ]]; then
+    # Before T11, provision a fresh unrestricted key through the AccountKeychain precompile.
+    kc_ss_json="$(cast wallet new --json)"
+    KC_SS_PK="$(wallet_json_field "$kc_ss_json" private_key)"
+    KC_SS_ADDR="$(wallet_json_field "$kc_ss_json" address)"
+    cast keychain auth "$KC_SS_ADDR" secp256k1 1893456000 \
+      --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+    fund_and_wait "$KC_SS_ADDR"
+  else
+    # From T11, direct authorization is unavailable. The setup above already provisioned this key
+    # through a transaction-embedded key authorization.
+    KC_SS_PK="$ACCESS_KEY"
+    KC_SS_ADDR="$ACCESS_KEY_ADDR"
+  fi
+
+  cast keychain ss "$KC_SS_ADDR" \
+    --scope 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D \
+    --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+  echo "OK: set-scope applied"
+
+  echo -e "\n=== CAST KEYCHAIN: SET-SCOPE ALLOWED ==="
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+    0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
+    --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR"
+  echo "OK: set-scope key allowed to call permitted target"
+
+  echo -e "\n=== CAST KEYCHAIN: SET-SCOPE BLOCKED ==="
+  if cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+    0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 'doesNotExist()' \
+    --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR" 2>&1; then
+    echo "ERROR: set-scope key should have been blocked for disallowed target"
+    exit 1
+  fi
+  echo "OK: set-scope key correctly blocked for disallowed target"
+
+  echo -e "\n=== CAST KEYCHAIN: REMOVE-SCOPE ==="
+  cast keychain rs "$KC_SS_ADDR" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D \
+    --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+
+  echo -e "\n=== CAST KEYCHAIN: REMOVE-SCOPE BLOCKED ==="
+  if cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+    0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
+    --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR" 2>&1; then
+    echo "ERROR: call should have been blocked after remove-scope"
+    exit 1
+  fi
+  echo "OK: call correctly blocked after remove-scope"
+else
+  echo -e "\n=== SKIPPING T3+ set-scope tests (HARDFORK=$HARDFORK) ==="
+fi
+
 # --- T3-only scope / call-restriction tests ---
 if [[ "$HARDFORK" == "T3" ]]; then
   echo -e "\n=== CAST KEYCHAIN: AUTHORIZE WITH --scope (ADDRESS ONLY, UNRESTRICTED) ==="
@@ -542,56 +596,6 @@ if [[ "$HARDFORK" == "T3" ]]; then
     0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
     --tempo.access-key "$KC_HEX_PK" --tempo.root-account "$ADDR"
   echo "OK: raw hex selector key allowed to call increment()"
-
-  echo -e "\n=== CAST KEYCHAIN: SET-SCOPE ==="
-  # Create a new unrestricted key, then add scope restrictions via set-scope
-  kc_ss_json="$(cast wallet new --json)"
-  KC_SS_PK="$(wallet_json_field "$kc_ss_json" private_key)"
-  KC_SS_ADDR="$(wallet_json_field "$kc_ss_json" address)"
-  cast keychain auth "$KC_SS_ADDR" secp256k1 1893456000 \
-    --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
-
-  # Now restrict it to only the counter contract
-  cast keychain ss "$KC_SS_ADDR" \
-    --scope 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D \
-    --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
-  echo "OK: set-scope applied"
-
-  echo -e "\n=== CAST KEYCHAIN: SET-SCOPE ALLOWED ==="
-  fund_and_wait "$KC_SS_ADDR"
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-    0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
-    --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR"
-  echo "OK: set-scope key allowed to call permitted target"
-
-  echo -e "\n=== CAST KEYCHAIN: SET-SCOPE BLOCKED ==="
-  if cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-    0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 'doesNotExist()' \
-    --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR" 2>&1; then
-    echo "ERROR: set-scope key should have been blocked for disallowed target"
-    exit 1
-  fi
-  echo "OK: set-scope key correctly blocked for disallowed target"
-
-  echo -e "\n=== CAST KEYCHAIN: REMOVE-SCOPE (BEFORE — CALL SUCCEEDS) ==="
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-    0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
-    --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR"
-  echo "OK: call to scoped target succeeds before remove-scope"
-
-  echo -e "\n=== CAST KEYCHAIN: REMOVE-SCOPE ==="
-  cast keychain rs "$KC_SS_ADDR" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D \
-    --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
-  echo "OK: remove-scope applied"
-
-  echo -e "\n=== CAST KEYCHAIN: REMOVE-SCOPE (AFTER — CALL FAILS) ==="
-  if cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-    0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
-    --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR" 2>&1; then
-    echo "ERROR: call should have been blocked after remove-scope"
-    exit 1
-  fi
-  echo "OK: call correctly blocked after remove-scope"
 
   echo -e "\n=== CAST KEYCHAIN: AUTHORIZE WITH RECIPIENT RESTRICTION ==="
   kc_recip_json="$(cast wallet new --json)"

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -21,6 +21,7 @@ use std::{
 };
 use tempo_alloy::accounts::TempoAccountsStore;
 use tempo_contracts::precompiles::TIP20_FACTORY_ADDRESS;
+use tempo_hardfork::TempoHardfork;
 use tempo_primitives::TempoTxEnvelope;
 
 /// Anvil test accounts (standard mnemonic).
@@ -656,6 +657,112 @@ casttest!(send_with_authorized_access_key_succeeds, async |_prj, cmd| {
         serde_json::from_str(output.trim()).expect("cast send emits a JSON receipt");
     assert!(receipt["transactionHash"].is_string(), "unexpected receipt: {output}");
     assert_eq!(receipt["status"], "0x1", "unexpected receipt: {output}");
+});
+
+// On-chain: `keychain set-scope` uses the legacy ABI before T11 and the RLP ABI from T11 onward.
+casttest!(keychain_set_scope_succeeds_across_t11, async |_prj, cmd| {
+    for hardfork in [TempoHardfork::T10, TempoHardfork::T11] {
+        let (_, handle) =
+            anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(hardfork.into()))).await;
+        let rpc = handle.http_endpoint();
+
+        if hardfork < TempoHardfork::T11 {
+            cmd.cast_fuse()
+                .args([
+                    "keychain",
+                    "authorize",
+                    accounts::ADDR2,
+                    "--private-key",
+                    accounts::PK1,
+                    "--rpc-url",
+                    &rpc,
+                ])
+                .assert_success();
+        } else {
+            let authorization = cmd
+                .cast_fuse()
+                .args([
+                    "key-authorization",
+                    "sign",
+                    accounts::ADDR2,
+                    "--chain-id",
+                    "31337",
+                    "--private-key",
+                    accounts::PK1,
+                ])
+                .assert_success()
+                .get_output()
+                .stdout_lossy()
+                .trim()
+                .to_string();
+            let tempo_home = tempfile::tempdir().unwrap();
+            cmd.cast_fuse();
+            cmd.env("TEMPO_HOME", tempo_home.path());
+            cmd.args([
+                "tempo",
+                "import-access-key",
+                "--account",
+                accounts::ADDR1,
+                "--access-key",
+                accounts::PK2,
+                "--authorization",
+                &authorization,
+            ])
+            .assert_success();
+            cmd.cast_fuse();
+            cmd.env("TEMPO_HOME", tempo_home.path());
+            cmd.args([
+                "send",
+                &path_usd(),
+                "approve(address,uint256)",
+                accounts::ADDR3,
+                "0",
+                "--from",
+                accounts::ADDR1,
+                "--tempo.fee-token",
+                &path_usd(),
+                "--rpc-url",
+                &rpc,
+            ])
+            .assert_success();
+        }
+
+        cmd.cast_fuse()
+            .args([
+                "keychain",
+                "set-scope",
+                accounts::ADDR2,
+                "--scope",
+                accounts::ADDR3,
+                "--private-key",
+                accounts::PK1,
+                "--rpc-url",
+                &rpc,
+            ])
+            .assert_success();
+
+        let output = cmd
+            .cast_fuse()
+            .args([
+                "keychain",
+                "inspect",
+                accounts::ADDR2,
+                "--root-account",
+                accounts::ADDR1,
+                "--rpc-url",
+                &rpc,
+                "--json",
+            ])
+            .assert_success()
+            .get_output()
+            .stdout_lossy();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(
+            parsed["data"]["allowed_calls"]["scopes"][0]["target"].as_str().map(str::to_lowercase),
+            Some(accounts::ADDR3.to_lowercase()),
+            "unexpected {hardfork:?} key info: {output}"
+        );
+    }
 });
 
 casttest!(send_with_local_sponsor_reports_sponsor_as_fee_payer, async |_prj, cmd| {


### PR DESCRIPTION
## Description

`setAllowedCalls` changed from the legacy tuple ABI to RLP-encoded scopes at T11. This adds hermetic T10 and T11 coverage that provisions a key using the appropriate mechanism, submits `cast keychain set-scope`, and verifies the stored restriction.

Before T11 it creates a key through direct AccountKeychain authorization; from T11 onward it reuses the key provisioned through transaction-embedded authorization. The flow confirms allowed, blocked, and removed-scope behavior.

Closes OSS-734.

This PR was written with Codex assistance.