### PR TITLE
fix(anvil): reject future log ranges

### DIFF
--- a/.changelog/anvil-reject-future-log-range.md
+++ b/.changelog/anvil-reject-future-log-range.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Reject `eth_getLogs` ranges whose `toBlock` exceeds the current chain head.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3673,6 +3673,13 @@ impl EthApi<FoundryNetwork> {
     /// Handler for ETH RPC call: `eth_getLogs`
     pub async fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
         node_info!("eth_getLogs");
+        let best = self.backend.best_number();
+        let to_block =
+            self.backend.convert_block_number(filter.block_option.get_to_block().copied());
+        if to_block > best {
+            return Err(BlockchainError::BlockOutOfRange(best, to_block));
+        }
+
         self.backend.logs(filter).await
     }
 

--- a/crates/anvil/tests/it/logs.rs
+++ b/crates/anvil/tests/it/logs.rs
@@ -313,3 +313,18 @@ async fn get_logs_unknown_block_hash_returns_error() {
         "expected `unknown block` in error, got: {err}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_logs_future_to_block_returns_error() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let best = provider.get_block_number().await.unwrap();
+    let filter = Filter::new().from_block(0).to_block(best + 1);
+
+    let err = provider.get_logs(&filter).await.unwrap_err();
+    assert!(
+        err.to_string().contains("BlockOutOfRangeError"),
+        "expected `BlockOutOfRangeError` in error, got: {err}"
+    );
+}


### PR DESCRIPTION
Rejects `eth_getLogs` requests whose `toBlock` exceeds the current head, matching execution API behavior instead of silently returning partial results. Persistent `eth_newFilter` ranges remain unchanged.