### PR TITLE
refactor(evm): set Monad cheatcode address at Executor builder level

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -46,6 +46,8 @@ use foundry_config::{
         value::{Dict, Map},
     },
 };
+#[cfg(feature = "monad")]
+use foundry_evm::core::evm::MonadEvmNetwork;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -53,7 +55,7 @@ use foundry_evm::{
         FoundryBlock, FoundryTransaction,
         evm::{EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, context_for_child_transaction},
     },
-    executors::TracingExecutor,
+    executors::{ExecutorBuilder, TracingExecutor},
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements},
 };
@@ -273,17 +275,23 @@ impl CallArgs {
 
         if evm_opts.networks.is_tempo() {
             return self
-                .run_with_network_and_opts::<TempoEvmNetwork>(config, evm_opts, auth_preflight)
+                .run_with_network_and_opts::<TempoEvmNetwork>(
+                    config,
+                    evm_opts,
+                    auth_preflight,
+                    ExecutorBuilder::<TempoEvmNetwork>::new(),
+                )
                 .await;
         }
 
         #[cfg(feature = "monad")]
         if evm_opts.networks.is_monad() {
             return self
-                .run_with_network_and_opts::<foundry_evm::core::evm::MonadEvmNetwork>(
+                .run_with_network_and_opts::<MonadEvmNetwork>(
                     config,
                     evm_opts,
                     auth_preflight,
+                    ExecutorBuilder::<MonadEvmNetwork>::new(),
                 )
                 .await;
         }
@@ -291,11 +299,22 @@ impl CallArgs {
         #[cfg(feature = "optimism")]
         if evm_opts.networks.is_optimism() {
             return self
-                .run_with_network_and_opts::<OpEvmNetwork>(config, evm_opts, auth_preflight)
+                .run_with_network_and_opts::<OpEvmNetwork>(
+                    config,
+                    evm_opts,
+                    auth_preflight,
+                    ExecutorBuilder::<OpEvmNetwork>::new(),
+                )
                 .await;
         }
 
-        self.run_with_network_and_opts::<EthEvmNetwork>(config, evm_opts, auth_preflight).await
+        self.run_with_network_and_opts::<EthEvmNetwork>(
+            config,
+            evm_opts,
+            auth_preflight,
+            ExecutorBuilder::<EthEvmNetwork>::new(),
+        )
+        .await
     }
 
     /// Returns whether resolving this call can disclose an authorization before the transaction
@@ -350,6 +369,7 @@ impl CallArgs {
         mut config: Box<Config>,
         evm_opts: EvmOpts,
         auth_preflight: AuthDisclosurePreflight,
+        executor_builder: ExecutorBuilder<FEN>,
     ) -> Result<()> {
         config.networks = evm_opts.networks;
         let mut state_overrides = self.get_state_overrides()?;
@@ -659,6 +679,7 @@ impl CallArgs {
                 })
                 .with_state_changes(verbosity > 4);
             let mut executor = TracingExecutor::<FEN>::new(
+                executor_builder,
                 (evm_env, tx_env),
                 fork,
                 None,

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -55,7 +55,7 @@ use foundry_evm::{
         env::FromAnyRpcTransaction as _,
         evm::{EthEvmNetwork, EvmEnvFor, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
     },
-    executors::{Executor, TracingExecutor},
+    executors::{Executor, ExecutorBuilder, TracingExecutor},
     hardforks::FoundryHardfork,
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
@@ -213,7 +213,9 @@ impl RunArgs {
         evm_opts.infer_network_from_fork().await?;
 
         if evm_opts.networks.is_tempo() {
-            return self.run_with_evm::<TempoEvmNetwork>(config, evm_opts).await;
+            return self
+                .run_with_evm(config, evm_opts, ExecutorBuilder::<TempoEvmNetwork>::new())
+                .await;
         }
 
         #[cfg(feature = "monad")]
@@ -223,16 +225,19 @@ impl RunArgs {
 
         #[cfg(feature = "optimism")]
         if evm_opts.networks.is_optimism() {
-            return self.run_with_evm::<OpEvmNetwork>(config, evm_opts).await;
+            return self
+                .run_with_evm(config, evm_opts, ExecutorBuilder::<OpEvmNetwork>::new())
+                .await;
         }
 
-        self.run_with_evm::<EthEvmNetwork>(config, evm_opts).await
+        self.run_with_evm(config, evm_opts, ExecutorBuilder::<EthEvmNetwork>::new()).await
     }
 
     async fn run_with_evm<FEN: FoundryEvmNetwork>(
         self,
         config: Box<Config>,
         evm_opts: EvmOpts,
+        executor_builder: ExecutorBuilder<FEN>,
     ) -> Result<()> {
         let target = self.fetch_target(&config).await?;
         if target.target_is_system && !self.replay_system_txes && !self.debug_trace_transaction {
@@ -241,7 +246,8 @@ impl RunArgs {
                 target.tx.tx_hash()
             );
         }
-        let Some(mut run) = self.prepare::<FEN>(config, evm_opts, target).await? else {
+        let Some(mut run) = self.prepare::<FEN>(config, evm_opts, target, executor_builder).await?
+        else {
             return Ok(());
         };
         let result = run.execute_ordinary()?;
@@ -251,7 +257,15 @@ impl RunArgs {
     #[cfg(feature = "monad")]
     async fn run_with_monad(self, config: Box<Config>, evm_opts: EvmOpts) -> Result<()> {
         let target = self.fetch_target(&config).await?;
-        let Some(mut run) = self.prepare::<MonadEvmNetwork>(config, evm_opts, target).await? else {
+        let Some(mut run) = self
+            .prepare::<MonadEvmNetwork>(
+                config,
+                evm_opts,
+                target,
+                ExecutorBuilder::<MonadEvmNetwork>::new(),
+            )
+            .await?
+        else {
             return Ok(());
         };
         let result = run.execute_monad().await?;
@@ -287,6 +301,7 @@ impl RunArgs {
         mut config: Box<Config>,
         evm_opts: EvmOpts,
         target: TargetFetch,
+        executor_builder: ExecutorBuilder<FEN>,
     ) -> Result<Option<PreparedRun<FEN>>> {
         #[cfg_attr(not(feature = "monad"), allow(unused_variables))]
         let TargetFetch { tx, provider, compute_units_per_second, .. } = target;
@@ -531,6 +546,7 @@ impl RunArgs {
         apply_chain_specific_tx_replay_env_changes_for_chain(&mut evm_env, chain.id());
 
         let mut executor = TracingExecutor::<FEN>::new(
+            executor_builder,
             (evm_env.clone(), tx_env),
             fork,
             evm_version,

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -328,7 +328,8 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
             None,
         );
 
-        let executor = ExecutorBuilder::default()
+        // TODO(monad-fen-dispatch): Select the concrete builder at Chisel network dispatch.
+        let executor = ExecutorBuilder::legacy_network_config()
             .inspectors(|stack| {
                 stack
                     .logs(self.config.foundry_config.live_logs)

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -1,8 +1,15 @@
 use crate::{executors::Executor, inspectors::InspectorStackBuilder};
+#[cfg(feature = "optimism")]
+use foundry_evm_core::evm::OpEvmNetwork;
 use foundry_evm_core::{
     backend::Backend,
-    evm::{BlockEnvFor, EvmEnvFor, FoundryEvmNetwork, SpecFor, TxEnvFor},
+    evm::{
+        BlockEnvFor, EthEvmNetwork, EvmEnvFor, FoundryEvmNetwork, SpecFor, TempoEvmNetwork,
+        TxEnvFor,
+    },
 };
+#[cfg(feature = "monad")]
+use foundry_evm_core::{constants::MONAD_CHEATCODE_ADDRESS, evm::MonadEvmNetwork};
 use foundry_evm_networks::NetworkConfigs;
 use revm::context::{Block, Transaction};
 
@@ -29,7 +36,7 @@ impl<FEN: FoundryEvmNetwork> Default for ExecutorBuilder<FEN> {
     #[inline]
     fn default() -> Self {
         Self {
-            stack: InspectorStackBuilder::new(),
+            stack: InspectorStackBuilder::new().extra_cheatcode_addresses(&[]),
             gas_limit: None,
             spec: None,
             legacy_assertions: false,
@@ -38,6 +45,16 @@ impl<FEN: FoundryEvmNetwork> Default for ExecutorBuilder<FEN> {
 }
 
 impl<FEN: FoundryEvmNetwork> ExecutorBuilder<FEN> {
+    /// Creates a builder that temporarily resolves additional cheatcode addresses from network
+    /// configuration.
+    #[doc(hidden)]
+    #[inline]
+    pub fn legacy_network_config() -> Self {
+        let mut this = Self::default();
+        this.stack.extra_cheatcode_addresses = None;
+        this
+    }
+
     /// Modify the inspector stack.
     #[inline]
     pub fn inspectors(
@@ -101,5 +118,40 @@ impl<FEN: FoundryEvmNetwork> ExecutorBuilder<FEN> {
             evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec);
         }
         Executor::new(db, evm_env, tx_env, stack.build(), networks, gas_limit, legacy_assertions)
+    }
+}
+
+impl ExecutorBuilder<EthEvmNetwork> {
+    /// Creates the default Ethereum executor builder.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "optimism")]
+impl ExecutorBuilder<OpEvmNetwork> {
+    /// Creates the default OP executor builder.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ExecutorBuilder<TempoEvmNetwork> {
+    /// Creates the default Tempo executor builder.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "monad")]
+impl ExecutorBuilder<MonadEvmNetwork> {
+    /// Creates a Monad executor builder with MonadVM cheatcode support.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+            .inspectors(|stack| stack.extra_cheatcode_addresses(&[MONAD_CHEATCODE_ADDRESS]))
     }
 }

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -2012,6 +2012,8 @@ mod tests {
         Vm::{blobhashesCall, mockCallRevert_1Call, revertToStateCall, snapshotStateCall},
     };
     use foundry_config::Config;
+    #[cfg(feature = "monad")]
+    use foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS;
     use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
     use foundry_evm_traces::InternalTraceMode;
     use revm::context::TxEnv;
@@ -2041,49 +2043,36 @@ mod tests {
     fn network_cheatcode_revert_handling_is_monad_specific() {
         let target = Address::from([0x11; 20]);
 
-        assert!(should_ignore_revert(
-            false,
-            target,
-            Some(foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS),
-            &[]
-        ));
+        assert!(should_ignore_revert(false, target, Some(MONAD_CHEATCODE_ADDRESS), &[]));
         assert!(!should_ignore_revert(
             false,
             target,
-            Some(foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS),
+            Some(MONAD_CHEATCODE_ADDRESS),
             NetworkConfigs::with_monad().extra_cheatcode_addresses(),
         ));
     }
 
     #[cfg(feature = "monad")]
     #[test]
-    fn executor_networks_follow_explicit_configuration() {
-        let ethereum = ExecutorBuilder::<EthEvmNetwork>::default().build(
+    fn executor_tooling_follows_concrete_builder() {
+        let ethereum = ExecutorBuilder::<EthEvmNetwork>::new().build(
             EvmEnvFor::<EthEvmNetwork>::default(),
             TxEnvFor::<EthEvmNetwork>::default(),
             Backend::spawn(None).unwrap(),
-            NetworkConfigs::default(),
+            NetworkConfigs::with_monad(),
         );
-        assert!(!ethereum.backend().networks().is_monad());
-        assert!(
-            !ethereum
-                .backend()
-                .is_persistent(&foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS)
-        );
+        assert!(ethereum.backend().networks().is_monad());
+        assert!(!ethereum.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
 
-        let monad = ExecutorBuilder::<foundry_evm_core::evm::MonadEvmNetwork>::default()
-            .inspectors(|stack| stack.networks(NetworkConfigs::default()))
-            .build(
-                EvmEnvFor::<foundry_evm_core::evm::MonadEvmNetwork>::default(),
-                TxEnvFor::<foundry_evm_core::evm::MonadEvmNetwork>::default(),
-                Backend::spawn(None).unwrap(),
-                NetworkConfigs::with_monad(),
-            );
+        let monad = ExecutorBuilder::<MonadEvmNetwork>::new().build(
+            EvmEnvFor::<MonadEvmNetwork>::default(),
+            TxEnvFor::<MonadEvmNetwork>::default(),
+            Backend::spawn(None).unwrap(),
+            NetworkConfigs::with_monad(),
+        );
         assert!(monad.inspector().networks.is_monad());
         assert!(monad.backend().networks().is_monad());
-        assert!(
-            monad.backend().is_persistent(&foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS)
-        );
+        assert!(monad.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -22,7 +22,10 @@ pub struct TracingExecutor<FEN: FoundryEvmNetwork> {
 }
 
 impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
+    /// Creates a tracing executor from tooling resolved by concrete network dispatch.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
+        builder: ExecutorBuilder<FEN>,
         env: (EvmEnvFor<FEN>, TxEnvFor<FEN>),
         fork: CreateFork,
         version: Option<EvmVersion>,
@@ -34,7 +37,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         let db = Backend::spawn(Some(fork))?;
         // configures a bare version of the evm executor: no cheatcode and log_collector inspector
         // is enabled, tracing will be enabled only for the targeted transaction
-        let mut executor = ExecutorBuilder::default()
+        let mut executor = builder
             .inspectors(|stack| {
                 stack.trace_requirements(trace_requirements).create2_deployer(create2_deployer)
             })

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -93,6 +93,8 @@ pub struct InspectorStackBuilder<BLOCK: Clone> {
     // family-neutral inspector inputs before selecting `FEN`, while Monad tooling is configured by
     // the concrete Monad construction path.
     pub networks: NetworkConfigs,
+    /// Explicitly resolved additional cheatcode addresses.
+    pub extra_cheatcode_addresses: Option<&'static [Address]>,
     /// The wallets to set in the cheatcodes context.
     pub wallets: Option<Wallets>,
     /// The CREATE2 deployer address.
@@ -114,6 +116,7 @@ impl<BLOCK: Clone> Default for InspectorStackBuilder<BLOCK> {
             chisel_state: None,
             enable_isolation: false,
             networks: NetworkConfigs::default(),
+            extra_cheatcode_addresses: None,
             wallets: None,
             create2_deployer: Default::default(),
         }
@@ -222,6 +225,13 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
         self
     }
 
+    /// Sets explicitly resolved additional cheatcode addresses.
+    #[inline]
+    pub const fn extra_cheatcode_addresses(mut self, addresses: &'static [Address]) -> Self {
+        self.extra_cheatcode_addresses = Some(addresses);
+        self
+    }
+
     #[inline]
     pub const fn create2_deployer(mut self, create2_deployer: Address) -> Self {
         self.create2_deployer = create2_deployer;
@@ -245,13 +255,15 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
             chisel_state,
             enable_isolation,
             networks,
+            extra_cheatcode_addresses,
             wallets,
             create2_deployer,
         } = self;
         let mut stack = InspectorStack::new();
-        // TODO(monad-fen-dispatch): This is the temporary resolution point for the staged cleanup.
-        // Move it to each command's initial FEN dispatch and pass only the resolved addresses here.
-        let extra_cheatcode_addresses = networks.extra_cheatcode_addresses();
+        // TODO(monad-fen-dispatch): Forge, Script, and Chisel still rely on this fallback until
+        // their concrete construction paths select the corresponding executor builder.
+        let extra_cheatcode_addresses =
+            extra_cheatcode_addresses.unwrap_or_else(|| networks.extra_cheatcode_addresses());
 
         // inspectors
         if let Some(config) = cheatcodes {

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -621,7 +621,8 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
         );
         cheats_config.isolate = self.isolation;
         let cheats_config = Arc::new(cheats_config);
-        ExecutorBuilder::default()
+        // TODO(monad-fen-dispatch): Select the concrete builder at Forge network dispatch.
+        ExecutorBuilder::legacy_network_config()
             .inspectors(|stack| {
                 stack
                     .logs(self.config.live_logs)

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -1060,7 +1060,8 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         };
 
         // We need to enable tracing to decode contract names: local or external.
-        let mut builder = ExecutorBuilder::default()
+        // TODO(monad-fen-dispatch): Select the concrete builder at Script network dispatch.
+        let mut builder = ExecutorBuilder::legacy_network_config()
             .inspectors(|stack| {
                 stack
                     .logs(self.config.live_logs)

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -45,7 +45,7 @@ use foundry_evm::{
             TxEnvFor,
         },
     },
-    executors::{EvmError, TracingExecutor},
+    executors::{EvmError, ExecutorBuilder, TracingExecutor},
     opts::{EvmOpts, ForkEndpointIdentity},
     utils::apply_chain_specific_tx_replay_env_changes_for_chain,
 };
@@ -256,6 +256,7 @@ impl VerifyBytecodeArgs {
                     endpoint_identity,
                     network_was_inferred,
                     replay_block_transactions::<EthEvmNetwork>,
+                    ExecutorBuilder::<EthEvmNetwork>::new(),
                 )
                 .await
             }
@@ -266,6 +267,7 @@ impl VerifyBytecodeArgs {
                     endpoint_identity,
                     network_was_inferred,
                     replay_block_transactions::<OpEvmNetwork>,
+                    ExecutorBuilder::<OpEvmNetwork>::new(),
                 )
                 .await
             }
@@ -275,6 +277,7 @@ impl VerifyBytecodeArgs {
                     endpoint_identity,
                     network_was_inferred,
                     replay_block_transactions::<TempoEvmNetwork>,
+                    ExecutorBuilder::<TempoEvmNetwork>::new(),
                 )
                 .await
             }
@@ -285,6 +288,7 @@ impl VerifyBytecodeArgs {
                     endpoint_identity,
                     network_was_inferred,
                     replay_monad_block_transactions,
+                    ExecutorBuilder::<MonadEvmNetwork>::new(),
                 )
                 .await
             }
@@ -297,6 +301,7 @@ impl VerifyBytecodeArgs {
         endpoint_identity: Option<ForkEndpointIdentity>,
         network_was_inferred: bool,
         replay_block: ReplayBlockFn<FEN>,
+        executor_builder: ExecutorBuilder<FEN>,
     ) -> Result<()>
     where
         FEN: FoundryEvmNetwork,
@@ -527,6 +532,7 @@ impl VerifyBytecodeArgs {
                 deploy_block,
                 deploy_block_info.as_ref(),
                 evm_opts,
+                executor_builder.clone(),
             )
             .await?;
             Self::ensure_endpoint_identity_unchanged(&config, endpoint_identity.as_ref()).await?;
@@ -821,6 +827,7 @@ impl VerifyBytecodeArgs {
                 simulation_block,
                 block.as_ref(),
                 evm_opts,
+                executor_builder,
             )
             .await?;
             Self::ensure_endpoint_identity_unchanged(&config, endpoint_identity.as_ref()).await?;

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -31,7 +31,7 @@ use foundry_evm::{
         decode::RevertDecoder,
         evm::{BlockContext, BlockEnvFor, ChainFor, EvmEnvFor, FoundryEvmNetwork, TxEnvFor},
     },
-    executors::TracingExecutor,
+    executors::{ExecutorBuilder, TracingExecutor},
     opts::EvmOpts,
     traces::TraceRequirements,
     utils::{apply_chain_and_block_specific_env_changes_for_chain, block_env_from_header},
@@ -356,6 +356,7 @@ pub async fn get_tracing_executor<FEN>(
     execution_blk_num: u64,
     execution_block: Option<&AnyRpcBlock>,
     evm_opts: EvmOpts,
+    executor_builder: ExecutorBuilder<FEN>,
 ) -> Result<(EvmEnvFor<FEN>, TxEnvFor<FEN>, TracingExecutor<FEN>)>
 where
     FEN: FoundryEvmNetwork,
@@ -380,6 +381,7 @@ where
     TracingExecutor::<FEN>::extend_precompile_labels(fork_config, networks, resolved_hardfork);
 
     let executor = TracingExecutor::<FEN>::new(
+        executor_builder,
         (evm_env.clone(), tx_env.clone()),
         fork,
         None,


### PR DESCRIPTION
This makes concrete FEN dispatch select executor tooling instead of resolving it later from `NetworkConfigs`. Each supported FEN exposes an inherent `ExecutorBuilder::new`: Ethereum, OP, and Tempo use the uncustomized baseline, while Monad installs the MonadVM cheatcode address.

Cast and Verify carry the selected builder through typed preparation into the single `TracingExecutor::new` constructor. This makes the concrete FEN authoritative even if later configuration disagrees. A temporary hidden fallback preserves the not-yet-converted runner paths and is removed by the stacked follow-up.
