### PR TITLE
fix(anvil): return null for unknown block counts

### DIFF
--- a/.changelog/anvil-unknown-block-transaction-count.md
+++ b/.changelog/anvil-unknown-block-transaction-count.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Return `null` from `eth_getBlockTransactionCountByNumber` for unknown blocks.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2708,11 +2708,12 @@ impl EthApi<FoundryNetwork> {
         block_number: BlockNumber,
     ) -> Result<Option<U256>> {
         node_info!("eth_getBlockTransactionCountByNumber");
-        let block_request = self.block_request(Some(block_number.into())).await?;
-        if let BlockRequest::Pending(txs) = block_request {
+        if block_number == BlockNumber::Pending {
+            let txs = self.pool.ready_transactions().collect();
             let block = self.backend.pending_block(txs).await;
             return Ok(Some(U256::from(block.block.body.transactions.len())));
         }
+
         let block = self.backend.block_by_number(block_number).await?;
         let txs = block.map(|b| match b.transactions() {
             BlockTransactions::Full(txs) => U256::from(txs.len()),

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -44,6 +44,20 @@ async fn can_get_block_number() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn unknown_block_transaction_count_is_none() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let count: Option<U256> = provider
+        .client()
+        .request("eth_getBlockTransactionCountByNumber", (BlockNumberOrTag::Number(1),))
+        .await
+        .unwrap();
+
+    assert!(count.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_dev_get_balance() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
Returns `null`, as specified by the Ethereum API, when `eth_getBlockTransactionCountByNumber` targets an unknown block instead of raising `BlockOutOfRangeError`.