### PR TITLE
fix(anvil): reject empty storage requests

### DIFF
--- a/.changelog/anvil-reject-empty-storage-values.md
+++ b/.changelog/anvil-reject-empty-storage-values.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Reject empty `eth_getStorageValues` requests.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2537,6 +2537,10 @@ impl EthApi<FoundryNetwork> {
     ) -> Result<HashMap<Address, Vec<B256>>> {
         node_info!("eth_getStorageValues");
 
+        if requests.is_empty() {
+            return Err(RpcError::invalid_params("empty request").into());
+        }
+
         let total_slots: usize = requests.values().map(|s| s.len()).sum();
         if total_slots > 1024 {
             return Err(BlockchainError::RpcError(RpcError::invalid_params(format!(

--- a/crates/anvil/tests/it/storage_values.rs
+++ b/crates/anvil/tests/it/storage_values.rs
@@ -41,6 +41,22 @@ async fn storage_values_batches_multiple_accounts() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn storage_values_rejects_empty_request() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let err = provider
+        .client()
+        .request::<_, HashMap<Address, Vec<B256>>>(
+            "eth_getStorageValues",
+            (HashMap::<Address, Vec<B256>>::default(), BlockId::latest()),
+        )
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("empty request"), "unexpected error: {err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn storage_values_rejects_more_than_1024_slots() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
Rejects empty `eth_getStorageValues` requests with `-32602`, matching the Execution API instead of returning an empty result.