### PR TITLE
refactor(evm): reuse resolved tool addresses

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -603,6 +603,9 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
 #[must_use]
 pub struct Backend<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// Active network configuration.
+    // TODO(monad-fen-dispatch): Remove this post-dispatch configuration. Extract Monad replay and
+    // fork positioning into concrete Monad code, and pass family-neutral chain data directly to
+    // ordinary block/environment updates.
     networks: NetworkConfigs,
     /// The access point for managing forks
     forks: MultiFork<AnyNetwork, SpecFor<FEN>, BlockEnvFor<FEN>>,

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -84,6 +84,8 @@ impl<FEN: FoundryEvmNetwork> ExecutorBuilder<FEN> {
         mut evm_env: EvmEnvFor<FEN>,
         tx_env: TxEnvFor<FEN>,
         db: Backend<FEN>,
+        // TODO(monad-fen-dispatch): Remove this argument after inspector inputs and backend fork
+        // behavior are resolved by the initial concrete FEN dispatch.
         networks: NetworkConfigs,
     ) -> Executor<FEN> {
         let Self { mut stack, gas_limit, spec, legacy_assertions, .. } = self;

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -351,7 +351,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             self.config.fail_on_revert,
             address,
             call.reverter,
-            self.executor_f.inspector().networks.extra_cheatcode_addresses(),
+            self.executor_f.inspector().extra_cheatcode_addresses(),
         ) || self.executor_f.is_raw_call_mut_success(address, &mut call, false);
 
         let mut result = FuzzTestResult {
@@ -490,7 +490,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             self.config.fail_on_revert,
             address,
             call.reverter,
-            state.0.inspector().networks.extra_cheatcode_addresses(),
+            state.0.inspector().extra_cheatcode_addresses(),
         ) || state.0.is_raw_call_mut_success(address, &mut call, false);
 
         if success {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1699,7 +1699,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // Set up fuzzer WITHOUT call_generator initially.
         // We defer call_override until after the initial invariant check to avoid
         // injecting random calls during setup which would break the invariant assertion.
-        let extra_cheatcode_addresses = executor.inspector().networks.extra_cheatcode_addresses();
+        let extra_cheatcode_addresses = executor.inspector().extra_cheatcode_addresses();
         executor.inspector_mut().set_fuzzer(
             Fuzzer::new(config.dictionary.max_fuzz_dictionary_values, mapping_slots)
                 .with_extra_cheatcode_addresses(extra_cheatcode_addresses)

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -279,7 +279,7 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
     ) -> Self {
         inspector.networks(networks);
         backend.set_networks(networks);
-        let extra_cheatcode_addresses = networks.extra_cheatcode_addresses();
+        let extra_cheatcode_addresses = inspector.extra_cheatcode_addresses();
         backend.extend_persistent_accounts(extra_cheatcode_addresses.iter().copied());
 
         // Need to create a non-empty contract on the cheatcodes address so `extcodesize` checks

--- a/crates/evm/evm/src/executors/showmap.rs
+++ b/crates/evm/evm/src/executors/showmap.rs
@@ -705,7 +705,7 @@ fn fuzz_replay_call_succeeded<FEN: FoundryEvmNetwork>(
         fail_on_revert,
         target_addr,
         call_result.reverter,
-        executor.inspector().networks.extra_cheatcode_addresses(),
+        executor.inspector().extra_cheatcode_addresses(),
     ) || executor.is_raw_call_mut_success(target_addr, call_result, false)
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -89,6 +89,9 @@ pub struct InspectorStackBuilder<BLOCK: Clone> {
     /// EVM context, enabling more precise gas accounting and transaction state changes.
     pub enable_isolation: bool,
     /// Networks with enabled features.
+    // TODO(monad-fen-dispatch): Remove this post-dispatch configuration. Callers must resolve
+    // family-neutral inspector inputs before selecting `FEN`, while Monad tooling is configured by
+    // the concrete Monad construction path.
     pub networks: NetworkConfigs,
     /// The wallets to set in the cheatcodes context.
     pub wallets: Option<Wallets>,
@@ -246,13 +249,14 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
             create2_deployer,
         } = self;
         let mut stack = InspectorStack::new();
+        // TODO(monad-fen-dispatch): This is the temporary resolution point for the staged cleanup.
+        // Move it to each command's initial FEN dispatch and pass only the resolved addresses here.
+        let extra_cheatcode_addresses = networks.extra_cheatcode_addresses();
 
         // inspectors
         if let Some(config) = cheatcodes {
             let mut cheatcodes = Cheatcodes::new(config);
-            // TODO(monad-fen-dispatch): Resolve this address slice at the initial FEN dispatch and
-            // pass it into the inspector builder without retaining post-dispatch `NetworkConfigs`.
-            cheatcodes.set_extra_cheatcode_addresses(networks.extra_cheatcode_addresses());
+            cheatcodes.set_extra_cheatcode_addresses(extra_cheatcode_addresses);
             // Set analysis capabilities if they are provided
             if let Some(analysis) = analysis {
                 stack.set_analysis(analysis.clone());
@@ -278,6 +282,7 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
 
         stack.enable_isolation(enable_isolation);
         stack.networks(networks);
+        stack.set_extra_cheatcode_addresses(extra_cheatcode_addresses);
         stack.set_create2_deployer(create2_deployer);
 
         if networks.is_tempo() {
@@ -421,6 +426,8 @@ pub struct InspectorStackInner {
     pub sancov_trace_cmp: bool,
     pub enable_isolation: bool,
     pub networks: NetworkConfigs,
+    /// Additional addresses installed and recognized as cheatcode contracts.
+    pub extra_cheatcode_addresses: &'static [Address],
     pub create2_deployer: Address,
     /// Flag marking if we are in the inner EVM context.
     pub in_inner_context: bool,
@@ -730,6 +737,18 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
     #[inline]
     pub const fn networks(&mut self, networks: NetworkConfigs) {
         self.inner.networks = networks;
+    }
+
+    /// Returns additional addresses installed and recognized as cheatcode contracts.
+    #[inline]
+    pub const fn extra_cheatcode_addresses(&self) -> &'static [Address] {
+        self.inner.extra_cheatcode_addresses
+    }
+
+    /// Sets additional addresses installed and recognized as cheatcode contracts.
+    #[inline]
+    pub const fn set_extra_cheatcode_addresses(&mut self, addresses: &'static [Address]) {
+        self.inner.extra_cheatcode_addresses = addresses;
     }
 
     /// Set the CREATE2 deployer address.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -3251,7 +3251,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             fuzz_config.fail_on_revert,
             self.address,
             raw_call_result.reverter,
-            self.executor.inspector().networks.extra_cheatcode_addresses(),
+            self.executor.inspector().extra_cheatcode_addresses(),
         ) || self.executor.is_raw_call_success(
             self.address,
             Cow::Borrowed(&raw_call_result.state_changeset),


### PR DESCRIPTION
Additional cheatcode addresses are independently recovered from `NetworkConfigs` across executor account installation, revert handling, fuzzing, invariants, showmap, and Forge reporting. These repeated lookups allow downstream runtime configuration to compete with the already-selected EVM type.

Resolve the address slice once while assembling the inspector stack and reuse that exact value throughout execution tooling. This keeps cheatcode recognition, persistent-account installation, and reporting aligned without introducing another network-family enum or FEN capability flag.

This remains an intermediate dependency-breaking step: explicit TODOs identify the temporary inspector resolution and the remaining `NetworkConfigs` ownership in `ExecutorBuilder` and `Backend`. Follow-up work will move resolution to initial command dispatch and extract concrete Monad replay and fork positioning before deleting those dependencies.
