### PR TITLE
fix(sol-macro-gen): don't panic on a $ in a Solidity contract name

### DIFF
--- a/.changelog/fix-bind-dollar-sign-panic.md
+++ b/.changelog/fix-bind-dollar-sign-panic.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-sol-macro-gen: patch
+---
+
+Fixed `forge bind` panicking on a contract name containing `$`, which is a legal Solidity identifier character but not a legal Rust one.

--- a/.changelog/fix-bind-dollar-sign-panic.md
+++ b/.changelog/fix-bind-dollar-sign-panic.md
@@ -1,6 +1,5 @@
 ---
 forge: patch
-forge-sol-macro-gen: patch
 ---
 
 Fixed `forge bind` panicking on a contract name containing `$`, which is a legal Solidity identifier character but not a legal Rust one.

--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -207,7 +207,7 @@ impl BindArgs {
                 let name = stem.split('.').next().unwrap();
 
                 // Best effort identifier cleanup.
-                let name = name.replace(char::is_whitespace, "").replace('-', "_");
+                let name = name.replace(char::is_whitespace, "").replace(['-', '$'], "_");
 
                 Some((name, path))
             })

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -479,8 +479,8 @@ forgetest!(bind_single_file_crate_and_module_match, |prj, cmd| {
     );
 });
 
-// https://github.com/foundry-rs/foundry/issues - `$` is valid in Solidity identifiers but not
-// in Rust ones; `forge bind` used to panic instead of sanitizing it.
+// `$` is valid in Solidity identifiers but not Rust identifiers; `forge bind` used to panic
+// instead of sanitizing it.
 forgetest!(bind_dollar_sign_in_contract_name, |prj, cmd| {
     prj.add_source(
         "Foo.sol",

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -478,3 +478,28 @@ forgetest!(bind_single_file_crate_and_module_match, |prj, cmd| {
         fs::read(module_path.join("mod.rs")).unwrap()
     );
 });
+
+// https://github.com/foundry-rs/foundry/issues - `$` is valid in Solidity identifiers but not
+// in Rust ones; `forge bind` used to panic instead of sanitizing it.
+forgetest!(bind_dollar_sign_in_contract_name, |prj, cmd| {
+    prj.add_source(
+        "Foo.sol",
+        r#"
+contract Foo$Bar {
+    uint256 public value;
+
+    function setValue(uint256 v) public {
+        value = v;
+    }
+}
+"#,
+    );
+
+    cmd.args(["bind"]).assert_success();
+
+    let bindings_path = prj.root().join("out/bindings");
+    let binding = fs::read_to_string(bindings_path.join("src/foo_bar.rs")).unwrap();
+    assert!(binding.contains("pub mod Foo_Bar"), "{binding}");
+    assert!(!binding.contains('$'), "{binding}");
+    assert_bindings_compile(&bindings_path);
+});

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -48,7 +48,9 @@ impl SolMacroGen {
 
     pub fn get_sol_input(&self) -> Result<SolInput> {
         let path = self.path.to_string_lossy().into_owned();
-        let name = proc_macro2::Ident::new(&self.name, Span::call_site());
+        let name: syn::Ident = syn::parse_str(&self.name).wrap_err_with(|| {
+            format!("`{}` is not a valid Rust identifier for generated bindings", self.name)
+        })?;
         let tokens = quote::quote! {
             #[sol(ignore_unlinked)]
             #name,
@@ -555,5 +557,17 @@ mod tests {
             adapter("alloy::sol_types::private::Vec<[u64; 48]>"),
             Some("::std::vec::Vec<[::serde_with::Same; 48]>".to_string())
         );
+    }
+
+    #[test]
+    fn get_sol_input_rejects_invalid_identifier_instead_of_panicking() {
+        // Regression test: `$` is valid in a Solidity identifier but not in a Rust one.
+        // `get_sol_input` must return an error here rather than panicking, even if an invalid
+        // name somehow reaches it uncleaned. End-to-end coverage (that `forge bind` correctly
+        // sanitizes `$` before it gets here) lives in `bind_dollar_sign_in_contract_name` in
+        // `crates/forge/tests/cli/bind.rs`.
+        let instance =
+            super::SolMacroGen::new(std::path::PathBuf::from("Foo.json"), "Foo$Bar".to_string());
+        assert!(instance.get_sol_input().is_err());
     }
 }

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -561,11 +561,7 @@ mod tests {
 
     #[test]
     fn get_sol_input_rejects_invalid_identifier_instead_of_panicking() {
-        // Regression test: `$` is valid in a Solidity identifier but not in a Rust one.
-        // `get_sol_input` must return an error here rather than panicking, even if an invalid
-        // name somehow reaches it uncleaned. End-to-end coverage (that `forge bind` correctly
-        // sanitizes `$` before it gets here) lives in `bind_dollar_sign_in_contract_name` in
-        // `crates/forge/tests/cli/bind.rs`.
+        // `$` is valid in Solidity identifiers but not Rust identifiers.
         let instance =
             super::SolMacroGen::new(std::path::PathBuf::from("Foo.json"), "Foo$Bar".to_string());
         assert!(instance.get_sol_input().is_err());


### PR DESCRIPTION
## What

`$` is legal in Solidity identifiers (`IdentifierStart`) but not in Rust ones. `forge bind` panicked when a contract name containing `$` reached `SolMacroGen::get_sol_input`, which called `proc_macro2::Ident::new` — a function that panics on invalid input rather than returning a `Result`.

```
$ forge bind --skip-build
The application panicked (crashed).
Message:  "Foo$Bar" is not a valid Ident
Location: crates/sol-macro-gen/src/sol_macro_gen.rs:38
```

## Fix — two layers

- `bind.rs`'s existing "best effort identifier cleanup" (already stripping whitespace and `-`) now also strips `$`. This is the fix for the actual `forge bind` CLI path — `SolMacroGen::new` has exactly one production caller in the codebase (`bind.rs:223`), immediately downstream of this cleanup.
- `get_sol_input` now parses the identifier via the fallible `syn::parse_str::<syn::Ident>` instead of the panicking `Ident::new`, so a library consumer of the published `forge-sol-macro-gen` crate passing an uncleaned name gets a clean error instead of a crash — defense in depth beyond the one CLI entry point.

## Testing

- New unit test `get_sol_input_rejects_invalid_identifier_instead_of_panicking`: confirms `get_sol_input` now errors instead of panicking on `Foo$Bar`.
- New end-to-end CLI test `bind_dollar_sign_in_contract_name`: creates a real contract named `Foo$Bar`, runs `forge bind`, asserts the generated bindings contain `pub mod Foo_Bar`, contain no `$`, and **actually compile** (`assert_bindings_compile`).
- Both tests pass. `cargo check -p forge-sol-macro-gen -p forge` clean.

## Review note

A synchronous adversarial review (Codex) was attempted but hit "model at capacity" partway through and didn't produce a completed pass — disclosing that honestly rather than claiming one. I self-reviewed instead: confirmed `SolMacroGen::new` has exactly one production caller and it's downstream of the `$`-cleanup (`grep -rn "SolMacroGen::new"` across the crate), and confirmed `syn::parse_str::<syn::Ident>` is the standard fallible-identifier-parsing path used elsewhere in this codebase.

No merge, no self-approve.
