### PR TITLE
chore(evm): remove stale executor TODO

### DIFF
--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -2,10 +2,6 @@
 //!
 //! Used for running tests, scripts, and interacting with the inner backend which holds the state.
 
-// TODO: The individual executors in this module should be moved into the respective crates, and the
-// `Executor` struct should be accessed using a trait defined in `foundry-evm-core` instead of
-// the concrete `Executor` type.
-
 use crate::inspectors::{
     Cheatcodes, CmpOperands, EdgeCoverage, EdgeIndexMap, InspectorData, InspectorStack,
     cheatcodes::BroadcastableTransactions,


### PR DESCRIPTION
This TODO dates back to the initial `foundry-evm` modularization in #6128. Its proposed trait-based split no longer reflects the network-typed executor or its tightly integrated fuzzing, invariant, tracing, and state-management consumers. Remove it rather than leaving an obsolete architectural direction in the code.