### PR TITLE
refactor(anvil): centralize OP fee context

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -58,6 +58,18 @@ pub(crate) enum BlockExecutionKind {
     TransactionPrefix,
 }
 
+/// Returns the block's blob gas budget.
+///
+/// OP Jovian repurposes the block gas limit as the DA-footprint budget. Every other execution
+/// profile uses the active EIP-4844 limit.
+pub(crate) const fn block_blob_gas_limit(
+    optimism_jovian: bool,
+    block_gas_limit: u64,
+    max_blob_gas_per_block: u64,
+) -> u64 {
+    if optimism_jovian { block_gas_limit } else { max_blob_gas_per_block }
+}
+
 /// Ethereum-only consensus transition configuration for an Anvil block executor.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct EthereumBlockTransitions {
@@ -242,7 +254,6 @@ pub struct AnvilBlockExecutor<E> {
     /// Maximum blob gas available to transactions in this block.
     max_blob_gas_per_block: u64,
     /// Whether OP Jovian repurposes `blobGasUsed` for the DA footprint.
-    #[cfg(feature = "optimism")]
     optimism_jovian: bool,
     /// State changes captured for deferred publication.
     state_changes: Option<Vec<EvmState>>,
@@ -258,9 +269,8 @@ impl<E: fmt::Debug> fmt::Debug for AnvilBlockExecutor<E> {
             .field("ethereum_transitions", &self.ethereum_transitions)
             .field("gas_used", &self.gas_used)
             .field("blob_gas_used", &self.blob_gas_used)
-            .field("max_blob_gas_per_block", &self.max_blob_gas_per_block);
-        #[cfg(feature = "optimism")]
-        debug.field("optimism_jovian", &self.optimism_jovian);
+            .field("max_blob_gas_per_block", &self.max_blob_gas_per_block)
+            .field("optimism_jovian", &self.optimism_jovian);
         debug.field("receipts", &self.receipts.len()).finish_non_exhaustive()
     }
 }
@@ -283,7 +293,6 @@ impl<E> AnvilBlockExecutor<E> {
             gas_used: 0,
             blob_gas_used: 0,
             max_blob_gas_per_block: u64::MAX,
-            #[cfg(feature = "optimism")]
             optimism_jovian: false,
             state_changes: None,
         }
@@ -347,14 +356,11 @@ where
             optimism::blob_gas_used(self.evm.db_mut(), tx.tx(), self.optimism_jovian)?;
         #[cfg(not(feature = "optimism"))]
         let blob_gas_used = tx.tx().blob_gas_used().unwrap_or_default();
-        #[cfg(feature = "optimism")]
-        let blob_gas_limit = if self.optimism_jovian {
-            self.evm.block().gas_limit()
-        } else {
-            self.max_blob_gas_per_block
-        };
-        #[cfg(not(feature = "optimism"))]
-        let blob_gas_limit = self.max_blob_gas_per_block;
+        let blob_gas_limit = block_blob_gas_limit(
+            self.optimism_jovian,
+            self.evm.block().gas_limit(),
+            self.max_blob_gas_per_block,
+        );
         if self.blob_gas_used.saturating_add(blob_gas_used) > blob_gas_limit {
             return Err(BlockExecutionError::msg("block blob gas limit exceeded"));
         }

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -58,18 +58,6 @@ pub(crate) enum BlockExecutionKind {
     TransactionPrefix,
 }
 
-/// Returns the block's blob gas budget.
-///
-/// OP Jovian repurposes the block gas limit as the DA-footprint budget. Every other execution
-/// profile uses the active EIP-4844 limit.
-pub(crate) const fn block_blob_gas_limit(
-    optimism_jovian: bool,
-    block_gas_limit: u64,
-    max_blob_gas_per_block: u64,
-) -> u64 {
-    if optimism_jovian { block_gas_limit } else { max_blob_gas_per_block }
-}
-
 /// Ethereum-only consensus transition configuration for an Anvil block executor.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct EthereumBlockTransitions {
@@ -780,6 +768,18 @@ where
     }
 
     tx_env
+}
+
+/// Returns the block's blob gas budget.
+///
+/// OP Jovian repurposes the block gas limit as the DA-footprint budget. Every other execution
+/// profile uses the active EIP-4844 limit.
+pub(crate) const fn block_blob_gas_limit(
+    optimism_jovian: bool,
+    block_gas_limit: u64,
+    max_blob_gas_per_block: u64,
+) -> u64 {
+    if optimism_jovian { block_gas_limit } else { max_blob_gas_per_block }
 }
 
 #[cfg(test)]

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -14,8 +14,8 @@ use crate::{
                 AnvilBlockExecutor, BlockExecutionKind, EthereumBlockTransitions,
                 ExecutedPoolTransactions, FoundryReceiptBuilder, PoolTransactionHooks,
                 PoolTxGasConfig, apply_ethereum_post_execution_changes,
-                apply_ethereum_pre_execution_changes, build_tx_env_for_pending,
-                execute_pool_transaction, execute_pool_transactions,
+                apply_ethereum_pre_execution_changes, block_blob_gas_limit,
+                build_tx_env_for_pending, execute_pool_transaction, execute_pool_transactions,
             },
             fork::{ClientFork, ForkEndpointIdentity},
             genesis::GenesisConfig,
@@ -1421,12 +1421,19 @@ impl<N: Network> Backend<N> {
     }
 
     #[cfg(feature = "optimism")]
-    fn is_optimism_jovian_at_header<H: BlockHeader>(&self, header: &H) -> bool {
+    fn is_optimism_jovian_at_header<H: BlockHeader>(
+        &self,
+        header: &H,
+        decoded: Option<bool>,
+    ) -> bool {
         if !self.is_optimism() {
             return false;
         }
+        if let Some(jovian) = decoded {
+            return jovian;
+        }
         if !header.extra_data().is_empty() {
-            return self.fees.is_optimism_jovian_header(header);
+            return false;
         }
         let hardfork = if self.get_fork().is_some() {
             FoundryHardfork::from_chain_and_timestamp(self.protocol_chain_id(), header.timestamp())
@@ -1438,7 +1445,11 @@ impl<N: Network> Backend<N> {
     }
 
     #[cfg(not(feature = "optimism"))]
-    fn is_optimism_jovian_at_header<H: BlockHeader>(&self, _header: &H) -> bool {
+    fn is_optimism_jovian_at_header<H: BlockHeader>(
+        &self,
+        _header: &H,
+        _decoded: Option<bool>,
+    ) -> bool {
         false
     }
 
@@ -5255,6 +5266,9 @@ where
                 if let Some(block_number) = arbitrum_rpc_block_number {
                     self.inject_arbitrum_precompile_at_block($evm.precompiles_mut(), block_number);
                 }
+                // Replay re-executes an already-valid historical prefix, so it does not apply the
+                // local EIP-4844 budget. Jovian still uses the source block's gas limit as its DA
+                // budget through `set_optimism_hardfork` below.
                 let mut executor = AnvilBlockExecutor::new(
                     $evm,
                     parent_hash,
@@ -7504,7 +7518,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         }
 
         let next_fees = selected_header.as_ref().map(|header| {
-            let next_block_base_fee = self.fees.get_next_block_base_fee_from_header(header);
+            let parent_fees = self.fees.get_parent_header_fees(header);
             let next_block_excess_blob_gas = self.networks.next_block_blob_excess_gas(
                 self.fees.blob_params(),
                 header.excess_blob_gas().unwrap_or_default(),
@@ -7518,8 +7532,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
                     header.timestamp,
                 ),
             );
-            let base_fee_extra_data = self.fees.base_fee_extra_data_from_header(header);
-            (next_block_base_fee, blob_excess_gas_and_price, base_fee_extra_data)
+            (parent_fees, blob_excess_gas_and_price)
         });
 
         let historical_states = state.historical_states.take();
@@ -7551,16 +7564,12 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         if let Some(block_env) = block_env {
             self.evm_env.write().block_env = block_env;
         }
-        if let Some((next_block_base_fee, blob_excess_gas_and_price, base_fee_extra_data)) =
-            next_fees
-        {
-            #[cfg(not(feature = "optimism"))]
-            let _ = base_fee_extra_data;
+        if let Some((parent_fees, blob_excess_gas_and_price)) = next_fees {
             #[cfg(feature = "optimism")]
             if self.is_optimism() {
-                self.fees.set_optimism_base_fee_rules(&base_fee_extra_data);
+                self.fees.set_optimism_base_fee_rules(&parent_fees.extra_data);
             }
-            self.fees.set_base_fee(next_block_base_fee);
+            self.fees.set_base_fee(parent_fees.base_fee);
             self.fees.set_blob_excess_gas_and_price(blob_excess_gas_and_price);
         }
 
@@ -7996,11 +8005,11 @@ impl Backend<FoundryNetwork> {
                     } else {
                         0
                     };
-                    let max_blob_gas = if optimism_jovian {
-                        block_env.gas_limit
-                    } else {
-                        blob_params.max_blob_gas_per_block()
-                    };
+                    let max_blob_gas = block_blob_gas_limit(
+                        optimism_jovian,
+                        block_env.gas_limit,
+                        blob_params.max_blob_gas_per_block(),
+                    );
                     if !optimism_jovian
                         && block_blob_gas_used.saturating_add(request_blob_gas_used) > max_blob_gas
                     {
@@ -8447,9 +8456,9 @@ impl Backend<FoundryNetwork> {
             Some(BlockRequest::Pending(pool_transactions)) => {
                 self.with_pending_block(pool_transactions, |state, block| {
                     let header = &block.block.header;
-                    let base_fee = self.fees.calculate_next_block_base_fee_from_header(header);
-                    let base_fee_extra_data = self.fees.base_fee_extra_data_from_header(header);
-                    let optimism_jovian = self.is_optimism_jovian_at_header(header);
+                    let parent_fees = self.fees.calculate_parent_header_fees(header);
+                    let optimism_jovian =
+                        self.is_optimism_jovian_at_header(header, parent_fees.optimism_jovian);
                     let monad_context = self.active_monad_context_before_mined_transaction(
                         &block.block,
                         block.block.body.transactions.len(),
@@ -8466,12 +8475,12 @@ impl Backend<FoundryNetwork> {
                         header.number(),
                         header.timestamp(),
                         header.hash_slow(),
-                        base_fee,
+                        parent_fees.base_fee,
                         monad_context,
                         header.base_fee_per_gas().unwrap_or_default(),
                         header.excess_blob_gas().unwrap_or_default(),
                         header.blob_gas_used().unwrap_or_default(),
-                        base_fee_extra_data,
+                        parent_fees.extra_data,
                         optimism_jovian,
                     )
                 })
@@ -8490,11 +8499,11 @@ impl Backend<FoundryNetwork> {
                 let base_number = base_block.header.number();
                 let base_timestamp = base_block.header.timestamp();
                 let base_hash = base_block.header.hash;
-                let base_fee =
-                    self.fees.calculate_next_block_base_fee_from_header(&base_block.header.inner);
-                let base_fee_extra_data =
-                    self.fees.base_fee_extra_data_from_header(&base_block.header.inner);
-                let optimism_jovian = self.is_optimism_jovian_at_header(&base_block.header.inner);
+                let parent_fees = self.fees.calculate_parent_header_fees(&base_block.header.inner);
+                let optimism_jovian = self.is_optimism_jovian_at_header(
+                    &base_block.header.inner,
+                    parent_fees.optimism_jovian,
+                );
 
                 #[cfg(feature = "monad")]
                 let monad_context = if self.is_monad() {
@@ -8512,12 +8521,12 @@ impl Backend<FoundryNetwork> {
                         base_number,
                         base_timestamp,
                         base_hash,
-                        base_fee,
+                        parent_fees.base_fee,
                         monad_context,
                         base_block.header.base_fee_per_gas().unwrap_or_default(),
                         base_block.header.excess_blob_gas().unwrap_or_default(),
                         base_block.header.blob_gas_used().unwrap_or_default(),
-                        base_fee_extra_data,
+                        parent_fees.extra_data,
                         optimism_jovian,
                     )
                 })

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -135,30 +135,6 @@ impl BaseFeeRules {
             }
         }
     }
-
-    fn next_block_base_fee<H: BlockHeader>(self, header: &H) -> u64 {
-        match self {
-            Self::Standard(params) => calc_next_block_base_fee(
-                header.gas_used(),
-                header.gas_limit(),
-                header.base_fee_per_gas().unwrap_or_default(),
-                params,
-            ),
-            #[cfg(feature = "optimism")]
-            Self::Optimism { fallback, .. } => {
-                if let Some(rules) = optimism::OptimismBaseFeeRules::decode(header.extra_data()) {
-                    rules.next_block_base_fee(header)
-                } else {
-                    calc_next_block_base_fee(
-                        header.gas_used(),
-                        header.gas_limit(),
-                        header.base_fee_per_gas().unwrap_or_default(),
-                        fallback,
-                    )
-                }
-            }
-        }
-    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -402,18 +378,15 @@ impl FeeManager {
         if (state.rules.spec_id as u8) < (SpecId::LONDON as u8) || state.base_fee == 0 {
             return 0;
         }
-        calculate_next_block_base_fee_from_header(state.rules, header)
+        calculate_parent_header_fees(state.rules, header).base_fee
     }
 
     /// Returns all fee metadata inherited from a parent header, honoring the configured zero-fee
     /// sentinel.
     pub(crate) fn get_parent_header_fees<H: BlockHeader>(&self, header: &H) -> ParentHeaderFees {
         let state = self.state.read();
-        if (state.rules.spec_id as u8) < (SpecId::LONDON as u8) {
-            return ParentHeaderFees::default();
-        }
         let mut fees = calculate_parent_header_fees(state.rules, header);
-        if state.base_fee == 0 {
+        if (state.rules.spec_id as u8) < (SpecId::LONDON as u8) || state.base_fee == 0 {
             fees.base_fee = 0;
         }
         fees
@@ -429,7 +402,7 @@ impl FeeManager {
         if (rules.spec_id as u8) < (SpecId::LONDON as u8) {
             return 0;
         }
-        calculate_next_block_base_fee_from_header(rules, header)
+        calculate_parent_header_fees(rules, header).base_fee
     }
 
     /// Returns all fee metadata inherited from a parent header without applying the configured
@@ -439,10 +412,11 @@ impl FeeManager {
         header: &H,
     ) -> ParentHeaderFees {
         let rules = self.state.read().rules;
+        let mut fees = calculate_parent_header_fees(rules, header);
         if (rules.spec_id as u8) < (SpecId::LONDON as u8) {
-            return ParentHeaderFees::default();
+            fees.base_fee = 0;
         }
-        calculate_parent_header_fees(rules, header)
+        fees
     }
 
     /// Calculates the next block blob base fee.
@@ -487,17 +461,6 @@ fn calculate_parent_header_fees<H: BlockHeader>(rules: FeeRules, header: &H) -> 
         };
     }
     rules.base_fee.parent_header_fees(header)
-}
-
-fn calculate_next_block_base_fee_from_header<H: BlockHeader>(rules: FeeRules, header: &H) -> u64 {
-    if let Some(hardfork) = rules.tempo_hardfork {
-        return tempo_next_block_base_fee(
-            hardfork,
-            header.gas_used(),
-            header.base_fee_per_gas().unwrap_or_default(),
-        );
-    }
-    rules.base_fee.next_block_base_fee(header)
 }
 
 /// Computes the next block's base fee for a Tempo chain.
@@ -878,6 +841,23 @@ mod tests {
             london.calculate_next_block_base_fee_per_gas(30_000_000, 30_000_000, INITIAL_BASE_FEE),
             0
         );
+    }
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn pre_london_parent_fees_preserve_optimism_metadata() {
+        let fees = fee_manager(SpecId::BERLIN);
+        let jovian = [1, 0, 0, 0, 250, 0, 0, 0, 2, 0, 0, 0, 0, 0, 76, 75, 64];
+        fees.set_optimism_base_fee_rules(&jovian);
+        let header = alloy_consensus::Header {
+            extra_data: Bytes::copy_from_slice(&jovian),
+            ..Default::default()
+        };
+
+        let parent_fees = fees.get_parent_header_fees(&header);
+        assert_eq!(parent_fees.base_fee, 0);
+        assert_eq!(parent_fees.extra_data.as_ref(), jovian);
+        assert_eq!(parent_fees.optimism_jovian, Some(true));
     }
 
     #[test]

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -102,15 +102,37 @@ impl BaseFeeRules {
         }
     }
 
-    fn extra_data_from_header<H: BlockHeader>(
-        self,
-        #[cfg_attr(not(feature = "optimism"), allow(unused_variables))] header: &H,
-    ) -> Bytes {
+    fn parent_header_fees<H: BlockHeader>(self, header: &H) -> ParentHeaderFees {
         match self {
-            Self::Standard(_) => Bytes::new(),
+            Self::Standard(params) => ParentHeaderFees {
+                base_fee: calc_next_block_base_fee(
+                    header.gas_used(),
+                    header.gas_limit(),
+                    header.base_fee_per_gas().unwrap_or_default(),
+                    params,
+                ),
+                ..Default::default()
+            },
             #[cfg(feature = "optimism")]
-            Self::Optimism { .. } => optimism::OptimismBaseFeeRules::decode(header.extra_data())
-                .map_or_else(Bytes::new, optimism::OptimismBaseFeeRules::extra_data),
+            Self::Optimism { fallback, .. } => {
+                let inherited = optimism::OptimismBaseFeeRules::decode(header.extra_data());
+                ParentHeaderFees {
+                    base_fee: inherited.map_or_else(
+                        || {
+                            calc_next_block_base_fee(
+                                header.gas_used(),
+                                header.gas_limit(),
+                                header.base_fee_per_gas().unwrap_or_default(),
+                                fallback,
+                            )
+                        },
+                        |rules| rules.next_block_base_fee(header),
+                    ),
+                    extra_data: inherited
+                        .map_or_else(Bytes::new, optimism::OptimismBaseFeeRules::extra_data),
+                    optimism_jovian: inherited.map(optimism::OptimismBaseFeeRules::is_jovian),
+                }
+            }
         }
     }
 
@@ -137,6 +159,16 @@ impl BaseFeeRules {
             }
         }
     }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ParentHeaderFees {
+    /// Base fee inherited by the child block.
+    pub(crate) base_fee: u64,
+    /// Dynamic fee parameters inherited by the child block.
+    pub(crate) extra_data: Bytes,
+    /// Whether the decoded Optimism fee parameters activate Jovian.
+    pub(crate) optimism_jovian: Option<bool>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -262,21 +294,6 @@ impl FeeManager {
         self.state.read().rules.base_fee.extra_data()
     }
 
-    /// Returns the dynamic Optimism-family fee parameters encoded by `header`, if any.
-    pub(crate) fn base_fee_extra_data_from_header<H: BlockHeader>(&self, header: &H) -> Bytes {
-        self.state.read().rules.base_fee.extra_data_from_header(header)
-    }
-
-    /// Returns whether `header` activates Jovian's DA-footprint base fee accounting.
-    #[cfg(feature = "optimism")]
-    pub(crate) fn is_optimism_jovian_header<H: BlockHeader>(&self, header: &H) -> bool {
-        if !matches!(self.state.read().rules.base_fee, BaseFeeRules::Optimism { .. }) {
-            return false;
-        }
-        optimism::OptimismBaseFeeRules::decode(header.extra_data())
-            .is_some_and(optimism::OptimismBaseFeeRules::is_jovian)
-    }
-
     pub fn elasticity(&self) -> f64 {
         1f64 / self.state.read().rules.base_fee.params().elasticity_multiplier as f64
     }
@@ -388,6 +405,20 @@ impl FeeManager {
         calculate_next_block_base_fee_from_header(state.rules, header)
     }
 
+    /// Returns all fee metadata inherited from a parent header, honoring the configured zero-fee
+    /// sentinel.
+    pub(crate) fn get_parent_header_fees<H: BlockHeader>(&self, header: &H) -> ParentHeaderFees {
+        let state = self.state.read();
+        if (state.rules.spec_id as u8) < (SpecId::LONDON as u8) {
+            return ParentHeaderFees::default();
+        }
+        let mut fees = calculate_parent_header_fees(state.rules, header);
+        if state.base_fee == 0 {
+            fees.base_fee = 0;
+        }
+        fees
+    }
+
     /// Calculates the next block base fee from a complete parent header without applying the
     /// configured zero-fee sentinel.
     pub(crate) fn calculate_next_block_base_fee_from_header<H: BlockHeader>(
@@ -399,6 +430,19 @@ impl FeeManager {
             return 0;
         }
         calculate_next_block_base_fee_from_header(rules, header)
+    }
+
+    /// Returns all fee metadata inherited from a parent header without applying the configured
+    /// zero-fee sentinel.
+    pub(crate) fn calculate_parent_header_fees<H: BlockHeader>(
+        &self,
+        header: &H,
+    ) -> ParentHeaderFees {
+        let rules = self.state.read().rules;
+        if (rules.spec_id as u8) < (SpecId::LONDON as u8) {
+            return ParentHeaderFees::default();
+        }
+        calculate_parent_header_fees(rules, header)
     }
 
     /// Calculates the next block blob base fee.
@@ -429,6 +473,20 @@ fn calculate_next_block_base_fee_per_gas(
         return tempo_next_block_base_fee(hardfork, gas_used, last_fee_per_gas);
     }
     calc_next_block_base_fee(gas_used, gas_limit, last_fee_per_gas, rules.base_fee.params())
+}
+
+fn calculate_parent_header_fees<H: BlockHeader>(rules: FeeRules, header: &H) -> ParentHeaderFees {
+    if let Some(hardfork) = rules.tempo_hardfork {
+        return ParentHeaderFees {
+            base_fee: tempo_next_block_base_fee(
+                hardfork,
+                header.gas_used(),
+                header.base_fee_per_gas().unwrap_or_default(),
+            ),
+            ..Default::default()
+        };
+    }
+    rules.base_fee.parent_header_fees(header)
 }
 
 fn calculate_next_block_base_fee_from_header<H: BlockHeader>(rules: FeeRules, header: &H) -> u64 {

--- a/crates/anvil/src/eth/fees/optimism.rs
+++ b/crates/anvil/src/eth/fees/optimism.rs
@@ -194,11 +194,11 @@ mod tests {
                 inherited: Some(OptimismBaseFeeRules::decode(cached).unwrap()),
                 fallback,
             };
+            let parent_fees = rules.parent_header_fees(&header);
 
-            assert_eq!(
-                rules.next_block_base_fee(&header),
-                supplied_rules.next_block_base_fee(&header)
-            );
+            assert_eq!(parent_fees.base_fee, supplied_rules.next_block_base_fee(&header));
+            assert_eq!(parent_fees.extra_data.as_ref(), supplied);
+            assert_eq!(parent_fees.optimism_jovian, Some(supplied_rules.is_jovian()));
         }
     }
 }


### PR DESCRIPTION
Follow-up to #16519. This centralizes the network-aware blob budget shared by mining and `eth_simulateV1`, and resolves parent-header fee metadata through one snapshot so Optimism extra data is decoded once rather than independently for the next base fee, child extra data, and Jovian detection. Historical transaction-prefix replay remains intentionally exempt from the local EIP-4844 budget because it re-executes an already-valid source prefix; Jovian replay still enforces the source block gas limit as its DA budget.

The other non-blocking findings from the original review remain unchanged deliberately: per-transaction DA-scalar reads match the upstream OP executor, the pool prefilter cannot know the Jovian footprint without duplicating executor work, and minimum-base-fee configurability is separate feature scope.

AI assistance was used to review the feedback and implement the refactor. The resulting behavior and diff were manually verified.
