### PR TITLE
fix(script): don't panic on a short call to the CREATE2 deployer

### DIFF
--- a/.changelog/fix-create2-deployer-short-input-panic.md
+++ b/.changelog/fix-create2-deployer-short-input-panic.md
@@ -1,0 +1,5 @@
+---
+forge-script: patch
+---
+
+Fixed a panic in `forge script` when a CREATE2 deployer call's input was shorter than the 32-byte salt prefix.

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -35,7 +35,9 @@ impl<N: Network> ScriptTransactionBuilder<N> {
     ) -> Result<()> {
         if let Some(to) = self.transaction.transaction.to() {
             if to == create2_deployer {
-                if let Some(input) = self.transaction.transaction.input() {
+                if let Some(input) = self.transaction.transaction.input()
+                    && input.len() >= 32
+                {
                     let (salt, init_code) = input.split_at(32);
 
                     self.set_create(
@@ -184,6 +186,44 @@ impl<N: Network> ScriptTransactionBuilder<N> {
 impl<N: Network> From<TransactionWithMetadata<N>> for ScriptTransactionBuilder<N> {
     fn from(transaction: TransactionWithMetadata<N>) -> Self {
         Self { transaction }
+    }
+}
+
+#[cfg(test)]
+mod create2_tests {
+    use super::*;
+    use alloy_network::Ethereum;
+    use alloy_primitives::{Bytes, address};
+    use alloy_rpc_types::TransactionRequest;
+
+    fn call_create2_deployer(input_len: usize) {
+        let create2_deployer = address!("0000000000000000000000000000000000001234");
+        let transaction = TransactionRequest::default()
+            .with_from(Address::repeat_byte(0x11))
+            .with_to(create2_deployer)
+            .with_nonce(0)
+            .with_input(Bytes::from(vec![0xab; input_len]));
+        let mut builder: ScriptTransactionBuilder<Ethereum> = ScriptTransactionBuilder::new(
+            TransactionMaybeSigned::new(transaction),
+            "http://localhost:8545".to_string(),
+        );
+        let decoder = CallTraceDecoder::new();
+        builder.set_call(&BTreeMap::new(), &decoder, create2_deployer).unwrap();
+    }
+
+    #[test]
+    fn set_call_does_not_panic_on_short_create2_input() {
+        // Input shorter than the 32-byte salt prefix must not panic.
+        call_create2_deployer(0);
+        call_create2_deployer(4);
+        call_create2_deployer(31);
+    }
+
+    #[test]
+    fn set_call_handles_exact_and_over_length_create2_input() {
+        // Exactly 32 bytes (empty init_code) and just past it must both succeed.
+        call_create2_deployer(32);
+        call_create2_deployer(33);
     }
 }
 


### PR DESCRIPTION
## What

`ScriptTransactionBuilder::set_call` unconditionally does `input.split_at(32)` on a CREATE2 deployer call's input, which panics (`mid > len`) whenever the input is shorter than the 32-byte salt prefix:

```
$ forge script script/C2.s.sol:C2Script --rpc-url http://127.0.0.1:8599
Script ran successfully.
The application panicked (crashed).
Message:  mid > len
Location: crates/script/src/transaction.rs:39
$ echo $?  ->  134  (SIGABRT)
```

This is reachable in plain simulation, no `--broadcast` needed - a script calling a configured `create2_deployer` address with any payload under 32 bytes (e.g. `CREATE2_DEPLOYER.call(hex"deadbeef")`) aborts the whole process.

Both sibling code paths in this codebase already guard the same 32-byte salt boundary correctly - `set_create`'s own `data.len() < 32 => return Ok(())` a few lines below, and `library_deployments.rs`'s `input.get(..32)`. This was a straightforward oversight in one path, not a new problem.

## Fix

Guard the split with `input.len() >= 32` before calling `split_at`, matching the early-return convention already established by `set_create`'s sibling check.

## Relationship to #16554

#16554 (opened today) fixes an adjacent but distinct panic in `crates/script/src/verify.rs`, reached via a different `split_at` call on a hand-corrupted sequence file. It does not touch `transaction.rs`, so this panic is still live on `master` independent of that PR. Flagging in case a maintainer wants to fold the two - happy to adjust.

## Testing

- Reproduced the exact panic (`mid > len` at `transaction.rs:39`) with a real unit test before the fix.
- Confirmed clean pass after the fix, with boundary coverage at 0, 4, 31, 32, and 33 byte inputs.
- Full `forge-script` crate test suite: 115/115 passing.
- `cargo clippy -p forge-script --lib -- -D warnings`: clean.
- `cargo fmt --check`: clean.

## receipts

Before (test run against unfixed code):
```
thread 'transaction::create2_tests::set_call_does_not_panic_on_short_create2_input' panicked at crates/script/src/transaction.rs:39:51:
mid > len
test transaction::create2_tests::set_call_does_not_panic_on_short_create2_input ... FAILED
```

After:
```
test transaction::create2_tests::set_call_does_not_panic_on_short_create2_input ... ok
test transaction::create2_tests::set_call_handles_exact_and_over_length_create2_input ... ok

test result: ok. 115 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.05s
```