### PR TITLE
fix(anvil): return pending block receipts

### DIFF
--- a/.changelog/anvil-pending-block-receipts.md
+++ b/.changelog/anvil-pending-block-receipts.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed `eth_getBlockReceipts("pending")` returning receipts from the latest mined block in fork mode.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3656,6 +3656,14 @@ impl EthApi<FoundryNetwork> {
     /// Handler for ETH RPC call: `eth_getBlockReceipts`
     pub async fn block_receipts(&self, number: BlockId) -> Result<Option<Vec<FoundryTxReceipt>>> {
         node_info!("eth_getBlockReceipts");
+        if number == BlockId::pending() {
+            let transactions = self.pool.ready_transactions().collect::<Vec<_>>();
+            if transactions.is_empty() {
+                return Ok(Some(Vec::new()));
+            }
+            return Ok(Some(self.backend.pending_block_receipts(transactions).await));
+        }
+
         self.backend.block_receipts(number).await
     }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -7271,6 +7271,33 @@ where
         MinedTransactionReceipt { inner, out: info.out.clone() }
     }
 
+    /// Executes the pending block and returns its transaction receipts.
+    pub async fn pending_block_receipts(
+        &self,
+        pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
+    ) -> Vec<FoundryTxReceipt> {
+        let BlockInfo { block, transactions, receipts } =
+            self.pending_block(pool_transactions).await;
+        let block_hash = block.header.hash_slow();
+        let mut pending_receipts = Vec::with_capacity(receipts.len());
+        let mut next_log_index = 0;
+
+        for (info, receipt) in transactions.iter().zip(receipts) {
+            let log_count = receipt.logs().len();
+            let receipt = self.build_mined_transaction_receipt(
+                info,
+                receipt,
+                block_hash,
+                &block,
+                next_log_index,
+            );
+            pending_receipts.push(receipt.inner);
+            next_log_index += log_count;
+        }
+
+        pending_receipts
+    }
+
     /// Returns the blocks receipts for the given number
     pub async fn block_receipts(
         &self,

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -311,6 +311,12 @@ async fn can_get_pending_block() {
     let block = provider.get_block(BlockId::pending()).full().await.unwrap().unwrap();
     assert_eq!(block.header.number, 1);
     assert_eq!(block.transactions.len(), 1);
+
+    let receipts = provider.get_block_receipts(BlockId::pending()).await.unwrap().unwrap();
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(receipts[0].transaction_hash(), *pending.tx_hash());
+    assert_eq!(receipts[0].block_number(), Some(block.header.number));
+    assert_eq!(receipts[0].block_hash(), Some(block.header.hash));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -2349,6 +2349,36 @@ async fn test_block_receipts() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_pending_block_receipts_do_not_return_fork_head_receipts() {
+    let (origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let sender = origin_handle.dev_wallets().next().unwrap().address();
+    origin_api
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default().from(sender).to(Address::random()).value(U256::from(1)),
+        ))
+        .await
+        .unwrap();
+
+    let (fork_api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64)),
+    )
+    .await;
+
+    let latest_receipts = fork_api.block_receipts(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(latest_receipts.len(), 1);
+
+    let pending_block =
+        fork_api.block_by_number_full(BlockNumberOrTag::Pending).await.unwrap().unwrap();
+    assert_eq!(pending_block.header.number, 2);
+    assert!(pending_block.transactions.is_empty());
+
+    let pending_receipts = fork_api.block_receipts(BlockId::pending()).await.unwrap().unwrap();
+    assert!(pending_receipts.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_override_fork_chain_id() {
     let chain_id_override = 5u64;
     let (_api, handle) = spawn(


### PR DESCRIPTION
Fixes `eth_getBlockReceipts("pending")` returning receipts from the latest mined block on forks. Pending receipts now correspond to the synthetic pending block, with an empty-pool fast path.