### PR TITLE
fix(verify): send User-Agent header on Sourcify HTTP clients

### DIFF
--- a/crates/evm/traces/src/identifier/external.rs
+++ b/crates/evm/traces/src/identifier/external.rs
@@ -534,7 +534,10 @@ struct SourcifyFetcher {
 impl SourcifyFetcher {
     fn new(chain: Chain) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .user_agent(foundry_common::DEFAULT_USER_AGENT)
+                .build()
+                .expect("Client::builder() with static config cannot fail"),
             url: format!("https://sourcify.dev/server/v2/contract/{}", chain.id()),
             invalid_api_key: AtomicBool::new(false),
         }

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -133,6 +133,7 @@ const MAX_RESPONSE_BODY: usize = 1024 * 1024;
 
 fn verification_client() -> Result<reqwest::Client> {
     reqwest::Client::builder()
+        .user_agent(foundry_common::DEFAULT_USER_AGENT)
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
         .build()


### PR DESCRIPTION
## Motivation

The Sourcify verification client (`crates/verify/src/sourcify.rs`) and the Sourcify trace-decoding fetcher (`crates/evm/traces/src/identifier/external.rs`) build plain reqwest clients, and reqwest sends no `User-Agent` header by default. The 4byte signature client already identifies itself as `foundry/<version>` via `DEFAULT_USER_AGENT` (through `RuntimeTransportBuilder`), so Foundry currently identifies itself on one Sourcify service but not the other two. Server operators can't distinguish Foundry traffic from anonymous clients, which matters for rate-limit tuning and for keeping compatibility with Foundry's request patterns during API changes.

## Solution

Apply the existing `foundry_common::DEFAULT_USER_AGENT` (`foundry/<version>`) to both remaining clients, matching what the 4byte client already does. No behavior change beyond the added header.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)