### PR TITLE
feat(cast): add ERC-4626 commands

### DIFF
--- a/.changelog/cast-erc4626-commands.md
+++ b/.changelog/cast-erc4626-commands.md
@@ -1,0 +1,5 @@
+---
+cast: minor
+---
+
+Added `cast erc4626` commands for the complete synchronous ERC-4626 vault interface.

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -1016,6 +1016,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         }
         CastSubcommand::TxPool { command } => command.run().await?,
         CastSubcommand::Erc20Token { command } => command.run().await?,
+        CastSubcommand::Erc4626 { command } => command.run().await?,
         CastSubcommand::Tip20Token { command } => command.run().await?,
         CastSubcommand::ReceivePolicy { command } => command.run().await?,
         CastSubcommand::Tip403 { command } => command.run().await?,

--- a/crates/cast/src/cmd/erc4626.rs
+++ b/crates/cast/src/cmd/erc4626.rs
@@ -1,0 +1,621 @@
+use std::str::FromStr;
+
+use crate::{
+    cmd::send::SendTxArgs,
+    format_uint_exp,
+    tx::{SendTxOpts, TxParams},
+};
+use alloy_eips::BlockId;
+use alloy_ens::NameOrAddress;
+use alloy_primitives::{Address, U256, address, hex};
+use alloy_sol_types::{SolCall, sol};
+use clap::Parser;
+use eyre::{Result, WrapErr};
+use foundry_cli::{
+    json::{print_json_success, print_scalar},
+    opts::RpcOpts,
+    utils::{LoadConfig, get_provider},
+};
+use foundry_common::shell;
+
+const NATIVE_ASSET: Address = address!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
+
+sol! {
+    #[sol(rpc)]
+    interface IERC4626 {
+        function asset() external view returns (address assetTokenAddress);
+        function totalAssets() external view returns (uint256 totalManagedAssets);
+        function convertToShares(uint256 assets) external view returns (uint256 shares);
+        function convertToAssets(uint256 shares) external view returns (uint256 assets);
+        function maxDeposit(address receiver) external view returns (uint256 maxAssets);
+        function previewDeposit(uint256 assets) external view returns (uint256 shares);
+        function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+        function maxMint(address receiver) external view returns (uint256 maxShares);
+        function previewMint(uint256 shares) external view returns (uint256 assets);
+        function mint(uint256 shares, address receiver) external returns (uint256 assets);
+        function maxWithdraw(address owner) external view returns (uint256 maxAssets);
+        function previewWithdraw(uint256 assets) external view returns (uint256 shares);
+        function withdraw(uint256 assets, address receiver, address owner)
+            external
+            returns (uint256 shares);
+        function maxRedeem(address owner) external view returns (uint256 maxShares);
+        function previewRedeem(uint256 shares) external view returns (uint256 assets);
+        function redeem(uint256 shares, address receiver, address owner)
+            external
+            returns (uint256 assets);
+
+        function balanceOf(address owner) external view returns (uint256 shares);
+    }
+}
+
+/// Interact with synchronous ERC-4626 tokenized vaults.
+#[derive(Debug, Parser, Clone)]
+pub enum Erc4626Subcommand {
+    /// Query the vault's underlying asset token.
+    Asset {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Query the total amount of underlying assets managed by the vault.
+    TotalAssets {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Convert an asset amount to the corresponding share amount.
+    ConvertToShares {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of underlying assets.
+        assets: U256,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Convert a share amount to the corresponding asset amount.
+    ConvertToAssets {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of vault shares.
+        shares: U256,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Query the maximum assets that may be deposited for a receiver.
+    MaxDeposit {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The receiver of the resulting vault shares.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        receiver: NameOrAddress,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Preview the shares received by depositing an asset amount.
+    PreviewDeposit {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of underlying assets.
+        assets: U256,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Deposit assets into the vault.
+    Deposit {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of underlying assets.
+        assets: U256,
+
+        /// The receiver of the resulting vault shares.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        receiver: NameOrAddress,
+
+        #[command(flatten)]
+        send_tx: SendTxOpts,
+
+        #[command(flatten)]
+        tx: TxParams,
+    },
+
+    /// Query the maximum shares that may be minted for a receiver.
+    MaxMint {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The receiver of the resulting vault shares.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        receiver: NameOrAddress,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Preview the assets required to mint a share amount.
+    PreviewMint {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of vault shares.
+        shares: U256,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Mint vault shares.
+    Mint {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of vault shares.
+        shares: U256,
+
+        /// The receiver of the resulting vault shares.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        receiver: NameOrAddress,
+
+        #[command(flatten)]
+        send_tx: SendTxOpts,
+
+        #[command(flatten)]
+        tx: TxParams,
+    },
+
+    /// Query the maximum assets that an owner may withdraw.
+    MaxWithdraw {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The owner of the vault shares.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        owner: NameOrAddress,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Preview the shares burned to withdraw an asset amount.
+    PreviewWithdraw {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of underlying assets.
+        assets: U256,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Withdraw assets from the vault.
+    Withdraw {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of underlying assets.
+        assets: U256,
+
+        /// The receiver of the withdrawn assets.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        receiver: NameOrAddress,
+
+        /// The owner of the vault shares.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        owner: NameOrAddress,
+
+        #[command(flatten)]
+        send_tx: SendTxOpts,
+
+        #[command(flatten)]
+        tx: TxParams,
+    },
+
+    /// Query the maximum shares that an owner may redeem.
+    MaxRedeem {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The owner of the vault shares.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        owner: NameOrAddress,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Preview the assets received by redeeming a share amount.
+    PreviewRedeem {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of vault shares.
+        shares: U256,
+
+        /// The block height to query at.
+        #[arg(long, short = 'B')]
+        block: Option<BlockId>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Redeem vault shares for assets.
+    Redeem {
+        /// The ERC-4626 vault contract address.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        vault: NameOrAddress,
+
+        /// The amount of vault shares.
+        shares: U256,
+
+        /// The receiver of the redeemed assets.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        receiver: NameOrAddress,
+
+        /// The owner of the vault shares.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        owner: NameOrAddress,
+
+        #[command(flatten)]
+        send_tx: SendTxOpts,
+
+        #[command(flatten)]
+        tx: TxParams,
+    },
+}
+
+impl Erc4626Subcommand {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            Self::Asset { vault, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let asset = IERC4626::new(vault, &provider)
+                    .asset()
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await?;
+                warn_if_native_asset(asset)?;
+                print_scalar(asset.to_string())
+            }
+            Self::TotalAssets { vault, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let assets = IERC4626::new(vault, &provider)
+                    .totalAssets()
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await?;
+                print_amount(assets)
+            }
+            Self::ConvertToShares { vault, assets, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let shares = IERC4626::new(vault, &provider)
+                    .convertToShares(assets)
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await?;
+                print_amount(shares)
+            }
+            Self::ConvertToAssets { vault, shares, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let assets = IERC4626::new(vault, &provider)
+                    .convertToAssets(shares)
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await?;
+                print_amount(assets)
+            }
+            Self::MaxDeposit { vault, receiver, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let receiver = receiver.resolve(&provider).await?;
+                let assets = IERC4626::new(vault, &provider)
+                    .maxDeposit(receiver)
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await?;
+                warn_if_zero_entry_max("maxDeposit", assets)?;
+                print_amount(assets)
+            }
+            Self::PreviewDeposit { vault, assets, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let shares = IERC4626::new(vault, &provider)
+                    .previewDeposit(assets)
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await
+                    .wrap_err(
+                        "previewDeposit failed; asynchronous ERC-7540 deposit vaults intentionally \
+                         revert this preview",
+                    )?;
+                print_amount(shares)
+            }
+            Self::Deposit { vault, assets, receiver, send_tx, tx } => {
+                let addresses = prepare_write(&vault, &[receiver], &send_tx).await?;
+                send_call(
+                    vault,
+                    IERC4626::depositCall { assets, receiver: addresses[0] },
+                    send_tx,
+                    tx,
+                )
+                .await
+            }
+            Self::MaxMint { vault, receiver, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let receiver = receiver.resolve(&provider).await?;
+                let shares = IERC4626::new(vault, &provider)
+                    .maxMint(receiver)
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await?;
+                warn_if_zero_entry_max("maxMint", shares)?;
+                print_amount(shares)
+            }
+            Self::PreviewMint { vault, shares, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let assets = IERC4626::new(vault, &provider)
+                    .previewMint(shares)
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await
+                    .wrap_err(
+                        "previewMint failed; asynchronous ERC-7540 deposit vaults intentionally \
+                         revert this preview",
+                    )?;
+                print_amount(assets)
+            }
+            Self::Mint { vault, shares, receiver, send_tx, tx } => {
+                let addresses = prepare_write(&vault, &[receiver], &send_tx).await?;
+                send_call(vault, IERC4626::mintCall { shares, receiver: addresses[0] }, send_tx, tx)
+                    .await
+            }
+            Self::MaxWithdraw { vault, owner, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let owner = owner.resolve(&provider).await?;
+                let block = block.unwrap_or_default();
+                let contract = IERC4626::new(vault, &provider);
+                let assets = contract.maxWithdraw(owner).block(block).call().await?;
+                if assets.is_zero()
+                    && contract
+                        .balanceOf(owner)
+                        .block(block)
+                        .call()
+                        .await
+                        .is_ok_and(|shares| !shares.is_zero())
+                {
+                    warn_if_zero_exit_max("maxWithdraw")?;
+                }
+                print_amount(assets)
+            }
+            Self::PreviewWithdraw { vault, assets, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let shares = IERC4626::new(vault, &provider)
+                    .previewWithdraw(assets)
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await
+                    .wrap_err(
+                        "previewWithdraw failed; asynchronous ERC-7540 redeem vaults intentionally \
+                         revert this preview",
+                    )?;
+                print_amount(shares)
+            }
+            Self::Withdraw { vault, assets, receiver, owner, send_tx, tx } => {
+                let addresses = prepare_write(&vault, &[receiver, owner], &send_tx).await?;
+                send_call(
+                    vault,
+                    IERC4626::withdrawCall { assets, receiver: addresses[0], owner: addresses[1] },
+                    send_tx,
+                    tx,
+                )
+                .await
+            }
+            Self::MaxRedeem { vault, owner, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let owner = owner.resolve(&provider).await?;
+                let block = block.unwrap_or_default();
+                let contract = IERC4626::new(vault, &provider);
+                let shares = contract.maxRedeem(owner).block(block).call().await?;
+                if shares.is_zero()
+                    && contract
+                        .balanceOf(owner)
+                        .block(block)
+                        .call()
+                        .await
+                        .is_ok_and(|balance| !balance.is_zero())
+                {
+                    warn_if_zero_exit_max("maxRedeem")?;
+                }
+                print_amount(shares)
+            }
+            Self::PreviewRedeem { vault, shares, block, rpc } => {
+                let config = rpc.load_config()?;
+                let provider = get_provider(&config)?;
+                let vault = vault.resolve(&provider).await?;
+                let assets = IERC4626::new(vault, &provider)
+                    .previewRedeem(shares)
+                    .block(block.unwrap_or_default())
+                    .call()
+                    .await
+                    .wrap_err(
+                        "previewRedeem failed; asynchronous ERC-7540 redeem vaults intentionally \
+                         revert this preview",
+                    )?;
+                print_amount(assets)
+            }
+            Self::Redeem { vault, shares, receiver, owner, send_tx, tx } => {
+                let addresses = prepare_write(&vault, &[receiver, owner], &send_tx).await?;
+                send_call(
+                    vault,
+                    IERC4626::redeemCall { shares, receiver: addresses[0], owner: addresses[1] },
+                    send_tx,
+                    tx,
+                )
+                .await
+            }
+        }
+    }
+}
+
+fn print_amount(amount: U256) -> Result<()> {
+    if shell::is_json() {
+        print_json_success(amount.to_string())
+    } else {
+        sh_println!("{}", format_uint_exp(amount))
+    }
+}
+
+fn warn_if_zero_entry_max(method: &str, amount: U256) -> Result<()> {
+    if amount.is_zero() {
+        sh_warn!(
+            "Vault reported zero from {method}; some ERC-4626 vaults intentionally return \
+             conservative maxima or gate deposits, so this may not mean deposits are impossible."
+        )?;
+    }
+    Ok(())
+}
+
+fn warn_if_zero_exit_max(method: &str) -> Result<()> {
+    sh_warn!(
+        "Vault reported zero from {method} even though the owner has shares; liquidity, gates, \
+         withdrawal queues, or a conservative implementation may prevent the base ERC-4626 exit."
+    )
+}
+
+fn warn_if_native_asset(asset: Address) -> Result<()> {
+    if asset == NATIVE_ASSET {
+        sh_warn!(
+            "Vault uses the ERC-7535 native-asset sentinel; base ERC-4626 write commands do not \
+             attach native value, so use `cast send --value` when the vault requires it."
+        )?;
+    }
+    Ok(())
+}
+
+async fn prepare_write(
+    vault: &NameOrAddress,
+    accounts: &[NameOrAddress],
+    send_tx: &SendTxOpts,
+) -> Result<Vec<Address>> {
+    let config = send_tx.eth.rpc.load_config()?;
+    let provider = get_provider(&config)?;
+    let vault = vault.resolve(&provider).await?;
+
+    if let Ok(asset) = IERC4626::new(vault, &provider).asset().call().await {
+        warn_if_native_asset(asset)?;
+    }
+
+    let mut resolved = Vec::with_capacity(accounts.len());
+    for account in accounts {
+        resolved.push(account.resolve(&provider).await?);
+    }
+    Ok(resolved)
+}
+
+async fn send_call<C: SolCall>(
+    vault: NameOrAddress,
+    call: C,
+    send_tx: SendTxOpts,
+    tx: TxParams,
+) -> Result<()> {
+    let data = hex::encode_prefixed(call.abi_encode());
+    SendTxArgs::contract_call(vault, data, send_tx, tx).run().await
+}

--- a/crates/cast/src/cmd/mod.rs
+++ b/crates/cast/src/cmd/mod.rs
@@ -33,6 +33,7 @@ pub mod creation_code;
 #[cfg(feature = "optimism")]
 pub mod da_estimate;
 pub mod erc20;
+pub mod erc4626;
 pub mod estimate;
 pub mod events;
 pub mod find_block;

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -27,7 +27,7 @@ use tempo_primitives::transaction::FEE_PAYER_SIGNATURE_MARKER;
 use crate::{
     cmd::{auth::confirm_auth_rpc_disclosure_during_build, tip20::iso4217_warning_message},
     tempo,
-    tx::{self, CastTxBuilder, CastTxSender, SendTxOpts},
+    tx::{self, CastTxBuilder, CastTxSender, SendTxOpts, TxParams},
 };
 use tempo_contracts::precompiles::{TIP20_FACTORY_ADDRESS, is_iso4217_currency};
 
@@ -104,6 +104,28 @@ pub enum SendTxSubcommands {
 }
 
 impl SendTxArgs {
+    /// Creates a `cast send` invocation for pre-encoded contract calldata.
+    pub(crate) fn contract_call(
+        to: NameOrAddress,
+        data: String,
+        send_tx: SendTxOpts,
+        tx: TxParams,
+    ) -> Self {
+        Self {
+            to: Some(to),
+            sig: None,
+            args: Vec::new(),
+            data: Some(data),
+            send_tx,
+            command: None,
+            unlocked: false,
+            force: false,
+            gas_estimate_multiplier: None,
+            tx: tx.into_transaction_opts(),
+            path: None,
+        }
+    }
+
     pub async fn run(self) -> Result<()> {
         if self.tx.tempo.session_id()?.is_some() {
             return self.run_generic::<TempoNetwork>(None, None).await;

--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -12,10 +12,7 @@ use alloy_primitives::{Address, B256};
 use alloy_provider::{Provider, ProviderBuilder as AlloyProviderBuilder};
 use alloy_signer::Signer;
 use clap::Parser;
-use foundry_cli::{
-    opts::TransactionOpts,
-    utils::{LoadConfig, get_chain, maybe_print_resolved_lane, resolve_lane},
-};
+use foundry_cli::utils::{LoadConfig, get_chain, maybe_print_resolved_lane, resolve_lane};
 use foundry_common::{
     FoundryTransactionBuilder,
     provider::ProviderBuilder,
@@ -441,23 +438,4 @@ where
         .await?;
     sponsor.attach_and_print::<TempoNetwork>(tx, payer).await?;
     Ok(())
-}
-
-impl TxParams {
-    fn into_transaction_opts(self) -> TransactionOpts {
-        TransactionOpts {
-            gas_limit: self.gas_limit,
-            gas_price: self.gas_price,
-            priority_gas_price: self.priority_gas_price,
-            value: None,
-            nonce: self.nonce,
-            legacy: false,
-            blob: false,
-            eip4844: false,
-            blob_gas_price: None,
-            auth: Vec::new(),
-            access_list: None,
-            tempo: self.tempo,
-        }
-    }
 }

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -13,6 +13,7 @@ use crate::cmd::{
     create2::Create2Args,
     creation_code::CreationCodeArgs,
     erc20::Erc20Subcommand,
+    erc4626::Erc4626Subcommand,
     estimate::EstimateArgs,
     events::EventsArgs,
     find_block::FindBlockArgs,
@@ -1377,6 +1378,13 @@ pub enum CastSubcommand {
     Erc20Token {
         #[command(subcommand)]
         command: Erc20Subcommand,
+    },
+
+    /// ERC-4626 tokenized vault operations.
+    #[command(name = "erc4626", visible_alias = "vault")]
+    Erc4626 {
+        #[command(subcommand)]
+        command: Erc4626Subcommand,
     },
 
     /// TIP-20 token operations (Tempo).

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -108,6 +108,24 @@ impl TxParams {
 
         self.tempo.apply::<N>(tx, self.nonce.map(|n| n.to()));
     }
+
+    /// Converts the shared compact transaction options into the full `cast send` options.
+    pub(crate) fn into_transaction_opts(self) -> TransactionOpts {
+        TransactionOpts {
+            gas_limit: self.gas_limit,
+            gas_price: self.gas_price,
+            priority_gas_price: self.priority_gas_price,
+            value: None,
+            nonce: self.nonce,
+            legacy: false,
+            blob: false,
+            eip4844: false,
+            blob_gas_price: None,
+            auth: Vec::new(),
+            access_list: None,
+            tempo: self.tempo,
+        }
+    }
 }
 
 /// Different sender kinds used by [`CastTxBuilder`].

--- a/crates/cast/tests/cli/erc4626.rs
+++ b/crates/cast/tests/cli/erc4626.rs
@@ -1,0 +1,280 @@
+//! End-to-end tests for `cast erc4626`.
+
+use alloy_primitives::U256;
+use anvil::{NodeConfig, NodeHandle};
+use foundry_test_utils::{rpc::next_http_archive_rpc_url, util::OutputExt};
+
+mod anvil_const {
+    pub const PK1: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    pub const ADDR1: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+    pub const ADDR2: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+    /// Contract address deployed by `ADDR1` at nonce zero.
+    pub const VAULT: &str = "0x5FbDB2315678afecb367f032d93F642f64180aa3";
+}
+
+const FORK_BLOCK: u64 = 25_519_075;
+
+struct ProductionVault {
+    project: &'static str,
+    address: &'static str,
+}
+
+const PRODUCTION_VAULTS: &[ProductionVault] = &[
+    ProductionVault {
+        project: "Morpho MetaMorpho",
+        address: "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+    },
+    ProductionVault { project: "Yearn V3", address: "0x028eC7330ff87667b6dfb0D94b954c820195336c" },
+    ProductionVault {
+        project: "Maple syrupUSDC",
+        address: "0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b",
+    },
+];
+
+fn read_amount(
+    cmd: &mut foundry_test_utils::TestCommand,
+    command: &str,
+    vault: &str,
+    args: &[&str],
+    rpc: &str,
+) -> U256 {
+    let output = cmd
+        .cast_fuse()
+        .args(["erc4626", command, vault])
+        .args(args)
+        .args(["--rpc-url", rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    output.split_whitespace().next().unwrap().parse().unwrap()
+}
+
+fn read_erc20_balance(
+    cmd: &mut foundry_test_utils::TestCommand,
+    token: &str,
+    owner: &str,
+    rpc: &str,
+) -> U256 {
+    let output = cmd
+        .cast_fuse()
+        .args(["erc20", "balance", token, owner, "--rpc-url", rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    output.split_whitespace().next().unwrap().parse().unwrap()
+}
+
+fn deploy_test_vault(cmd: &mut foundry_test_utils::TestCommand, rpc: &str, private_key: &str) {
+    cmd.args([
+        "create",
+        "--private-key",
+        private_key,
+        "--rpc-url",
+        rpc,
+        "--broadcast",
+        "src/TestVault.sol:TestVault",
+    ])
+    .assert_success();
+}
+
+async fn setup_test_vault(
+    prj: &foundry_test_utils::TestProject,
+    cmd: &mut foundry_test_utils::TestCommand,
+) -> (String, NodeHandle) {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_source("TestVault.sol", include_str!("../fixtures/TestVault.sol"));
+    deploy_test_vault(cmd, &rpc, anvil_const::PK1);
+
+    (rpc, handle)
+}
+
+forgetest_async!(erc4626_complete_synchronous_interface, |prj, cmd| {
+    let (rpc, _handle) = setup_test_vault(&prj, &mut cmd).await;
+
+    let asset = cmd
+        .cast_fuse()
+        .args(["vault", "asset", anvil_const::VAULT, "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert_eq!(read_amount(&mut cmd, "total-assets", anvil_const::VAULT, &[], &rpc), U256::ZERO);
+    assert_eq!(
+        read_amount(&mut cmd, "convert-to-shares", anvil_const::VAULT, &["100"], &rpc),
+        U256::from(100)
+    );
+    assert_eq!(
+        read_amount(&mut cmd, "convert-to-assets", anvil_const::VAULT, &["100"], &rpc),
+        U256::from(100)
+    );
+
+    let max_deposit = cmd
+        .cast_fuse()
+        .args(["erc4626", "max-deposit", anvil_const::VAULT, anvil_const::ADDR1, "--rpc-url", &rpc])
+        .assert_success();
+    assert!(max_deposit.get_output().stderr_lossy().contains("conservative maxima"));
+    assert_eq!(
+        read_amount(&mut cmd, "preview-deposit", anvil_const::VAULT, &["100"], &rpc),
+        U256::from(100)
+    );
+
+    let max_mint = cmd
+        .cast_fuse()
+        .args(["erc4626", "max-mint", anvil_const::VAULT, anvil_const::ADDR1, "--rpc-url", &rpc])
+        .assert_success();
+    assert!(max_mint.get_output().stderr_lossy().contains("conservative maxima"));
+    assert_eq!(
+        read_amount(&mut cmd, "preview-mint", anvil_const::VAULT, &["50"], &rpc),
+        U256::from(50)
+    );
+
+    cmd.cast_fuse()
+        .args([
+            "erc20",
+            "approve",
+            &asset,
+            anvil_const::VAULT,
+            "1000",
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_success();
+
+    cmd.cast_fuse()
+        .args([
+            "erc4626",
+            "deposit",
+            anvil_const::VAULT,
+            "100",
+            anvil_const::ADDR1,
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_success();
+    cmd.cast_fuse()
+        .args([
+            "erc4626",
+            "mint",
+            anvil_const::VAULT,
+            "50",
+            anvil_const::ADDR1,
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_success();
+
+    let max_withdraw = cmd
+        .cast_fuse()
+        .args([
+            "erc4626",
+            "max-withdraw",
+            anvil_const::VAULT,
+            anvil_const::ADDR1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+    assert!(max_withdraw.get_output().stderr_lossy().contains("even though the owner has shares"));
+    assert_eq!(
+        read_amount(&mut cmd, "preview-withdraw", anvil_const::VAULT, &["25"], &rpc),
+        U256::from(25)
+    );
+
+    let max_redeem = cmd
+        .cast_fuse()
+        .args(["erc4626", "max-redeem", anvil_const::VAULT, anvil_const::ADDR1, "--rpc-url", &rpc])
+        .assert_success();
+    assert!(max_redeem.get_output().stderr_lossy().contains("even though the owner has shares"));
+    assert_eq!(
+        read_amount(&mut cmd, "preview-redeem", anvil_const::VAULT, &["25"], &rpc),
+        U256::from(25)
+    );
+
+    cmd.cast_fuse()
+        .args([
+            "erc4626",
+            "withdraw",
+            anvil_const::VAULT,
+            "25",
+            anvil_const::ADDR2,
+            anvil_const::ADDR1,
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_success();
+    cmd.cast_fuse()
+        .args([
+            "erc4626",
+            "redeem",
+            anvil_const::VAULT,
+            "25",
+            anvil_const::ADDR2,
+            anvil_const::ADDR1,
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_success();
+
+    assert_eq!(
+        read_amount(&mut cmd, "total-assets", anvil_const::VAULT, &[], &rpc),
+        U256::from(100)
+    );
+    assert_eq!(
+        read_erc20_balance(&mut cmd, anvil_const::VAULT, anvil_const::ADDR1, &rpc),
+        U256::from(100)
+    );
+    assert_eq!(read_erc20_balance(&mut cmd, &asset, anvil_const::ADDR2, &rpc), U256::from(50));
+});
+
+casttest!(erc4626_fork_reads_multiple_production_vaults, async |_prj, cmd| {
+    let fork = NodeConfig::test()
+        .with_eth_rpc_url(Some(next_http_archive_rpc_url()))
+        .with_fork_block_number(Some(FORK_BLOCK));
+    let (_, handle) = anvil::spawn(fork).await;
+    let rpc = handle.http_endpoint();
+
+    let read_calls: &[(&str, &[&str])] = &[
+        ("asset", &[]),
+        ("total-assets", &[]),
+        ("convert-to-shares", &["1"]),
+        ("convert-to-assets", &["1"]),
+        ("max-deposit", &[anvil_const::ADDR1]),
+        ("preview-deposit", &["1"]),
+        ("max-mint", &[anvil_const::ADDR1]),
+        ("preview-mint", &["1"]),
+        ("max-withdraw", &[anvil_const::ADDR1]),
+        ("preview-withdraw", &["1"]),
+        ("max-redeem", &[anvil_const::ADDR1]),
+        ("preview-redeem", &["1"]),
+    ];
+
+    for vault in PRODUCTION_VAULTS {
+        for (command, args) in read_calls {
+            let output = cmd
+                .cast_fuse()
+                .args(["erc4626", command, vault.address])
+                .args(*args)
+                .args(["--rpc-url", &rpc])
+                .assert_success()
+                .get_output()
+                .stdout_lossy();
+            assert!(!output.trim().is_empty(), "{} {command} returned no output", vault.project);
+        }
+    }
+});

--- a/crates/cast/tests/cli/erc4626.rs
+++ b/crates/cast/tests/cli/erc4626.rs
@@ -13,7 +13,9 @@ mod anvil_const {
     pub const VAULT: &str = "0x5FbDB2315678afecb367f032d93F642f64180aa3";
 }
 
-const FORK_BLOCK: u64 = 25_519_075;
+const ETHEREUM_FORK_BLOCK: u64 = 25_519_075;
+const TEMPO_FORK_BLOCK: u64 = 37_847_799;
+const TEMPO_RPC_URL: &str = "https://rpc.tempo.xyz";
 
 struct ProductionVault {
     project: &'static str,
@@ -31,6 +33,44 @@ const PRODUCTION_VAULTS: &[ProductionVault] = &[
         address: "0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b",
     },
 ];
+
+const TEMPO_VAULT: ProductionVault = ProductionVault {
+    project: "Morpho on Tempo",
+    address: "0x83a1491f3e7f8dAAB8F787a631334b9ca7a87023",
+};
+
+const READ_CALLS: &[(&str, &[&str])] = &[
+    ("asset", &[]),
+    ("total-assets", &[]),
+    ("convert-to-shares", &["1"]),
+    ("convert-to-assets", &["1"]),
+    ("max-deposit", &[anvil_const::ADDR1]),
+    ("preview-deposit", &["1"]),
+    ("max-mint", &[anvil_const::ADDR1]),
+    ("preview-mint", &["1"]),
+    ("max-withdraw", &[anvil_const::ADDR1]),
+    ("preview-withdraw", &["1"]),
+    ("max-redeem", &[anvil_const::ADDR1]),
+    ("preview-redeem", &["1"]),
+];
+
+fn assert_read_surface(
+    cmd: &mut foundry_test_utils::TestCommand,
+    vault: &ProductionVault,
+    rpc: &str,
+) {
+    for (command, args) in READ_CALLS {
+        let output = cmd
+            .cast_fuse()
+            .args(["erc4626", command, vault.address])
+            .args(*args)
+            .args(["--rpc-url", rpc])
+            .assert_success()
+            .get_output()
+            .stdout_lossy();
+        assert!(!output.trim().is_empty(), "{} {command} returned no output", vault.project);
+    }
+}
 
 fn read_amount(
     cmd: &mut foundry_test_utils::TestCommand,
@@ -245,36 +285,21 @@ forgetest_async!(erc4626_complete_synchronous_interface, |prj, cmd| {
 casttest!(erc4626_fork_reads_multiple_production_vaults, async |_prj, cmd| {
     let fork = NodeConfig::test()
         .with_eth_rpc_url(Some(next_http_archive_rpc_url()))
-        .with_fork_block_number(Some(FORK_BLOCK));
+        .with_fork_block_number(Some(ETHEREUM_FORK_BLOCK));
     let (_, handle) = anvil::spawn(fork).await;
     let rpc = handle.http_endpoint();
 
-    let read_calls: &[(&str, &[&str])] = &[
-        ("asset", &[]),
-        ("total-assets", &[]),
-        ("convert-to-shares", &["1"]),
-        ("convert-to-assets", &["1"]),
-        ("max-deposit", &[anvil_const::ADDR1]),
-        ("preview-deposit", &["1"]),
-        ("max-mint", &[anvil_const::ADDR1]),
-        ("preview-mint", &["1"]),
-        ("max-withdraw", &[anvil_const::ADDR1]),
-        ("preview-withdraw", &["1"]),
-        ("max-redeem", &[anvil_const::ADDR1]),
-        ("preview-redeem", &["1"]),
-    ];
-
     for vault in PRODUCTION_VAULTS {
-        for (command, args) in read_calls {
-            let output = cmd
-                .cast_fuse()
-                .args(["erc4626", command, vault.address])
-                .args(*args)
-                .args(["--rpc-url", &rpc])
-                .assert_success()
-                .get_output()
-                .stdout_lossy();
-            assert!(!output.trim().is_empty(), "{} {command} returned no output", vault.project);
-        }
+        assert_read_surface(&mut cmd, vault, &rpc);
     }
+});
+
+casttest!(flaky_erc4626_fork_reads_tempo_vault, async |_prj, cmd| {
+    let fork = NodeConfig::test_tempo()
+        .with_eth_rpc_url(Some(TEMPO_RPC_URL.to_string()))
+        .with_fork_block_number(Some(TEMPO_FORK_BLOCK));
+    let (_, handle) = anvil::spawn(fork).await;
+    let rpc = handle.http_endpoint();
+
+    assert_read_surface(&mut cmd, &TEMPO_VAULT, &rpc);
 });

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -38,6 +38,7 @@ use tempo_primitives::{
 extern crate foundry_test_utils;
 
 mod erc20;
+mod erc4626;
 mod keychain;
 mod read_networks;
 mod remote_trace;

--- a/crates/cast/tests/fixtures/TestVault.sol
+++ b/crates/cast/tests/fixtures/TestVault.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract TestVaultAsset {
+    string public name = "Test Vault Asset";
+    string public symbol = "TVA";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "Insufficient allowance");
+        allowance[from][msg.sender] = allowed - amount;
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function mint(address to, uint256 amount) external {
+        totalSupply += amount;
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "Insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}
+
+contract TestVault {
+    TestVaultAsset public immutable underlying;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
+    event Withdraw(
+        address indexed sender,
+        address indexed receiver,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
+
+    constructor() {
+        underlying = new TestVaultAsset();
+        underlying.mint(msg.sender, 1_000 ether);
+    }
+
+    function asset() external view returns (address) {
+        return address(underlying);
+    }
+
+    function totalAssets() external view returns (uint256) {
+        return underlying.balanceOf(address(this));
+    }
+
+    function convertToShares(uint256 assets) external pure returns (uint256) {
+        return assets;
+    }
+
+    function convertToAssets(uint256 shares) external pure returns (uint256) {
+        return shares;
+    }
+
+    // Conservative zero maxima exercise the CLI's compatibility warnings while writes remain live.
+    function maxDeposit(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewDeposit(uint256 assets) external pure returns (uint256) {
+        return assets;
+    }
+
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
+        shares = assets;
+        require(underlying.transferFrom(msg.sender, address(this), assets));
+        _mint(receiver, shares);
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function maxMint(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewMint(uint256 shares) external pure returns (uint256) {
+        return shares;
+    }
+
+    function mint(uint256 shares, address receiver) external returns (uint256 assets) {
+        assets = shares;
+        require(underlying.transferFrom(msg.sender, address(this), assets));
+        _mint(receiver, shares);
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function maxWithdraw(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewWithdraw(uint256 assets) external pure returns (uint256) {
+        return assets;
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner)
+        external
+        returns (uint256 shares)
+    {
+        shares = assets;
+        _spendAllowance(owner, shares);
+        _burn(owner, shares);
+        require(underlying.transfer(receiver, assets));
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    function maxRedeem(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewRedeem(uint256 shares) external pure returns (uint256) {
+        return shares;
+    }
+
+    function redeem(uint256 shares, address receiver, address owner)
+        external
+        returns (uint256 assets)
+    {
+        assets = shares;
+        _spendAllowance(owner, shares);
+        _burn(owner, shares);
+        require(underlying.transfer(receiver, assets));
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    function _mint(address receiver, uint256 shares) internal {
+        totalSupply += shares;
+        balanceOf[receiver] += shares;
+    }
+
+    function _burn(address owner, uint256 shares) internal {
+        require(balanceOf[owner] >= shares, "Insufficient shares");
+        balanceOf[owner] -= shares;
+        totalSupply -= shares;
+    }
+
+    function _spendAllowance(address owner, uint256 shares) internal {
+        if (msg.sender != owner) {
+            uint256 allowed = allowance[owner][msg.sender];
+            require(allowed >= shares, "Insufficient allowance");
+            allowance[owner][msg.sender] = allowed - shares;
+        }
+    }
+}


### PR DESCRIPTION
Adds `cast erc4626` (with `cast vault` as an alias) for all sixteen ERC-4626-specific methods in the synchronous base interface. Read commands accept the usual RPC and block options, while deposit, mint, withdraw, and redeem use ABI-generated calldata and the shared `cast send` transaction path so wallet, browser, and Tempo behavior stays aligned with the generic sender. The vault's inherited ERC-20 share operations remain available through `cast erc20`.

The command emits targeted compatibility guidance when a vault reports conservative zero deposit or mint maxima, when it reports a zero exit maximum for an owner that still has shares, and when `asset()` returns the ERC-7535 native-asset sentinel. Failed preview calls also explain the intentional ERC-7540 asynchronous-vault behavior. End-to-end coverage executes every base selector against a local writable vault, uses a table-driven fixed-block Ethereum fork for Morpho MetaMorpho, Yearn V3, and Maple syrupUSDC, and runs the same complete read surface through a pinned Tempo mainnet fork of this [Morpho-style vault](https://explore.tempo.xyz/address/0x83a1491f3e7f8dAAB8F787a631334b9ca7a87023?tab=contract).

### Follow-ups

Separate changes can add ERC-7540 request/claim flows and ERC-7575 multi-asset share discovery, first-class ERC-7535 native-value writes, slippage-bounded ERC-5143 or router-style operations, permit/approval composition, and a richer vault summary or position command with asset/share unit formatting. Keeping those extensions outside this PR leaves the initial surface exactly aligned with the broadly deployed synchronous ERC-4626 selectors.

Codex was used for protocol research, implementation, tests, and PR text.
