### PR TITLE
fix(cheatcodes): expectSafeMemory panics on short/unexpanded CALL calldata to the cheatcode address

### DIFF
--- a/.changelog/safe-memory-call-calldata.md
+++ b/.changelog/safe-memory-call-calldata.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-cheatcodes: patch
+---
+
+Prevented `expectSafeMemory` from panicking on calls to the cheatcode address with short or unexpanded calldata.

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -3920,12 +3920,8 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                             if to == CHEATCODE_ADDRESS {
                                 let args_offset = try_or_return!(interpreter.stack.peek(3)).saturating_to::<usize>();
                                 let args_size = try_or_return!(interpreter.stack.peek(4)).saturating_to::<usize>();
-                                // `args_size` shorter than a selector can never match, and reading
-                                // past the interpreter's current (pre-expansion) memory buffer would
-                                // panic (debug) or be UB (release) inside `slice_len`. This hook runs
-                                // in `step`, before the CALL has expanded memory to cover its own
-                                // args, so an out-of-bounds range here is a live condition, not just
-                                // theoretical.
+                                // CALL expands its input memory after this hook runs, so only inspect
+                                // calldata already within the current memory.
                                 if args_size >= SELECTOR_LEN
                                     && args_offset.saturating_add(args_size) <= interpreter.memory.size()
                                 {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -3920,9 +3920,19 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                             if to == CHEATCODE_ADDRESS {
                                 let args_offset = try_or_return!(interpreter.stack.peek(3)).saturating_to::<usize>();
                                 let args_size = try_or_return!(interpreter.stack.peek(4)).saturating_to::<usize>();
-                                let memory_word = interpreter.memory.slice_len(args_offset, args_size);
-                                if memory_word[..SELECTOR_LEN] == stopExpectSafeMemoryCall::SELECTOR {
-                                    return
+                                // `args_size` shorter than a selector can never match, and reading
+                                // past the interpreter's current (pre-expansion) memory buffer would
+                                // panic (debug) or be UB (release) inside `slice_len`. This hook runs
+                                // in `step`, before the CALL has expanded memory to cover its own
+                                // args, so an out-of-bounds range here is a live condition, not just
+                                // theoretical.
+                                if args_size >= SELECTOR_LEN
+                                    && args_offset.saturating_add(args_size) <= interpreter.memory.size()
+                                {
+                                    let memory_word = interpreter.memory.slice_len(args_offset, args_size);
+                                    if memory_word[..SELECTOR_LEN] == stopExpectSafeMemoryCall::SELECTOR {
+                                        return
+                                    }
                                 }
                             }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -3920,8 +3920,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                             if to == CHEATCODE_ADDRESS {
                                 let args_offset = try_or_return!(interpreter.stack.peek(3)).saturating_to::<usize>();
                                 let args_size = try_or_return!(interpreter.stack.peek(4)).saturating_to::<usize>();
-                                // CALL expands its input memory after this hook runs, so only inspect
-                                // calldata already within the current memory.
+                                // CALL has not expanded input memory yet.
                                 if args_size >= SELECTOR_LEN
                                     && args_offset.saturating_add(args_size) <= interpreter.memory.size()
                                 {

--- a/testdata/default/cheats/MemSafety.t.sol
+++ b/testdata/default/cheats/MemSafety.t.sol
@@ -160,6 +160,43 @@ contract MemSafetyTest is Test {
     }
 
     ////////////////////////////////////////////////////////////////
+    //        CALL with short/out-of-range calldata to `vm`        //
+    ////////////////////////////////////////////////////////////////
+
+    /// @dev Tests that a disallowed `CALL` to the cheatcode address with calldata shorter
+    ///      than a selector (4 bytes) is rejected as a normal unsafe memory write, instead
+    ///      of panicking while checking whether it's a `stopExpectSafeMemory()` call.
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testExpectSafeMemory_CALL_shortCalldataToCheatcodeAddress() public {
+        vm.expectSafeMemory(0x80, 0xA0);
+
+        vm.expectRevert();
+
+        // Call the cheatcode address with 0-byte calldata (too short to be a selector) and
+        // write the return data outside the allowed range, so the disallowed-write path is
+        // taken and must check the calldata without panicking.
+        assembly {
+            pop(call(gas(), 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D, 0x00, 0x00, 0x00, 0x200, 0x20))
+        }
+    }
+
+    /// @dev Tests that a disallowed `CALL` to the cheatcode address whose calldata range
+    ///      reaches past memory that hasn't been expanded yet is rejected as a normal
+    ///      unsafe memory write, instead of panicking/UB while reading it.
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testExpectSafeMemory_CALL_unexpandedCalldataToCheatcodeAddress() public {
+        vm.expectSafeMemory(0x80, 0xA0);
+
+        vm.expectRevert();
+
+        // Call the cheatcode address with calldata pointing at memory well past what has
+        // been expanded so far, and write the return data outside the allowed range.
+        assembly {
+            pop(call(gas(), 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D, 0x00, 0x100000, 0x04, 0x200, 0x20))
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////
     //                          CALLCODE                          //
     ////////////////////////////////////////////////////////////////
 

--- a/testdata/default/cheats/MemSafety.t.sol
+++ b/testdata/default/cheats/MemSafety.t.sol
@@ -163,34 +163,27 @@ contract MemSafetyTest is Test {
     //        CALL with short/out-of-range calldata to `vm`        //
     ////////////////////////////////////////////////////////////////
 
-    /// @dev Tests that a disallowed `CALL` to the cheatcode address with calldata shorter
-    ///      than a selector (4 bytes) is rejected as a normal unsafe memory write, instead
-    ///      of panicking while checking whether it's a `stopExpectSafeMemory()` call.
+    /// @dev Short calldata must revert without panicking.
     /// forge-config: default.allow_internal_expect_revert = true
     function testExpectSafeMemory_CALL_shortCalldataToCheatcodeAddress() public {
         vm.expectSafeMemory(0x80, 0xA0);
 
         vm.expectRevert();
 
-        // Call the cheatcode address with 0-byte calldata (too short to be a selector) and
-        // write the return data outside the allowed range, so the disallowed-write path is
-        // taken and must check the calldata without panicking.
+        // Empty calldata and a return buffer outside the allowed range.
         assembly {
             pop(call(gas(), 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D, 0x00, 0x00, 0x00, 0x200, 0x20))
         }
     }
 
-    /// @dev Tests that a disallowed `CALL` to the cheatcode address whose calldata range
-    ///      reaches past memory that hasn't been expanded yet is rejected as a normal
-    ///      unsafe memory write, instead of panicking/UB while reading it.
+    /// @dev Unexpanded calldata must revert without reading past memory.
     /// forge-config: default.allow_internal_expect_revert = true
     function testExpectSafeMemory_CALL_unexpandedCalldataToCheatcodeAddress() public {
         vm.expectSafeMemory(0x80, 0xA0);
 
         vm.expectRevert();
 
-        // Call the cheatcode address with calldata pointing at memory well past what has
-        // been expanded so far, and write the return data outside the allowed range.
+        // Both calldata and the return buffer lie outside their allowed ranges.
         assembly {
             pop(call(gas(), 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D, 0x00, 0x100000, 0x04, 0x200, 0x20))
         }


### PR DESCRIPTION
## What

The `stopExpectSafeMemory()` special case in the CALL-opcode branch of `check_mem_opcodes` (`crates/cheatcodes/src/inspector.rs`) reads `args_size` bytes of calldata via `interpreter.memory.slice_len(args_offset, args_size)`, then indexes the first `SELECTOR_LEN` (4) bytes to compare against the selector — without checking that the slice is actually at least 4 bytes long, or that `[args_offset, args_offset + args_size)` is within the interpreter's current (pre-expansion) memory buffer.

This hook runs in `step()`, before the `CALL` opcode itself has expanded memory to cover its own args — so a disallowed `CALL` to the cheatcode address with short or out-of-range calldata is a live condition, not theoretical. Two distinct ways to trigger it:

- **`args_size < 4`**: `memory_word[..SELECTOR_LEN]` panics with `range end index 4 out of range for slice of length 0`.
- **`args_offset + args_size` past current `memory.size()`**: `slice_len` → `slice_range` hits revm's own `debug_unreachable!` — panics in debug builds, UB in release builds per revm's documented `# Safety` section on that method.

## Fix

Guard both cases before calling `slice_len`, falling through to the existing `disallowed_mem_write()` path instead — which is the correct behavior for a genuinely out-of-range `CALL` to the cheatcode address anyway (it's disallowed regardless of whether it happens to also be a `stopExpectSafeMemory()` call).

## Testing

Added two regression tests to `MemSafety.t.sol`:
- `testExpectSafeMemory_CALL_shortCalldataToCheatcodeAddress` — 0-byte calldata to the cheatcode address.
- `testExpectSafeMemory_CALL_unexpandedCalldataToCheatcodeAddress` — calldata pointing well past currently-expanded memory.

Real red-before/green-after, not just a passing test after the fact — reverted just this fix and reran both new tests against the unmodified code:

```
The application panicked (crashed).
Message:  range end index 4 out of range for slice of length 0
   at crates/cheatcodes/src/inspector.rs:3924
Ran 0 test suites in 2.65s (0.00ns CPU time): 0 tests passed, 0 failed, 0 skipped (0 total tests)
```

With the fix restored, full suite green:

```
Ran 28 tests for default/cheats/MemSafety.t.sol:MemSafetyTest
[PASS] testExpectSafeMemory_CALL_shortCalldataToCheatcodeAddress() (gas: 3565)
[PASS] testExpectSafeMemory_CALL_unexpandedCalldataToCheatcodeAddress() (gas: 3546)
...
Suite result: ok. 28 passed; 0 failed; 0 skipped; finished in 21.99ms
```

`cargo clippy -p foundry-cheatcodes --lib -- -D warnings` clean, `cargo fmt --all -- --check` clean.

Dupe-checked — no open issue/PR on this. The original PR that introduced this code (#7686, merged 2024-04-16) never handled these cases.

closes nothing — filed independently, no corresponding issue was open.

AI assistance: Codex performed a follow-up review and shortened comments.
