### PR TITLE
fix(cast): don't panic on a block timestamp outside chrono's range

### DIFF
--- a/.changelog/cast-age-timestamp-panic.md
+++ b/.changelog/cast-age-timestamp-panic.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fixed `cast age` panicking when a block's timestamp falls outside the range Chrono can represent as a `DateTime`, instead of returning a clean error.

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1084,7 +1084,12 @@ where
     pub async fn age<B: Into<BlockId>>(&self, block: B) -> Result<String> {
         let timestamp_str =
             Self::block_field_as_num(self, block, String::from("timestamp")).await?.to_string();
-        let datetime = DateTime::from_timestamp(timestamp_str.parse::<i64>().unwrap(), 0).unwrap();
+        let timestamp = timestamp_str
+            .parse::<i64>()
+            .wrap_err_with(|| format!("block timestamp `{timestamp_str}` out of range"))?;
+        let datetime = DateTime::from_timestamp(timestamp, 0).ok_or_eyre(format!(
+            "block timestamp `{timestamp_str}` is outside the representable date range"
+        ))?;
         Ok(datetime.format("%a %b %e %H:%M:%S %Y").to_string())
     }
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -346,6 +346,39 @@ casttest!(finds_block, |_prj, cmd| {
 "#]]);
 });
 
+// tests that `cast age` reports a clean error instead of panicking on a block timestamp
+// that parses as i64 but falls outside chrono's representable calendar range.
+casttest!(age_rejects_out_of_range_timestamp, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+
+    // A timestamp far beyond chrono's representable calendar range, but well within u64/i64 -
+    // anvil accepts it happily via `evm_setNextBlockTimestamp`.
+    cmd.args(["rpc", "--rpc-url", rpc.as_str(), "evm_setNextBlockTimestamp", "20000000000000"])
+        .assert_success();
+    cmd.cast_fuse().args(["rpc", "--rpc-url", rpc.as_str(), "evm_mine"]).assert_success();
+
+    cmd.cast_fuse().args(["age", "latest", "--rpc-url", rpc.as_str()]).assert_failure().stderr_eq(
+        str![[r#"
+Error: block timestamp `20000000000000` is outside the representable date range
+
+"#]],
+    );
+});
+
+// tests that `cast age` still works for a normal, in-range block timestamp
+casttest!(age_reports_normal_timestamp, |_prj, cmd| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+
+    // <https://etherscan.io/block/15007840>, timestamp 1655904485
+    cmd.args(["age", "15007840", "--rpc-url", eth_rpc_url.as_str()]).assert_success().stdout_eq(
+        str![[r#"
+Wed Jun 22 13:28:05 2022 UTC
+
+"#]],
+    );
+});
+
 // tests that we can create a new wallet
 casttest!(new_wallet, |_prj, cmd| {
     cmd.args(["wallet", "new"])


### PR DESCRIPTION
## What

`cast age` double-unwrapped a block's timestamp: once parsing it as `i64`, once converting it to a chrono `DateTime`. `DateTime::from_timestamp` returns `None` outside chrono's representable calendar range — well within the i64/u64 range, but beyond what a calendar date can represent — so this crashed the process instead of producing an error.

## Repro (live, against anvil)

```
$ cast rpc evm_setNextBlockTimestamp 20000000000000 && cast rpc evm_mine
$ cast age
The application panicked (crashed).
Message:  called `Option::unwrap()` on a `None` value
Location: crates/cast/src/lib.rs:964
```

anvil's own `evm_setNextBlockTimestamp` accepts this value happily (it's a valid, if unusual, block timestamp per the Yellow Paper's unbounded 256-bit definition), then `cast age` crashes reading it back.

## Fix

Propagates both failure points via `eyre` (`wrap_err_with`/`ok_or_eyre`, matching this file's existing error-handling style) instead of `unwrap()`, so an out-of-range timestamp now produces a clean CLI error.

## Testing

- New regression test `age_rejects_out_of_range_timestamp`: spawns a local anvil node, sets an out-of-range next-block timestamp via the exact repro above, mines it, and asserts `cast age` now fails cleanly with a specific error message instead of panicking.
- New regression test `age_reports_normal_timestamp`: asserts the happy path is unchanged for a normal historical block (mainnet block 15007840).
- Zero tests previously covered `Cast::age` at all.
- `cargo test -p cast --test cli age_`: both new tests pass (17/18 in the filtered run — the sole failure, `flaky_storage_layout_complex_proxy`, is a pre-existing, unrelated, solc-version-dependent flaky test with no connection to this diff).
- `cargo clippy -p cast --lib --bins`: clean.
- `rustfmt --check`: clean.
- Codex adversarial review (run synchronously): confirmed the error propagation is correct and idiomatic for this codebase, found no additional panic-producing timestamp case in this path, and flagged two nits (a missing changelog entry, since fixed; and tightening the happy-path snapshot's time wildcards, since fixed).

Added a changelog entry per this repo's convention.