### PR TITLE
refactor(evm): narrow inspector network config

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -142,7 +142,7 @@ use foundry_evm::{
         get_blob_params_by_hardfork,
     },
 };
-use foundry_evm_networks::{NetworkConfigs, arbitrum};
+use foundry_evm_networks::{NetworkConfigs, arbitrum, inject_chain_precompiles};
 #[cfg(feature = "optimism")]
 use foundry_primitives::get_deposit_tx_parts;
 use foundry_primitives::{
@@ -1352,7 +1352,7 @@ impl<N: Network> Backend<N> {
             PrecompilesMap::from_static(Precompiles::new(PrecompileSpecId::from_spec_id(spec_id)));
         let chain_id = self.protocol_chain_id();
         let timestamp = self.evm_env.read().block_env.timestamp.saturating_to();
-        self.networks.inject_chain_precompiles(&mut precompiles, chain_id, timestamp);
+        inject_chain_precompiles(&mut precompiles, chain_id, timestamp);
 
         let mut precompiles_map = BTreeMap::<String, Address>::default();
         for address in precompiles.addresses() {
@@ -2232,7 +2232,7 @@ impl<N: Network> Backend<N> {
 
     fn inject_configured_precompiles(&self, precompiles: &mut PrecompilesMap, evm_env: &EvmEnv) {
         self.networks.inject_precompiles(precompiles);
-        self.networks.inject_chain_precompiles(
+        inject_chain_precompiles(
             precompiles,
             self.protocol_chain_id(),
             evm_env.block_env.timestamp.saturating_to(),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -142,7 +142,7 @@ use foundry_evm::{
         get_blob_params_by_hardfork,
     },
 };
-use foundry_evm_networks::{NetworkConfigs, arbitrum, inject_chain_precompiles};
+use foundry_evm_networks::{NetworkConfigs, apply_bsc_p256_precompile, arbitrum};
 #[cfg(feature = "optimism")]
 use foundry_primitives::get_deposit_tx_parts;
 use foundry_primitives::{
@@ -1352,7 +1352,7 @@ impl<N: Network> Backend<N> {
             PrecompilesMap::from_static(Precompiles::new(PrecompileSpecId::from_spec_id(spec_id)));
         let chain_id = self.protocol_chain_id();
         let timestamp = self.evm_env.read().block_env.timestamp.saturating_to();
-        inject_chain_precompiles(&mut precompiles, chain_id, timestamp);
+        apply_bsc_p256_precompile(&mut precompiles, chain_id, timestamp);
 
         let mut precompiles_map = BTreeMap::<String, Address>::default();
         for address in precompiles.addresses() {
@@ -2232,7 +2232,7 @@ impl<N: Network> Backend<N> {
 
     fn inject_configured_precompiles(&self, precompiles: &mut PrecompilesMap, evm_env: &EvmEnv) {
         self.networks.inject_precompiles(precompiles);
-        inject_chain_precompiles(
+        apply_bsc_p256_precompile(
             precompiles,
             self.protocol_chain_id(),
             evm_env.block_env.timestamp.saturating_to(),

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -25,7 +25,7 @@ use alloy_primitives::{Address, B256, ChainId, TxKind, U256, keccak256, map::Add
 use alloy_rpc_types::{BlockNumberOrTag, BlockTransactions};
 use eyre::Context;
 use foundry_common::{SYSTEM_TRANSACTION_TYPE, is_known_system_sender};
-use foundry_evm_networks::{NetworkConfigs, inject_chain_precompiles};
+use foundry_evm_networks::{NetworkConfigs, apply_bsc_p256_precompile};
 pub use foundry_fork_db::{
     BlockchainDb, ForkBlock, ForkBlockEnv, SharedBackend, cache::BlockchainDbMeta,
 };
@@ -3260,7 +3260,7 @@ fn inject_replay_precompiles(
     timestamp: u64,
 ) {
     networks.inject_precompiles(precompiles);
-    inject_chain_precompiles(precompiles, chain_id, timestamp);
+    apply_bsc_p256_precompile(precompiles, chain_id, timestamp);
 }
 
 #[cfg(test)]

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -25,7 +25,7 @@ use alloy_primitives::{Address, B256, ChainId, TxKind, U256, keccak256, map::Add
 use alloy_rpc_types::{BlockNumberOrTag, BlockTransactions};
 use eyre::Context;
 use foundry_common::{SYSTEM_TRANSACTION_TYPE, is_known_system_sender};
-use foundry_evm_networks::NetworkConfigs;
+use foundry_evm_networks::{NetworkConfigs, inject_chain_precompiles};
 pub use foundry_fork_db::{
     BlockchainDb, ForkBlock, ForkBlockEnv, SharedBackend, cache::BlockchainDbMeta,
 };
@@ -3260,7 +3260,7 @@ fn inject_replay_precompiles(
     timestamp: u64,
 ) {
     networks.inject_precompiles(precompiles);
-    networks.inject_chain_precompiles(precompiles, chain_id, timestamp);
+    inject_chain_precompiles(precompiles, chain_id, timestamp);
 }
 
 #[cfg(test)]

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -1,7 +1,7 @@
 use alloy_evm::{
     EthEvm, EthEvmFactory, Evm, EvmEnv, EvmFactory, eth::EthEvmContext, precompiles::PrecompilesMap,
 };
-use foundry_evm_networks::inject_chain_precompiles;
+use foundry_evm_networks::apply_bsc_p256_precompile;
 use foundry_fork_db::DatabaseError;
 use revm::{
     context::{
@@ -59,7 +59,7 @@ impl FoundryEvmFactory for EthEvmFactory {
         eth_evm.cfg.tx_chain_id_check = true;
         let networks = eth_evm.inspector().get_networks();
         networks.inject_precompiles(eth_evm.precompiles_mut());
-        inject_chain_precompiles(eth_evm.precompiles_mut(), chain_id, timestamp);
+        apply_bsc_p256_precompile(eth_evm.precompiles_mut(), chain_id, timestamp);
         eth_evm
     }
 

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -1,6 +1,7 @@
 use alloy_evm::{
     EthEvm, EthEvmFactory, Evm, EvmEnv, EvmFactory, eth::EthEvmContext, precompiles::PrecompilesMap,
 };
+use foundry_evm_networks::inject_chain_precompiles;
 use foundry_fork_db::DatabaseError;
 use revm::{
     context::{
@@ -58,7 +59,7 @@ impl FoundryEvmFactory for EthEvmFactory {
         eth_evm.cfg.tx_chain_id_check = true;
         let networks = eth_evm.inspector().get_networks();
         networks.inject_precompiles(eth_evm.precompiles_mut());
-        networks.inject_chain_precompiles(eth_evm.precompiles_mut(), chain_id, timestamp);
+        inject_chain_precompiles(eth_evm.precompiles_mut(), chain_id, timestamp);
         eth_evm
     }
 

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -388,7 +388,6 @@ impl FoundryEvmFactory for MonadEvmFactory {
         let mut monad_evm = self.create_evm_with_inspector(db, evm_env, inspector);
         monad_evm.ctx_mut().chain = chain_context;
         monad_evm.cfg.tx_chain_id_check = true;
-        monad_evm.inspector().get_networks().inject_precompiles(monad_evm.precompiles_mut());
         monad_evm
     }
 
@@ -421,8 +420,6 @@ impl FoundryEvmFactory for MonadEvmFactory {
 
         evm.0.ctx.chain = chain_context;
         evm.0.ctx.cfg.tx_chain_id_check = true;
-        evm.0.inspector.get_networks().inject_precompiles(&mut evm.0.precompiles);
-
         Box::new(evm)
     }
 }

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -1,4 +1,4 @@
-use alloy_evm::{Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
+use alloy_evm::{EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use alloy_op_evm::{OpEvm, OpEvmContext, OpEvmFactory, OpTx};
 use foundry_fork_db::DatabaseError;
 use op_alloy_network::Optimism;
@@ -80,7 +80,6 @@ impl FoundryEvmFactory for OpEvmFactory {
         let mut op_evm = Self::default().create_evm_with_inspector(db, evm_env, inspector);
         op_evm.ctx_mut().chain = chain_context;
         op_evm.cfg.tx_chain_id_check = true;
-        op_evm.inspector().get_networks().inject_precompiles(op_evm.precompiles_mut());
         op_evm
     }
 

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -65,8 +65,6 @@ impl FoundryEvmFactory for TempoEvmFactory {
             tempo_evm.cfg.tx_gas_limit_cap = spec.tx_gas_limit_cap();
         }
 
-        let networks = tempo_evm.inspector().get_networks();
-        networks.inject_precompiles(tempo_evm.precompiles_mut());
         // Re-extend Tempo precompiles, preserving shared non-creditable slots.
         let cfg = tempo_evm.cfg.clone();
         let non_creditable_slots = tempo_evm.non_creditable_slots();

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -52,8 +52,8 @@ pub mod utils;
 
 /// Foundry-specific inspector methods, decoupled from any particular EVM context type.
 ///
-/// This trait holds Foundry-specific extensions (create2 factory, console logging,
-/// network config, deployer address). It has no `Inspector<CTX>` supertrait so it can
+/// This trait holds Foundry-specific extensions (create2 factory, console logging, temporary Celo
+/// configuration, deployer address). It has no `Inspector<CTX>` supertrait so it can
 /// be used in generic code with `I: FoundryInspectorExt + Inspector<CTX>`.
 #[auto_impl(&mut, Box)]
 pub trait InspectorExt {
@@ -70,7 +70,7 @@ pub trait InspectorExt {
         let _ = msg;
     }
 
-    /// Returns configured networks.
+    /// Returns configuration retained for Celo precompile support.
     fn get_networks(&self) -> NetworkConfigs {
         NetworkConfigs::default()
     }

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -1,4 +1,7 @@
-use crate::{executors::Executor, inspectors::InspectorStackBuilder};
+use crate::{
+    executors::Executor,
+    inspectors::{InspectorStackBuilder, TempoLabels},
+};
 use alloy_primitives::Address;
 #[cfg(feature = "optimism")]
 use foundry_evm_core::evm::OpEvmNetwork;
@@ -138,10 +141,10 @@ impl ExecutorBuilder<OpEvmNetwork> {
 }
 
 impl ExecutorBuilder<TempoEvmNetwork> {
-    /// Creates the default Tempo executor builder.
+    /// Creates a Tempo executor builder with its native label inspector.
     #[inline]
     pub fn new() -> Self {
-        Self::default()
+        Self::default().inspectors(|stack| stack.tempo_labels(TempoLabels::default()))
     }
 }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -2014,7 +2014,7 @@ mod tests {
     use foundry_config::Config;
     #[cfg(feature = "monad")]
     use foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS;
-    use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
+    use foundry_evm_core::{constants::MAGIC_SKIP, evm::TempoEvmNetwork, opts::EvmOpts};
     use foundry_evm_traces::InternalTraceMode;
     use revm::context::TxEnv;
     use std::{sync::mpsc, thread};
@@ -2073,6 +2073,25 @@ mod tests {
         assert!(monad.inspector().networks.is_monad());
         assert!(monad.backend().networks().is_monad());
         assert!(monad.backend().is_persistent(&MONAD_CHEATCODE_ADDRESS));
+    }
+
+    #[test]
+    fn tempo_labels_follow_concrete_builder() {
+        let ethereum = ExecutorBuilder::<EthEvmNetwork>::new().build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            Backend::spawn(None).unwrap(),
+            NetworkConfigs::with_tempo(),
+        );
+        assert!(ethereum.inspector().tempo_labels.is_none());
+
+        let tempo = ExecutorBuilder::<TempoEvmNetwork>::new().build(
+            EvmEnvFor::<TempoEvmNetwork>::default(),
+            TxEnvFor::<TempoEvmNetwork>::default(),
+            Backend::spawn(None).unwrap(),
+            NetworkConfigs::default(),
+        );
+        assert!(tempo.inspector().tempo_labels.is_some());
     }
 
     #[test]

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -88,11 +88,11 @@ pub struct InspectorStackBuilder<BLOCK: Clone> {
     /// In isolation mode all top-level calls are executed as a separate transaction in a separate
     /// EVM context, enabling more precise gas accounting and transaction state changes.
     pub enable_isolation: bool,
-    /// Networks with enabled features.
-    // TODO(monad-fen-dispatch): Remove this post-dispatch configuration. Callers must resolve
-    // family-neutral inspector inputs before selecting `FEN`, while Monad tooling is configured by
-    // the concrete Monad construction path.
+    /// Configuration retained for Celo precompile support.
+    // TODO(monad-fen-dispatch): Replace this residual with a concrete Celo execution owner.
     pub networks: NetworkConfigs,
+    /// Concrete Tempo label inspector selected by the Tempo executor builder.
+    tempo_labels: Option<Box<TempoLabels>>,
     /// Explicitly resolved additional cheatcode addresses.
     pub extra_cheatcode_addresses: &'static [Address],
     /// The wallets to set in the cheatcodes context.
@@ -116,6 +116,7 @@ impl<BLOCK: Clone> Default for InspectorStackBuilder<BLOCK> {
             chisel_state: None,
             enable_isolation: false,
             networks: NetworkConfigs::default(),
+            tempo_labels: None,
             extra_cheatcode_addresses: &[],
             wallets: None,
             create2_deployer: Default::default(),
@@ -225,6 +226,13 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
         self
     }
 
+    /// Installs the Tempo label inspector.
+    #[inline]
+    pub(crate) fn tempo_labels(mut self, inspector: TempoLabels) -> Self {
+        self.tempo_labels = Some(Box::new(inspector));
+        self
+    }
+
     /// Sets explicitly resolved additional cheatcode addresses.
     #[inline]
     pub const fn extra_cheatcode_addresses(mut self, addresses: &'static [Address]) -> Self {
@@ -255,6 +263,7 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
             chisel_state,
             enable_isolation,
             networks,
+            tempo_labels,
             extra_cheatcode_addresses,
             wallets,
             create2_deployer,
@@ -289,12 +298,9 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
 
         stack.enable_isolation(enable_isolation);
         stack.networks(networks);
+        stack.inner.tempo_labels = tempo_labels;
         stack.set_extra_cheatcode_addresses(extra_cheatcode_addresses);
         stack.set_create2_deployer(create2_deployer);
-
-        if networks.is_tempo() {
-            stack.inner.tempo_labels = Some(Box::default());
-        }
 
         // environment, must come after all of the inspectors
         if let Some(block) = block {

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -870,8 +870,8 @@ impl NetworkConfigs {
     }
 }
 
-/// Injects chain-specific precompiles active at the given timestamp.
-pub fn inject_chain_precompiles(
+/// Applies the BSC P256 precompile active at the given timestamp.
+pub fn apply_bsc_p256_precompile(
     precompiles: &mut PrecompilesMap,
     chain_id: ChainId,
     timestamp: u64,
@@ -1484,7 +1484,7 @@ mod tests {
     fn removes_bsc_p256_before_haber() {
         let mut precompiles = PrecompilesMap::from_static(Precompiles::osaka());
         assert!(precompiles.get(&BSC_P256_ADDRESS).is_some());
-        inject_chain_precompiles(
+        apply_bsc_p256_precompile(
             &mut precompiles,
             BSC_MAINNET_CHAIN_ID,
             BSC_MAINNET_HABER_TIMESTAMP - 1,

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -791,23 +791,6 @@ impl NetworkConfigs {
         }
     }
 
-    /// Injects chain-specific precompiles active at the given timestamp.
-    pub fn inject_chain_precompiles(
-        self,
-        precompiles: &mut PrecompilesMap,
-        chain_id: ChainId,
-        timestamp: u64,
-    ) {
-        let Some(p256verify) = bsc_p256_precompile(chain_id, timestamp) else { return };
-        precompiles.apply_precompile(&BSC_P256_ADDRESS, move |_| {
-            p256verify.map(|p256verify| {
-                DynPrecompile::new(p256verify.id().clone(), move |input| {
-                    p256verify.execute(input.data, input.gas, input.reservoir)
-                })
-            })
-        });
-    }
-
     /// Returns precompile labels for configured networks at the given hardfork, to be used in
     /// traces.
     pub fn precompiles_label(self, hardfork: Option<FoundryHardfork>) -> AddressHashMap<String> {
@@ -885,6 +868,22 @@ impl NetworkConfigs {
         }
         precompiles
     }
+}
+
+/// Injects chain-specific precompiles active at the given timestamp.
+pub fn inject_chain_precompiles(
+    precompiles: &mut PrecompilesMap,
+    chain_id: ChainId,
+    timestamp: u64,
+) {
+    let Some(p256verify) = bsc_p256_precompile(chain_id, timestamp) else { return };
+    precompiles.apply_precompile(&BSC_P256_ADDRESS, move |_| {
+        p256verify.map(|p256verify| {
+            DynPrecompile::new(p256verify.id().clone(), move |input| {
+                p256verify.execute(input.data, input.gas, input.reservoir)
+            })
+        })
+    });
 }
 
 impl From<NetworkVariant> for NetworkConfigs {
@@ -1485,7 +1484,7 @@ mod tests {
     fn removes_bsc_p256_before_haber() {
         let mut precompiles = PrecompilesMap::from_static(Precompiles::osaka());
         assert!(precompiles.get(&BSC_P256_ADDRESS).is_some());
-        NetworkConfigs::default().inject_chain_precompiles(
+        inject_chain_precompiles(
             &mut precompiles,
             BSC_MAINNET_CHAIN_ID,
             BSC_MAINNET_HABER_TIMESTAMP - 1,


### PR DESCRIPTION
Moves Tempo label-inspector selection to the concrete Tempo executor builder and resolves BSC P256 activation directly from chain ID and timestamp. It also removes Celo precompile injection from OP, Tempo, and Monad factories, where it was only reachable through conflicting runtime configuration.

The inspector’s `NetworkConfigs` dependency remains temporarily for Celo under the Ethereum factory. This preserves Celo transfer-precompile behavior, including fork transitions, while isolating the final ownership problem for a follow-up rather than introducing another generic policy abstraction.
