### PR TITLE
fix(cast): restore Tempo keychain scope ABI

### DIFF
--- a/.changelog/fix-tempo-keychain-scope.md
+++ b/.changelog/fix-tempo-keychain-scope.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fixed `cast keychain set-scope` against the restored Tempo Account Keychain ABI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88cf3d065edfb29a13278215b8521d3ef72a41e2432e019c1f0dd8e30649a5d"
+checksum = "fa2d25cf04344ea5eeb47e0cd21c794e646a029959bf5700bd8c05342c0353fe"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1a3f2206f2ba4206fdeeddce6640eed3e26b8a13ac41444adb66b76d8e650"
+checksum = "201b9e973fe90b2effd9ab356d4f2a46ab56046ba9d46f163367553e72c045b0"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208699c66c453fbb4c50d2e602f8ceff8a5f1fa48ac8b6ee3b6357fdc93da311"
+checksum = "1dba4e59c3581a39e03e0b0b4a46ee9c41315b5d843b1e903271952b32bedb7c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c902f0ca3f8353c41e3e1ec3cf26be49412525bc48ab9d3c4710d7be4f01832"
+checksum = "ce7b00f0cb42c66ec353076ded1dff1fbf818f6e0e26c40c8a8456c04483fca4"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdcbd48d60e029be4a325c3a2f1312761caea4ed249f18ba9e8ed24ca1bf01e6"
+checksum = "c64558980fb038cd34b4285ec2b36a2a8bd8d4ddd13b3f6e42d97cb5ee29938e"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c9f7c535f99a7e7b64cc520968b09ed14cec3715572fcc277cfbff602808cd"
+checksum = "1ffb0e793abdbaea9d01259493c8272c3af295d03389e70a2acdf53b57ad1edf"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abd404fbc12f543823005146b73fd07621bdc0baaa950d26995c543a9d73811"
+checksum = "32c2c0ec8425d9663dac939ba75750f17d2933d2f020814b4f8fde4a60da6d26"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -976,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a7fd71864526bfeca8903010d5bb7fd28a0a4f5cc55818304c9cad8f0d63ab"
+checksum = "96b37db6a7ad8170596345f864522f789cc7af093f516d6cdf34bbdcfba8adab"
 dependencies = [
  "serde",
  "winnow 1.0.4",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfc2ba3fb0e865de4934bcad6d37fc51e9ffcd5294be1322eab38e4494e051b"
+checksum = "1f40e33a0f588dde548c3b6767a71e61b593421a8c1b253b9cf1441dc7cf7ab5"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -7822,9 +7822,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -12494,9 +12494,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e452eb8cb83fc8b81597eb07c8d39f770d04905af9c5bffce8bea7213df29960"
+checksum = "4c6415502cd1e9ed58b3ceb415164b812d5572757b1a6f0e280ae806723c1fab"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -12587,7 +12587,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12627,7 +12627,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12650,7 +12650,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12662,7 +12662,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12674,7 +12674,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12705,7 +12705,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12717,13 +12717,12 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy",
  "alloy-evm",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rlp",
  "bitflags 2.13.1",
  "commonware-codec",
  "commonware-cryptography",
@@ -12745,7 +12744,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12756,7 +12755,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12784,7 +12783,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed429402890168b5ea5252a398671114fe053e05#ed429402890168b5ea5252a398671114fe053e05"
+source = "git+https://github.com/tempoxyz/tempo?rev=5e149ec51a30386b0c0fa8376ba02508d4e21b5d#5e149ec51a30386b0c0fa8376ba02508d4e21b5d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13973,9 +13972,9 @@ dependencies = [
 
 [[package]]
 name = "watchexec"
-version = "8.4.0"
+version = "8.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36efc5587efd608a3823cbe8af1d994124504432f73aa4d69111607447c382b8"
+checksum = "578d47d6c02968128e8a88b787e956f1cd7de0a8ca7ad5a24dcd8cf807d478cc"
 dependencies = [
  "async-priority-channel",
  "atomic-take",
@@ -14016,9 +14015,9 @@ dependencies = [
 
 [[package]]
 name = "watchexec-supervisor"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2af581c9bc3d2ba52e6f7a41edb465ad09d9bf4c575279cf7c2f8743d81adc1"
+checksum = "3ea7d764ea524ffd92213dcf8e4bca8fe603ebd3ef9e0caf07c3cae0461a5122"
 dependencies = [
  "futures",
  "process-wrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -529,20 +529,20 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "965692a8a5457896b2269
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
 
 # Monad
 alloy-monad-evm = { version = "0.7.0", default-features = false, features = [
@@ -634,9 +634,9 @@ op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "56
 alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ed429402890168b5ea5252a398671114fe053e05" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "5e149ec51a30386b0c0fa8376ba02508d4e21b5d" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -41,7 +41,7 @@ use tempo_contracts::precompiles::{
     ISignatureVerifier, ITIP20, PATH_USD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS,
     account_keychain::{
         authorizeAdminKeyCall, authorizeKeyCall, authorizeKeyWithWitnessCall,
-        legacyAuthorizeKeyCall, legacySetAllowedCallsCall, setAllowedCallsCall,
+        legacyAuthorizeKeyCall,
     },
 };
 use tempo_primitives::transaction::{
@@ -3410,26 +3410,13 @@ async fn run_set_scope(
     send_tx: SendTxOpts,
     force: bool,
 ) -> Result<()> {
-    let config = send_tx.eth.load_config()?;
-    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
-    let is_t11 = is_tempo_hardfork_active(&provider, TempoHardfork::T11).await?;
-    let calldata = encode_set_allowed_calls_calldata(key_address, scopes, is_t11);
+    let calldata = encode_set_allowed_calls_calldata(key_address, scopes);
     send_keychain_tx(calldata, tx_opts, &send_tx, None, force).await?;
     Ok(())
 }
 
-fn encode_set_allowed_calls_calldata(
-    key_address: Address,
-    scopes: Vec<CallScope>,
-    is_t11: bool,
-) -> Vec<u8> {
-    if !is_t11 {
-        return legacySetAllowedCallsCall { keyId: key_address, scopes }.abi_encode();
-    }
-
-    let scopes: Vec<_> = scopes.into_iter().map(abi_scope_to_auth_scope).collect();
-    let encoded_scopes = alloy_rlp::encode(scopes);
-    setAllowedCallsCall { keyId: key_address, scopes: encoded_scopes.into() }.abi_encode()
+fn encode_set_allowed_calls_calldata(key_address: Address, scopes: Vec<CallScope>) -> Vec<u8> {
+    IAccountKeychain::setAllowedCallsCall { keyId: key_address, scopes }.abi_encode()
 }
 
 /// `cast keychain rs` — remove call scope for a target.
@@ -3504,8 +3491,7 @@ async fn run_policy_add_call(
         return Ok(());
     }
 
-    let is_t11 = is_tempo_hardfork_active(&provider, TempoHardfork::T11).await?;
-    let calldata = encode_set_allowed_calls_calldata(key_address, vec![target_scope], is_t11);
+    let calldata = encode_set_allowed_calls_calldata(key_address, vec![target_scope]);
     send_keychain_tx(calldata, tx_opts, &send_tx, None, force).await?;
     Ok(())
 }
@@ -4504,7 +4490,7 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_set_allowed_calls_calldata_by_hardfork() {
+    fn test_encode_set_allowed_calls_calldata() {
         let key_address = target_addr(0x11);
         let target = target_addr(0x22);
         let recipient = target_addr(0x33);
@@ -4512,19 +4498,10 @@ mod tests {
         let scopes =
             vec![CallScope { target, selectorRules: vec![rule(selector, vec![recipient])] }];
 
-        let legacy = encode_set_allowed_calls_calldata(key_address, scopes.clone(), false);
-        let legacy = legacySetAllowedCallsCall::abi_decode(&legacy).unwrap();
-        assert_eq!(legacy.keyId, key_address);
-        assert_eq!(legacy.scopes, scopes);
-
-        let t11 = encode_set_allowed_calls_calldata(key_address, scopes, true);
-        let t11 = setAllowedCallsCall::abi_decode(&t11).unwrap();
-        assert_eq!(t11.keyId, key_address);
-        let scopes: Vec<AuthCallScope> = alloy_rlp::decode_exact(&t11.scopes).unwrap();
-        assert_eq!(scopes.len(), 1);
-        assert_eq!(scopes[0].target, target);
-        assert_eq!(scopes[0].selector_rules[0].selector, selector);
-        assert_eq!(scopes[0].selector_rules[0].recipients, vec![recipient]);
+        let calldata = encode_set_allowed_calls_calldata(key_address, scopes.clone());
+        let call = IAccountKeychain::setAllowedCallsCall::abi_decode(&calldata).unwrap();
+        assert_eq!(call.keyId, key_address);
+        assert_eq!(call.scopes, scopes);
     }
 
     fn rule(selector: [u8; 4], recipients: Vec<Address>) -> SelectorRule {


### PR DESCRIPTION
Tempo restored the pre-T11 Account Keychain ABI in [tempoxyz/tempo#7398](https://github.com/tempoxyz/tempo/pull/7398), but Cast still selected the removed bytes-encoded `setAllowedCalls` variant for T11 and later. This updates the Tempo dependencies and makes both `cast keychain set-scope` and policy call edits encode the supported `CallScope[]` ABI.

This PR was written by Codex.

Prompted by: @grandizzy
