### PR TITLE
fix(cast): avoid panic when creation-code args exceed bytecode length

### DIFF
--- a/.changelog/cast-creation-code-underflow.md
+++ b/.changelog/cast-creation-code-underflow.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fixed a panic (`attempt to subtract with overflow`) in `cast creation-code --without-args`/`--only-args` when a user-supplied `--abi-path` ABI declares more constructor argument bytes than the deployed bytecode actually contains, returning an error instead.

--- a/crates/cast/src/cmd/creation_code.rs
+++ b/crates/cast/src/cmd/creation_code.rs
@@ -119,6 +119,14 @@ pub async fn parse_code_output(
     }
 
     let args_size = constructor.inputs.len() * 32;
+    if bytecode.len() < args_size {
+        return Err(eyre!(
+            "Invalid creation bytecode length: have {} bytes, need at least {} for {} constructor inputs",
+            bytecode.len(),
+            args_size,
+            constructor.inputs.len()
+        ));
+    }
 
     let bytecode = if without_args {
         Bytes::from(bytecode[..bytecode.len() - args_size].to_vec())
@@ -129,6 +137,147 @@ pub async fn parse_code_output(
     };
 
     Ok(bytecode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    // Constructor ABI declaring 2 uint256 inputs (64 bytes encoded), paired with a
+    // deployed bytecode shorter than that - e.g. an EIP-1167 minimal proxy is only
+    // ~45 bytes. `--abi-path` is user-supplied and documented as not needing to match
+    // the actually-deployed contract, so this combination is directly reachable.
+    const TWO_UINT_CONSTRUCTOR_ABI: &str = r#"[{
+        "type": "constructor",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {"name": "a", "type": "uint256", "internalType": "uint256"},
+            {"name": "b", "type": "uint256", "internalType": "uint256"}
+        ]
+    }]"#;
+
+    fn write_abi_file(contents: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(contents.as_bytes()).unwrap();
+        file
+    }
+
+    // 20 bytes of "code" (0xAA) followed by 64 bytes of "args" (0xBB), so a correct
+    // split is verifiable by content, not just by length.
+    fn code_plus_args_bytecode() -> Bytes {
+        let mut b = vec![0xAAu8; 20];
+        b.extend(vec![0xBBu8; 64]);
+        Bytes::from(b)
+    }
+
+    #[tokio::test]
+    async fn without_args_errors_instead_of_panicking_on_undersized_bytecode() {
+        let abi_file = write_abi_file(TWO_UINT_CONSTRUCTOR_ABI);
+        // 20-byte bytecode, but the ABI declares 64 bytes of constructor args.
+        let bytecode = Bytes::from(vec![0u8; 20]);
+
+        let result = parse_code_output(
+            bytecode,
+            Address::ZERO,
+            &Config::default(),
+            Some(abi_file.path().to_str().unwrap()),
+            true,
+            false,
+        )
+        .await;
+
+        assert!(result.is_err(), "expected an error, not a panic, on undersized bytecode");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Invalid creation bytecode length"), "unexpected message: {msg}");
+    }
+
+    #[tokio::test]
+    async fn only_args_errors_instead_of_panicking_on_undersized_bytecode() {
+        let abi_file = write_abi_file(TWO_UINT_CONSTRUCTOR_ABI);
+        let bytecode = Bytes::from(vec![0u8; 20]);
+
+        let result = parse_code_output(
+            bytecode,
+            Address::ZERO,
+            &Config::default(),
+            Some(abi_file.path().to_str().unwrap()),
+            false,
+            true,
+        )
+        .await;
+
+        assert!(result.is_err(), "expected an error, not a panic, on undersized bytecode");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Invalid creation bytecode length"), "unexpected message: {msg}");
+    }
+
+    #[tokio::test]
+    async fn errors_instead_of_panicking_at_the_exact_equality_boundary() {
+        let abi_file = write_abi_file(TWO_UINT_CONSTRUCTOR_ABI);
+        // bytecode.len() == args_size exactly: no room for any actual code.
+        let bytecode = Bytes::from(vec![0u8; 64]);
+
+        let result = parse_code_output(
+            bytecode.clone(),
+            Address::ZERO,
+            &Config::default(),
+            Some(abi_file.path().to_str().unwrap()),
+            true,
+            false,
+        )
+        .await;
+        assert_eq!(result.unwrap().len(), 0, "without_args should return empty code, not error");
+
+        let result = parse_code_output(
+            bytecode,
+            Address::ZERO,
+            &Config::default(),
+            Some(abi_file.path().to_str().unwrap()),
+            false,
+            true,
+        )
+        .await;
+        assert_eq!(result.unwrap().len(), 64, "only_args should return the whole slice");
+    }
+
+    #[tokio::test]
+    async fn without_args_still_succeeds_on_correctly_sized_bytecode() {
+        let abi_file = write_abi_file(TWO_UINT_CONSTRUCTOR_ABI);
+        let bytecode = code_plus_args_bytecode();
+
+        let result = parse_code_output(
+            bytecode,
+            Address::ZERO,
+            &Config::default(),
+            Some(abi_file.path().to_str().unwrap()),
+            true,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, Bytes::from(vec![0xAAu8; 20]));
+    }
+
+    #[tokio::test]
+    async fn only_args_still_succeeds_on_correctly_sized_bytecode() {
+        let abi_file = write_abi_file(TWO_UINT_CONSTRUCTOR_ABI);
+        let bytecode = code_plus_args_bytecode();
+
+        let result = parse_code_output(
+            bytecode,
+            Address::ZERO,
+            &Config::default(),
+            Some(abi_file.path().to_str().unwrap()),
+            false,
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, Bytes::from(vec![0xBBu8; 64]));
+    }
 }
 
 /// Fetches the creation code of a contract from Etherscan and RPC.


### PR DESCRIPTION
## What

`cast creation-code --without-args`/`--only-args` computed `args_size = constructor.inputs.len() * 32` from a user-supplied `--abi-path` ABI, then indexed `bytecode[..bytecode.len() - args_size]` / `bytecode[bytecode.len() - args_size..]` with no bounds check — panicking (`attempt to subtract with overflow`) whenever the ABI declares more constructor bytes than the actual deployed bytecode contains.

`--abi-path` is user-supplied and documented as not needing to match the deployed contract, so this is directly reachable: pointing it at any short contract (e.g. an EIP-1167 minimal proxy, ~45 bytes) with an ABI declaring >=2 constructor inputs (64+ bytes) underflows.

## Why this is a two-line fix

The identical underflow already exists — and is already fixed — one file over. `crates/cast/src/cmd/constructor_args.rs` guards this exact case, added in #11700 ("chore(cast): avoid panic when decoding constructor args and add bounds check"). That PR touched only `constructor_args.rs`, leaving the sibling copy in `creation_code.rs` unfixed. This PR ports the same guard (identical error message) into `creation_code.rs`, covering both the `without_args` and `only_args` branches.

## Testing

Added 5 unit tests directly against `parse_code_output` (no network needed):
- Both branches (`without_args`, `only_args`) return a clear `Err` instead of panicking on undersized bytecode.
- The exact-equality boundary (`bytecode.len() == args_size`) is handled correctly (empty code / full-slice args, not an off-by-one).
- Both branches still succeed and return the correct bytes on correctly-sized input, verified by content (distinct code/args byte patterns), not just length.

Confirmed red-before/green-after by hand: temporarily removing the guard reproduces the exact panic (`attempt to subtract with overflow` at both slice sites), restoring it makes all 5 tests pass.

```
running 5 tests
test cmd::creation_code::tests::errors_instead_of_panicking_at_the_exact_equality_boundary ... ok
test cmd::creation_code::tests::without_args_errors_instead_of_panicking_on_undersized_bytecode ... ok
test cmd::creation_code::tests::only_args_still_succeeds_on_correctly_sized_bytecode ... ok
test cmd::creation_code::tests::only_args_errors_instead_of_panicking_on_undersized_bytecode ... ok
test cmd::creation_code::tests::without_args_still_succeeds_on_correctly_sized_bytecode ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 323 filtered out; finished in 0.01s
```

`cargo clippy -p cast -- -D warnings` clean, `rustfmt` clean.

Codex adversarial review (independent pass) found no blocking issues, confirmed the guard placement is correct for both branches and the exact-equality boundary, and confirmed the `<` (not `<=`) comparison is correct. It flagged one pre-existing, out-of-scope limitation shared with #11700's own fix: `constructor.inputs.len() * 32` is only the ABI head size, not the full encoding size for dynamic-type constructor arguments (e.g. a `string` arg encodes to more than one word) — noting it here rather than attempting to fix it in this diff, to keep this PR a surgical port of the existing precedent.