### PR TITLE
refactor(cheatcodes): resolve tool addresses early

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -813,6 +813,9 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// Additional, user configurable context this Inspector has access to when inspecting a call.
     pub config: Arc<CheatsConfig>,
 
+    /// Additional addresses recognized as cheatcode contracts by this executor.
+    pub extra_cheatcode_addresses: &'static [Address],
+
     /// Test-scoped context holding data that needs to be reset every test run
     pub test_context: TestContext,
 
@@ -952,6 +955,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             fs_commit: true,
             labels: config.labels.clone(),
             config,
+            extra_cheatcode_addresses: &[],
             block: Default::default(),
             fork_block_number_override: Default::default(),
             active_delegations: Default::default(),
@@ -1016,6 +1020,12 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             context_snapshots: Default::default(),
             in_isolation_context: false,
         }
+    }
+
+    /// Sets additional addresses recognized as cheatcode contracts.
+    #[inline]
+    pub const fn set_extra_cheatcode_addresses(&mut self, addresses: &'static [Address]) {
+        self.extra_cheatcode_addresses = addresses;
     }
 
     /// Enables cheatcode analysis capabilities by providing a solar compiler instance.
@@ -1470,7 +1480,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
 
         #[cfg(feature = "monad")]
         if crate::monad::is_monad_cheatcode_call(
-            self.config.evm_opts.networks.extra_cheatcode_addresses(),
+            self.extra_cheatcode_addresses,
             call.target_address,
         ) {
             let checkpoint = ecx.journal_mut().checkpoint();
@@ -2399,7 +2409,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         #[cfg(feature = "monad")]
         let cheatcode_call = cheatcode_call
             || crate::monad::is_monad_cheatcode_call(
-                self.config.evm_opts.networks.extra_cheatcode_addresses(),
+                self.extra_cheatcode_addresses,
                 call.target_address,
             );
         let curr_depth = ecx.journal().depth();

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -250,6 +250,9 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
         // inspectors
         if let Some(config) = cheatcodes {
             let mut cheatcodes = Cheatcodes::new(config);
+            // TODO(monad-fen-dispatch): Resolve this address slice at the initial FEN dispatch and
+            // pass it into the inspector builder without retaining post-dispatch `NetworkConfigs`.
+            cheatcodes.set_extra_cheatcode_addresses(networks.extra_cheatcode_addresses());
             // Set analysis capabilities if they are provided
             if let Some(analysis) = analysis {
                 stack.set_analysis(analysis.clone());


### PR DESCRIPTION
Monad cheatcode call handling currently reaches through `CheatsConfig` and `EvmOpts` into `NetworkConfigs` for every call and call-end event. That makes runtime configuration, rather than the constructed inspector, authoritative after typed EVM dispatch.

Store the already-resolved additional cheatcode addresses directly on the cheatcode inspector and use that value for call recognition and cleanup. This deliberately breaks the deepest configuration dependency first; a TODO marks the remaining temporary resolution in inspector construction, which will move to the initial FEN dispatch.
