### PR TITLE
fix(forge): stop reporting a false diff for zero-gas snapshot tolerance checks

### DIFF
--- a/.changelog/zero-gas-snapshot-tolerance.md
+++ b/.changelog/zero-gas-snapshot-tolerance.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed false gas snapshot diffs for zero-gas tests when using a tolerance.

--- a/crates/forge/src/cmd/snapshot.rs
+++ b/crates/forge/src/cmd/snapshot.rs
@@ -391,7 +391,12 @@ impl GasSnapshotDiff {
 
     /// Determines the percentage change
     fn gas_diff(&self) -> f64 {
-        self.gas_change() as f64 / self.target_gas_used.gas() as f64
+        let target_gas = self.target_gas_used.gas();
+        if target_gas > 0 {
+            self.gas_change() as f64 / target_gas as f64
+        } else {
+            0.0
+        }
     }
 }
 
@@ -588,6 +593,13 @@ fn within_tolerance(source_gas: u64, target_gas: u64, tolerance_pct: Option<u32>
         } else {
             (target_gas, source_gas)
         };
+        if hi == 0 {
+            // Both values are 0 (e.g. Invariant/Symbolic/Replay tests report 0 gas by
+            // design) - there's no meaningful percentage difference to compute, and
+            // `0.0 / 0.0` would produce NaN, which always compares false and would
+            // incorrectly flag these tests as out of tolerance.
+            return true;
+        }
         let diff = (1. - (lo as f64 / hi as f64)) * 100.;
         diff < tolerance as f64
     } else {
@@ -606,6 +618,9 @@ mod tests {
         assert!(!within_tolerance(100, 106, Some(5)));
         assert!(!within_tolerance(106, 100, Some(5)));
         assert!(within_tolerance(100, 100, None));
+        // Invariant/Symbolic/Replay tests report 0 gas by design - a 0-vs-0 comparison
+        // must not fall into the NaN trap that division-by-zero would otherwise cause.
+        assert!(within_tolerance(0, 0, Some(5)));
     }
 
     #[test]

--- a/crates/forge/src/cmd/snapshot.rs
+++ b/crates/forge/src/cmd/snapshot.rs
@@ -395,13 +395,10 @@ impl GasSnapshotDiff {
         if target_gas > 0 {
             self.gas_change() as f64 / target_gas as f64
         } else if self.source_gas_used.gas() == 0 {
-            // Both zero (e.g. Invariant/Symbolic/Replay tests, which report 0 gas by
-            // design) - there's no change to report.
+            // No percentage change when both values are zero.
             0.0
         } else {
-            // Target is zero but source isn't: an unbounded increase from a
-            // not-applicable baseline. `f64::INFINITY` preserves that signal instead
-            // of silently reading as "no change".
+            // Preserve an unbounded increase from zero.
             f64::INFINITY
         }
     }
@@ -601,10 +598,7 @@ fn within_tolerance(source_gas: u64, target_gas: u64, tolerance_pct: Option<u32>
             (target_gas, source_gas)
         };
         if hi == 0 {
-            // Both values are 0 (e.g. Invariant/Symbolic/Replay tests report 0 gas by
-            // design) - there's no meaningful percentage difference to compute, and
-            // `0.0 / 0.0` would produce NaN, which always compares false and would
-            // incorrectly flag these tests as out of tolerance.
+            // No percentage difference when both values are zero.
             return true;
         }
         let diff = (1. - (lo as f64 / hi as f64)) * 100.;
@@ -625,8 +619,6 @@ mod tests {
         assert!(!within_tolerance(100, 106, Some(5)));
         assert!(!within_tolerance(106, 100, Some(5)));
         assert!(within_tolerance(100, 100, None));
-        // Invariant/Symbolic/Replay tests report 0 gas by design - a 0-vs-0 comparison
-        // must not fall into the NaN trap that division-by-zero would otherwise cause.
         assert!(within_tolerance(0, 0, Some(5)));
     }
 

--- a/crates/forge/src/cmd/snapshot.rs
+++ b/crates/forge/src/cmd/snapshot.rs
@@ -394,8 +394,15 @@ impl GasSnapshotDiff {
         let target_gas = self.target_gas_used.gas();
         if target_gas > 0 {
             self.gas_change() as f64 / target_gas as f64
-        } else {
+        } else if self.source_gas_used.gas() == 0 {
+            // Both zero (e.g. Invariant/Symbolic/Replay tests, which report 0 gas by
+            // design) - there's no change to report.
             0.0
+        } else {
+            // Target is zero but source isn't: an unbounded increase from a
+            // not-applicable baseline. `f64::INFINITY` preserves that signal instead
+            // of silently reading as "no change".
+            f64::INFINITY
         }
     }
 }


### PR DESCRIPTION
## What

`forge snapshot --check --tolerance N` reports a diff for tests whose gas is 0 on both sides — even though the snapshot is byte-identical — because the comparison math divides by zero and gets `NaN`, and any comparison against `NaN` evaluates `false` in Rust.

Zero gas isn't a hypothetical edge case here: Invariant, Symbolic, and Replay test kinds report `gas() == 0` by design (see `TestResult::gas()`). So any repo with an invariant test running `--check --tolerance` in CI fails permanently, and regenerating the snapshot can never fix it — the bug is in the comparison, not the data.

```
$ forge snapshot --check                 # exit 0
$ forge snapshot --check --tolerance 5   # exit 1
Diff in "InvTest::invariant_alwaysTrue()": consumed "(runs: 256, ...)" gas,
                                           expected "(runs: 256, ...)" gas
```
Identical source and target, reported as a diff.

The aggregate summary path a few lines below `within_tolerance` already guards this exact case (`if overall_gas_used > 0 { ... } else { 0.0 }`) — the per-entry comparison never got the same guard. `gas_diff()` (used for `--diff`'s percentage display) had the identical unguarded division.

## Fix

- `within_tolerance`: early-return `true` when both values are 0 (no meaningful percentage to compute, and 0 vs 0 is trivially within any tolerance).
- `gas_diff`: only treat `target == 0 && source == 0` as `0.0` (no change). `target == 0 && source > 0` still returns `f64::INFINITY`, preserving the original (pre-bug) signal for a genuine unbounded increase from a not-applicable baseline, rather than silently reading as "no change".
- New `test_tolerance` case pinning `within_tolerance(0, 0, Some(5))`.

## Testing

`cargo test -p forge --lib cmd::snapshot::tests::test_tolerance` — passes, including the new 0-vs-0 case.

Ran a synchronous adversarial review pass before opening this: it caught that my first draft of the `gas_diff` fix collapsed a genuine `0 → 100` increase to a misleading `0.000%` instead of preserving the unbounded-increase signal. Fixed in the second commit — only the true `0 vs 0` case reads as no-change now.

**Known pre-existing, out-of-scope caveats** (not fixed here, noted for visibility): the tolerance boundary check uses `<` despite the doc comment's "up to" wording (so a diff exactly equal to the tolerance is rejected), and the gas-snapshot parser doesn't currently appear to recognize Symbolic/Replay report formats, so in practice this fix's most immediate effect is on Invariant snapshots.