### PR TITLE
fix(anvil): reject reversed log ranges

### DIFF
--- a/.changelog/anvil-reject-reversed-log-range.md
+++ b/.changelog/anvil-reject-reversed-log-range.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Reject `eth_getLogs` requests whose block range is reversed.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3679,6 +3679,11 @@ impl EthApi<FoundryNetwork> {
         if to_block > best {
             return Err(BlockchainError::BlockOutOfRange(best, to_block));
         }
+        let from_block =
+            self.backend.convert_block_number(filter.block_option.get_from_block().copied());
+        if from_block > to_block {
+            return Err(RpcError::invalid_params("invalid block range params").into());
+        }
 
         self.backend.logs(filter).await
     }

--- a/crates/anvil/tests/it/logs.rs
+++ b/crates/anvil/tests/it/logs.rs
@@ -328,3 +328,18 @@ async fn get_logs_future_to_block_returns_error() {
         "expected `BlockOutOfRangeError` in error, got: {err}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_logs_reversed_block_range_returns_error() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    api.mine_one().await.unwrap();
+
+    let filter = Filter::new().from_block(1).to_block(0);
+
+    let err = provider.get_logs(&filter).await.unwrap_err();
+    assert!(
+        err.to_string().contains("invalid block range params"),
+        "expected `invalid block range params` in error, got: {err}"
+    );
+}


### PR DESCRIPTION
Rejects `eth_getLogs` requests where `fromBlock` exceeds `toBlock`, matching the Execution API instead of silently returning an empty result.