### PR TITLE
fix(anvil): ots_getBlockTransactions reports page size as transaction_count

### DIFF
--- a/.changelog/anvil-otterscan-transaction-count.md
+++ b/.changelog/anvil-otterscan-transaction-count.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed `ots_getBlockTransactions` reporting a page's transaction count instead of the block's total transaction count.

--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -373,6 +373,12 @@ impl EthApi<FoundryNetwork> {
             return Err(BlockchainError::DataUnavailable);
         }
 
+        // Capture the block's real transaction count before cropping to the requested page -
+        // `OtsBlock`'s `transaction_count` must reflect the whole block (matching Erigon, the
+        // reference `ots_` implementation), not just the page size, or pagination breaks for
+        // any consumer (e.g. Otterscan) that uses this field to compute the page count.
+        let transaction_count = block.transactions().len();
+
         block.transactions = match block.transactions() {
             BlockTransactions::Full(txs) => BlockTransactions::Full(
                 txs.iter().skip(page * page_size).take(page_size).cloned().collect(),
@@ -400,7 +406,6 @@ impl EthApi<FoundryNetwork> {
         .into_iter()
         .collect::<Result<Vec<_>>>()?;
 
-        let transaction_count = block.transactions().len();
         let fullblock = OtsBlock { block: block.inner.clone(), transaction_count };
 
         let ots_block_txs = OtsBlockTransactions { fullblock, receipts };

--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -373,10 +373,7 @@ impl EthApi<FoundryNetwork> {
             return Err(BlockchainError::DataUnavailable);
         }
 
-        // Capture the block's real transaction count before cropping to the requested page -
-        // `OtsBlock`'s `transaction_count` must reflect the whole block (matching Erigon, the
-        // reference `ots_` implementation), not just the page size, or pagination breaks for
-        // any consumer (e.g. Otterscan) that uses this field to compute the page count.
+        // Preserve the total transaction count before pagination.
         let transaction_count = block.transactions().len();
 
         block.transactions = match block.transactions() {

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -373,9 +373,6 @@ async fn ots_get_block_transactions() {
         assert!(result.receipts.len() <= page_size);
         let len = result.receipts.len();
         assert!(len <= page_size);
-        // `transaction_count` must reflect the WHOLE block (10 txs), not the page - it's used
-        // by consumers (e.g. Otterscan) to compute the total page count, and a page-sized value
-        // makes it look like there's never more than one page.
         assert_eq!(result.fullblock.transaction_count, 10);
 
         result.receipts.iter().enumerate().for_each(|(i, receipt)| {

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -373,7 +373,10 @@ async fn ots_get_block_transactions() {
         assert!(result.receipts.len() <= page_size);
         let len = result.receipts.len();
         assert!(len <= page_size);
-        assert!(result.fullblock.transaction_count == result.receipts.len());
+        // `transaction_count` must reflect the WHOLE block (10 txs), not the page - it's used
+        // by consumers (e.g. Otterscan) to compute the total page count, and a page-sized value
+        // makes it look like there's never more than one page.
+        assert_eq!(result.fullblock.transaction_count, 10);
 
         result.receipts.iter().enumerate().for_each(|(i, receipt)| {
             let expected = hashes.pop_front();


### PR DESCRIPTION
## What

`ots_getBlockTransactions` cropped `block.transactions` to the requested page *before* computing `transaction_count` from it, so `transaction_count` could never exceed `page_size` regardless of the block's real size.

Reachable in practice via anvil's own RPC surface - live repro:

```
eth_getBlockByNumber                -> 5 txs in a block          (ground truth)
ots_getBlockTransactions [4, 0, 2]  -> transactionCount = 2       (wrong, should be 5)
ots_getBlockTransactions [4, 1, 2]  -> transactionCount = 2       (wrong, should be 5)
```

Otterscan's own UI uses `transactionCount` to compute the total page count. Against anvil it always looks like there's exactly one page, so later transactions are unreachable through pagination.

Erigon, the reference `ots_` namespace implementation, computes `transactionCount` against the full block before cropping to the page.

## Fix

Capture `transaction_count` from `block.transactions().len()` before the pagination crop, instead of recomputing it from the already-cropped list afterward.

## Heads up for review

The existing test at `crates/anvil/tests/it/otterscan.rs` asserted `transaction_count == result.receipts.len()` - i.e. it pinned the buggy behavior as correct. I flipped it to assert the real total (`10`, the test's actual block size) on every page. That's an intentional fix to the test, not a regression.

## Testing

- `cargo test -p anvil --test it ots_get_block_transactions -- --nocapture` - passes, including the flipped assertion across all 4 pages of a 10-tx block.
- `cargo check -p anvil --lib --tests` - clean.
- Independent adversarial review (Codex, read-only sandbox): no findings, confirmed the capture point is correct (nothing mutates the transaction list between block construction and the capture), confirmed `build_ots_block_tx` has no other caller so the fix is scoped to this one endpoint, and confirmed the flipped test assertion checks the correct invariant.

Minimal, surgical diff - two files, 10 lines.