### PR TITLE
docs(dev): clarify network dispatch ownership

### DIFF
--- a/docs/dev/networks.md
+++ b/docs/dev/networks.md
@@ -16,10 +16,52 @@ Compile-time support and runtime selection are separate:
   [`FoundryEvmFactory`](../../crates/evm/core/src/evm/mod.rs). Tool entry points dispatch to a
   concrete implementation only after runtime selection.
 
+`NetworkConfigs` is discovery and selection state, not an execution-policy container. Its lifetime
+ends when a tool selects its concrete `FoundryEvmNetwork`. After that dispatch, the selected types,
+factory, context, and narrow resolved inputs are authoritative.
+
 An optional RPC capability probe must not become a requirement for an otherwise valid endpoint.
 Before an endpoint has positively identified a custom execution family, failed optional probes
 should fall back to mandatory standard RPC discovery. Once the endpoint has been identified,
 subsequent identity checks can remain strict.
+
+## Single-dispatch invariant
+
+Each tool must resolve configuration and select an execution family exactly once, at its outermost
+execution boundary:
+
+```text
+CLI, config, and RPC discovery
+              |
+              v
+       NetworkConfigs
+              |
+              v
+   concrete FoundryEvmNetwork dispatch
+```
+
+Code below that boundary must not receive, store, or reconstruct `NetworkConfigs`. In particular,
+executors, backends, inspectors, replay helpers, nested EVM construction, and typed runner state
+must not repeat `is_monad()`, `is_tempo()`, or equivalent family checks after the concrete FEN has
+been selected.
+
+Do not disguise downstream dispatch as:
+
+- an associated capability boolean on `FoundryEvmNetwork` or `FoundryEvmFactory`;
+- a generic policy trait whose ordinary implementations are no-ops;
+- a callback table selected from runtime network configuration;
+- an optional custom-family context whose presence selects an algorithm;
+- an execution-family enum carried alongside an already concrete FEN.
+
+When behavior belongs to only one execution family, prefer a concrete struct or implementation for
+that family. Small concrete duplication is preferable to making every generic path understand a
+foreign execution lifecycle. Family-neutral data may cross the dispatch boundary only in the
+narrow form required by its owner, such as a chain ID, timestamp, address list, or resolved
+precompile set.
+
+Do not confuse an Alloy `Network` with an execution family. `AnyNetwork` is useful at permissive RPC
+decoding boundaries, but decoding a foreign transaction does not give an Ethereum executor that
+network's execution semantics.
 
 ## Ownership boundaries
 
@@ -28,8 +70,8 @@ subsequent identity checks can remain strict.
 | Alloy `Network` | RPC transaction requests, envelopes, receipts, and response types |
 | Alloy `EvmFactory` and Foundry's `FoundryEvmFactory` adapter | Spec, block and transaction environments, halt reasons, precompiles, and construction of the concrete EVM context |
 | REVM context and journal | Execution-time state mutation, checkpoints, commits, and reverts |
-| `NetworkConfigs` and hardfork types | Runtime selection, chain and endpoint inference, feature configuration, and hardfork validation |
-| Foundry tools | CLI/config plumbing, dispatch, forks, scripts, cheatcodes, tracing, verification, and user-visible behavior |
+| `NetworkConfigs` and hardfork types | Pre-dispatch selection, chain and endpoint inference, feature configuration, and hardfork validation |
+| Foundry tools | CLI/config plumbing, one authoritative dispatch per execution entry point, and tool-specific workflows and user-visible behavior |
 
 Do not encode protocol behavior only as a chain-ID branch in a tool. Put execution semantics in the
 network factory or context, selection in the network configuration layer, and tool-specific workflow
@@ -48,11 +90,15 @@ state. Then implement the integration in layers.
 3. Add the concrete `FoundryEvmNetwork` and `FoundryEvmFactory` adapter under
    `crates/evm/core/src/evm/`. Keep conversions between RPC types and execution types at this
    boundary.
-4. Thread the associated spec, block, transaction, halt, context, and journal types through the EVM
-   backend. Avoid converting back to Ethereum types in generic paths.
-5. Add runtime dispatch to every affected entry point. Search for existing `NetworkVariant` and
-   `FoundryEvmNetwork` matches in Forge, Cast, Anvil, Chisel, scripting, verification, tracing, and
-   cheatcodes.
+4. Thread the associated spec, block, transaction, halt, context, and journal types through typed
+   execution code. Keep custom-family state and algorithms in concrete implementations instead of
+   adding optional custom state to the generic backend. Avoid converting back to Ethereum types in
+   generic paths.
+5. Identify the outermost execution boundary of every affected tool. Resolve `NetworkConfigs`
+   there, dispatch once to a concrete FEN, and pass only typed or narrowly resolved inputs below the
+   boundary. Search Forge, Cast, Anvil, Chisel, scripting, verification, tracing, and cheatcodes for
+   entry points, then verify that shared runners, executors, inspectors, backends, and replay helpers
+   do not dispatch again.
 6. Feature-gate optional dependencies consistently through every crate and binary that reaches the
    integration. A default build, a build with the feature, and the published release build are three
    distinct configurations.
@@ -78,7 +124,8 @@ of auxiliary state, document:
 
 If state must survive a nested execution, implement the transfer explicitly at the factory, context,
 or journal boundary. Do not rely on cloning the ordinary account database to preserve state owned by
-another component.
+another component. Do not add optional custom-family state to a generic context or return generic
+"context update" signals when only one concrete family can use them.
 
 ## Tool coverage
 
@@ -94,7 +141,9 @@ family and hardfork semantics. Audit at least:
 - trace decoding, labels, verification, and contract-size or fee rules.
 
 Unsupported combinations should fail at the selection boundary with a specific error. Ordinary
-Ethereum and other enabled families must continue to use their existing path.
+Ethereum and other enabled families must continue to use their existing path. Once a workflow has
+selected a concrete FEN, helpers used by that workflow must not accept a second runtime execution
+profile.
 
 ## Tests and CI
 
@@ -107,9 +156,12 @@ Use a layered test plan:
    proxies over live providers.
 4. Exercise explicit selection, inferred selection, an unknown chain, and a conflicting or disabled
    family. Test optional endpoint probes independently from mandatory RPC methods.
-5. Compile the workspace without optional features, with each feature independently, and with the
+5. Exercise the same workflow through each supported dispatch branch and verify that enabling one
+   family does not change another family's execution. Add a source-boundary check when practical to
+   prevent `NetworkConfigs` from being introduced into post-dispatch modules.
+6. Compile the workspace without optional features, with each feature independently, and with the
    release feature set. Verify that enabling one family does not change another family's execution.
-6. Add the focused library and integration suites to normal pull-request CI. Do not rely only on a
+7. Add the focused library and integration suites to normal pull-request CI. Do not rely only on a
    downstream repository or a nightly flaky-test job for release-critical behavior.
 
 Keep feature propagation synchronized across workspace manifests, the root `Makefile`, and the


### PR DESCRIPTION
Clarifies the custom EVM integration guide around the boundary between runtime network discovery and typed execution. `NetworkConfigs` owns pre-dispatch selection and inference; once a tool selects a concrete `FoundryEvmNetwork`, downstream executors, backends, inspectors, replay helpers, and nested EVM construction must treat that typed choice as authoritative.

The guide now documents the single-dispatch invariant, calls out capability flags and optional custom-family context as disguised downstream dispatch, and updates the integration and testing checklists to favor concrete family implementations and mechanically enforceable boundaries.

Part of #16248.
