### PR TITLE
fix(tempo): restore keychain selector ABI

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -172,24 +172,25 @@ ACCESS_KEY="$(wallet_json_field "$access_wallet_json" private_key)"
 ACCESS_KEY_ADDR="$(wallet_json_field "$access_wallet_json" address)"
 printf "Access key address: %s\n" "$ACCESS_KEY_ADDR"
 
-# Temporarily skip direct keychain authorization checks.
-DIRECT_KEYCHAIN_AUTH=false
-
-if [[ "$DIRECT_KEYCHAIN_AUTH" == "false" ]]; then
-  echo "Direct key authorization unavailable; provisioning with transaction key_authorization"
-  export TEMPO_HOME="$tmp_dir/tempo-home"
-  CHAIN_ID=$(cast chain-id --rpc-url "$ETH_RPC_URL")
-  AUTHORIZATION=$(cast key-authorization sign "$ACCESS_KEY_ADDR" \
-    --chain-id "$CHAIN_ID" \
-    --expiry 1893456000 \
-    --private-key "$PK")
-  cast tempo import-access-key \
-    --account "$ADDR" \
-    --access-key "$ACCESS_KEY" \
-    --authorization "$AUTHORIZATION"
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-    0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
-    --from "$ADDR"
+# Authorize the access key on-chain first (required for gas estimation)
+# Account Keychain precompile: 0xAAAAAAAA00000000000000000000000000000000
+# SignatureType: 0 = Secp256k1, Expiry: 1893456000 (year 2030), enforceLimits: false, limits: [], allowAnyCalls: true
+if [[ "$HARDFORK" == "T2" ]]; then
+  # Legacy: authorizeKey with flat params (pre-T3)
+  cast send --rpc-url "$ETH_RPC_URL" 0xAAAAAAAA00000000000000000000000000000000 \
+    'authorizeKey(address,uint8,uint64,bool,(address,uint256)[])' \
+    "$ACCESS_KEY_ADDR" 0 1893456000 false "[]" \
+    --private-key "$PK"
+else
+  # TIP-1011 (T3+): authorizeKey takes a KeyRestrictions struct
+  # KeyRestrictions = (uint64 expiry, bool enforceLimits, TokenLimit[] limits, bool allowAnyCalls, CallScope[] allowedCalls)
+  # TokenLimit = (address token, uint256 amount, uint64 period)
+  # CallScope = (address target, SelectorRule[] selectorRules)
+  # SelectorRule = (bytes4 selector, address[] recipients)
+  cast send --rpc-url "$ETH_RPC_URL" 0xAAAAAAAA00000000000000000000000000000000 \
+    'authorizeKey(address,uint8,(uint64,bool,(address,uint256,uint64)[],bool,(address,(bytes4,address[])[])[])) ' \
+    "$ACCESS_KEY_ADDR" 0 "(1893456000,false,[],true,[])" \
+    --private-key "$PK"
 fi
 
 # Fund the access key address (needed for gas)
@@ -204,8 +205,6 @@ echo -e "\n=== CAST SEND WITH ACCESS-KEY ==="
 cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --tempo.access-key "$ACCESS_KEY" --tempo.root-account "$ADDR"
 
 # --- cast keychain subcommand tests ---
-
-if [[ "$DIRECT_KEYCHAIN_AUTH" == "true" ]]; then
 
 echo -e "\n=== CAST KEYCHAIN: AUTHORIZE ==="
 kc_wallet_json="$(cast wallet new --json)"
@@ -278,15 +277,6 @@ if cast keychain auth "$KC_LIMITED_ADDR" secp256k1 1893456000 \
   exit 1
 fi
 echo "OK: duplicate authorize correctly rejected"
-else
-  echo -e "\n=== SKIPPING DIRECT KEYCHAIN AUTHORIZATION TESTS (TIP-1099 ACTIVE) ==="
-
-  echo -e "\n=== CAST KEYCHAIN: KEY-INFO ==="
-  KC_INFO=$(cast keychain info "$ADDR" "$ACCESS_KEY_ADDR" --rpc-url "$ETH_RPC_URL")
-  echo "$KC_INFO"
-  echo "$KC_INFO" | grep -q "secp256k1"
-
-fi
 
 if [[ "$HARDFORK_UPPER" == "T6" ]]; then
   echo -e "\n=== CAST KEYCHAIN: T6 AUTHORIZE ADMIN ==="
@@ -415,20 +405,13 @@ fi
 # --- T3+ set-scope tests ---
 if [[ ! "$HARDFORK_UPPER" =~ ^T(0|1|1B|2)$ ]]; then
   echo -e "\n=== CAST KEYCHAIN: SET-SCOPE ==="
-  if [[ "$DIRECT_KEYCHAIN_AUTH" == "true" ]]; then
-    # Before T11, provision a fresh unrestricted key through the AccountKeychain precompile.
-    kc_ss_json="$(cast wallet new --json)"
-    KC_SS_PK="$(wallet_json_field "$kc_ss_json" private_key)"
-    KC_SS_ADDR="$(wallet_json_field "$kc_ss_json" address)"
-    cast keychain auth "$KC_SS_ADDR" secp256k1 1893456000 \
-      --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
-    fund_and_wait "$KC_SS_ADDR"
-  else
-    # From T11, direct authorization is unavailable. The setup above already provisioned this key
-    # through a transaction-embedded key authorization.
-    KC_SS_PK="$ACCESS_KEY"
-    KC_SS_ADDR="$ACCESS_KEY_ADDR"
-  fi
+  # Provision a fresh unrestricted key through the AccountKeychain precompile.
+  kc_ss_json="$(cast wallet new --json)"
+  KC_SS_PK="$(wallet_json_field "$kc_ss_json" private_key)"
+  KC_SS_ADDR="$(wallet_json_field "$kc_ss_json" address)"
+  cast keychain auth "$KC_SS_ADDR" secp256k1 1893456000 \
+    --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+  fund_and_wait "$KC_SS_ADDR"
 
   cast keychain ss "$KC_SS_ADDR" \
     --scope 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D \
@@ -464,25 +447,6 @@ if [[ ! "$HARDFORK_UPPER" =~ ^T(0|1|1B|2)$ ]]; then
   echo "OK: call correctly blocked after remove-scope"
 else
   echo -e "\n=== SKIPPING T3+ set-scope tests (HARDFORK=$HARDFORK) ==="
-fi
-
-if [[ "$DIRECT_KEYCHAIN_AUTH" == "false" ]]; then
-  echo -e "\n=== CAST KEYCHAIN: REVOKE ==="
-  cast keychain rev "$ACCESS_KEY_ADDR" \
-    --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
-
-  KC_INFO_REV=$(cast keychain info "$ADDR" "$ACCESS_KEY_ADDR" --rpc-url "$ETH_RPC_URL")
-  echo "$KC_INFO_REV"
-  echo "$KC_INFO_REV" | grep -q "revoked"
-
-  echo -e "\n=== CAST KEYCHAIN: REVOKED KEY REJECTION ==="
-  if cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-    0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
-    --tempo.access-key "$ACCESS_KEY" --tempo.root-account "$ADDR" 2>&1; then
-    echo "ERROR: revoked key should have been rejected"
-    exit 1
-  fi
-  echo "OK: revoked key correctly rejected"
 fi
 
 # --- T3-only scope / call-restriction tests ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3264,7 +3264,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.20",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3423,7 +3423,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4657,7 +4657,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4964,7 +4964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7395,7 +7395,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8259,7 +8259,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9554,7 +9554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9706,7 +9706,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11083,7 +11083,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11142,7 +11142,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11907,7 +11907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12036,7 +12036,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -12107,7 +12107,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint 0.5.1",
  "num-rational",
@@ -12581,13 +12581,13 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12627,7 +12627,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12650,7 +12650,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12662,7 +12662,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12674,7 +12674,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12705,7 +12705,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12717,13 +12717,12 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy",
  "alloy-evm",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rlp",
  "bitflags 2.13.1",
  "commonware-codec",
  "commonware-cryptography",
@@ -12745,7 +12744,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12756,7 +12755,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12784,7 +12783,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12810,7 +12809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13990,7 +13989,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14138,7 +14137,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -529,20 +529,20 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "965692a8a5457896b2269
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
 
 # Monad
 alloy-monad-evm = { version = "0.7.0", default-features = false, features = [
@@ -634,9 +634,9 @@ op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "56
 alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -41,7 +41,7 @@ use tempo_contracts::precompiles::{
     ISignatureVerifier, ITIP20, PATH_USD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS,
     account_keychain::{
         authorizeAdminKeyCall, authorizeKeyCall, authorizeKeyWithWitnessCall,
-        legacyAuthorizeKeyCall, legacySetAllowedCallsCall, setAllowedCallsCall,
+        legacyAuthorizeKeyCall,
     },
 };
 use tempo_primitives::transaction::{
@@ -3410,26 +3410,10 @@ async fn run_set_scope(
     send_tx: SendTxOpts,
     force: bool,
 ) -> Result<()> {
-    let config = send_tx.eth.load_config()?;
-    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
-    let is_t11 = is_tempo_hardfork_active(&provider, TempoHardfork::T11).await?;
-    let calldata = encode_set_allowed_calls_calldata(key_address, scopes, is_t11);
+    let calldata =
+        IAccountKeychain::setAllowedCallsCall { keyId: key_address, scopes }.abi_encode();
     send_keychain_tx(calldata, tx_opts, &send_tx, None, force).await?;
     Ok(())
-}
-
-fn encode_set_allowed_calls_calldata(
-    key_address: Address,
-    scopes: Vec<CallScope>,
-    is_t11: bool,
-) -> Vec<u8> {
-    if !is_t11 {
-        return legacySetAllowedCallsCall { keyId: key_address, scopes }.abi_encode();
-    }
-
-    let scopes: Vec<_> = scopes.into_iter().map(abi_scope_to_auth_scope).collect();
-    let encoded_scopes = alloy_rlp::encode(scopes);
-    setAllowedCallsCall { keyId: key_address, scopes: encoded_scopes.into() }.abi_encode()
 }
 
 /// `cast keychain rs` — remove call scope for a target.
@@ -3504,8 +3488,9 @@ async fn run_policy_add_call(
         return Ok(());
     }
 
-    let is_t11 = is_tempo_hardfork_active(&provider, TempoHardfork::T11).await?;
-    let calldata = encode_set_allowed_calls_calldata(key_address, vec![target_scope], is_t11);
+    let calldata =
+        IAccountKeychain::setAllowedCallsCall { keyId: key_address, scopes: vec![target_scope] }
+            .abi_encode();
     send_keychain_tx(calldata, tx_opts, &send_tx, None, force).await?;
     Ok(())
 }
@@ -4501,30 +4486,6 @@ mod tests {
             hard_fork: Some("T3".to_string()),
         };
         assert_eq!(active_from_anvil_node_info(&ethereum_t3, TempoHardfork::T3), None);
-    }
-
-    #[test]
-    fn test_encode_set_allowed_calls_calldata_by_hardfork() {
-        let key_address = target_addr(0x11);
-        let target = target_addr(0x22);
-        let recipient = target_addr(0x33);
-        let selector = [0xaa, 0xbb, 0xcc, 0xdd];
-        let scopes =
-            vec![CallScope { target, selectorRules: vec![rule(selector, vec![recipient])] }];
-
-        let legacy = encode_set_allowed_calls_calldata(key_address, scopes.clone(), false);
-        let legacy = legacySetAllowedCallsCall::abi_decode(&legacy).unwrap();
-        assert_eq!(legacy.keyId, key_address);
-        assert_eq!(legacy.scopes, scopes);
-
-        let t11 = encode_set_allowed_calls_calldata(key_address, scopes, true);
-        let t11 = setAllowedCallsCall::abi_decode(&t11).unwrap();
-        assert_eq!(t11.keyId, key_address);
-        let scopes: Vec<AuthCallScope> = alloy_rlp::decode_exact(&t11.scopes).unwrap();
-        assert_eq!(scopes.len(), 1);
-        assert_eq!(scopes[0].target, target);
-        assert_eq!(scopes[0].selector_rules[0].selector, selector);
-        assert_eq!(scopes[0].selector_rules[0].recipients, vec![recipient]);
     }
 
     fn rule(selector: [u8; 4], recipients: Vec<Address>) -> SelectorRule {

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -659,73 +659,24 @@ casttest!(send_with_authorized_access_key_succeeds, async |_prj, cmd| {
     assert_eq!(receipt["status"], "0x1", "unexpected receipt: {output}");
 });
 
-// On-chain: `keychain set-scope` uses the legacy ABI before T11 and the RLP ABI from T11 onward.
+// On-chain: `keychain set-scope` keeps the tuple ABI across T11.
 casttest!(keychain_set_scope_succeeds_across_t11, async |_prj, cmd| {
     for hardfork in [TempoHardfork::T10, TempoHardfork::T11] {
         let (_, handle) =
             anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(hardfork.into()))).await;
         let rpc = handle.http_endpoint();
 
-        if hardfork < TempoHardfork::T11 {
-            cmd.cast_fuse()
-                .args([
-                    "keychain",
-                    "authorize",
-                    accounts::ADDR2,
-                    "--private-key",
-                    accounts::PK1,
-                    "--rpc-url",
-                    &rpc,
-                ])
-                .assert_success();
-        } else {
-            let authorization = cmd
-                .cast_fuse()
-                .args([
-                    "key-authorization",
-                    "sign",
-                    accounts::ADDR2,
-                    "--chain-id",
-                    "31337",
-                    "--private-key",
-                    accounts::PK1,
-                ])
-                .assert_success()
-                .get_output()
-                .stdout_lossy()
-                .trim()
-                .to_string();
-            let tempo_home = tempfile::tempdir().unwrap();
-            cmd.cast_fuse();
-            cmd.env("TEMPO_HOME", tempo_home.path());
-            cmd.args([
-                "tempo",
-                "import-access-key",
-                "--account",
-                accounts::ADDR1,
-                "--access-key",
-                accounts::PK2,
-                "--authorization",
-                &authorization,
-            ])
-            .assert_success();
-            cmd.cast_fuse();
-            cmd.env("TEMPO_HOME", tempo_home.path());
-            cmd.args([
-                "send",
-                &path_usd(),
-                "approve(address,uint256)",
-                accounts::ADDR3,
-                "0",
-                "--from",
-                accounts::ADDR1,
-                "--tempo.fee-token",
-                &path_usd(),
+        cmd.cast_fuse()
+            .args([
+                "keychain",
+                "authorize",
+                accounts::ADDR2,
+                "--private-key",
+                accounts::PK1,
                 "--rpc-url",
                 &rpc,
             ])
             .assert_success();
-        }
 
         cmd.cast_fuse()
             .args([


### PR DESCRIPTION
Restores direct AccountKeychain authorization and tuple-encoded `setAllowedCalls` now that TIP-1099 is not proceeding. This reverts the compatibility changes from #16375, #16527, #16548, #16549, and #16558 while retaining cross-T11 `set-scope` coverage, and updates the Tempo dependencies to a post-removal revision; maintainers should apply `L-ignore` because the change is CI-only.

This PR was written with Codex assistance.

Prompted by: @klkvr
