### PR TITLE
fix(anvil): enforce fork hash boundary

### DIFF
--- a/.changelog/anvil-fork-hash-boundary.md
+++ b/.changelog/anvil-fork-hash-boundary.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed hash-based RPC lookups exposing upstream blocks newer than the configured fork point.

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -633,14 +633,9 @@ impl<N: Network> ClientFork<N> {
         &self,
         hash: B256,
     ) -> Result<Option<N::BlockResponse>, TransportError> {
-        if let Some(mut block) = self.storage_read().blocks.get(&hash).cloned() {
+        Ok(self.block_by_hash_at_fork(hash).await?.map(|mut block| {
             block.transactions_mut().convert_to_hashes();
-            return Ok(Some(block));
-        }
-
-        Ok(self.fetch_full_block(hash).await?.map(|mut b| {
-            b.transactions_mut().convert_to_hashes();
-            b
+            block
         }))
     }
 
@@ -648,12 +643,24 @@ impl<N: Network> ClientFork<N> {
         &self,
         hash: B256,
     ) -> Result<Option<N::BlockResponse>, TransportError> {
-        if let Some(block) = self.storage_read().blocks.get(&hash).cloned()
-            && let Some(block) = self.convert_to_full_block(block)
-        {
-            return Ok(Some(block));
+        Ok(self
+            .block_by_hash_at_fork(hash)
+            .await?
+            .and_then(|block| self.convert_to_full_block(block)))
+    }
+
+    async fn block_by_hash_at_fork(
+        &self,
+        hash: B256,
+    ) -> Result<Option<N::BlockResponse>, TransportError> {
+        if let Some(block) = self.storage_read().blocks.get(&hash).cloned() {
+            return Ok(self.predates_fork_inclusive(block.header().number()).then_some(block));
         }
-        self.fetch_full_block(hash).await
+
+        Ok(self
+            .fetch_full_block(hash)
+            .await?
+            .filter(|block| self.predates_fork_inclusive(block.header().number())))
     }
 
     pub async fn block_by_number(

--- a/crates/anvil/tests/it/block_index.rs
+++ b/crates/anvil/tests/it/block_index.rs
@@ -108,6 +108,46 @@ async fn raw_transaction_by_block_and_index_matches_by_hash() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn fork_hash_lookups_exclude_newer_upstream_blocks() {
+    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let (_fork_api, fork_handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+            .with_fork_block_number(Some(0u64)),
+    )
+    .await;
+    let (block_hash, block_number, _tx_hash) = mine_block_with_transfer(&origin_handle).await;
+    let provider = fork_handle.http_provider();
+
+    let by_number: Option<Value> = provider
+        .client()
+        .request("eth_getBlockByNumber", (BlockNumberOrTag::Number(block_number), false))
+        .await
+        .unwrap();
+    assert_eq!(by_number, None);
+
+    for full in [false, true] {
+        let by_hash: Option<Value> =
+            provider.client().request("eth_getBlockByHash", (block_hash, full)).await.unwrap();
+        assert_eq!(by_hash, None);
+    }
+
+    let tx: Option<Value> = provider
+        .client()
+        .request("eth_getTransactionByBlockHashAndIndex", (block_hash, Index::from(0)))
+        .await
+        .unwrap();
+    assert_eq!(tx, None);
+
+    let raw: Option<Bytes> = provider
+        .client()
+        .request("eth_getRawTransactionByBlockHashAndIndex", (block_hash, Index::from(0)))
+        .await
+        .unwrap();
+    assert_eq!(raw, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn pending_transaction_by_block_number_and_index() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let wallet = handle.dev_wallets().next().unwrap();


### PR DESCRIPTION
Prevents hash-based block and indexed transaction RPCs from exposing upstream blocks newer than Anvil’s pinned fork point.