### PR TITLE
fix(cheatcodes): don't panic on a bare type name in parseJsonType/parseTomlType

### DIFF
--- a/.changelog/fix-parse-json-type-panic-on-bare-name.md
+++ b/.changelog/fix-parse-json-type-panic-on-bare-name.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-cheatcodes: patch
+---
+
+Fixed `vm.parseJsonType`/`vm.parseTomlType` (and related type-resolving cheatcodes) panicking instead of returning the intended error when given a bare type/struct name.

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -1137,11 +1137,7 @@ mod tests {
 
     #[test]
     fn test_resolve_type_bare_struct_name_errors_instead_of_panicking() {
-        // `EncodeType::parse` returns `Ok` with an empty `types` vec (not `Err`) for input
-        // that has no `(` - e.g. a bare struct/type name a user might pass by mistake. Before
-        // the fix, indexing `encoded.types[0]` unconditionally panicked here instead of
-        // falling through to the `bail!` below, which aborts the whole process in release
-        // builds (`panic = "abort"`).
+        // `EncodeType::parse` succeeds with an empty type list for inputs without `(`.
         let err = resolve_type("Foo", None).unwrap_err();
         assert!(
             err.to_string().contains("valid Solidity type or a EIP712 `encodeType` string"),

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -814,8 +814,10 @@ pub(super) fn resolve_type(
         return ordered_ty(ty);
     };
 
-    if let Ok(encoded) = EncodeType::parse(type_description) {
-        let main_type = encoded.types[0].type_name;
+    if let Ok(encoded) = EncodeType::parse(type_description)
+        && let Some(main) = encoded.types.first()
+    {
+        let main_type = main.type_name;
         let mut resolver = Resolver::default();
         for t in &encoded.types {
             resolver.ingest(t.to_owned());
@@ -1131,6 +1133,20 @@ mod tests {
             return Ok(());
         }
         panic!("Expected Person to be CustomStruct");
+    }
+
+    #[test]
+    fn test_resolve_type_bare_struct_name_errors_instead_of_panicking() {
+        // `EncodeType::parse` returns `Ok` with an empty `types` vec (not `Err`) for input
+        // that has no `(` - e.g. a bare struct/type name a user might pass by mistake. Before
+        // the fix, indexing `encoded.types[0]` unconditionally panicked here instead of
+        // falling through to the `bail!` below, which aborts the whole process in release
+        // builds (`panic = "abort"`).
+        let err = resolve_type("Foo", None).unwrap_err();
+        assert!(
+            err.to_string().contains("valid Solidity type or a EIP712 `encodeType` string"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`resolve_type()` (`crates/cheatcodes/src/json.rs`) is the shared helper behind `vm.parseJsonType`/`vm.parseTomlType` and the other type-resolving cheatcodes. On the EIP-712 `encodeType` fallback path it did:

```rust
if let Ok(encoded) = EncodeType::parse(type_description) {
    let main_type = encoded.types[0].type_name;  // unconditional index
    ...
}
```

`EncodeType::parse` returns `Ok` with an **empty** `types` vec (not `Err`) whenever the input has no `(` — e.g. a bare struct/type name, which is the single most natural mistake a user can make when calling this cheatcode. The `bail!` a few lines below was meant to catch exactly this case, but it's dead code: the `Err` branch it's guarding against never fires here, so the unconditional `encoded.types[0]` panics instead.

Since this repo's release profile is `panic = "abort"`, this kills the entire `forge` process rather than surfacing the (already-written) error message.

## Repro

Confirmed empirically (pre-fix, reverted temporarily to check):

```
$ resolve_type("Foo", None)
thread '...' panicked at crates/cheatcodes/src/json.rs:818:38:
index out of bounds: the len is 0 but the index is 0
```

Equivalent Solidity-side repro: `vm.parseJsonType('{"a":1}', "Foo")` aborts the whole process instead of reverting with the intended error.

## Fix

```rust
if let Ok(encoded) = EncodeType::parse(type_description)
    && let Some(main) = encoded.types.first()
{
    let main_type = main.type_name;
    ...
}
```

An empty `types` vec now falls through to the existing `bail!("type description should be a valid Solidity type or a EIP712 \`encodeType\` string")` instead of panicking. Let-chains are already used elsewhere in this codebase (edition 2024, rust-version 1.89).

Checked for the same pattern elsewhere in the file/crate — the only other `EncodeType::parse` call site (`utils.rs`) already goes through `canonicalize()`, which safely errors on an empty type list, so this is the only unguarded spot.

## Testing

- Added `test_resolve_type_bare_struct_name_errors_instead_of_panicking`, asserting `resolve_type("Foo", None)` now returns the intended `Err` instead of panicking.
- Full `json::tests` suite (12 tests) green: `cargo test -p foundry-cheatcodes --lib json::` — all pass, no regressions.
- Empirically reproduced the pre-fix panic (see Repro above) by temporarily reverting the fix and running a `#[should_panic(expected = "index out of bounds")]` test against the original code, confirming the exact mechanism before restoring the fix.
- `cargo fmt --check` clean.
- Codex adversarial review (independent pass): confirmed the let-chain is behaviorally equivalent to the original indexing for every non-empty `types` vector (no regression on valid input), confirmed no other `EncodeType::parse` + unguarded-index site exists elsewhere in the crate, no other issues found.

## receipts

No sim/UI involved — this is a Rust CLI/cheatcode library fix; the receipts are the real command output above (red-then-green panic repro, full test suite, Codex review) rather than a screenshot.

closes nothing — filed independently, no corresponding issue was open (dupe-checked, nothing found).