### PR TITLE
fix(evm): saturate folded-stack-trace gas subtraction on resetGasMetering

### DIFF
--- a/.changelog/pr-16563.md
+++ b/.changelog/pr-16563.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-traces: patch
+---
+
+Fixed `forge test --flamegraph` producing an absurd gas value (or panicking in debug builds) for an internal call whose gas metering was reset via `vm.resetGasMetering()`.

--- a/crates/evm/traces/src/folded_stack_trace.rs
+++ b/crates/evm/traces/src/folded_stack_trace.rs
@@ -105,7 +105,11 @@ impl EvmFoldedStackTraceBuilder {
         if let Some(decoded_step) = &step.decoded {
             match decoded_step.as_ref() {
                 DecodedTraceStep::InternalCall(decoded_internal_call, step_end_idx) => {
-                    let gas_used = step.gas_remaining - steps[*step_end_idx].gas_remaining;
+                    // `resetGasMetering` (a real cheatcode) can make exit gas_remaining higher than
+                    // entry gas_remaining for an internal-call frame; saturate rather than
+                    // underflow into a near-u64::MAX garbage value (or panic in debug builds).
+                    let gas_used =
+                        step.gas_remaining.saturating_sub(steps[*step_end_idx].gas_remaining);
                     self.fst.enter(decoded_internal_call.func_name.clone(), gas_used);
                     step_exits.push(*step_end_idx);
                 }
@@ -378,6 +382,32 @@ mod tests {
         assert_eq!(
             super::build(&arena, false),
             vec!["fallback 70", "fallback;DebugVarsTest::foo(uint256) 30",]
+        );
+    }
+
+    #[test]
+    fn folded_stack_trace_saturates_internal_call_gas_on_reset_metering() {
+        // `vm.resetGasMetering()` can make the exit step's gas_remaining higher than the
+        // entry step's for an internal-call frame. Regression test for the raw subtraction
+        // that used to underflow to a near-u64::MAX value (or panic in debug builds).
+        let mut arena = CallTraceArena::default();
+        let root = &mut arena.nodes_mut()[0];
+        root.trace.gas_used = 100;
+        root.trace.gas_limit = 100;
+        root.trace.steps = vec![trace_step(70), trace_step(100)];
+        root.trace.steps[0].decoded = Some(Box::new(DecodedTraceStep::InternalCall(
+            DecodedInternalCall {
+                func_name: "DebugVarsTest::resetsGas()".to_string(),
+                args: None,
+                return_data: None,
+            },
+            1,
+        )));
+        root.ordering = vec![TraceMemberOrder::Step(0), TraceMemberOrder::Step(1)];
+
+        assert_eq!(
+            super::build(&arena, false),
+            vec!["fallback 100", "fallback;DebugVarsTest::resetsGas() 0",]
         );
     }
 }

--- a/crates/evm/traces/src/folded_stack_trace.rs
+++ b/crates/evm/traces/src/folded_stack_trace.rs
@@ -105,9 +105,7 @@ impl EvmFoldedStackTraceBuilder {
         if let Some(decoded_step) = &step.decoded {
             match decoded_step.as_ref() {
                 DecodedTraceStep::InternalCall(decoded_internal_call, step_end_idx) => {
-                    // `resetGasMetering` (a real cheatcode) can make exit gas_remaining higher than
-                    // entry gas_remaining for an internal-call frame; saturate rather than
-                    // underflow into a near-u64::MAX garbage value (or panic in debug builds).
+                    // Gas metering resets can increase the remaining gas across an internal call.
                     let gas_used =
                         step.gas_remaining.saturating_sub(steps[*step_end_idx].gas_remaining);
                     self.fst.enter(decoded_internal_call.func_name.clone(), gas_used);
@@ -387,9 +385,7 @@ mod tests {
 
     #[test]
     fn folded_stack_trace_saturates_internal_call_gas_on_reset_metering() {
-        // `vm.resetGasMetering()` can make the exit step's gas_remaining higher than the
-        // entry step's for an internal-call frame. Regression test for the raw subtraction
-        // that used to underflow to a near-u64::MAX value (or panic in debug builds).
+        // Model an internal call whose gas meter resets before returning.
         let mut arena = CallTraceArena::default();
         let root = &mut arena.nodes_mut()[0];
         root.trace.gas_used = 100;


### PR DESCRIPTION
## What

`process_step()` in `crates/evm/traces/src/folded_stack_trace.rs` computed an internal call's gas usage as a raw `u64` subtraction between the call's entry and exit `gas_remaining`:

```rust
let gas_used = step.gas_remaining - steps[*step_end_idx].gas_remaining;
```

`vm.resetGasMetering()` can make the exit step's `gas_remaining` *higher* than the entry step's for that frame (it resets the gas counter mid-call), which underflows this subtraction:

- In a release build: wraps to a near-`u64::MAX` value. Visible directly in `--flamegraph` output as an absurd entry, e.g. `18,446,744,073,709,496,320 gas (9906951704459732.00%)` for an internal function that actually used a few hundred gas.
- In a debug build: hard panics with `attempt to subtract with overflow` (confirmed — see Testing below).

Every other subtraction site in this same file is already defensive against this class of issue (`subtract_children`'s `parent.gas.saturating_sub(*gas)` a few lines down) — this was the one remaining raw subtraction.

## Fix

Use `saturating_sub`, matching:
- The existing parent-gas subtraction a few lines below in this same file.
- `revm-inspectors`' own pinned trace writer, which uses `end.gas_used.saturating_sub(start.gas_used)` for the identical decoded-internal-call computation.

Zero is the correct fallback here, not an approximation to improve on — once `resetGasMetering()` puts the entry and exit readings in different metering epochs, their difference isn't recoverable from those two values alone; any nonzero clamp would be inventing a number.

## Testing

- Added `folded_stack_trace_saturates_internal_call_gas_on_reset_metering`, mirroring the existing `folded_stack_trace_keeps_precise_internal_function_names` test shape but with increasing `gas_remaining` across the two steps (simulating a mid-call metering reset).
- Confirmed real red→green: temporarily reverted just the fix line (keeping the new test) and re-ran — it panicked with `attempt to subtract with overflow` at the exact original line, exactly matching the failure mode this PR fixes. Restored the fix and re-ran clean.
- `cargo test -p foundry-evm-traces --lib folded_stack_trace` — 6/6 pass.
- `cargo fmt --check -p foundry-evm-traces` — clean.

## Review

No existing issue/PR covers this (searched by both the underflow's mechanism and the file). Ran an independent adversarial pass over the diff — no blocking findings; it flagged that `saturating_sub` is the correct localized fix and independently surfaced the same `revm-inspectors` precedent cited above, and confirmed no other subtraction/indexing site in this diff or file is affected.
