### PR TITLE
fix(script): honor RPC config

### DIFF
--- a/.changelog/16587-script-rpc-timeout.md
+++ b/.changelog/16587-script-rpc-timeout.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Honor configured RPC transport options, including `eth_rpc_timeout`, while broadcasting and resuming scripts.

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -192,7 +192,12 @@ impl<N: Network> ProviderBuilder<N> {
     /// Defaults to `http://localhost:8545` and `Mainnet`.
     pub fn from_config(config: &Config) -> Result<Self> {
         let url = config.get_rpc_url_or_localhost_http()?;
-        let mut builder = Self::new(url.as_ref())
+        Self::from_config_with_url(config, url.as_ref())
+    }
+
+    /// Constructs a [ProviderBuilder] for `url`, applying transport options from [Config].
+    pub fn from_config_with_url(config: &Config, url: &str) -> Result<Self> {
+        let mut builder = Self::new(url)
             .accept_invalid_certs(config.eth_rpc_accept_invalid_certs)
             .no_proxy(config.eth_rpc_no_proxy)
             .curl_mode(config.eth_rpc_curl);
@@ -713,6 +718,22 @@ mod tests {
 
         assert!(builder.accept_invalid_certs);
         assert!(builder.no_proxy);
+        assert_eq!(builder.timeout, Duration::from_secs(7));
+    }
+
+    #[test]
+    fn from_config_with_url_overrides_rpc_url() {
+        let config = Config {
+            eth_rpc_url: Some("http://configured.example".to_string()),
+            eth_rpc_timeout: Some(7),
+            ..Default::default()
+        };
+
+        let builder =
+            ProviderBuilder::<AnyNetwork>::from_config_with_url(&config, "http://sequence.example")
+                .unwrap();
+
+        assert_eq!(builder.url.unwrap().as_str(), "http://sequence.example/");
         assert_eq!(builder.timeout, Duration::from_secs(7));
     }
 }

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -192,7 +192,13 @@ impl<N: Network> ProviderBuilder<N> {
     /// Defaults to `http://localhost:8545` and `Mainnet`.
     pub fn from_config(config: &Config) -> Result<Self> {
         let url = config.get_rpc_url_or_localhost_http()?;
-        Self::from_config_with_url(config, url.as_ref())
+        let mut builder = Self::from_config_with_url(config, url.as_ref())?;
+
+        if let Ok(chain) = config.chain.unwrap_or_default().try_into() {
+            builder = builder.chain(chain);
+        }
+
+        Ok(builder)
     }
 
     /// Constructs a [ProviderBuilder] for `url`, applying transport options from [Config].
@@ -201,10 +207,6 @@ impl<N: Network> ProviderBuilder<N> {
             .accept_invalid_certs(config.eth_rpc_accept_invalid_certs)
             .no_proxy(config.eth_rpc_no_proxy)
             .curl_mode(config.eth_rpc_curl);
-
-        if let Ok(chain) = config.chain.unwrap_or_default().try_into() {
-            builder = builder.chain(chain);
-        }
 
         if let Some(jwt) = config.get_rpc_jwt_secret()? {
             builder = builder.jwt(jwt.as_ref());
@@ -708,6 +710,7 @@ mod tests {
     fn from_config_applies_rpc_transport_options() {
         let config = Config {
             eth_rpc_url: Some("http://example.com".to_string()),
+            chain: Some(NamedChain::Polygon.into()),
             eth_rpc_accept_invalid_certs: true,
             eth_rpc_no_proxy: true,
             eth_rpc_timeout: Some(7),
@@ -719,12 +722,14 @@ mod tests {
         assert!(builder.accept_invalid_certs);
         assert!(builder.no_proxy);
         assert_eq!(builder.timeout, Duration::from_secs(7));
+        assert_eq!(builder.chain, NamedChain::Polygon);
     }
 
     #[test]
     fn from_config_with_url_overrides_rpc_url() {
         let config = Config {
             eth_rpc_url: Some("http://configured.example".to_string()),
+            chain: Some(NamedChain::Polygon.into()),
             eth_rpc_timeout: Some(7),
             ..Default::default()
         };
@@ -735,5 +740,6 @@ mod tests {
 
         assert_eq!(builder.url.unwrap().as_str(), "http://sequence.example/");
         assert_eq!(builder.timeout, Duration::from_secs(7));
+        assert_eq!(builder.chain, NamedChain::Mainnet);
     }
 }

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1120,6 +1120,47 @@ forgetest_async!(can_deploy_unlocked, |prj, cmd| {
         .broadcast(ScriptOutcome::OkBroadcast);
 });
 
+forgetest_async!(broadcast_honors_rpc_timeout, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let upstream = handle.http_endpoint();
+    let client = reqwest::Client::new();
+    let app = Router::new().fallback(move |body: BodyBytes| {
+        let upstream = upstream.clone();
+        let client = client.clone();
+        async move {
+            let request: Value = serde_json::from_slice(&body).unwrap();
+            if request.get("method").and_then(Value::as_str) == Some("eth_sendTransaction") {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
+            client
+                .post(upstream)
+                .header("content-type", "application/json")
+                .body(body)
+                .send()
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let _proxy = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let mut tester = ScriptTester::new_broadcast(cmd, &endpoint, prj.root());
+    tester
+        .sender("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".parse().unwrap())
+        .unlocked()
+        .args(&["--rpc-timeout", "1"])
+        .add_sig("BroadcastTest", "deployOther()")
+        .arg("--broadcast");
+    tester.cmd.assert_failure().stderr_eq(str![[r#"
+Error: Failed to send transaction after 4 attempts Err([..]operation timed out)
+
+"#]]);
+});
+
 forgetest_async!(can_deploy_script_remember_key, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -318,6 +318,7 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
     pub async fn wait_for_pending(mut self) -> Result<Self> {
         let progress = ScriptProgress::default();
         let progress_ref = &progress;
+        let config = &self.script_config.config;
         let futs = self
             .sequence
             .sequences_mut()
@@ -325,7 +326,8 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
             .enumerate()
             .map(|(sequence_idx, sequence)| async move {
                 let rpc_url = sequence.rpc_url();
-                let provider = Arc::new(ProviderBuilder::new(rpc_url).build()?);
+                let provider =
+                    Arc::new(ProviderBuilder::from_config_with_url(config, rpc_url)?.build()?);
                 progress_ref
                     .wait_for_pending(
                         sequence_idx,
@@ -450,7 +452,13 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
         for i in 0..self.sequence.sequences().len() {
             let mut sequence = self.sequence.sequences_mut().get_mut(i).unwrap();
 
-            let provider = Arc::new(ProviderBuilder::new(sequence.rpc_url()).build()?);
+            let provider = Arc::new(
+                ProviderBuilder::from_config_with_url(
+                    &self.script_config.config,
+                    sequence.rpc_url(),
+                )?
+                .build()?,
+            );
             let already_broadcasted = sequence.receipts.len();
 
             let seq_progress = progress.get_sequence_progress(i, sequence);
@@ -844,7 +852,13 @@ impl BundledState<TempoEvmNetwork> {
             );
         }
 
-        let provider = Arc::new(ProviderBuilder::<TempoNetwork>::new(sequence.rpc_url()).build()?);
+        let provider = Arc::new(
+            ProviderBuilder::<TempoNetwork>::from_config_with_url(
+                &self.script_config.config,
+                sequence.rpc_url(),
+            )?
+            .build()?,
+        );
 
         // Resume detection happens before signer resolution, gas estimation, and sponsor attachment
         // so that recovering an already-submitted batch tx never requires the original

--- a/crates/script/src/providers.rs
+++ b/crates/script/src/providers.rs
@@ -6,7 +6,7 @@ use foundry_common::provider::{
     ProviderBuilder,
     fee::{ResolvedEip1559Fees, estimate_eip1559_fees},
 };
-use foundry_config::{Chain, Eip1559FeeEstimatePreset};
+use foundry_config::{Chain, Config, Eip1559FeeEstimatePreset};
 use std::{ops::Deref, sync::Arc};
 
 /// Contains a map of RPC urls to single instances of [`ProviderInfo`].
@@ -28,11 +28,12 @@ impl<N: Network> ProvidersManager<N> {
         chain: Option<u64>,
         is_legacy: bool,
         fee_estimate: Eip1559FeeEstimatePreset,
+        config: &Config,
     ) -> Result<&ProviderInfo<N>> {
         Ok(match self.inner.entry(rpc.to_string()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let info = ProviderInfo::new(rpc, chain, is_legacy, fee_estimate).await?;
+                let info = ProviderInfo::new(rpc, chain, is_legacy, fee_estimate, config).await?;
                 entry.insert(info)
             }
         })
@@ -68,8 +69,9 @@ impl<N: Network> ProviderInfo<N> {
         chain: Option<u64>,
         mut is_legacy: bool,
         fee_estimate: Eip1559FeeEstimatePreset,
+        config: &Config,
     ) -> Result<Self> {
-        let provider = Arc::new(ProviderBuilder::new(rpc).build()?);
+        let provider = Arc::new(ProviderBuilder::from_config_with_url(config, rpc)?.build()?);
         let chain = match chain {
             Some(chain) => chain,
             None => provider.get_chain_id().await?,

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -659,6 +659,7 @@ impl<FEN: FoundryEvmNetwork> FilledTransactionsState<FEN> {
                     self.execution_artifacts.rpc_data.chain_ids.get(&tx.rpc).copied(),
                     self.args.legacy,
                     self.script_config.config.eip1559_fee_estimate,
+                    &self.script_config.config,
                 )
                 .await?;
 


### PR DESCRIPTION
Script broadcasting recreated providers using only each sequence's RPC URL, discarding configured transport options and restoring the default 45-second timeout. Build sequence providers with the active RPC transport configuration so `--rpc-timeout`, `eth_rpc_timeout`, and `ETH_RPC_TIMEOUT` apply during broadcast and resume, including multi-chain and Tempo batch flows.

Closes #16587.

This PR was developed with assistance from OpenAI Codex.
