### PR TITLE
test(cast): normalize Safe executable suffix

### DIFF
--- a/crates/cast/tests/cli/safe.rs
+++ b/crates/cast/tests/cli/safe.rs
@@ -1657,7 +1657,7 @@ casttest!(safe_simulation_requires_executor, |_prj, cmd| {
 error: the following required arguments were not provided:
   --from <ADDRESS>
 
-Usage: cast safe simulate --from <ADDRESS> --rpc-url <URL> <SAFE> <SAFE_TX_HASH>
+Usage: cast[..] safe simulate --from <ADDRESS> --rpc-url <URL> <SAFE> <SAFE_TX_HASH>
 
 For more information, try '--help'.
 


### PR DESCRIPTION
Normalizes the Safe simulation error snapshot so it accepts the Windows `cast.exe` suffix. This test-only CI fix should receive the `L-ignore` label.

This PR was written by Centaur with AI assistance.

Prompted by: @grandizzy
