### PR TITLE
fix(anvil): omit non-blob gas price

### DIFF
--- a/.changelog/anvil-omit-non-blob-gas-price.md
+++ b/.changelog/anvil-omit-non-blob-gas-price.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Omit blob gas fields from receipts for non-blob transactions.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -7210,9 +7210,9 @@ where
 
         // Cancun specific
         let excess_blob_gas = block.header.excess_blob_gas();
-        let blob_gas_price =
-            alloy_eips::eip4844::calc_blob_gasprice(excess_blob_gas.unwrap_or_default());
         let blob_gas_used = transaction.blob_gas_used();
+        let blob_gas_price = blob_gas_used
+            .map(|_| alloy_eips::eip4844::calc_blob_gasprice(excess_blob_gas.unwrap_or_default()));
 
         let effective_gas_price = transaction.effective_gas_price(block.header.base_fee_per_gas());
 
@@ -7235,7 +7235,7 @@ where
             block_hash: Some(block_hash),
             from: info.from,
             to: info.to,
-            blob_gas_price: Some(blob_gas_price),
+            blob_gas_price,
             blob_gas_used,
         };
 

--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -26,6 +26,20 @@ use foundry_test_utils::rpc;
 use serde_json::{Value, json};
 
 #[tokio::test(flavor = "multi_thread")]
+async fn non_blob_receipt_omits_blob_fields() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
+    let (_api, handle) = spawn(node_config).await;
+    let provider = http_provider(&handle.http_endpoint());
+    let accounts = handle.dev_accounts().collect::<Vec<_>>();
+
+    let tx = TransactionRequest::default().with_from(accounts[0]).with_to(accounts[1]);
+    let receipt = provider.send_transaction(tx.into()).await.unwrap().get_receipt().await.unwrap();
+
+    assert_eq!(receipt.blob_gas_used, None);
+    assert_eq!(receipt.blob_gas_price, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_send_eip4844_transaction() {
     let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
     let (api, handle) = spawn(node_config).await;


### PR DESCRIPTION
Omits `blobGasPrice` from non-blob transaction receipts, matching the Execution API. Blob transaction receipts remain unchanged.