### PR TITLE
fix(cheatcodes): enforce protocol initcode limit

### DIFF
--- a/.changelog/fix-execute-transaction-initcode-limit.md
+++ b/.changelog/fix-execute-transaction-initcode-limit.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Enforce protocol initcode size limits in `vm.executeTransaction` when contract size checks are disabled for tests.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1349,10 +1349,14 @@ impl Cheatcode for executeTransactionCall {
         // Enable nonce checks for realistic simulation.
         ccx.ecx.cfg_env_mut().disable_nonce_check = false;
 
-        // Resolve the limit through the active EVM's concrete `Cfg` implementation. Monad's
-        // implementation supplies its protocol default while ordinary EVMs retain revm's default;
-        // explicit cfg overrides remain effective without redispatching on runtime network config.
+        // Resolve the limit through the active EVM's concrete `Cfg` implementation. Replace the
+        // unlimited code-size override used for test contracts with the user-configured value so
+        // it does not implicitly make the initcode limit unlimited as well.
+        let code_size_limit = ccx.ecx.cfg_env().limit_contract_code_size;
+        let configured_code_size_limit = ccx.state.config.evm_opts.env.code_size_limit;
+        ccx.ecx.cfg_env_mut().limit_contract_code_size = configured_code_size_limit;
         let initcode_size_limit = ccx.ecx.cfg().max_initcode_size();
+        ccx.ecx.cfg_env_mut().limit_contract_code_size = code_size_limit;
         ccx.ecx.cfg_env_mut().limit_contract_initcode_size = Some(initcode_size_limit);
 
         // Reset the tx gas limit cap so revm applies the spec-defined default (EIP-7825).

--- a/testdata/default/cheats/ExecuteTransaction.t.sol
+++ b/testdata/default/cheats/ExecuteTransaction.t.sol
@@ -171,6 +171,43 @@ contract ExecuteTransactionTest is Test {
         assertEq(address(to).balance, 17 - value);
         assertEq(address(random).balance, value);
     }
+
+    function test_execute_rejects_oversized_initcode() public {
+        uint256 privateKey = 1;
+        vm.chainId(1);
+        vm.deal(vm.addr(privateKey), 1 ether);
+
+        bytes[] memory unsigned = new bytes[](9);
+        unsigned[1] = hex"01"; // gas price
+        unsigned[2] = hex"989680"; // gas limit
+        unsigned[5] = new bytes(131_073);
+        unsigned[6] = hex"01"; // chain ID
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, keccak256(vm.toRlp(unsigned)));
+
+        bytes[] memory signed = new bytes[](9);
+        for (uint256 i; i < 6; i++) {
+            signed[i] = unsigned[i];
+        }
+        signed[6] = abi.encodePacked(v + 10); // EIP-155 replay-protected v for chain ID 1
+        signed[7] = _trimLeadingZeros(r);
+        signed[8] = _trimLeadingZeros(s);
+
+        bytes memory rawTx = vm.toRlp(signed);
+        vm._expectCheatcodeRevert();
+        vm.executeTransaction(rawTx);
+    }
+
+    function _trimLeadingZeros(bytes32 value) private pure returns (bytes memory out) {
+        uint256 offset;
+        while (offset < 32 && value[offset] == bytes1(0)) {
+            offset++;
+        }
+        out = new bytes(32 - offset);
+        for (uint256 i; i < out.length; i++) {
+            out[i] = value[offset + i];
+        }
+    }
 }
 
 contract MyERC20 {


### PR DESCRIPTION
`vm.executeTransaction` inherited Forge's implicit unlimited test-contract code-size override when resolving the active initcode limit. This preserves user-configured limits while resolving the network default independently, and adds regression coverage for oversized creation transactions.

This PR was written with Codex.

Prompted by: @grandizzy
