### PR TITLE
fix(ci): install libudev for Linux tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,9 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes libudev-dev
       # External tests dependencies
       - name: Setup Node.js
         if: contains(matrix.name, 'external')


### PR DESCRIPTION
Install `libudev-dev` in the reusable Linux test job. Depot workers no longer consistently provide the linker target required by the Ledger HID dependency, causing `cargo nextest` to fail with `unable to find library -ludev`.

This is CI-only; a maintainer should apply `L-ignore`.