### PR TITLE
fix(lint): track storage pointer aliases in uninitialized-state

### DIFF
--- a/.changelog/uninitialized-state-storage-pointer-aliases.md
+++ b/.changelog/uninitialized-state-storage-pointer-aliases.md
@@ -1,0 +1,5 @@
+---
+forge-lint: patch
+---
+
+Fixed the `uninitialized-state` lint incorrectly warning about state variables written through local storage-pointer aliases.

--- a/crates/lint/src/sol/med/uninitialized_state_variables.rs
+++ b/crates/lint/src/sol/med/uninitialized_state_variables.rs
@@ -74,10 +74,7 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
             }
         }
 
-        // Local `storage` pointers that alias a candidate state variable (directly, or
-        // transitively through another alias), e.g. `Data storage p = someStateVar;`.
-        // Writes through such a local (`p.val = v`) are writes to the aliased state
-        // variable and must be attributed back to it.
+        // Possible state-variable targets of local storage pointers.
         let mut aliases: HashMap<VariableId, HashSet<VariableId>> = HashMap::new();
 
         // Walk every function in the inheritance chain.
@@ -269,9 +266,6 @@ fn collect_stmt_writes_checked<'hir>(
             if let Some(initializer) = hir.variable(*var_id).initializer {
                 collect_expr_writes_checked(hir, initializer, candidates, writes, bases, aliases)?;
 
-                // If this local is a `storage` pointer initialized from a candidate state
-                // variable (or from another already-known alias), record it so writes
-                // through the local later in this function attribute back correctly.
                 if hir.variable(*var_id).data_location == Some(DataLocation::Storage)
                     && let Some(target) = resolve_alias_targets(initializer, candidates, aliases)
                 {
@@ -301,12 +295,7 @@ fn collect_expr_writes_checked<'hir>(
 ) -> Result<(), ()> {
     match &expr.kind {
         ExprKind::Assign(lhs, _, rhs) => {
-            // A bare identifier `lhs` that is itself a known local storage-pointer alias
-            // is a pointer *reassignment* (`p = other;`) — it repoints `p`, it does not
-            // write through to whatever `p` previously aliased. Skip the generic lvalue
-            // write here; the retargeting below records the new alias instead. Any other
-            // lvalue shape (`someStateVar = x`, `p.val = x`, `p[i] = x`, ...) is a real
-            // write and still goes through the normal path.
+            // Reassigning a bare storage pointer repoints it rather than writing its target.
             let is_bare_alias_repoint = matches!(
                 &lhs.peel_parens().kind,
                 ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..])
@@ -318,11 +307,7 @@ fn collect_expr_writes_checked<'hir>(
             collect_expr_writes_checked(hir, lhs, candidates, writes, bases, aliases)?;
             collect_expr_writes_checked(hir, rhs, candidates, writes, bases, aliases)?;
 
-            // Reassigning a local `storage` pointer (whether previously aliased or not,
-            // e.g. a `storage` parameter aliased for the first time via assignment) must
-            // (re)target the alias, or writes through `p` afterward would misattribute to
-            // a stale target instead of the new one. If the new target can't be resolved,
-            // drop any stale mapping rather than keep attributing to the old one.
+            // Replace the alias target, dropping stale targets when the RHS is unresolved.
             if let ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) = &lhs.peel_parens().kind
                 && !candidates.contains(id)
                 && hir.variable(*id).data_location == Some(DataLocation::Storage)
@@ -548,10 +533,7 @@ fn mark_storage_args<'hir>(
     }
 }
 
-/// Peels index/slice/member wrappers to find the root identifier of a storage-pointer
-/// initializer expression, resolving it against known state-variable candidates or
-/// previously-registered aliases (so chained aliasing, e.g. `Data storage q = p;` where
-/// `p` itself aliases a state variable, still resolves back to the original state var).
+/// Resolves a storage pointer to its possible state-variable targets.
 fn resolve_alias_targets(
     expr: &Expr<'_>,
     candidates: &HashSet<VariableId>,

--- a/crates/lint/src/sol/med/uninitialized_state_variables.rs
+++ b/crates/lint/src/sol/med/uninitialized_state_variables.rs
@@ -78,7 +78,7 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
         // transitively through another alias), e.g. `Data storage p = someStateVar;`.
         // Writes through such a local (`p.val = v`) are writes to the aliased state
         // variable and must be attributed back to it.
-        let mut aliases: HashMap<VariableId, VariableId> = HashMap::new();
+        let mut aliases: HashMap<VariableId, HashSet<VariableId>> = HashMap::new();
 
         // Walk every function in the inheritance chain.
         // Bail out conservatively if any function body contains inline assembly,
@@ -187,7 +187,7 @@ fn collect_block_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
-    aliases: &mut HashMap<VariableId, VariableId>,
+    aliases: &mut HashMap<VariableId, HashSet<VariableId>>,
 ) -> Result<(), ()> {
     for stmt in block.stmts {
         collect_stmt_writes_checked(hir, stmt, candidates, writes, bases, aliases)?;
@@ -201,33 +201,69 @@ fn collect_stmt_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
-    aliases: &mut HashMap<VariableId, VariableId>,
+    aliases: &mut HashMap<VariableId, HashSet<VariableId>>,
 ) -> Result<(), ()> {
     match &stmt.kind {
         // Assembly can write storage directly; bail conservatively.
         StmtKind::AssemblyBlock(_) | StmtKind::Switch(_) | StmtKind::Err(_) => return Err(()),
-        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
             collect_block_writes_checked(hir, *block, candidates, writes, bases, aliases)?;
+        }
+        StmtKind::Loop(block, _) => {
+            let mut body_aliases = aliases.clone();
+            collect_block_writes_checked(
+                hir,
+                *block,
+                candidates,
+                writes,
+                bases,
+                &mut body_aliases,
+            )?;
+            merge_aliases(aliases, body_aliases);
         }
         StmtKind::If(condition, then_stmt, else_stmt) => {
             collect_expr_writes_checked(hir, condition, candidates, writes, bases, aliases)?;
-            collect_stmt_writes_checked(hir, then_stmt, candidates, writes, bases, aliases)?;
+            let mut then_aliases = aliases.clone();
+            collect_stmt_writes_checked(
+                hir,
+                then_stmt,
+                candidates,
+                writes,
+                bases,
+                &mut then_aliases,
+            )?;
             if let Some(else_stmt) = else_stmt {
-                collect_stmt_writes_checked(hir, else_stmt, candidates, writes, bases, aliases)?;
+                let mut else_aliases = aliases.clone();
+                collect_stmt_writes_checked(
+                    hir,
+                    else_stmt,
+                    candidates,
+                    writes,
+                    bases,
+                    &mut else_aliases,
+                )?;
+                merge_aliases(&mut then_aliases, else_aliases);
+                *aliases = then_aliases;
+            } else {
+                merge_aliases(aliases, then_aliases);
             }
         }
         StmtKind::Try(stmt_try) => {
             collect_expr_writes_checked(hir, &stmt_try.expr, candidates, writes, bases, aliases)?;
+            let mut joined_aliases = aliases.clone();
             for clause in stmt_try.clauses {
+                let mut clause_aliases = aliases.clone();
                 collect_block_writes_checked(
                     hir,
                     clause.block,
                     candidates,
                     writes,
                     bases,
-                    aliases,
+                    &mut clause_aliases,
                 )?;
+                merge_aliases(&mut joined_aliases, clause_aliases);
             }
+            *aliases = joined_aliases;
         }
         StmtKind::DeclSingle(var_id) => {
             if let Some(initializer) = hir.variable(*var_id).initializer {
@@ -237,7 +273,7 @@ fn collect_stmt_writes_checked<'hir>(
                 // variable (or from another already-known alias), record it so writes
                 // through the local later in this function attribute back correctly.
                 if hir.variable(*var_id).data_location == Some(DataLocation::Storage)
-                    && let Some(target) = resolve_alias_target(initializer, candidates, aliases)
+                    && let Some(target) = resolve_alias_targets(initializer, candidates, aliases)
                 {
                     aliases.insert(*var_id, target);
                 }
@@ -261,7 +297,7 @@ fn collect_expr_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
-    aliases: &mut HashMap<VariableId, VariableId>,
+    aliases: &mut HashMap<VariableId, HashSet<VariableId>>,
 ) -> Result<(), ()> {
     match &expr.kind {
         ExprKind::Assign(lhs, _, rhs) => {
@@ -291,9 +327,9 @@ fn collect_expr_writes_checked<'hir>(
                 && !candidates.contains(id)
                 && hir.variable(*id).data_location == Some(DataLocation::Storage)
             {
-                match resolve_alias_target(rhs, candidates, aliases) {
-                    Some(target) => {
-                        aliases.insert(*id, target);
+                match resolve_alias_targets(rhs, candidates, aliases) {
+                    Some(targets) => {
+                        aliases.insert(*id, targets);
                     }
                     None => {
                         aliases.remove(id);
@@ -370,8 +406,26 @@ fn collect_expr_writes_checked<'hir>(
         }
         ExprKind::Ternary(condition, then_expr, else_expr) => {
             collect_expr_writes_checked(hir, condition, candidates, writes, bases, aliases)?;
-            collect_expr_writes_checked(hir, then_expr, candidates, writes, bases, aliases)?;
-            collect_expr_writes_checked(hir, else_expr, candidates, writes, bases, aliases)?;
+            let mut then_aliases = aliases.clone();
+            collect_expr_writes_checked(
+                hir,
+                then_expr,
+                candidates,
+                writes,
+                bases,
+                &mut then_aliases,
+            )?;
+            let mut else_aliases = aliases.clone();
+            collect_expr_writes_checked(
+                hir,
+                else_expr,
+                candidates,
+                writes,
+                bases,
+                &mut else_aliases,
+            )?;
+            merge_aliases(&mut then_aliases, else_aliases);
+            *aliases = then_aliases;
         }
         ExprKind::Tuple(exprs) => {
             for expr in exprs.iter().flatten() {
@@ -461,7 +515,7 @@ fn mark_storage_args<'hir>(
     args: &CallArgs<'hir>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
-    aliases: &HashMap<VariableId, VariableId>,
+    aliases: &HashMap<VariableId, HashSet<VariableId>>,
 ) {
     if let CallArgsKind::Unnamed(_) = args.kind {
         for (i, arg_expr) in args.exprs().enumerate() {
@@ -498,23 +552,32 @@ fn mark_storage_args<'hir>(
 /// initializer expression, resolving it against known state-variable candidates or
 /// previously-registered aliases (so chained aliasing, e.g. `Data storage q = p;` where
 /// `p` itself aliases a state variable, still resolves back to the original state var).
-fn resolve_alias_target(
+fn resolve_alias_targets(
     expr: &Expr<'_>,
     candidates: &HashSet<VariableId>,
-    aliases: &HashMap<VariableId, VariableId>,
-) -> Option<VariableId> {
+    aliases: &HashMap<VariableId, HashSet<VariableId>>,
+) -> Option<HashSet<VariableId>> {
     match &expr.peel_parens().kind {
         ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) => {
             if candidates.contains(id) {
-                Some(*id)
+                Some(HashSet::from([*id]))
             } else {
-                aliases.get(id).copied()
+                aliases.get(id).cloned()
             }
         }
         ExprKind::Index(base, _) | ExprKind::Slice(base, _, _) | ExprKind::Member(base, _) => {
-            resolve_alias_target(base, candidates, aliases)
+            resolve_alias_targets(base, candidates, aliases)
         }
         _ => None,
+    }
+}
+
+fn merge_aliases(
+    aliases: &mut HashMap<VariableId, HashSet<VariableId>>,
+    other: HashMap<VariableId, HashSet<VariableId>>,
+) {
+    for (alias, targets) in other {
+        aliases.entry(alias).or_default().extend(targets);
     }
 }
 
@@ -522,14 +585,14 @@ fn collect_lvalue_writes(
     expr: &Expr<'_>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
-    aliases: &HashMap<VariableId, VariableId>,
+    aliases: &HashMap<VariableId, HashSet<VariableId>>,
 ) {
     match &expr.peel_parens().kind {
         ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) => {
             if candidates.contains(id) {
                 writes.insert(*id);
-            } else if let Some(&target) = aliases.get(id) {
-                writes.insert(target);
+            } else if let Some(targets) = aliases.get(id) {
+                writes.extend(targets);
             }
         }
         ExprKind::Tuple(exprs) => {

--- a/crates/lint/src/sol/med/uninitialized_state_variables.rs
+++ b/crates/lint/src/sol/med/uninitialized_state_variables.rs
@@ -14,7 +14,10 @@ use solar::{
         },
     },
 };
-use std::{collections::HashSet, ops::ControlFlow};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::ControlFlow,
+};
 
 declare_forge_lint!(
     UNINITIALIZED_STATE_VARIABLES,
@@ -71,6 +74,12 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
             }
         }
 
+        // Local `storage` pointers that alias a candidate state variable (directly, or
+        // transitively through another alias), e.g. `Data storage p = someStateVar;`.
+        // Writes through such a local (`p.val = v`) are writes to the aliased state
+        // variable and must be attributed back to it.
+        let mut aliases: HashMap<VariableId, VariableId> = HashMap::new();
+
         // Walk every function in the inheritance chain.
         // Bail out conservatively if any function body contains inline assembly,
         // because we cannot soundly track reads or writes through it.
@@ -88,6 +97,7 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
                             &candidate_set,
                             &mut written,
                             bases,
+                            &mut aliases,
                         )
                         .is_err()
                         {
@@ -97,8 +107,15 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
                 }
 
                 if let Some(body) = function.body
-                    && collect_block_writes_checked(hir, body, &candidate_set, &mut written, bases)
-                        .is_err()
+                    && collect_block_writes_checked(
+                        hir,
+                        body,
+                        &candidate_set,
+                        &mut written,
+                        bases,
+                        &mut aliases,
+                    )
+                    .is_err()
                 {
                     return;
                 }
@@ -106,8 +123,15 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
 
             for base_modifier in hir.contract(cid).bases_args {
                 for expr in base_modifier.args.exprs() {
-                    if collect_expr_writes_checked(hir, expr, &candidate_set, &mut written, bases)
-                        .is_err()
+                    if collect_expr_writes_checked(
+                        hir,
+                        expr,
+                        &candidate_set,
+                        &mut written,
+                        bases,
+                        &mut aliases,
+                    )
+                    .is_err()
                     {
                         return;
                     }
@@ -117,8 +141,15 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
             // Walk state-vars initializer expressions for side-effect writes to other state vars
             for var_id in hir.contract(cid).variables() {
                 if let Some(init) = hir.variable(var_id).initializer
-                    && collect_expr_writes_checked(hir, init, &candidate_set, &mut written, bases)
-                        .is_err()
+                    && collect_expr_writes_checked(
+                        hir,
+                        init,
+                        &candidate_set,
+                        &mut written,
+                        bases,
+                        &mut aliases,
+                    )
+                    .is_err()
                 {
                     return;
                 }
@@ -156,9 +187,10 @@ fn collect_block_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
+    aliases: &mut HashMap<VariableId, VariableId>,
 ) -> Result<(), ()> {
     for stmt in block.stmts {
-        collect_stmt_writes_checked(hir, stmt, candidates, writes, bases)?;
+        collect_stmt_writes_checked(hir, stmt, candidates, writes, bases, aliases)?;
     }
     Ok(())
 }
@@ -169,29 +201,46 @@ fn collect_stmt_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
+    aliases: &mut HashMap<VariableId, VariableId>,
 ) -> Result<(), ()> {
     match &stmt.kind {
         // Assembly can write storage directly; bail conservatively.
         StmtKind::AssemblyBlock(_) | StmtKind::Switch(_) | StmtKind::Err(_) => return Err(()),
         StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
-            collect_block_writes_checked(hir, *block, candidates, writes, bases)?;
+            collect_block_writes_checked(hir, *block, candidates, writes, bases, aliases)?;
         }
         StmtKind::If(condition, then_stmt, else_stmt) => {
-            collect_expr_writes_checked(hir, condition, candidates, writes, bases)?;
-            collect_stmt_writes_checked(hir, then_stmt, candidates, writes, bases)?;
+            collect_expr_writes_checked(hir, condition, candidates, writes, bases, aliases)?;
+            collect_stmt_writes_checked(hir, then_stmt, candidates, writes, bases, aliases)?;
             if let Some(else_stmt) = else_stmt {
-                collect_stmt_writes_checked(hir, else_stmt, candidates, writes, bases)?;
+                collect_stmt_writes_checked(hir, else_stmt, candidates, writes, bases, aliases)?;
             }
         }
         StmtKind::Try(stmt_try) => {
-            collect_expr_writes_checked(hir, &stmt_try.expr, candidates, writes, bases)?;
+            collect_expr_writes_checked(hir, &stmt_try.expr, candidates, writes, bases, aliases)?;
             for clause in stmt_try.clauses {
-                collect_block_writes_checked(hir, clause.block, candidates, writes, bases)?;
+                collect_block_writes_checked(
+                    hir,
+                    clause.block,
+                    candidates,
+                    writes,
+                    bases,
+                    aliases,
+                )?;
             }
         }
         StmtKind::DeclSingle(var_id) => {
             if let Some(initializer) = hir.variable(*var_id).initializer {
-                collect_expr_writes_checked(hir, initializer, candidates, writes, bases)?;
+                collect_expr_writes_checked(hir, initializer, candidates, writes, bases, aliases)?;
+
+                // If this local is a `storage` pointer initialized from a candidate state
+                // variable (or from another already-known alias), record it so writes
+                // through the local later in this function attribute back correctly.
+                if hir.variable(*var_id).data_location == Some(DataLocation::Storage)
+                    && let Some(target) = resolve_alias_target(initializer, candidates, aliases)
+                {
+                    aliases.insert(*var_id, target);
+                }
             }
         }
         StmtKind::DeclMulti(_, expr)
@@ -199,7 +248,7 @@ fn collect_stmt_writes_checked<'hir>(
         | StmtKind::Revert(expr)
         | StmtKind::Return(Some(expr))
         | StmtKind::Expr(expr) => {
-            collect_expr_writes_checked(hir, expr, candidates, writes, bases)?
+            collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?
         }
         StmtKind::Return(None) | StmtKind::Break | StmtKind::Continue | StmtKind::Placeholder => {}
     }
@@ -212,38 +261,71 @@ fn collect_expr_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
+    aliases: &mut HashMap<VariableId, VariableId>,
 ) -> Result<(), ()> {
     match &expr.kind {
         ExprKind::Assign(lhs, _, rhs) => {
-            collect_lvalue_writes(lhs, candidates, writes);
-            collect_expr_writes_checked(hir, lhs, candidates, writes, bases)?;
-            collect_expr_writes_checked(hir, rhs, candidates, writes, bases)?;
+            // A bare identifier `lhs` that is itself a known local storage-pointer alias
+            // is a pointer *reassignment* (`p = other;`) — it repoints `p`, it does not
+            // write through to whatever `p` previously aliased. Skip the generic lvalue
+            // write here; the retargeting below records the new alias instead. Any other
+            // lvalue shape (`someStateVar = x`, `p.val = x`, `p[i] = x`, ...) is a real
+            // write and still goes through the normal path.
+            let is_bare_alias_repoint = matches!(
+                &lhs.peel_parens().kind,
+                ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..])
+                    if !candidates.contains(id) && aliases.contains_key(id)
+            );
+            if !is_bare_alias_repoint {
+                collect_lvalue_writes(lhs, candidates, writes, aliases);
+            }
+            collect_expr_writes_checked(hir, lhs, candidates, writes, bases, aliases)?;
+            collect_expr_writes_checked(hir, rhs, candidates, writes, bases, aliases)?;
+
+            // Reassigning a local `storage` pointer (whether previously aliased or not,
+            // e.g. a `storage` parameter aliased for the first time via assignment) must
+            // (re)target the alias, or writes through `p` afterward would misattribute to
+            // a stale target instead of the new one. If the new target can't be resolved,
+            // drop any stale mapping rather than keep attributing to the old one.
+            if let ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) = &lhs.peel_parens().kind
+                && !candidates.contains(id)
+                && hir.variable(*id).data_location == Some(DataLocation::Storage)
+            {
+                match resolve_alias_target(rhs, candidates, aliases) {
+                    Some(target) => {
+                        aliases.insert(*id, target);
+                    }
+                    None => {
+                        aliases.remove(id);
+                    }
+                }
+            }
         }
         ExprKind::Delete(inner) => {
-            collect_lvalue_writes(inner, candidates, writes);
-            collect_expr_writes_checked(hir, inner, candidates, writes, bases)?;
+            collect_lvalue_writes(inner, candidates, writes, aliases);
+            collect_expr_writes_checked(hir, inner, candidates, writes, bases, aliases)?;
         }
         ExprKind::Unary(op, inner) => {
             if op.kind.has_side_effects() {
-                collect_lvalue_writes(inner, candidates, writes);
+                collect_lvalue_writes(inner, candidates, writes, aliases);
             }
-            collect_expr_writes_checked(hir, inner, candidates, writes, bases)?;
+            collect_expr_writes_checked(hir, inner, candidates, writes, bases, aliases)?;
         }
         ExprKind::Array(exprs) => {
             for expr in *exprs {
-                collect_expr_writes_checked(hir, expr, candidates, writes, bases)?;
+                collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?;
             }
         }
         ExprKind::Binary(lhs, _, rhs) => {
-            collect_expr_writes_checked(hir, lhs, candidates, writes, bases)?;
-            collect_expr_writes_checked(hir, rhs, candidates, writes, bases)?;
+            collect_expr_writes_checked(hir, lhs, candidates, writes, bases, aliases)?;
+            collect_expr_writes_checked(hir, rhs, candidates, writes, bases, aliases)?;
         }
         ExprKind::Call(callee, args, named_args) => {
             if let ExprKind::Member(base, _) = &callee.kind {
                 // Covers push/pop and library dispatch (`using Lib for T` with `T storage self`);
                 // can't resolve callee without Gcx. Treat the receiver as a write target to avoid
                 // false positives.
-                collect_lvalue_writes(base, candidates, writes);
+                collect_lvalue_writes(base, candidates, writes, aliases);
             }
 
             // Direct calls to internal functions that take a `storage` parameter
@@ -253,45 +335,47 @@ fn collect_expr_writes_checked<'hir>(
             // callees (`BaseSetter._set(slot, v)`, `super._set(slot, v)`).
             let funcs = collect_callee_funcs(hir, callee, bases);
             if !funcs.is_empty() {
-                mark_storage_args(&funcs, hir, args, candidates, writes);
+                mark_storage_args(&funcs, hir, args, candidates, writes, aliases);
             }
 
-            collect_expr_writes_checked(hir, callee, candidates, writes, bases)?;
+            collect_expr_writes_checked(hir, callee, candidates, writes, bases, aliases)?;
             for expr in args.exprs() {
-                collect_expr_writes_checked(hir, expr, candidates, writes, bases)?;
+                collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?;
             }
             if let Some(named_args) = named_args {
                 for arg in named_args.args {
-                    collect_expr_writes_checked(hir, &arg.value, candidates, writes, bases)?;
+                    collect_expr_writes_checked(
+                        hir, &arg.value, candidates, writes, bases, aliases,
+                    )?;
                 }
             }
         }
         ExprKind::Index(base, index) => {
-            collect_expr_writes_checked(hir, base, candidates, writes, bases)?;
+            collect_expr_writes_checked(hir, base, candidates, writes, bases, aliases)?;
             if let Some(index) = index {
-                collect_expr_writes_checked(hir, index, candidates, writes, bases)?;
+                collect_expr_writes_checked(hir, index, candidates, writes, bases, aliases)?;
             }
         }
         ExprKind::Slice(base, start, end) => {
-            collect_expr_writes_checked(hir, base, candidates, writes, bases)?;
+            collect_expr_writes_checked(hir, base, candidates, writes, bases, aliases)?;
             if let Some(start) = start {
-                collect_expr_writes_checked(hir, start, candidates, writes, bases)?;
+                collect_expr_writes_checked(hir, start, candidates, writes, bases, aliases)?;
             }
             if let Some(end) = end {
-                collect_expr_writes_checked(hir, end, candidates, writes, bases)?;
+                collect_expr_writes_checked(hir, end, candidates, writes, bases, aliases)?;
             }
         }
         ExprKind::Member(base, _) | ExprKind::Payable(base) => {
-            collect_expr_writes_checked(hir, base, candidates, writes, bases)?;
+            collect_expr_writes_checked(hir, base, candidates, writes, bases, aliases)?;
         }
         ExprKind::Ternary(condition, then_expr, else_expr) => {
-            collect_expr_writes_checked(hir, condition, candidates, writes, bases)?;
-            collect_expr_writes_checked(hir, then_expr, candidates, writes, bases)?;
-            collect_expr_writes_checked(hir, else_expr, candidates, writes, bases)?;
+            collect_expr_writes_checked(hir, condition, candidates, writes, bases, aliases)?;
+            collect_expr_writes_checked(hir, then_expr, candidates, writes, bases, aliases)?;
+            collect_expr_writes_checked(hir, else_expr, candidates, writes, bases, aliases)?;
         }
         ExprKind::Tuple(exprs) => {
             for expr in exprs.iter().flatten() {
-                collect_expr_writes_checked(hir, expr, candidates, writes, bases)?;
+                collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?;
             }
         }
         ExprKind::Ident(_)
@@ -377,6 +461,7 @@ fn mark_storage_args<'hir>(
     args: &CallArgs<'hir>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
+    aliases: &HashMap<VariableId, VariableId>,
 ) {
     if let CallArgsKind::Unnamed(_) = args.kind {
         for (i, arg_expr) in args.exprs().enumerate() {
@@ -386,7 +471,7 @@ fn mark_storage_args<'hir>(
                 })
             });
             if any_storage {
-                collect_lvalue_writes(arg_expr, candidates, writes);
+                collect_lvalue_writes(arg_expr, candidates, writes, aliases);
             }
         }
     }
@@ -403,9 +488,33 @@ fn mark_storage_args<'hir>(
                 })
             });
             if any_storage {
-                collect_lvalue_writes(&named_arg.value, candidates, writes);
+                collect_lvalue_writes(&named_arg.value, candidates, writes, aliases);
             }
         }
+    }
+}
+
+/// Peels index/slice/member wrappers to find the root identifier of a storage-pointer
+/// initializer expression, resolving it against known state-variable candidates or
+/// previously-registered aliases (so chained aliasing, e.g. `Data storage q = p;` where
+/// `p` itself aliases a state variable, still resolves back to the original state var).
+fn resolve_alias_target(
+    expr: &Expr<'_>,
+    candidates: &HashSet<VariableId>,
+    aliases: &HashMap<VariableId, VariableId>,
+) -> Option<VariableId> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) => {
+            if candidates.contains(id) {
+                Some(*id)
+            } else {
+                aliases.get(id).copied()
+            }
+        }
+        ExprKind::Index(base, _) | ExprKind::Slice(base, _, _) | ExprKind::Member(base, _) => {
+            resolve_alias_target(base, candidates, aliases)
+        }
+        _ => None,
     }
 }
 
@@ -413,18 +522,23 @@ fn collect_lvalue_writes(
     expr: &Expr<'_>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
+    aliases: &HashMap<VariableId, VariableId>,
 ) {
     match &expr.peel_parens().kind {
-        ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) if candidates.contains(id) => {
-            writes.insert(*id);
+        ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) => {
+            if candidates.contains(id) {
+                writes.insert(*id);
+            } else if let Some(&target) = aliases.get(id) {
+                writes.insert(target);
+            }
         }
         ExprKind::Tuple(exprs) => {
             for expr in exprs.iter().flatten() {
-                collect_lvalue_writes(expr, candidates, writes);
+                collect_lvalue_writes(expr, candidates, writes, aliases);
             }
         }
         ExprKind::Index(base, _) | ExprKind::Slice(base, _, _) | ExprKind::Member(base, _) => {
-            collect_lvalue_writes(base, candidates, writes)
+            collect_lvalue_writes(base, candidates, writes, aliases)
         }
         _ => {}
     }

--- a/crates/lint/src/sol/med/uninitialized_state_variables.rs
+++ b/crates/lint/src/sol/med/uninitialized_state_variables.rs
@@ -10,7 +10,7 @@ use solar::{
         Hir,
         hir::{
             Block, CallArgs, CallArgsKind, ContractId, DataLocation, Expr, ExprKind, Function,
-            ItemId, Res, Stmt, StmtKind, TypeKind, VariableId, Visit,
+            ItemId, LoopSource, Res, Stmt, StmtKind, TypeKind, VariableId, Visit,
         },
     },
 };
@@ -74,9 +74,6 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
             }
         }
 
-        // Possible state-variable targets of local storage pointers.
-        let mut aliases: HashMap<VariableId, HashSet<VariableId>> = HashMap::new();
-
         // Walk every function in the inheritance chain.
         // Bail out conservatively if any function body contains inline assembly,
         // because we cannot soundly track reads or writes through it.
@@ -85,6 +82,8 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
         for &cid in bases {
             for func_id in hir.contract(cid).all_functions() {
                 let function = hir.function(func_id);
+                // Local variable IDs cannot cross function boundaries.
+                let mut aliases = HashMap::new();
 
                 for modifier in function.modifiers {
                     for expr in modifier.args.exprs() {
@@ -120,6 +119,7 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
 
             for base_modifier in hir.contract(cid).bases_args {
                 for expr in base_modifier.args.exprs() {
+                    let mut aliases = HashMap::new();
                     if collect_expr_writes_checked(
                         hir,
                         expr,
@@ -137,8 +137,9 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
 
             // Walk state-vars initializer expressions for side-effect writes to other state vars
             for var_id in hir.contract(cid).variables() {
-                if let Some(init) = hir.variable(var_id).initializer
-                    && collect_expr_writes_checked(
+                if let Some(init) = hir.variable(var_id).initializer {
+                    let mut aliases = HashMap::new();
+                    if collect_expr_writes_checked(
                         hir,
                         init,
                         &candidate_set,
@@ -147,8 +148,9 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
                         &mut aliases,
                     )
                     .is_err()
-                {
-                    return;
+                    {
+                        return;
+                    }
                 }
             }
         }
@@ -178,18 +180,51 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
     }
 }
 
+type Aliases = HashMap<VariableId, HashSet<VariableId>>;
+
+#[derive(Default)]
+struct Flow {
+    falls_through: bool,
+    breaks: Option<Aliases>,
+    continues: Option<Aliases>,
+}
+
+impl Flow {
+    const fn fallthrough() -> Self {
+        Self { falls_through: true, breaks: None, continues: None }
+    }
+}
+
 fn collect_block_writes_checked<'hir>(
     hir: &'hir Hir<'hir>,
     block: Block<'hir>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
-    aliases: &mut HashMap<VariableId, HashSet<VariableId>>,
-) -> Result<(), ()> {
-    for stmt in block.stmts {
-        collect_stmt_writes_checked(hir, stmt, candidates, writes, bases, aliases)?;
+    aliases: &mut Aliases,
+) -> Result<Flow, ()> {
+    collect_stmts_writes_checked(hir, block.stmts, candidates, writes, bases, aliases)
+}
+
+fn collect_stmts_writes_checked<'hir>(
+    hir: &'hir Hir<'hir>,
+    stmts: &'hir [Stmt<'hir>],
+    candidates: &HashSet<VariableId>,
+    writes: &mut HashSet<VariableId>,
+    bases: &'hir [ContractId],
+    aliases: &mut Aliases,
+) -> Result<Flow, ()> {
+    let mut flow = Flow::fallthrough();
+    for stmt in stmts {
+        if !flow.falls_through {
+            break;
+        }
+        let stmt_flow = collect_stmt_writes_checked(hir, stmt, candidates, writes, bases, aliases)?;
+        merge_optional_aliases(&mut flow.breaks, stmt_flow.breaks);
+        merge_optional_aliases(&mut flow.continues, stmt_flow.continues);
+        flow.falls_through = stmt_flow.falls_through;
     }
-    Ok(())
+    Ok(flow)
 }
 
 fn collect_stmt_writes_checked<'hir>(
@@ -198,30 +233,53 @@ fn collect_stmt_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
-    aliases: &mut HashMap<VariableId, HashSet<VariableId>>,
-) -> Result<(), ()> {
+    aliases: &mut Aliases,
+) -> Result<Flow, ()> {
     match &stmt.kind {
         // Assembly can write storage directly; bail conservatively.
-        StmtKind::AssemblyBlock(_) | StmtKind::Switch(_) | StmtKind::Err(_) => return Err(()),
+        StmtKind::AssemblyBlock(_) | StmtKind::Switch(_) | StmtKind::Err(_) => Err(()),
         StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
-            collect_block_writes_checked(hir, *block, candidates, writes, bases, aliases)?;
+            collect_block_writes_checked(hir, *block, candidates, writes, bases, aliases)
         }
-        StmtKind::Loop(block, _) => {
-            let mut body_aliases = aliases.clone();
-            collect_block_writes_checked(
-                hir,
-                *block,
-                candidates,
-                writes,
-                bases,
-                &mut body_aliases,
-            )?;
-            merge_aliases(aliases, body_aliases);
+        StmtKind::Loop(block, source) => {
+            let entry = aliases.clone();
+            let mut head = entry.clone();
+            // Re-run the loop until every reachable alias target has propagated through its
+            // backedges. Alias sets only grow at the loop head, so this always converges.
+            loop {
+                let mut iteration_aliases = head.clone();
+                let flow = collect_loop_iteration(
+                    hir,
+                    *block,
+                    *source,
+                    candidates,
+                    writes,
+                    bases,
+                    &mut iteration_aliases,
+                )?;
+
+                let mut next_head = entry.clone();
+                if flow.falls_through {
+                    merge_aliases(&mut next_head, iteration_aliases);
+                }
+                if let Some(continued) = flow.continues {
+                    merge_aliases(&mut next_head, continued);
+                }
+
+                if next_head == head {
+                    if let Some(exits) = flow.breaks {
+                        *aliases = exits;
+                        return Ok(Flow::fallthrough());
+                    }
+                    return Ok(Flow::default());
+                }
+                head = next_head;
+            }
         }
         StmtKind::If(condition, then_stmt, else_stmt) => {
             collect_expr_writes_checked(hir, condition, candidates, writes, bases, aliases)?;
             let mut then_aliases = aliases.clone();
-            collect_stmt_writes_checked(
+            let then_flow = collect_stmt_writes_checked(
                 hir,
                 then_stmt,
                 candidates,
@@ -229,8 +287,8 @@ fn collect_stmt_writes_checked<'hir>(
                 bases,
                 &mut then_aliases,
             )?;
-            if let Some(else_stmt) = else_stmt {
-                let mut else_aliases = aliases.clone();
+            let mut else_aliases = aliases.clone();
+            let else_flow = if let Some(else_stmt) = else_stmt {
                 collect_stmt_writes_checked(
                     hir,
                     else_stmt,
@@ -238,19 +296,37 @@ fn collect_stmt_writes_checked<'hir>(
                     writes,
                     bases,
                     &mut else_aliases,
-                )?;
-                merge_aliases(&mut then_aliases, else_aliases);
-                *aliases = then_aliases;
+                )?
             } else {
-                merge_aliases(aliases, then_aliases);
+                Flow::fallthrough()
+            };
+
+            let mut fallthrough = None;
+            if then_flow.falls_through {
+                merge_optional_aliases(&mut fallthrough, Some(then_aliases));
             }
+            if else_flow.falls_through {
+                merge_optional_aliases(&mut fallthrough, Some(else_aliases));
+            }
+            let falls_through = fallthrough.is_some();
+            if let Some(joined) = fallthrough {
+                *aliases = joined;
+            }
+            Ok(Flow {
+                falls_through,
+                breaks: merge_optional(then_flow.breaks, else_flow.breaks),
+                continues: merge_optional(then_flow.continues, else_flow.continues),
+            })
         }
         StmtKind::Try(stmt_try) => {
             collect_expr_writes_checked(hir, &stmt_try.expr, candidates, writes, bases, aliases)?;
-            let mut joined_aliases = aliases.clone();
+            let before = aliases.clone();
+            let mut fallthrough = None;
+            let mut breaks = None;
+            let mut continues = None;
             for clause in stmt_try.clauses {
-                let mut clause_aliases = aliases.clone();
-                collect_block_writes_checked(
+                let mut clause_aliases = before.clone();
+                let flow = collect_block_writes_checked(
                     hir,
                     clause.block,
                     candidates,
@@ -258,9 +334,17 @@ fn collect_stmt_writes_checked<'hir>(
                     bases,
                     &mut clause_aliases,
                 )?;
-                merge_aliases(&mut joined_aliases, clause_aliases);
+                if flow.falls_through {
+                    merge_optional_aliases(&mut fallthrough, Some(clause_aliases));
+                }
+                merge_optional_aliases(&mut breaks, flow.breaks);
+                merge_optional_aliases(&mut continues, flow.continues);
             }
-            *aliases = joined_aliases;
+            let falls_through = fallthrough.is_some();
+            if let Some(joined) = fallthrough {
+                *aliases = joined;
+            }
+            Ok(Flow { falls_through, breaks, continues })
         }
         StmtKind::DeclSingle(var_id) => {
             if let Some(initializer) = hir.variable(*var_id).initializer {
@@ -272,17 +356,91 @@ fn collect_stmt_writes_checked<'hir>(
                     aliases.insert(*var_id, target);
                 }
             }
+            Ok(Flow::fallthrough())
         }
-        StmtKind::DeclMulti(_, expr)
-        | StmtKind::Emit(expr)
-        | StmtKind::Revert(expr)
-        | StmtKind::Return(Some(expr))
-        | StmtKind::Expr(expr) => {
-            collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?
+        StmtKind::DeclMulti(_, expr) | StmtKind::Emit(expr) | StmtKind::Expr(expr) => {
+            collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?;
+            Ok(Flow::fallthrough())
         }
-        StmtKind::Return(None) | StmtKind::Break | StmtKind::Continue | StmtKind::Placeholder => {}
+        StmtKind::Revert(expr) | StmtKind::Return(Some(expr)) => {
+            collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?;
+            Ok(Flow::default())
+        }
+        StmtKind::Return(None) => Ok(Flow::default()),
+        StmtKind::Break => Ok(Flow { breaks: Some(aliases.clone()), ..Flow::default() }),
+        StmtKind::Continue => Ok(Flow { continues: Some(aliases.clone()), ..Flow::default() }),
+        StmtKind::Placeholder => Ok(Flow::fallthrough()),
     }
-    Ok(())
+}
+
+fn collect_loop_iteration<'hir>(
+    hir: &'hir Hir<'hir>,
+    block: Block<'hir>,
+    source: LoopSource,
+    candidates: &HashSet<VariableId>,
+    writes: &mut HashSet<VariableId>,
+    bases: &'hir [ContractId],
+    aliases: &mut Aliases,
+) -> Result<Flow, ()> {
+    if source == LoopSource::DoWhile
+        && let Some((condition, body)) = block.stmts.split_last()
+    {
+        let mut body_flow =
+            collect_stmts_writes_checked(hir, body, candidates, writes, bases, aliases)?;
+        let mut condition_aliases = None;
+        if body_flow.falls_through {
+            merge_optional_aliases(&mut condition_aliases, Some(aliases.clone()));
+        }
+        merge_optional_aliases(&mut condition_aliases, body_flow.continues.take());
+
+        if let Some(mut condition_aliases) = condition_aliases {
+            let condition_flow = collect_stmt_writes_checked(
+                hir,
+                condition,
+                candidates,
+                writes,
+                bases,
+                &mut condition_aliases,
+            )?;
+            if condition_flow.falls_through {
+                *aliases = condition_aliases;
+            }
+            merge_optional_aliases(&mut body_flow.breaks, condition_flow.breaks);
+            return Ok(Flow {
+                falls_through: condition_flow.falls_through,
+                breaks: body_flow.breaks,
+                continues: condition_flow.continues,
+            });
+        }
+        return Ok(Flow { breaks: body_flow.breaks, ..Flow::default() });
+    }
+
+    let mut flow = collect_block_writes_checked(hir, block, candidates, writes, bases, aliases)?;
+    if source == LoopSource::ForWithUpdate
+        && let Some(next) = for_loop_next_expr(block)
+        && let Some(continued) = &mut flow.continues
+    {
+        collect_expr_writes_checked(hir, next, candidates, writes, bases, continued)?;
+    }
+    Ok(flow)
+}
+
+fn for_loop_next_expr<'hir>(block: Block<'hir>) -> Option<&'hir Expr<'hir>> {
+    let [stmt] = block.stmts else { return None };
+    let inner = match &stmt.kind {
+        StmtKind::If(_, then_stmt, _) => {
+            let StmtKind::Block(inner) = &then_stmt.kind else { return None };
+            inner
+        }
+        StmtKind::Block(inner) => inner,
+        _ => return None,
+    };
+    if inner.span != block.span {
+        return None;
+    }
+    let [_, next] = inner.stmts else { return None };
+    let StmtKind::Expr(next) = &next.kind else { return None };
+    Some(*next)
 }
 
 fn collect_expr_writes_checked<'hir>(
@@ -291,7 +449,7 @@ fn collect_expr_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
-    aliases: &mut HashMap<VariableId, HashSet<VariableId>>,
+    aliases: &mut Aliases,
 ) -> Result<(), ()> {
     match &expr.kind {
         ExprKind::Assign(lhs, _, rhs) => {
@@ -302,7 +460,7 @@ fn collect_expr_writes_checked<'hir>(
                     if !candidates.contains(id) && aliases.contains_key(id)
             );
             if !is_bare_alias_repoint {
-                collect_lvalue_writes(lhs, candidates, writes, aliases);
+                collect_lvalue_writes(lhs, candidates, writes, Some(aliases));
             }
             collect_expr_writes_checked(hir, lhs, candidates, writes, bases, aliases)?;
             collect_expr_writes_checked(hir, rhs, candidates, writes, bases, aliases)?;
@@ -323,12 +481,12 @@ fn collect_expr_writes_checked<'hir>(
             }
         }
         ExprKind::Delete(inner) => {
-            collect_lvalue_writes(inner, candidates, writes, aliases);
+            collect_lvalue_writes(inner, candidates, writes, Some(aliases));
             collect_expr_writes_checked(hir, inner, candidates, writes, bases, aliases)?;
         }
         ExprKind::Unary(op, inner) => {
             if op.kind.has_side_effects() {
-                collect_lvalue_writes(inner, candidates, writes, aliases);
+                collect_lvalue_writes(inner, candidates, writes, Some(aliases));
             }
             collect_expr_writes_checked(hir, inner, candidates, writes, bases, aliases)?;
         }
@@ -345,18 +503,21 @@ fn collect_expr_writes_checked<'hir>(
             if let ExprKind::Member(base, _) = &callee.kind {
                 // Covers push/pop and library dispatch (`using Lib for T` with `T storage self`);
                 // can't resolve callee without Gcx. Treat the receiver as a write target to avoid
-                // false positives.
-                collect_lvalue_writes(base, candidates, writes, aliases);
+                // false positives. Do not extend this heuristic through aliases: the call may be
+                // read-only.
+                collect_lvalue_writes(base, candidates, writes, None);
             }
 
             // Direct calls to internal functions that take a `storage` parameter
             // mutate the corresponding argument in place; treat it as a write.
             //
             // Handles bare identifier callees (`_set(slot, v)`) and qualified member
-            // callees (`BaseSetter._set(slot, v)`, `super._set(slot, v)`).
+            // callees (`BaseSetter._set(slot, v)`, `super._set(slot, v)`). This conservative
+            // heuristic remains limited to direct state arguments because storage parameters may
+            // be read-only.
             let funcs = collect_callee_funcs(hir, callee, bases);
             if !funcs.is_empty() {
-                mark_storage_args(&funcs, hir, args, candidates, writes, aliases);
+                mark_storage_args(&funcs, hir, args, candidates, writes);
             }
 
             collect_expr_writes_checked(hir, callee, candidates, writes, bases, aliases)?;
@@ -500,7 +661,6 @@ fn mark_storage_args<'hir>(
     args: &CallArgs<'hir>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
-    aliases: &HashMap<VariableId, HashSet<VariableId>>,
 ) {
     if let CallArgsKind::Unnamed(_) = args.kind {
         for (i, arg_expr) in args.exprs().enumerate() {
@@ -510,7 +670,7 @@ fn mark_storage_args<'hir>(
                 })
             });
             if any_storage {
-                collect_lvalue_writes(arg_expr, candidates, writes, aliases);
+                collect_lvalue_writes(arg_expr, candidates, writes, None);
             }
         }
     }
@@ -527,7 +687,7 @@ fn mark_storage_args<'hir>(
                 })
             });
             if any_storage {
-                collect_lvalue_writes(&named_arg.value, candidates, writes, aliases);
+                collect_lvalue_writes(&named_arg.value, candidates, writes, None);
             }
         }
     }
@@ -554,26 +714,38 @@ fn resolve_alias_targets(
     }
 }
 
-fn merge_aliases(
-    aliases: &mut HashMap<VariableId, HashSet<VariableId>>,
-    other: HashMap<VariableId, HashSet<VariableId>>,
-) {
+fn merge_aliases(aliases: &mut Aliases, other: Aliases) {
     for (alias, targets) in other {
         aliases.entry(alias).or_default().extend(targets);
     }
+}
+
+fn merge_optional_aliases(aliases: &mut Option<Aliases>, other: Option<Aliases>) {
+    if let Some(other) = other {
+        if let Some(aliases) = aliases {
+            merge_aliases(aliases, other);
+        } else {
+            *aliases = Some(other);
+        }
+    }
+}
+
+fn merge_optional(mut aliases: Option<Aliases>, other: Option<Aliases>) -> Option<Aliases> {
+    merge_optional_aliases(&mut aliases, other);
+    aliases
 }
 
 fn collect_lvalue_writes(
     expr: &Expr<'_>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
-    aliases: &HashMap<VariableId, HashSet<VariableId>>,
+    aliases: Option<&Aliases>,
 ) {
     match &expr.peel_parens().kind {
         ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) => {
             if candidates.contains(id) {
                 writes.insert(*id);
-            } else if let Some(targets) = aliases.get(id) {
+            } else if let Some(targets) = aliases.and_then(|aliases| aliases.get(id)) {
                 writes.extend(targets);
             }
         }

--- a/crates/lint/src/sol/med/uninitialized_state_variables.rs
+++ b/crates/lint/src/sol/med/uninitialized_state_variables.rs
@@ -10,7 +10,7 @@ use solar::{
         Hir,
         hir::{
             Block, CallArgs, CallArgsKind, ContractId, DataLocation, Expr, ExprKind, Function,
-            ItemId, LoopSource, Res, Stmt, StmtKind, TypeKind, VariableId, Visit,
+            ItemId, Res, Stmt, StmtKind, TypeKind, VariableId, Visit,
         },
     },
 };
@@ -78,12 +78,12 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
         // Bail out conservatively if any function body contains inline assembly,
         // because we cannot soundly track reads or writes through it.
         let bases = contract.linearized_bases;
+        let no_aliases = Aliases::new();
 
         for &cid in bases {
             for func_id in hir.contract(cid).all_functions() {
                 let function = hir.function(func_id);
-                // Local variable IDs cannot cross function boundaries.
-                let mut aliases = HashMap::new();
+                let aliases = collect_storage_aliases(hir, function, &candidate_set);
 
                 for modifier in function.modifiers {
                     for expr in modifier.args.exprs() {
@@ -93,7 +93,7 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
                             &candidate_set,
                             &mut written,
                             bases,
-                            &mut aliases,
+                            &aliases,
                         )
                         .is_err()
                         {
@@ -109,7 +109,7 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
                         &candidate_set,
                         &mut written,
                         bases,
-                        &mut aliases,
+                        &aliases,
                     )
                     .is_err()
                 {
@@ -119,14 +119,13 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
 
             for base_modifier in hir.contract(cid).bases_args {
                 for expr in base_modifier.args.exprs() {
-                    let mut aliases = HashMap::new();
                     if collect_expr_writes_checked(
                         hir,
                         expr,
                         &candidate_set,
                         &mut written,
                         bases,
-                        &mut aliases,
+                        &no_aliases,
                     )
                     .is_err()
                     {
@@ -137,20 +136,18 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
 
             // Walk state-vars initializer expressions for side-effect writes to other state vars
             for var_id in hir.contract(cid).variables() {
-                if let Some(init) = hir.variable(var_id).initializer {
-                    let mut aliases = HashMap::new();
-                    if collect_expr_writes_checked(
+                if let Some(init) = hir.variable(var_id).initializer
+                    && collect_expr_writes_checked(
                         hir,
                         init,
                         &candidate_set,
                         &mut written,
                         bases,
-                        &mut aliases,
+                        &no_aliases,
                     )
                     .is_err()
-                    {
-                        return;
-                    }
+                {
+                    return;
                 }
             }
         }
@@ -180,51 +177,18 @@ impl<'hir> LateLintPass<'hir> for UninitializedStateVariables {
     }
 }
 
-type Aliases = HashMap<VariableId, HashSet<VariableId>>;
-
-#[derive(Default)]
-struct Flow {
-    falls_through: bool,
-    breaks: Option<Aliases>,
-    continues: Option<Aliases>,
-}
-
-impl Flow {
-    const fn fallthrough() -> Self {
-        Self { falls_through: true, breaks: None, continues: None }
-    }
-}
-
 fn collect_block_writes_checked<'hir>(
     hir: &'hir Hir<'hir>,
     block: Block<'hir>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
-    aliases: &mut Aliases,
-) -> Result<Flow, ()> {
-    collect_stmts_writes_checked(hir, block.stmts, candidates, writes, bases, aliases)
-}
-
-fn collect_stmts_writes_checked<'hir>(
-    hir: &'hir Hir<'hir>,
-    stmts: &'hir [Stmt<'hir>],
-    candidates: &HashSet<VariableId>,
-    writes: &mut HashSet<VariableId>,
-    bases: &'hir [ContractId],
-    aliases: &mut Aliases,
-) -> Result<Flow, ()> {
-    let mut flow = Flow::fallthrough();
-    for stmt in stmts {
-        if !flow.falls_through {
-            break;
-        }
-        let stmt_flow = collect_stmt_writes_checked(hir, stmt, candidates, writes, bases, aliases)?;
-        merge_optional_aliases(&mut flow.breaks, stmt_flow.breaks);
-        merge_optional_aliases(&mut flow.continues, stmt_flow.continues);
-        flow.falls_through = stmt_flow.falls_through;
+    aliases: &Aliases,
+) -> Result<(), ()> {
+    for stmt in block.stmts {
+        collect_stmt_writes_checked(hir, stmt, candidates, writes, bases, aliases)?;
     }
-    Ok(flow)
+    Ok(())
 }
 
 fn collect_stmt_writes_checked<'hir>(
@@ -233,214 +197,49 @@ fn collect_stmt_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
-    aliases: &mut Aliases,
-) -> Result<Flow, ()> {
+    aliases: &Aliases,
+) -> Result<(), ()> {
     match &stmt.kind {
         // Assembly can write storage directly; bail conservatively.
-        StmtKind::AssemblyBlock(_) | StmtKind::Switch(_) | StmtKind::Err(_) => Err(()),
-        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
-            collect_block_writes_checked(hir, *block, candidates, writes, bases, aliases)
-        }
-        StmtKind::Loop(block, source) => {
-            let entry = aliases.clone();
-            let mut head = entry.clone();
-            // Re-run the loop until every reachable alias target has propagated through its
-            // backedges. Alias sets only grow at the loop head, so this always converges.
-            loop {
-                let mut iteration_aliases = head.clone();
-                let flow = collect_loop_iteration(
-                    hir,
-                    *block,
-                    *source,
-                    candidates,
-                    writes,
-                    bases,
-                    &mut iteration_aliases,
-                )?;
-
-                let mut next_head = entry.clone();
-                if flow.falls_through {
-                    merge_aliases(&mut next_head, iteration_aliases);
-                }
-                if let Some(continued) = flow.continues {
-                    merge_aliases(&mut next_head, continued);
-                }
-
-                if next_head == head {
-                    if let Some(exits) = flow.breaks {
-                        *aliases = exits;
-                        return Ok(Flow::fallthrough());
-                    }
-                    return Ok(Flow::default());
-                }
-                head = next_head;
-            }
+        StmtKind::AssemblyBlock(_) | StmtKind::Switch(_) | StmtKind::Err(_) => return Err(()),
+        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+            collect_block_writes_checked(hir, *block, candidates, writes, bases, aliases)?;
         }
         StmtKind::If(condition, then_stmt, else_stmt) => {
             collect_expr_writes_checked(hir, condition, candidates, writes, bases, aliases)?;
-            let mut then_aliases = aliases.clone();
-            let then_flow = collect_stmt_writes_checked(
-                hir,
-                then_stmt,
-                candidates,
-                writes,
-                bases,
-                &mut then_aliases,
-            )?;
-            let mut else_aliases = aliases.clone();
-            let else_flow = if let Some(else_stmt) = else_stmt {
-                collect_stmt_writes_checked(
-                    hir,
-                    else_stmt,
-                    candidates,
-                    writes,
-                    bases,
-                    &mut else_aliases,
-                )?
-            } else {
-                Flow::fallthrough()
-            };
-
-            let mut fallthrough = None;
-            if then_flow.falls_through {
-                merge_optional_aliases(&mut fallthrough, Some(then_aliases));
+            collect_stmt_writes_checked(hir, then_stmt, candidates, writes, bases, aliases)?;
+            if let Some(else_stmt) = else_stmt {
+                collect_stmt_writes_checked(hir, else_stmt, candidates, writes, bases, aliases)?;
             }
-            if else_flow.falls_through {
-                merge_optional_aliases(&mut fallthrough, Some(else_aliases));
-            }
-            let falls_through = fallthrough.is_some();
-            if let Some(joined) = fallthrough {
-                *aliases = joined;
-            }
-            Ok(Flow {
-                falls_through,
-                breaks: merge_optional(then_flow.breaks, else_flow.breaks),
-                continues: merge_optional(then_flow.continues, else_flow.continues),
-            })
         }
         StmtKind::Try(stmt_try) => {
             collect_expr_writes_checked(hir, &stmt_try.expr, candidates, writes, bases, aliases)?;
-            let before = aliases.clone();
-            let mut fallthrough = None;
-            let mut breaks = None;
-            let mut continues = None;
             for clause in stmt_try.clauses {
-                let mut clause_aliases = before.clone();
-                let flow = collect_block_writes_checked(
+                collect_block_writes_checked(
                     hir,
                     clause.block,
                     candidates,
                     writes,
                     bases,
-                    &mut clause_aliases,
+                    aliases,
                 )?;
-                if flow.falls_through {
-                    merge_optional_aliases(&mut fallthrough, Some(clause_aliases));
-                }
-                merge_optional_aliases(&mut breaks, flow.breaks);
-                merge_optional_aliases(&mut continues, flow.continues);
             }
-            let falls_through = fallthrough.is_some();
-            if let Some(joined) = fallthrough {
-                *aliases = joined;
-            }
-            Ok(Flow { falls_through, breaks, continues })
         }
         StmtKind::DeclSingle(var_id) => {
             if let Some(initializer) = hir.variable(*var_id).initializer {
                 collect_expr_writes_checked(hir, initializer, candidates, writes, bases, aliases)?;
-
-                if hir.variable(*var_id).data_location == Some(DataLocation::Storage)
-                    && let Some(target) = resolve_alias_targets(initializer, candidates, aliases)
-                {
-                    aliases.insert(*var_id, target);
-                }
             }
-            Ok(Flow::fallthrough())
         }
-        StmtKind::DeclMulti(_, expr) | StmtKind::Emit(expr) | StmtKind::Expr(expr) => {
-            collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?;
-            Ok(Flow::fallthrough())
+        StmtKind::DeclMulti(_, expr)
+        | StmtKind::Emit(expr)
+        | StmtKind::Revert(expr)
+        | StmtKind::Return(Some(expr))
+        | StmtKind::Expr(expr) => {
+            collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?
         }
-        StmtKind::Revert(expr) | StmtKind::Return(Some(expr)) => {
-            collect_expr_writes_checked(hir, expr, candidates, writes, bases, aliases)?;
-            Ok(Flow::default())
-        }
-        StmtKind::Return(None) => Ok(Flow::default()),
-        StmtKind::Break => Ok(Flow { breaks: Some(aliases.clone()), ..Flow::default() }),
-        StmtKind::Continue => Ok(Flow { continues: Some(aliases.clone()), ..Flow::default() }),
-        StmtKind::Placeholder => Ok(Flow::fallthrough()),
+        StmtKind::Return(None) | StmtKind::Break | StmtKind::Continue | StmtKind::Placeholder => {}
     }
-}
-
-fn collect_loop_iteration<'hir>(
-    hir: &'hir Hir<'hir>,
-    block: Block<'hir>,
-    source: LoopSource,
-    candidates: &HashSet<VariableId>,
-    writes: &mut HashSet<VariableId>,
-    bases: &'hir [ContractId],
-    aliases: &mut Aliases,
-) -> Result<Flow, ()> {
-    if source == LoopSource::DoWhile
-        && let Some((condition, body)) = block.stmts.split_last()
-    {
-        let mut body_flow =
-            collect_stmts_writes_checked(hir, body, candidates, writes, bases, aliases)?;
-        let mut condition_aliases = None;
-        if body_flow.falls_through {
-            merge_optional_aliases(&mut condition_aliases, Some(aliases.clone()));
-        }
-        merge_optional_aliases(&mut condition_aliases, body_flow.continues.take());
-
-        if let Some(mut condition_aliases) = condition_aliases {
-            let condition_flow = collect_stmt_writes_checked(
-                hir,
-                condition,
-                candidates,
-                writes,
-                bases,
-                &mut condition_aliases,
-            )?;
-            if condition_flow.falls_through {
-                *aliases = condition_aliases;
-            }
-            merge_optional_aliases(&mut body_flow.breaks, condition_flow.breaks);
-            return Ok(Flow {
-                falls_through: condition_flow.falls_through,
-                breaks: body_flow.breaks,
-                continues: condition_flow.continues,
-            });
-        }
-        return Ok(Flow { breaks: body_flow.breaks, ..Flow::default() });
-    }
-
-    let mut flow = collect_block_writes_checked(hir, block, candidates, writes, bases, aliases)?;
-    if source == LoopSource::ForWithUpdate
-        && let Some(next) = for_loop_next_expr(block)
-        && let Some(continued) = &mut flow.continues
-    {
-        collect_expr_writes_checked(hir, next, candidates, writes, bases, continued)?;
-    }
-    Ok(flow)
-}
-
-fn for_loop_next_expr<'hir>(block: Block<'hir>) -> Option<&'hir Expr<'hir>> {
-    let [stmt] = block.stmts else { return None };
-    let inner = match &stmt.kind {
-        StmtKind::If(_, then_stmt, _) => {
-            let StmtKind::Block(inner) = &then_stmt.kind else { return None };
-            inner
-        }
-        StmtKind::Block(inner) => inner,
-        _ => return None,
-    };
-    if inner.span != block.span {
-        return None;
-    }
-    let [_, next] = inner.stmts else { return None };
-    let StmtKind::Expr(next) = &next.kind else { return None };
-    Some(*next)
+    Ok(())
 }
 
 fn collect_expr_writes_checked<'hir>(
@@ -449,44 +248,24 @@ fn collect_expr_writes_checked<'hir>(
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
     bases: &'hir [ContractId],
-    aliases: &mut Aliases,
+    aliases: &Aliases,
 ) -> Result<(), ()> {
     match &expr.kind {
         ExprKind::Assign(lhs, _, rhs) => {
             // Reassigning a bare storage pointer repoints it rather than writing its target.
-            let is_bare_alias_repoint = matches!(
-                &lhs.peel_parens().kind,
-                ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..])
-                    if !candidates.contains(id) && aliases.contains_key(id)
-            );
-            if !is_bare_alias_repoint {
-                collect_lvalue_writes(lhs, candidates, writes, Some(aliases));
+            if !is_storage_pointer(hir, lhs) {
+                collect_lvalue_writes(lhs, candidates, writes, aliases);
             }
             collect_expr_writes_checked(hir, lhs, candidates, writes, bases, aliases)?;
             collect_expr_writes_checked(hir, rhs, candidates, writes, bases, aliases)?;
-
-            // Replace the alias target, dropping stale targets when the RHS is unresolved.
-            if let ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) = &lhs.peel_parens().kind
-                && !candidates.contains(id)
-                && hir.variable(*id).data_location == Some(DataLocation::Storage)
-            {
-                match resolve_alias_targets(rhs, candidates, aliases) {
-                    Some(targets) => {
-                        aliases.insert(*id, targets);
-                    }
-                    None => {
-                        aliases.remove(id);
-                    }
-                }
-            }
         }
         ExprKind::Delete(inner) => {
-            collect_lvalue_writes(inner, candidates, writes, Some(aliases));
+            collect_lvalue_writes(inner, candidates, writes, aliases);
             collect_expr_writes_checked(hir, inner, candidates, writes, bases, aliases)?;
         }
         ExprKind::Unary(op, inner) => {
             if op.kind.has_side_effects() {
-                collect_lvalue_writes(inner, candidates, writes, Some(aliases));
+                collect_lvalue_writes(inner, candidates, writes, aliases);
             }
             collect_expr_writes_checked(hir, inner, candidates, writes, bases, aliases)?;
         }
@@ -503,21 +282,18 @@ fn collect_expr_writes_checked<'hir>(
             if let ExprKind::Member(base, _) = &callee.kind {
                 // Covers push/pop and library dispatch (`using Lib for T` with `T storage self`);
                 // can't resolve callee without Gcx. Treat the receiver as a write target to avoid
-                // false positives. Do not extend this heuristic through aliases: the call may be
-                // read-only.
-                collect_lvalue_writes(base, candidates, writes, None);
+                // false positives.
+                collect_lvalue_writes(base, candidates, writes, aliases);
             }
 
             // Direct calls to internal functions that take a `storage` parameter
             // mutate the corresponding argument in place; treat it as a write.
             //
             // Handles bare identifier callees (`_set(slot, v)`) and qualified member
-            // callees (`BaseSetter._set(slot, v)`, `super._set(slot, v)`). This conservative
-            // heuristic remains limited to direct state arguments because storage parameters may
-            // be read-only.
+            // callees (`BaseSetter._set(slot, v)`, `super._set(slot, v)`).
             let funcs = collect_callee_funcs(hir, callee, bases);
             if !funcs.is_empty() {
-                mark_storage_args(&funcs, hir, args, candidates, writes);
+                mark_storage_args(&funcs, hir, args, candidates, writes, aliases);
             }
 
             collect_expr_writes_checked(hir, callee, candidates, writes, bases, aliases)?;
@@ -552,26 +328,8 @@ fn collect_expr_writes_checked<'hir>(
         }
         ExprKind::Ternary(condition, then_expr, else_expr) => {
             collect_expr_writes_checked(hir, condition, candidates, writes, bases, aliases)?;
-            let mut then_aliases = aliases.clone();
-            collect_expr_writes_checked(
-                hir,
-                then_expr,
-                candidates,
-                writes,
-                bases,
-                &mut then_aliases,
-            )?;
-            let mut else_aliases = aliases.clone();
-            collect_expr_writes_checked(
-                hir,
-                else_expr,
-                candidates,
-                writes,
-                bases,
-                &mut else_aliases,
-            )?;
-            merge_aliases(&mut then_aliases, else_aliases);
-            *aliases = then_aliases;
+            collect_expr_writes_checked(hir, then_expr, candidates, writes, bases, aliases)?;
+            collect_expr_writes_checked(hir, else_expr, candidates, writes, bases, aliases)?;
         }
         ExprKind::Tuple(exprs) => {
             for expr in exprs.iter().flatten() {
@@ -661,6 +419,7 @@ fn mark_storage_args<'hir>(
     args: &CallArgs<'hir>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
+    aliases: &Aliases,
 ) {
     if let CallArgsKind::Unnamed(_) = args.kind {
         for (i, arg_expr) in args.exprs().enumerate() {
@@ -670,7 +429,7 @@ fn mark_storage_args<'hir>(
                 })
             });
             if any_storage {
-                collect_lvalue_writes(arg_expr, candidates, writes, None);
+                collect_lvalue_writes(arg_expr, candidates, writes, aliases);
             }
         }
     }
@@ -687,65 +446,23 @@ fn mark_storage_args<'hir>(
                 })
             });
             if any_storage {
-                collect_lvalue_writes(&named_arg.value, candidates, writes, None);
+                collect_lvalue_writes(&named_arg.value, candidates, writes, aliases);
             }
         }
     }
-}
-
-/// Resolves a storage pointer to its possible state-variable targets.
-fn resolve_alias_targets(
-    expr: &Expr<'_>,
-    candidates: &HashSet<VariableId>,
-    aliases: &HashMap<VariableId, HashSet<VariableId>>,
-) -> Option<HashSet<VariableId>> {
-    match &expr.peel_parens().kind {
-        ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) => {
-            if candidates.contains(id) {
-                Some(HashSet::from([*id]))
-            } else {
-                aliases.get(id).cloned()
-            }
-        }
-        ExprKind::Index(base, _) | ExprKind::Slice(base, _, _) | ExprKind::Member(base, _) => {
-            resolve_alias_targets(base, candidates, aliases)
-        }
-        _ => None,
-    }
-}
-
-fn merge_aliases(aliases: &mut Aliases, other: Aliases) {
-    for (alias, targets) in other {
-        aliases.entry(alias).or_default().extend(targets);
-    }
-}
-
-fn merge_optional_aliases(aliases: &mut Option<Aliases>, other: Option<Aliases>) {
-    if let Some(other) = other {
-        if let Some(aliases) = aliases {
-            merge_aliases(aliases, other);
-        } else {
-            *aliases = Some(other);
-        }
-    }
-}
-
-fn merge_optional(mut aliases: Option<Aliases>, other: Option<Aliases>) -> Option<Aliases> {
-    merge_optional_aliases(&mut aliases, other);
-    aliases
 }
 
 fn collect_lvalue_writes(
     expr: &Expr<'_>,
     candidates: &HashSet<VariableId>,
     writes: &mut HashSet<VariableId>,
-    aliases: Option<&Aliases>,
+    aliases: &Aliases,
 ) {
     match &expr.peel_parens().kind {
         ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) => {
             if candidates.contains(id) {
                 writes.insert(*id);
-            } else if let Some(targets) = aliases.and_then(|aliases| aliases.get(id)) {
+            } else if let Some(targets) = aliases.get(id) {
                 writes.extend(targets);
             }
         }
@@ -759,6 +476,119 @@ fn collect_lvalue_writes(
         }
         _ => {}
     }
+}
+
+/// Maps each local `storage` pointer of a function to the state variables it may reference.
+type Aliases = HashMap<VariableId, HashSet<VariableId>>;
+
+/// Collects the state variables each local `storage` pointer in `function` may reference.
+///
+/// The analysis is flow-insensitive: every assignment to a pointer contributes to its target set,
+/// so a write through the pointer counts as a write to each state variable it could reference.
+fn collect_storage_aliases<'hir>(
+    hir: &'hir Hir<'hir>,
+    function: &'hir Function<'hir>,
+    candidates: &HashSet<VariableId>,
+) -> Aliases {
+    let Some(body) = function.body else { return Aliases::new() };
+    let mut collector = StorageAliasCollector { hir, edges: HashMap::new() };
+    for stmt in body.stmts {
+        let _ = collector.visit_stmt(stmt);
+    }
+
+    let mut aliases = Aliases::new();
+    for &pointer in collector.edges.keys() {
+        let mut targets = HashSet::new();
+        let mut seen = HashSet::new();
+        let mut stack = vec![pointer];
+        while let Some(var_id) = stack.pop() {
+            if !seen.insert(var_id) {
+                continue;
+            }
+            if candidates.contains(&var_id) {
+                targets.insert(var_id);
+            } else if let Some(roots) = collector.edges.get(&var_id) {
+                stack.extend(roots);
+            }
+        }
+        if !targets.is_empty() {
+            aliases.insert(pointer, targets);
+        }
+    }
+    aliases
+}
+
+/// Records `pointer -> root variable` edges for every assignment to a local `storage` pointer.
+/// Roots are state variables or other pointers, which are resolved transitively afterwards.
+struct StorageAliasCollector<'hir> {
+    hir: &'hir Hir<'hir>,
+    edges: HashMap<VariableId, HashSet<VariableId>>,
+}
+
+impl<'hir> Visit<'hir> for StorageAliasCollector<'hir> {
+    type BreakValue = Never;
+
+    fn hir(&self) -> &'hir Hir<'hir> {
+        self.hir
+    }
+
+    fn visit_stmt(&mut self, stmt: &'hir Stmt<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let StmtKind::DeclSingle(var_id) = &stmt.kind
+            && let Some(initializer) = self.hir.variable(*var_id).initializer
+        {
+            self.record(*var_id, initializer);
+        }
+        self.walk_stmt(stmt)
+    }
+
+    fn visit_expr(&mut self, expr: &'hir Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let ExprKind::Assign(lhs, None, rhs) = &expr.kind
+            && let ExprKind::Ident([Res::Item(ItemId::Variable(var_id)), ..]) =
+                &lhs.peel_parens().kind
+        {
+            self.record(*var_id, rhs);
+        }
+        self.walk_expr(expr)
+    }
+}
+
+impl StorageAliasCollector<'_> {
+    fn record(&mut self, var_id: VariableId, rhs: &Expr<'_>) {
+        if is_local_storage_var(self.hir, var_id) {
+            collect_root_vars(rhs, self.edges.entry(var_id).or_default());
+        }
+    }
+}
+
+/// Collects the variables an expression is rooted in, looking through indexing, member access,
+/// and ternaries.
+fn collect_root_vars(expr: &Expr<'_>, roots: &mut HashSet<VariableId>) {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) => {
+            roots.insert(*id);
+        }
+        ExprKind::Index(base, _) | ExprKind::Slice(base, _, _) | ExprKind::Member(base, _) => {
+            collect_root_vars(base, roots)
+        }
+        ExprKind::Ternary(_, then_expr, else_expr) => {
+            collect_root_vars(then_expr, roots);
+            collect_root_vars(else_expr, roots);
+        }
+        _ => {}
+    }
+}
+
+/// Whether `expr` is a bare local `storage` pointer.
+fn is_storage_pointer(hir: &Hir<'_>, expr: &Expr<'_>) -> bool {
+    matches!(
+        &expr.peel_parens().kind,
+        ExprKind::Ident([Res::Item(ItemId::Variable(id)), ..]) if is_local_storage_var(hir, *id)
+    )
+}
+
+fn is_local_storage_var(hir: &Hir<'_>, var_id: VariableId) -> bool {
+    let var = hir.variable(var_id);
+    !var.kind.is_state() && var.data_location == Some(DataLocation::Storage)
 }
 
 struct ReadVarCollector<'hir> {

--- a/crates/lint/src/sol/med/uninitialized_state_variables.rs
+++ b/crates/lint/src/sol/med/uninitialized_state_variables.rs
@@ -495,6 +495,9 @@ fn collect_storage_aliases<'hir>(
     for stmt in body.stmts {
         let _ = collector.visit_stmt(stmt);
     }
+    if collector.edges.is_empty() {
+        return Aliases::new();
+    }
 
     let mut aliases = Aliases::new();
     for &pointer in collector.edges.keys() {
@@ -533,26 +536,52 @@ impl<'hir> Visit<'hir> for StorageAliasCollector<'hir> {
     }
 
     fn visit_stmt(&mut self, stmt: &'hir Stmt<'hir>) -> ControlFlow<Self::BreakValue> {
-        if let StmtKind::DeclSingle(var_id) = &stmt.kind
-            && let Some(initializer) = self.hir.variable(*var_id).initializer
-        {
-            self.record(*var_id, initializer);
+        match &stmt.kind {
+            StmtKind::DeclSingle(var_id) => {
+                if let Some(initializer) = self.hir.variable(*var_id).initializer {
+                    self.record(*var_id, initializer);
+                }
+            }
+            StmtKind::DeclMulti(vars, initializer) => {
+                if let ExprKind::Tuple(values) = &initializer.peel_parens().kind {
+                    for (var_id, value) in vars.iter().zip(values.iter()) {
+                        if let (Some(var_id), Some(value)) = (var_id, value) {
+                            self.record(*var_id, value);
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
         self.walk_stmt(stmt)
     }
 
     fn visit_expr(&mut self, expr: &'hir Expr<'hir>) -> ControlFlow<Self::BreakValue> {
-        if let ExprKind::Assign(lhs, None, rhs) = &expr.kind
-            && let ExprKind::Ident([Res::Item(ItemId::Variable(var_id)), ..]) =
-                &lhs.peel_parens().kind
-        {
-            self.record(*var_id, rhs);
+        if let ExprKind::Assign(lhs, None, rhs) = &expr.kind {
+            self.record_assignment(lhs, rhs);
         }
         self.walk_expr(expr)
     }
 }
 
 impl StorageAliasCollector<'_> {
+    /// Records `lhs = rhs`, matching tuple destructuring element-wise.
+    fn record_assignment(&mut self, lhs: &Expr<'_>, rhs: &Expr<'_>) {
+        match (&lhs.peel_parens().kind, &rhs.peel_parens().kind) {
+            (ExprKind::Tuple(targets), ExprKind::Tuple(values)) => {
+                for (target, value) in targets.iter().zip(values.iter()) {
+                    if let (Some(target), Some(value)) = (target, value) {
+                        self.record_assignment(target, value);
+                    }
+                }
+            }
+            (ExprKind::Ident([Res::Item(ItemId::Variable(var_id)), ..]), _) => {
+                self.record(*var_id, rhs);
+            }
+            _ => {}
+        }
+    }
+
     fn record(&mut self, var_id: VariableId, rhs: &Expr<'_>) {
         if is_local_storage_var(self.hir, var_id) {
             collect_root_vars(rhs, self.edges.entry(var_id).or_default());
@@ -586,6 +615,7 @@ fn is_storage_pointer(hir: &Hir<'_>, expr: &Expr<'_>) -> bool {
     )
 }
 
+/// Whether `var_id` is a local variable or parameter with the `storage` data location.
 fn is_local_storage_var(hir: &Hir<'_>, var_id: VariableId) -> bool {
     let var = hir.variable(var_id);
     !var.kind.is_state() && var.data_location == Some(DataLocation::Storage)

--- a/crates/lint/testdata/UninitializedStateVariables.sol
+++ b/crates/lint/testdata/UninitializedStateVariables.sol
@@ -518,3 +518,52 @@ contract StoragePointerReassigned {
         return slotB.val;
     }
 }
+
+// ── Local storage pointer: conditional reassignment ──────────────────────────
+// After the join, `p` may still point to `slotA` or may point to `slotB`.
+// The write through it therefore makes both state variables potentially written.
+
+contract StoragePointerConditionallyReassigned {
+    struct Data { uint256 val; }
+    Data public slotA;
+    Data public slotB;
+
+    function set(bool chooseB, uint256 v) external {
+        Data storage p = slotA;
+        if (chooseB) p = slotB;
+        p.val = v;
+    }
+
+    function getA() public view returns (uint256) {
+        return slotA.val;
+    }
+
+    function getB() public view returns (uint256) {
+        return slotB.val;
+    }
+}
+
+// ── Local storage pointer: reassignment in a potentially empty loop ─────────
+// The loop may execute zero times, so the post-loop write may target either slot.
+
+contract StoragePointerReassignedInLoop {
+    struct Data { uint256 val; }
+    Data public slotA;
+    Data public slotB;
+
+    function set(uint256 count, uint256 v) external {
+        Data storage p = slotA;
+        for (uint256 i; i < count; ++i) {
+            p = slotB;
+        }
+        p.val = v;
+    }
+
+    function getA() public view returns (uint256) {
+        return slotA.val;
+    }
+
+    function getB() public view returns (uint256) {
+        return slotB.val;
+    }
+}

--- a/crates/lint/testdata/UninitializedStateVariables.sol
+++ b/crates/lint/testdata/UninitializedStateVariables.sol
@@ -420,11 +420,6 @@ contract SuperNonStorageChild is SuperNonStorageBase {
     function init() external { super._init(slot); }
 }
 
-// ── Local storage pointer: aliasing a state var and writing through it ───────
-// `Data storage p = slot; p.val = v;` is the standard gas-saving idiom of
-// caching a storage slot in a local pointer instead of repeated field lookups.
-// The write through `p` must be attributed back to `slot`.
-
 contract StoragePointerAlias {
     struct Data { uint256 val; }
     Data public slot;
@@ -438,10 +433,6 @@ contract StoragePointerAlias {
         return slot.val;
     }
 }
-
-// ── Local storage pointer: chained aliasing ───────────────────────────────────
-// `q` aliases `p`, which aliases `slot`; the write through `q` must still
-// resolve back to `slot`.
 
 contract StoragePointerChainedAlias {
     struct Data { uint256 val; }
@@ -458,10 +449,6 @@ contract StoragePointerChainedAlias {
     }
 }
 
-// ── Local storage pointer: declared but never used to write ──────────────────
-// A local storage pointer that is only read through must NOT suppress a
-// genuine warning — aliasing alone is not a write.
-
 contract StoragePointerReadOnly {
     struct Data { uint256 val; }
     Data public slot; //~WARN: state variable is read but never written
@@ -471,10 +458,6 @@ contract StoragePointerReadOnly {
         return p.val;
     }
 }
-
-// ── Local storage pointer to an array element, then indexed write ────────────
-// `items[i]` is a storage pointer to a struct; writing a field through it
-// must attribute back to the array state variable.
 
 contract StoragePointerArrayElement {
     struct Data { uint256 val; }
@@ -493,11 +476,6 @@ contract StoragePointerArrayElement {
         return items[i].val;
     }
 }
-
-// ── Local storage pointer: reassigned mid-function to a different state var ──
-// `p` initially aliases `slotA`, then is reassigned to alias `slotB`; the
-// write through `p` after the reassignment must attribute to `slotB`, not
-// the stale `slotA` target.
 
 contract StoragePointerReassigned {
     struct Data { uint256 val; }
@@ -519,10 +497,6 @@ contract StoragePointerReassigned {
     }
 }
 
-// ── Local storage pointer: conditional reassignment ──────────────────────────
-// After the join, `p` may still point to `slotA` or may point to `slotB`.
-// The write through it therefore makes both state variables potentially written.
-
 contract StoragePointerConditionallyReassigned {
     struct Data { uint256 val; }
     Data public slotA;
@@ -542,9 +516,6 @@ contract StoragePointerConditionallyReassigned {
         return slotB.val;
     }
 }
-
-// ── Local storage pointer: reassignment in a potentially empty loop ─────────
-// The loop may execute zero times, so the post-loop write may target either slot.
 
 contract StoragePointerReassignedInLoop {
     struct Data { uint256 val; }

--- a/crates/lint/testdata/UninitializedStateVariables.sol
+++ b/crates/lint/testdata/UninitializedStateVariables.sol
@@ -461,11 +461,7 @@ contract StoragePointerReadOnly {
 
 contract StoragePointerArrayElement {
     struct Data { uint256 val; }
-    Data[] public items;
-
-    function push() external {
-        items.push();
-    }
+    Data[2] public items;
 
     function set(uint256 i, uint256 v) external {
         Data storage p = items[i];
@@ -537,4 +533,145 @@ contract StoragePointerReassignedInLoop {
     function getB() public view returns (uint256) {
         return slotB.val;
     }
+}
+
+contract StoragePointerMultiIterationLoop {
+    struct Data { uint256 val; }
+    Data public slotA;
+    Data public slotB;
+    Data public slotC;
+
+    function set(uint256 count, uint256 v) external {
+        Data storage p = slotA;
+        Data storage q = slotB;
+        for (uint256 i; i < count; ++i) {
+            p = q;
+            q = slotC;
+        }
+        p.val = v;
+    }
+
+    function getA() public view returns (uint256) { return slotA.val; }
+    function getB() public view returns (uint256) { return slotB.val; }
+    function getC() public view returns (uint256) { return slotC.val; }
+}
+
+contract StoragePointerDoWhile {
+    struct Data { uint256 val; }
+    Data public slotA; //~WARN: state variable is read but never written
+    Data public slotB;
+
+    function set(bool again, uint256 v) external {
+        Data storage p = slotA;
+        do {
+            p = slotB;
+        } while (again);
+        p.val = v;
+    }
+
+    function getA() public view returns (uint256) { return slotA.val; }
+    function getB() public view returns (uint256) { return slotB.val; }
+}
+
+contract StoragePointerTerminatingBranch {
+    struct Data { uint256 val; }
+    Data public slotA;
+    Data public slotB; //~WARN: state variable is read but never written
+
+    function set(bool stop, uint256 v) external {
+        Data storage p = slotA;
+        if (stop) {
+            p = slotB;
+            return;
+        }
+        p.val = v;
+    }
+
+    function getA() public view returns (uint256) { return slotA.val; }
+    function getB() public view returns (uint256) { return slotB.val; }
+}
+
+contract StoragePointerTryJoin {
+    struct Data { uint256 val; }
+    Data public slotA; //~WARN: state variable is read but never written
+    Data public slotB;
+
+    function succeeds() external {}
+
+    function set(uint256 v) external {
+        Data storage p = slotA;
+        try this.succeeds() {
+            p = slotB;
+        } catch {
+            p = slotB;
+        }
+        p.val = v;
+    }
+
+    function getA() public view returns (uint256) { return slotA.val; }
+    function getB() public view returns (uint256) { return slotB.val; }
+}
+
+contract StoragePointerTernaryJoin {
+    struct Data { uint256 val; }
+    Data public slotA;
+    Data public slotB;
+
+    function set(bool chooseB, uint256 v) external {
+        Data storage p = slotA;
+        chooseB ? p = slotB : p = slotA;
+        p.val = v;
+    }
+
+    function getA() public view returns (uint256) { return slotA.val; }
+    function getB() public view returns (uint256) { return slotB.val; }
+}
+
+contract StoragePointerReadOnlyCall {
+    struct Data { uint256 val; }
+    Data public slot; //~WARN: state variable is read but never written
+
+    function inspect(Data storage target) internal view returns (uint256) {
+        return target.val;
+    }
+
+    function get() external view returns (uint256) {
+        Data storage p = slot;
+        return inspect(p);
+    }
+}
+
+library StoragePointerReadLib {
+    struct Data { uint256 val; }
+    function get(Data storage self) internal view returns (uint256) { return self.val; }
+}
+
+contract StoragePointerReadOnlyLibraryCall {
+    using StoragePointerReadLib for StoragePointerReadLib.Data;
+    StoragePointerReadLib.Data public slot; //~WARN: state variable is read but never written
+
+    function get() external view returns (uint256) {
+        StoragePointerReadLib.Data storage p = slot;
+        return p.get();
+    }
+}
+
+contract StoragePointerUnconditionedForUpdate {
+    struct Data { uint256 val; }
+    Data public slotA;
+    Data public slotB; //~WARN: state variable is read but never written
+
+    function set(uint256 count, uint256 v) external {
+        Data storage p = slotA;
+        uint256 i;
+        for (;; p = slotA) {
+            p.val = v;
+            if (i++ == count) break;
+            p = slotB;
+            continue;
+        }
+    }
+
+    function getA() public view returns (uint256) { return slotA.val; }
+    function getB() public view returns (uint256) { return slotB.val; }
 }

--- a/crates/lint/testdata/UninitializedStateVariables.sol
+++ b/crates/lint/testdata/UninitializedStateVariables.sol
@@ -419,3 +419,102 @@ contract SuperNonStorageChild is SuperNonStorageBase {
     function use_() external view returns (uint256) { return slot.val; }
     function init() external { super._init(slot); }
 }
+
+// ── Local storage pointer: aliasing a state var and writing through it ───────
+// `Data storage p = slot; p.val = v;` is the standard gas-saving idiom of
+// caching a storage slot in a local pointer instead of repeated field lookups.
+// The write through `p` must be attributed back to `slot`.
+
+contract StoragePointerAlias {
+    struct Data { uint256 val; }
+    Data public slot;
+
+    function set(uint256 v) external {
+        Data storage p = slot;
+        p.val = v;
+    }
+
+    function get() public view returns (uint256) {
+        return slot.val;
+    }
+}
+
+// ── Local storage pointer: chained aliasing ───────────────────────────────────
+// `q` aliases `p`, which aliases `slot`; the write through `q` must still
+// resolve back to `slot`.
+
+contract StoragePointerChainedAlias {
+    struct Data { uint256 val; }
+    Data public slot;
+
+    function set(uint256 v) external {
+        Data storage p = slot;
+        Data storage q = p;
+        q.val = v;
+    }
+
+    function get() public view returns (uint256) {
+        return slot.val;
+    }
+}
+
+// ── Local storage pointer: declared but never used to write ──────────────────
+// A local storage pointer that is only read through must NOT suppress a
+// genuine warning — aliasing alone is not a write.
+
+contract StoragePointerReadOnly {
+    struct Data { uint256 val; }
+    Data public slot; //~WARN: state variable is read but never written
+
+    function get() external view returns (uint256) {
+        Data storage p = slot;
+        return p.val;
+    }
+}
+
+// ── Local storage pointer to an array element, then indexed write ────────────
+// `items[i]` is a storage pointer to a struct; writing a field through it
+// must attribute back to the array state variable.
+
+contract StoragePointerArrayElement {
+    struct Data { uint256 val; }
+    Data[] public items;
+
+    function push() external {
+        items.push();
+    }
+
+    function set(uint256 i, uint256 v) external {
+        Data storage p = items[i];
+        p.val = v;
+    }
+
+    function get(uint256 i) public view returns (uint256) {
+        return items[i].val;
+    }
+}
+
+// ── Local storage pointer: reassigned mid-function to a different state var ──
+// `p` initially aliases `slotA`, then is reassigned to alias `slotB`; the
+// write through `p` after the reassignment must attribute to `slotB`, not
+// the stale `slotA` target.
+
+contract StoragePointerReassigned {
+    struct Data { uint256 val; }
+    Data public slotA; //~WARN: state variable is read but never written
+    Data public slotB;
+
+    function set(uint256 v) external {
+        Data storage p = slotA;
+        p = slotB;
+        p.val = v;
+    }
+
+    function getA() public view returns (uint256) {
+        return slotA.val;
+    }
+
+    function getB() public view returns (uint256) {
+        return slotB.val;
+    }
+}

--- a/crates/lint/testdata/UninitializedStateVariables.sol
+++ b/crates/lint/testdata/UninitializedStateVariables.sol
@@ -429,9 +429,7 @@ contract StoragePointerAlias {
         p.val = v;
     }
 
-    function get() public view returns (uint256) {
-        return slot.val;
-    }
+    function get() public view returns (uint256) { return slot.val; }
 }
 
 contract StoragePointerChainedAlias {
@@ -444,9 +442,7 @@ contract StoragePointerChainedAlias {
         q.val = v;
     }
 
-    function get() public view returns (uint256) {
-        return slot.val;
-    }
+    function get() public view returns (uint256) { return slot.val; }
 }
 
 contract StoragePointerReadOnly {
@@ -468,32 +464,11 @@ contract StoragePointerArrayElement {
         p.val = v;
     }
 
-    function get(uint256 i) public view returns (uint256) {
-        return items[i].val;
-    }
+    function get(uint256 i) public view returns (uint256) { return items[i].val; }
 }
 
+// Alias tracking is flow-insensitive: a pointer may reference every target it is ever assigned.
 contract StoragePointerReassigned {
-    struct Data { uint256 val; }
-    Data public slotA; //~WARN: state variable is read but never written
-    Data public slotB;
-
-    function set(uint256 v) external {
-        Data storage p = slotA;
-        p = slotB;
-        p.val = v;
-    }
-
-    function getA() public view returns (uint256) {
-        return slotA.val;
-    }
-
-    function getB() public view returns (uint256) {
-        return slotB.val;
-    }
-}
-
-contract StoragePointerConditionallyReassigned {
     struct Data { uint256 val; }
     Data public slotA;
     Data public slotB;
@@ -504,38 +479,11 @@ contract StoragePointerConditionallyReassigned {
         p.val = v;
     }
 
-    function getA() public view returns (uint256) {
-        return slotA.val;
-    }
-
-    function getB() public view returns (uint256) {
-        return slotB.val;
-    }
+    function getA() public view returns (uint256) { return slotA.val; }
+    function getB() public view returns (uint256) { return slotB.val; }
 }
 
 contract StoragePointerReassignedInLoop {
-    struct Data { uint256 val; }
-    Data public slotA;
-    Data public slotB;
-
-    function set(uint256 count, uint256 v) external {
-        Data storage p = slotA;
-        for (uint256 i; i < count; ++i) {
-            p = slotB;
-        }
-        p.val = v;
-    }
-
-    function getA() public view returns (uint256) {
-        return slotA.val;
-    }
-
-    function getB() public view returns (uint256) {
-        return slotB.val;
-    }
-}
-
-contract StoragePointerMultiIterationLoop {
     struct Data { uint256 val; }
     Data public slotA;
     Data public slotB;
@@ -556,70 +504,13 @@ contract StoragePointerMultiIterationLoop {
     function getC() public view returns (uint256) { return slotC.val; }
 }
 
-contract StoragePointerDoWhile {
-    struct Data { uint256 val; }
-    Data public slotA; //~WARN: state variable is read but never written
-    Data public slotB;
-
-    function set(bool again, uint256 v) external {
-        Data storage p = slotA;
-        do {
-            p = slotB;
-        } while (again);
-        p.val = v;
-    }
-
-    function getA() public view returns (uint256) { return slotA.val; }
-    function getB() public view returns (uint256) { return slotB.val; }
-}
-
-contract StoragePointerTerminatingBranch {
-    struct Data { uint256 val; }
-    Data public slotA;
-    Data public slotB; //~WARN: state variable is read but never written
-
-    function set(bool stop, uint256 v) external {
-        Data storage p = slotA;
-        if (stop) {
-            p = slotB;
-            return;
-        }
-        p.val = v;
-    }
-
-    function getA() public view returns (uint256) { return slotA.val; }
-    function getB() public view returns (uint256) { return slotB.val; }
-}
-
-contract StoragePointerTryJoin {
-    struct Data { uint256 val; }
-    Data public slotA; //~WARN: state variable is read but never written
-    Data public slotB;
-
-    function succeeds() external {}
-
-    function set(uint256 v) external {
-        Data storage p = slotA;
-        try this.succeeds() {
-            p = slotB;
-        } catch {
-            p = slotB;
-        }
-        p.val = v;
-    }
-
-    function getA() public view returns (uint256) { return slotA.val; }
-    function getB() public view returns (uint256) { return slotB.val; }
-}
-
-contract StoragePointerTernaryJoin {
+contract StoragePointerTernary {
     struct Data { uint256 val; }
     Data public slotA;
     Data public slotB;
 
     function set(bool chooseB, uint256 v) external {
-        Data storage p = slotA;
-        chooseB ? p = slotB : p = slotA;
+        Data storage p = chooseB ? slotB : slotA;
         p.val = v;
     }
 
@@ -627,51 +518,40 @@ contract StoragePointerTernaryJoin {
     function getB() public view returns (uint256) { return slotB.val; }
 }
 
-contract StoragePointerReadOnlyCall {
+// Repointing a storage pointer is not a write to either target.
+contract StoragePointerRepointOnly {
     struct Data { uint256 val; }
-    Data public slot; //~WARN: state variable is read but never written
-
-    function inspect(Data storage target) internal view returns (uint256) {
-        return target.val;
-    }
-
-    function get() external view returns (uint256) {
-        Data storage p = slot;
-        return inspect(p);
-    }
-}
-
-library StoragePointerReadLib {
-    struct Data { uint256 val; }
-    function get(Data storage self) internal view returns (uint256) { return self.val; }
-}
-
-contract StoragePointerReadOnlyLibraryCall {
-    using StoragePointerReadLib for StoragePointerReadLib.Data;
-    StoragePointerReadLib.Data public slot; //~WARN: state variable is read but never written
-
-    function get() external view returns (uint256) {
-        StoragePointerReadLib.Data storage p = slot;
-        return p.get();
-    }
-}
-
-contract StoragePointerUnconditionedForUpdate {
-    struct Data { uint256 val; }
-    Data public slotA;
+    Data public slotA; //~WARN: state variable is read but never written
     Data public slotB; //~WARN: state variable is read but never written
 
-    function set(uint256 count, uint256 v) external {
+    function get() external view returns (uint256) {
         Data storage p = slotA;
-        uint256 i;
-        for (;; p = slotA) {
-            p.val = v;
-            if (i++ == count) break;
-            p = slotB;
-            continue;
-        }
+        p = slotB;
+        return p.val;
+    }
+}
+
+contract StoragePointerStorageArg {
+    struct Data { uint256 val; }
+    Data public slot;
+
+    function _set(Data storage target, uint256 v) internal { target.val = v; }
+
+    function set(uint256 v) external {
+        Data storage p = slot;
+        _set(p, v);
     }
 
-    function getA() public view returns (uint256) { return slotA.val; }
-    function getB() public view returns (uint256) { return slotB.val; }
+    function get() public view returns (uint256) { return slot.val; }
+}
+
+contract StoragePointerPush {
+    uint256[] public items;
+
+    function add(uint256 v) external {
+        uint256[] storage arr = items;
+        arr.push(v);
+    }
+
+    function count() external view returns (uint256) { return items.length; }
 }

--- a/crates/lint/testdata/UninitializedStateVariables.sol
+++ b/crates/lint/testdata/UninitializedStateVariables.sol
@@ -555,3 +555,45 @@ contract StoragePointerPush {
 
     function count() external view returns (uint256) { return items.length; }
 }
+
+contract StoragePointerTupleDeclaration {
+    struct Data { uint256 val; }
+    Data public slotA;
+    Data public slotB;
+
+    function set(uint256 v) external {
+        (Data storage p, Data storage q) = (slotA, slotB);
+        p.val = v;
+        (q, ) = (slotA, uint256(0));
+        q.val = v;
+    }
+
+    function getA() public view returns (uint256) { return slotA.val; }
+    function getB() public view returns (uint256) { return slotB.val; }
+}
+
+contract StoragePointerInModifier {
+    struct Data { uint256 val; }
+    Data public slot;
+
+    modifier bump() {
+        Data storage p = slot;
+        p.val += 1;
+        _;
+    }
+
+    function get() external view bump returns (uint256) { return slot.val; }
+}
+
+// A pointer passed to a `memory` parameter is copied, not written.
+contract StoragePointerMemoryArg {
+    struct Data { uint256 val; }
+    Data public slot; //~WARN: state variable is read but never written
+
+    function _read(Data memory d) internal pure returns (uint256) { return d.val; }
+
+    function get() external view returns (uint256) {
+        Data storage p = slot;
+        return _read(p);
+    }
+}

--- a/crates/lint/testdata/UninitializedStateVariables.stderr
+++ b/crates/lint/testdata/UninitializedStateVariables.stderr
@@ -86,3 +86,19 @@ LL │     Data public slot;
    │
    ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
 
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
+LL │     Data public slot;
+   │     ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
+LL │     Data public slotA;
+   │     ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+

--- a/crates/lint/testdata/UninitializedStateVariables.stderr
+++ b/crates/lint/testdata/UninitializedStateVariables.stderr
@@ -102,3 +102,51 @@ LL │     Data public slotA;
    │
    ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
 
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
+LL │     Data public slotA;
+   │     ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
+LL │     Data public slotB;
+   │     ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
+LL │     Data public slotA;
+   │     ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
+LL │     Data public slot;
+   │     ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
+LL │     StoragePointerReadLib.Data public slot;
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
+LL │     Data public slotB;
+   │     ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+

--- a/crates/lint/testdata/UninitializedStateVariables.stderr
+++ b/crates/lint/testdata/UninitializedStateVariables.stderr
@@ -110,3 +110,11 @@ LL │     Data public slotB;
    │
    ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
 
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
+LL │     Data public slot;
+   │     ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+

--- a/crates/lint/testdata/UninitializedStateVariables.stderr
+++ b/crates/lint/testdata/UninitializedStateVariables.stderr
@@ -105,46 +105,6 @@ LL │     Data public slotA;
 warning[uninitialized-state]: state variable is read but never written
    ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
    │
-LL │     Data public slotA;
-   │     ━━━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
-
-warning[uninitialized-state]: state variable is read but never written
-   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
-   │
-LL │     Data public slotB;
-   │     ━━━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
-
-warning[uninitialized-state]: state variable is read but never written
-   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
-   │
-LL │     Data public slotA;
-   │     ━━━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
-
-warning[uninitialized-state]: state variable is read but never written
-   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
-   │
-LL │     Data public slot;
-   │     ━━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
-
-warning[uninitialized-state]: state variable is read but never written
-   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
-   │
-LL │     StoragePointerReadLib.Data public slot;
-   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
-
-warning[uninitialized-state]: state variable is read but never written
-   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
-   │
 LL │     Data public slotB;
    │     ━━━━━━━━━━━━━━━━━━
    │


### PR DESCRIPTION
`uninitialized-state` only matched writes against a state variable's own id, so the common `Data storage p = slot; p.val = v;` idiom left `slot` reported as read but never written.

Each function now gets a flow-insensitive map from its local `storage` pointers to the state variables they may reference, built from pointer declarations, reassignments, and tuple destructuring, and resolved transitively through pointer chains, indexing, member access, and ternaries. Writes, `delete`, increments, `push`/`pop`-style member calls, and storage arguments of internal calls made through a pointer are attributed to every possible target. This keeps the lint on the side of suppressing warnings, the same trade-off it already makes for member calls on state variables. Reassigning a bare pointer repoints it and is not a write to its previous target.

The original flow-sensitive implementation with loop fixpoints and break/continue tracking was replaced with this pre-pass; the precision it bought, warning on a target the pointer was later reassigned away from, is not worth the machinery for a heuristic lint.

Takes over the original PR by @gomesalexandre; the follow-up commits replace the alias analysis and its fixture cases and, after review, add tuple-declared pointers plus fixture cases for pointers in modifiers and pointers passed to `memory` parameters. AI assistance was used.

Book update: https://github.com/foundry-rs/book/pull/2061
