### PR TITLE
fix(doc): skip code fences and inline code when rewriting homepage links

### DIFF
--- a/.changelog/doc-fence-link-corruption.md
+++ b/.changelog/doc-fence-link-corruption.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `forge doc` rewriting `](` sequences inside code fences and inline code spans as if they were markdown links, which corrupted Solidity syntax like `new address[](2)` on the generated documentation homepage. Also fixed a panic when a homepage README ends in an unclosed link target followed by a trailing backslash.

--- a/.changelog/doc-fence-link-corruption.md
+++ b/.changelog/doc-fence-link-corruption.md
@@ -1,5 +1,6 @@
 ---
 forge: patch
+forge-doc: patch
 ---
 
 Fixed `forge doc` rewriting `](` sequences inside code fences and inline code spans as if they were markdown links, which corrupted Solidity syntax like `new address[](2)` on the generated documentation homepage. Also fixed a panic when a homepage README ends in an unclosed link target followed by a trailing backslash.

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -897,11 +897,12 @@ fn italicize_dev(content: &str) -> String {
     if trimmed.is_empty() { String::new() } else { format!("<i>\n\n{trimmed}\n\n</i>") }
 }
 
-/// Byte ranges that MDX parses as code. An HTML entity would render literally inside these ranges,
-/// so neutralization skips them. If malformed MDX cannot be parsed, returning no ranges favors
-/// neutralizing possible ESM over preserving an invalid code example byte-for-byte.
-fn code_regions(text: &str) -> Vec<Range<usize>> {
-    let Ok(tree) = to_mdast(text, &ParseOptions::mdx()) else { return Vec::new() };
+/// Byte ranges that Markdown parses as code under `options`. An HTML entity would render literally
+/// inside these ranges, so neutralization skips them. If malformed MDX cannot be parsed, returning
+/// no ranges favors neutralizing possible ESM over preserving an invalid code example
+/// byte-for-byte.
+pub(crate) fn code_regions(text: &str, options: &ParseOptions) -> Vec<Range<usize>> {
+    let Ok(tree) = to_mdast(text, options) else { return Vec::new() };
     let mut regions = Vec::new();
     collect_code_regions(&tree, &mut regions);
     regions
@@ -948,7 +949,11 @@ fn logical_lines(text: &str) -> impl Iterator<Item = (usize, &str)> {
 }
 
 /// Check a position against sorted, merged ranges while advancing monotonically.
-fn region_contains(regions: &[Range<usize>], cursor: &mut usize, position: usize) -> bool {
+pub(crate) fn region_contains(
+    regions: &[Range<usize>],
+    cursor: &mut usize,
+    position: usize,
+) -> bool {
     while regions.get(*cursor).is_some_and(|region| region.end <= position) {
         *cursor += 1;
     }
@@ -962,7 +967,7 @@ fn region_contains(regions: &[Range<usize>], cursor: &mut usize, position: usize
 /// code span or fenced code block is left untouched (see `code_regions`): the entity would render
 /// literally and corrupt the example, and MDX would not execute it there.
 fn neutralize_esm(text: &str) -> String {
-    let regions = code_regions(text);
+    let regions = code_regions(text, &ParseOptions::mdx());
     let mut region_cursor = 0;
     let mut copied = 0;
     let mut out = String::with_capacity(text.len());

--- a/crates/doc/src/vocs.rs
+++ b/crates/doc/src/vocs.rs
@@ -455,18 +455,18 @@ fn rewrite_homepage_links(
             }
         }
         let target = &rest[..i];
+        if !closed {
+            out.push_str(target);
+            rest = &rest[i..];
+            break;
+        }
         match try_rewrite_target(target, base_dir, root, src_to_url, repo, commit) {
             Some(new) => out.push_str(&new),
             None => out.push_str(target),
         }
-        if closed {
-            out.push(')');
-            rest = &rest[i + 1..];
-            consumed += i + 1;
-        } else {
-            rest = &rest[i..];
-            break;
-        }
+        out.push(')');
+        rest = &rest[i + 1..];
+        consumed += i + 1;
     }
     out.push_str(rest);
     out
@@ -741,7 +741,14 @@ A lone ` backtick is not a code span: [Logo](https://github.com/x/y/raw/abc123/i
         let map = SourceToUrl::new();
         let root = Path::new("/repo");
         let input = "See [Foo](abc\\";
-        let out = rewrite_homepage_links(input, root, root, &map, None, None);
+        let out = rewrite_homepage_links(
+            input,
+            root,
+            root,
+            &map,
+            Some("https://github.com/x/y"),
+            Some("abc123"),
+        );
         assert_eq!(out, input, "unclosed target should be left untouched, not panic");
     }
 }

--- a/crates/doc/src/vocs.rs
+++ b/crates/doc/src/vocs.rs
@@ -323,36 +323,51 @@ fn build_source_to_url(pages: &[PathBuf]) -> SourceToUrl {
 /// Without this, README content with template placeholders like `{FOO}` or
 /// HTML-like tokens like `<TOKEN>` would be interpreted as MDX expressions/JSX
 /// and break `vocs dev` / `vocs build`.
-fn escape_mdx_outside_code_fences(text: &str) -> String {
-    struct Fence {
-        marker: char,
-        len: usize,
+/// Shared fence-open/fence-close detection for a single markdown line, used
+/// by both `escape_mdx_outside_code_fences` and `code_regions` so the two
+/// line-walkers agree on what counts as "inside a code fence".
+struct FenceState {
+    marker: char,
+    len: usize,
+}
+
+impl FenceState {
+    /// If `trimmed` (a line with leading whitespace stripped) opens a code
+    /// fence, return the state to track until it closes.
+    fn opens(trimmed: &str) -> Option<Self> {
+        let marker = trimmed.chars().next()?;
+        if !matches!(marker, '`' | '~') {
+            return None;
+        }
+        let len = trimmed.chars().take_while(|&ch| ch == marker).count();
+        if len < 3 || marker == '`' && trimmed[len..].contains('`') {
+            return None;
+        }
+        Some(Self { marker, len })
     }
 
+    /// Whether `trimmed` closes this fence (a line of `>= len` fence markers
+    /// and nothing else).
+    fn closes(&self, trimmed: &str) -> bool {
+        // Fence markers are ASCII, so their character count is also the byte index.
+        let marker_len = trimmed.chars().take_while(|&ch| ch == self.marker).count();
+        let suffix = &trimmed[marker_len..];
+        marker_len >= self.len && suffix.trim().is_empty()
+    }
+}
+
+fn escape_mdx_outside_code_fences(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
-    let mut fence: Option<Fence> = None;
+    let mut fence: Option<FenceState> = None;
     for line in text.split_inclusive('\n') {
         let trimmed = line.trim_start();
         if let Some(open) = fence.as_ref() {
             out.push_str(line);
-            let marker_len = trimmed.chars().take_while(|&ch| ch == open.marker).count();
-            // Fence markers are ASCII, so their character count is also the byte index.
-            let suffix = &trimmed[marker_len..];
-            if marker_len >= open.len && suffix.trim().is_empty() {
+            if open.closes(trimmed) {
                 fence = None;
             }
         } else {
-            let opening = trimmed.chars().next().and_then(|marker| {
-                if !matches!(marker, '`' | '~') {
-                    return None;
-                }
-                let len = trimmed.chars().take_while(|&ch| ch == marker).count();
-                if len < 3 || marker == '`' && trimmed[len..].contains('`') {
-                    return None;
-                }
-                Some(Fence { marker, len })
-            });
-            if let Some(opening) = opening {
+            if let Some(opening) = FenceState::opens(trimmed) {
                 fence = Some(opening);
                 out.push_str(line);
                 continue;
@@ -392,10 +407,80 @@ fn escape_mdx_outside_code_fences(text: &str) -> String {
     out
 }
 
+/// Byte ranges of `text` that sit inside a code fence or an inline code span
+/// (`` `...` ``), reusing `FenceState` so this agrees with
+/// `escape_mdx_outside_code_fences` about what counts as "code". Used by
+/// `rewrite_homepage_links` so it never mistakes Solidity syntax like
+/// `new address[](2)` for a markdown link.
+fn code_regions(text: &str) -> Vec<std::ops::Range<usize>> {
+    let mut regions = Vec::new();
+    let mut fence: Option<FenceState> = None;
+    let mut offset = 0usize;
+    for line in text.split_inclusive('\n') {
+        let line_start = offset;
+        offset += line.len();
+        let trimmed = line.trim_start();
+
+        if let Some(open) = fence.as_ref() {
+            regions.push(line_start..offset);
+            if open.closes(trimmed) {
+                fence = None;
+            }
+            continue;
+        }
+        if let Some(opening) = FenceState::opens(trimmed) {
+            fence = Some(opening);
+            regions.push(line_start..offset);
+            continue;
+        }
+
+        // Inline code spans (`` `...` `` or longer runs of backticks) within
+        // this line, mirroring escape_mdx_outside_code_fences's tick pairing.
+        let mut pending_ticks = 0usize;
+        let mut inline_code_ticks = 0usize;
+        let mut span_start: Option<usize> = None;
+        let mut pos = line_start;
+        for ch in line.chars() {
+            let ch_len = ch.len_utf8();
+            if ch == '`' {
+                pending_ticks += 1;
+                pos += ch_len;
+                continue;
+            }
+            if pending_ticks > 0 {
+                if inline_code_ticks == 0 {
+                    inline_code_ticks = pending_ticks;
+                    span_start = Some(pos - pending_ticks);
+                } else if inline_code_ticks == pending_ticks {
+                    inline_code_ticks = 0;
+                    if let Some(start) = span_start.take() {
+                        regions.push(start..pos);
+                    }
+                }
+                pending_ticks = 0;
+            }
+            pos += ch_len;
+        }
+        // An unterminated run of backticks (odd number of tick groups) opens
+        // an inline span that extends to end-of-line, matching how
+        // escape_mdx_outside_code_fences treats the remainder of the line as
+        // inline code once `inline_code_ticks > 0`.
+        if inline_code_ticks > 0
+            && let Some(start) = span_start
+        {
+            regions.push(start..offset);
+        }
+    }
+    regions
+}
+
 /// Rewrite inline `[text](url)` markdown links in the homepage:
 /// * `.sol` paths that resolve to a known page → vocs URL.
 /// * Any other relative path under `root` → `{repo}/blob/{commit}/...`.
 /// * Absolute URLs, anchors, and unresolved targets are left untouched.
+/// * Anything inside a code fence or inline code span is left untouched —
+///   Solidity syntax like `new address[](2)` looks like a markdown link
+///   (`](`) to a naive scanner but is not one.
 fn rewrite_homepage_links(
     text: &str,
     base_dir: &Path,
@@ -404,11 +489,15 @@ fn rewrite_homepage_links(
     repo: Option<&str>,
     commit: Option<&str>,
 ) -> String {
+    let protected = code_regions(text);
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
+    let mut consumed = 0usize;
     while let Some(open) = rest.find("](") {
+        let abs_open = consumed + open;
         out.push_str(&rest[..open + 2]);
         rest = &rest[open + 2..];
+        consumed += open + 2;
         // Scan the URL, counting parens so we don't split on `(` / `)` inside it.
         let bytes = rest.as_bytes();
         let mut i = 0;
@@ -429,7 +518,10 @@ fn rewrite_homepage_links(
                     i += 1;
                 }
                 b'\\' => {
-                    i += 2; // skip escaped character
+                    // Skip the escaped character. Clamp so a trailing
+                    // backslash at the very end of the text can't push `i`
+                    // past `bytes.len()` and panic the slice below.
+                    i = (i + 2).min(bytes.len());
                 }
                 _ => {
                     i += 1;
@@ -437,13 +529,20 @@ fn rewrite_homepage_links(
             }
         }
         let target = &rest[..i];
-        match try_rewrite_target(target, base_dir, root, src_to_url, repo, commit) {
+        let in_protected = protected.iter().any(|r| r.contains(&abs_open));
+        let rewritten = if in_protected {
+            None
+        } else {
+            try_rewrite_target(target, base_dir, root, src_to_url, repo, commit)
+        };
+        match rewritten {
             Some(new) => out.push_str(&new),
             None => out.push_str(target),
         }
         if closed {
             out.push(')');
             rest = &rest[i + 1..];
+            consumed += i + 1;
         } else {
             rest = &rest[i..];
             break;
@@ -674,5 +773,63 @@ End {brace}.
         assert_eq!(json_str(r#"Acme\"#), r#""Acme\\""#);
         assert_eq!(json_str("Bob's Docs"), r#""Bob's Docs""#);
         assert_eq!(json_str(r#"Quote " Docs"#), r#""Quote \" Docs""#);
+    }
+
+    #[test]
+    fn rewrite_homepage_links_leaves_code_fences_alone() {
+        // `new address[](2)` contains a literal `](` that a naive scanner
+        // mistakes for a markdown link — the fenced Solidity must survive
+        // byte-for-byte, while a real link in the surrounding prose still
+        // gets rewritten.
+        let map = build_source_to_url(&[PathBuf::from("src/contract.Foo.mdx")]);
+        let root = Path::new("/repo");
+        let repo = Some("https://github.com/x/y");
+        let commit = Some("abc123");
+        let input = "\
+See [Foo](./src/Foo.sol) for details.
+
+```solidity
+function deploy() external {
+    address[] memory targets = new address[](2);
+    bytes memory data = new bytes(4);
+}
+```
+
+Also uses `new bytes(4)` inline.
+";
+        let out = rewrite_homepage_links(input, Path::new("/repo"), root, &map, repo, commit);
+
+        // Real link outside the fence is still rewritten.
+        assert!(out.contains("[Foo](/src/contract.Foo)"), "prose link must still be rewritten");
+        // Fenced Solidity is untouched — no GitHub URL leaked into the array length.
+        assert!(
+            out.contains("new address[](2)"),
+            "array allocation inside a fence must survive unchanged, got: {out}"
+        );
+        assert!(
+            !out.contains("address[](https://"),
+            "must not rewrite `](` inside a code fence, got: {out}"
+        );
+        // Inline-code span outside the fence is also untouched.
+        assert!(
+            out.contains("`new bytes(4)`"),
+            "array allocation inside inline code must survive unchanged, got: {out}"
+        );
+        assert!(
+            !out.contains("bytes(https://"),
+            "must not rewrite `](` inside an inline code span, got: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_homepage_links_handles_trailing_unclosed_backslash() {
+        // A dangling `](` with no closing paren, ending in a literal
+        // backslash as the very last byte of the text, must not panic on an
+        // out-of-bounds slice.
+        let map = SourceToUrl::new();
+        let root = Path::new("/repo");
+        let input = "See [Foo](abc\\";
+        let out = rewrite_homepage_links(input, root, root, &map, None, None);
+        assert_eq!(out, input, "unclosed target should be left untouched, not panic");
     }
 }

--- a/crates/doc/src/vocs.rs
+++ b/crates/doc/src/vocs.rs
@@ -9,6 +9,7 @@ use path_slash::PathExt;
 use std::{
     collections::HashMap,
     fs,
+    ops::Range,
     path::{Component, Path, PathBuf},
 };
 
@@ -317,15 +318,9 @@ fn build_source_to_url(pages: &[PathBuf]) -> SourceToUrl {
     map
 }
 
-/// Escape MDX-sensitive characters (`{` and `<`) in plain-text regions of a
-/// Markdown document, leaving fenced code blocks (` ``` ` or `~~~`) untouched.
-///
-/// Without this, README content with template placeholders like `{FOO}` or
-/// HTML-like tokens like `<TOKEN>` would be interpreted as MDX expressions/JSX
-/// and break `vocs dev` / `vocs build`.
-/// Shared fence-open/fence-close detection for a single markdown line, used
-/// by both `escape_mdx_outside_code_fences` and `code_regions` so the two
-/// line-walkers agree on what counts as "inside a code fence".
+/// Fence-open/close detection for a single markdown line, shared by
+/// `escape_mdx_outside_code_fences` and `code_regions` so both agree on what
+/// counts as "inside a code fence".
 struct FenceState {
     marker: char,
     len: usize,
@@ -356,6 +351,12 @@ impl FenceState {
     }
 }
 
+/// Escape MDX-sensitive characters (`{` and `<`) in plain-text regions of a
+/// Markdown document, leaving fenced code blocks (` ``` ` or `~~~`) untouched.
+///
+/// Without this, README content with template placeholders like `{FOO}` or
+/// HTML-like tokens like `<TOKEN>` would be interpreted as MDX expressions/JSX
+/// and break `vocs dev` / `vocs build`.
 fn escape_mdx_outside_code_fences(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut fence: Option<FenceState> = None;
@@ -407,12 +408,8 @@ fn escape_mdx_outside_code_fences(text: &str) -> String {
     out
 }
 
-/// Byte ranges of `text` that sit inside a code fence or an inline code span
-/// (`` `...` ``), reusing `FenceState` so this agrees with
-/// `escape_mdx_outside_code_fences` about what counts as "code". Used by
-/// `rewrite_homepage_links` so it never mistakes Solidity syntax like
-/// `new address[](2)` for a markdown link.
-fn code_regions(text: &str) -> Vec<std::ops::Range<usize>> {
+/// Byte ranges of `text` that sit inside a code fence or an inline code span.
+fn code_regions(text: &str) -> Vec<Range<usize>> {
     let mut regions = Vec::new();
     let mut fence: Option<FenceState> = None;
     let mut offset = 0usize;
@@ -434,8 +431,8 @@ fn code_regions(text: &str) -> Vec<std::ops::Range<usize>> {
             continue;
         }
 
-        // Inline code spans (`` `...` `` or longer runs of backticks) within
-        // this line, mirroring escape_mdx_outside_code_fences's tick pairing.
+        // Inline code spans within this line, mirroring the tick pairing in
+        // `escape_mdx_outside_code_fences`.
         let mut pending_ticks = 0usize;
         let mut inline_code_ticks = 0usize;
         let mut span_start: Option<usize> = None;
@@ -461,10 +458,7 @@ fn code_regions(text: &str) -> Vec<std::ops::Range<usize>> {
             }
             pos += ch_len;
         }
-        // An unterminated run of backticks (odd number of tick groups) opens
-        // an inline span that extends to end-of-line, matching how
-        // escape_mdx_outside_code_fences treats the remainder of the line as
-        // inline code once `inline_code_ticks > 0`.
+        // An unterminated inline span extends to the end of the line.
         if inline_code_ticks > 0
             && let Some(start) = span_start
         {
@@ -478,9 +472,7 @@ fn code_regions(text: &str) -> Vec<std::ops::Range<usize>> {
 /// * `.sol` paths that resolve to a known page → vocs URL.
 /// * Any other relative path under `root` → `{repo}/blob/{commit}/...`.
 /// * Absolute URLs, anchors, and unresolved targets are left untouched.
-/// * Anything inside a code fence or inline code span is left untouched —
-///   Solidity syntax like `new address[](2)` looks like a markdown link
-///   (`](`) to a naive scanner but is not one.
+/// * Code fences and inline code spans are left untouched.
 fn rewrite_homepage_links(
     text: &str,
     base_dir: &Path,
@@ -489,7 +481,7 @@ fn rewrite_homepage_links(
     repo: Option<&str>,
     commit: Option<&str>,
 ) -> String {
-    let protected = code_regions(text);
+    let code_regions = code_regions(text);
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
     let mut consumed = 0usize;
@@ -498,6 +490,10 @@ fn rewrite_homepage_links(
         out.push_str(&rest[..open + 2]);
         rest = &rest[open + 2..];
         consumed += open + 2;
+        // Solidity syntax like `new address[](2)` inside code is not a link.
+        if code_regions.iter().any(|region| region.contains(&abs_open)) {
+            continue;
+        }
         // Scan the URL, counting parens so we don't split on `(` / `)` inside it.
         let bytes = rest.as_bytes();
         let mut i = 0;
@@ -518,9 +514,8 @@ fn rewrite_homepage_links(
                     i += 1;
                 }
                 b'\\' => {
-                    // Skip the escaped character. Clamp so a trailing
-                    // backslash at the very end of the text can't push `i`
-                    // past `bytes.len()` and panic the slice below.
+                    // Skip the escaped character; clamp so a trailing backslash
+                    // can't index past the end of the text.
                     i = (i + 2).min(bytes.len());
                 }
                 _ => {
@@ -529,13 +524,7 @@ fn rewrite_homepage_links(
             }
         }
         let target = &rest[..i];
-        let in_protected = protected.iter().any(|r| r.contains(&abs_open));
-        let rewritten = if in_protected {
-            None
-        } else {
-            try_rewrite_target(target, base_dir, root, src_to_url, repo, commit)
-        };
-        match rewritten {
+        match try_rewrite_target(target, base_dir, root, src_to_url, repo, commit) {
             Some(new) => out.push_str(&new),
             None => out.push_str(target),
         }
@@ -776,11 +765,7 @@ End {brace}.
     }
 
     #[test]
-    fn rewrite_homepage_links_leaves_code_fences_alone() {
-        // `new address[](2)` contains a literal `](` that a naive scanner
-        // mistakes for a markdown link — the fenced Solidity must survive
-        // byte-for-byte, while a real link in the surrounding prose still
-        // gets rewritten.
+    fn rewrite_homepage_links_leaves_code_alone() {
         let map = build_source_to_url(&[PathBuf::from("src/contract.Foo.mdx")]);
         let root = Path::new("/repo");
         let repo = Some("https://github.com/x/y");
@@ -791,41 +776,29 @@ See [Foo](./src/Foo.sol) for details.
 ```solidity
 function deploy() external {
     address[] memory targets = new address[](2);
-    bytes memory data = new bytes(4);
 }
 ```
 
-Also uses `new bytes(4)` inline.
+Also uses `new address[](2)` inline, then links [Contrib](./CONTRIBUTING.md).
 ";
-        let out = rewrite_homepage_links(input, Path::new("/repo"), root, &map, repo, commit);
+        let expected = "\
+See [Foo](/src/contract.Foo) for details.
 
-        // Real link outside the fence is still rewritten.
-        assert!(out.contains("[Foo](/src/contract.Foo)"), "prose link must still be rewritten");
-        // Fenced Solidity is untouched — no GitHub URL leaked into the array length.
-        assert!(
-            out.contains("new address[](2)"),
-            "array allocation inside a fence must survive unchanged, got: {out}"
-        );
-        assert!(
-            !out.contains("address[](https://"),
-            "must not rewrite `](` inside a code fence, got: {out}"
-        );
-        // Inline-code span outside the fence is also untouched.
-        assert!(
-            out.contains("`new bytes(4)`"),
-            "array allocation inside inline code must survive unchanged, got: {out}"
-        );
-        assert!(
-            !out.contains("bytes(https://"),
-            "must not rewrite `](` inside an inline code span, got: {out}"
-        );
+```solidity
+function deploy() external {
+    address[] memory targets = new address[](2);
+}
+```
+
+Also uses `new address[](2)` inline, then links [Contrib](https://github.com/x/y/blob/abc123/CONTRIBUTING.md).
+";
+        let out = rewrite_homepage_links(input, root, root, &map, repo, commit);
+        assert_eq!(out, expected);
     }
 
     #[test]
     fn rewrite_homepage_links_handles_trailing_unclosed_backslash() {
-        // A dangling `](` with no closing paren, ending in a literal
-        // backslash as the very last byte of the text, must not panic on an
-        // out-of-bounds slice.
+        // A dangling `](` whose target ends in a backslash must not panic.
         let map = SourceToUrl::new();
         let root = Path::new("/repo");
         let input = "See [Foo](abc\\";

--- a/crates/doc/src/vocs.rs
+++ b/crates/doc/src/vocs.rs
@@ -3,13 +3,16 @@
 //! Generates `vocs.config.ts`, `pages/index.mdx`, `package.json`, and `.gitignore`
 //! from the emitted MDX pages.
 
-use crate::utils::{git_raw_url, git_source_url};
+use crate::{
+    render::{code_regions, region_contains},
+    utils::{git_raw_url, git_source_url},
+};
 use foundry_config::DocConfig;
+use markdown::ParseOptions;
 use path_slash::PathExt;
 use std::{
     collections::HashMap,
     fs,
-    ops::Range,
     path::{Component, Path, PathBuf},
 };
 
@@ -318,39 +321,6 @@ fn build_source_to_url(pages: &[PathBuf]) -> SourceToUrl {
     map
 }
 
-/// Fence-open/close detection for a single markdown line, shared by
-/// `escape_mdx_outside_code_fences` and `code_regions` so both agree on what
-/// counts as "inside a code fence".
-struct FenceState {
-    marker: char,
-    len: usize,
-}
-
-impl FenceState {
-    /// If `trimmed` (a line with leading whitespace stripped) opens a code
-    /// fence, return the state to track until it closes.
-    fn opens(trimmed: &str) -> Option<Self> {
-        let marker = trimmed.chars().next()?;
-        if !matches!(marker, '`' | '~') {
-            return None;
-        }
-        let len = trimmed.chars().take_while(|&ch| ch == marker).count();
-        if len < 3 || marker == '`' && trimmed[len..].contains('`') {
-            return None;
-        }
-        Some(Self { marker, len })
-    }
-
-    /// Whether `trimmed` closes this fence (a line of `>= len` fence markers
-    /// and nothing else).
-    fn closes(&self, trimmed: &str) -> bool {
-        // Fence markers are ASCII, so their character count is also the byte index.
-        let marker_len = trimmed.chars().take_while(|&ch| ch == self.marker).count();
-        let suffix = &trimmed[marker_len..];
-        marker_len >= self.len && suffix.trim().is_empty()
-    }
-}
-
 /// Escape MDX-sensitive characters (`{` and `<`) in plain-text regions of a
 /// Markdown document, leaving fenced code blocks (` ``` ` or `~~~`) untouched.
 ///
@@ -358,17 +328,35 @@ impl FenceState {
 /// HTML-like tokens like `<TOKEN>` would be interpreted as MDX expressions/JSX
 /// and break `vocs dev` / `vocs build`.
 fn escape_mdx_outside_code_fences(text: &str) -> String {
+    struct Fence {
+        marker: char,
+        len: usize,
+    }
+
     let mut out = String::with_capacity(text.len());
-    let mut fence: Option<FenceState> = None;
+    let mut fence: Option<Fence> = None;
     for line in text.split_inclusive('\n') {
         let trimmed = line.trim_start();
         if let Some(open) = fence.as_ref() {
             out.push_str(line);
-            if open.closes(trimmed) {
+            let marker_len = trimmed.chars().take_while(|&ch| ch == open.marker).count();
+            // Fence markers are ASCII, so their character count is also the byte index.
+            let suffix = &trimmed[marker_len..];
+            if marker_len >= open.len && suffix.trim().is_empty() {
                 fence = None;
             }
         } else {
-            if let Some(opening) = FenceState::opens(trimmed) {
+            let opening = trimmed.chars().next().and_then(|marker| {
+                if !matches!(marker, '`' | '~') {
+                    return None;
+                }
+                let len = trimmed.chars().take_while(|&ch| ch == marker).count();
+                if len < 3 || marker == '`' && trimmed[len..].contains('`') {
+                    return None;
+                }
+                Some(Fence { marker, len })
+            });
+            if let Some(opening) = opening {
                 fence = Some(opening);
                 out.push_str(line);
                 continue;
@@ -408,66 +396,6 @@ fn escape_mdx_outside_code_fences(text: &str) -> String {
     out
 }
 
-/// Byte ranges of `text` that sit inside a code fence or an inline code span.
-fn code_regions(text: &str) -> Vec<Range<usize>> {
-    let mut regions = Vec::new();
-    let mut fence: Option<FenceState> = None;
-    let mut offset = 0usize;
-    for line in text.split_inclusive('\n') {
-        let line_start = offset;
-        offset += line.len();
-        let trimmed = line.trim_start();
-
-        if let Some(open) = fence.as_ref() {
-            regions.push(line_start..offset);
-            if open.closes(trimmed) {
-                fence = None;
-            }
-            continue;
-        }
-        if let Some(opening) = FenceState::opens(trimmed) {
-            fence = Some(opening);
-            regions.push(line_start..offset);
-            continue;
-        }
-
-        // Inline code spans within this line, mirroring the tick pairing in
-        // `escape_mdx_outside_code_fences`.
-        let mut pending_ticks = 0usize;
-        let mut inline_code_ticks = 0usize;
-        let mut span_start: Option<usize> = None;
-        let mut pos = line_start;
-        for ch in line.chars() {
-            let ch_len = ch.len_utf8();
-            if ch == '`' {
-                pending_ticks += 1;
-                pos += ch_len;
-                continue;
-            }
-            if pending_ticks > 0 {
-                if inline_code_ticks == 0 {
-                    inline_code_ticks = pending_ticks;
-                    span_start = Some(pos - pending_ticks);
-                } else if inline_code_ticks == pending_ticks {
-                    inline_code_ticks = 0;
-                    if let Some(start) = span_start.take() {
-                        regions.push(start..pos);
-                    }
-                }
-                pending_ticks = 0;
-            }
-            pos += ch_len;
-        }
-        // An unterminated inline span extends to the end of the line.
-        if inline_code_ticks > 0
-            && let Some(start) = span_start
-        {
-            regions.push(start..offset);
-        }
-    }
-    regions
-}
-
 /// Rewrite inline `[text](url)` markdown links in the homepage:
 /// * `.sol` paths that resolve to a known page → vocs URL.
 /// * Any other relative path under `root` → `{repo}/blob/{commit}/...`.
@@ -481,7 +409,10 @@ fn rewrite_homepage_links(
     repo: Option<&str>,
     commit: Option<&str>,
 ) -> String {
-    let code_regions = code_regions(text);
+    // The README is plain GitHub-flavored Markdown at this point, so parse it as such rather than
+    // as MDX, which may fail on unescaped `{`/`<` and would leave every region unprotected.
+    let code_regions = code_regions(text, &ParseOptions::gfm());
+    let mut region_cursor = 0;
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
     let mut consumed = 0usize;
@@ -491,7 +422,7 @@ fn rewrite_homepage_links(
         rest = &rest[open + 2..];
         consumed += open + 2;
         // Solidity syntax like `new address[](2)` inside code is not a link.
-        if code_regions.iter().any(|region| region.contains(&abs_open)) {
+        if region_contains(&code_regions, &mut region_cursor, abs_open) {
             continue;
         }
         // Scan the URL, counting parens so we don't split on `(` / `)` inside it.
@@ -780,6 +711,10 @@ function deploy() external {
 ```
 
 Also uses `new address[](2)` inline, then links [Contrib](./CONTRIBUTING.md).
+
+A lone ` backtick is not a code span: [Logo](./img/logo.png).
+
+    address[] memory indented = new address[](2);
 ";
         let expected = "\
 See [Foo](/src/contract.Foo) for details.
@@ -791,6 +726,10 @@ function deploy() external {
 ```
 
 Also uses `new address[](2)` inline, then links [Contrib](https://github.com/x/y/blob/abc123/CONTRIBUTING.md).
+
+A lone ` backtick is not a code span: [Logo](https://github.com/x/y/raw/abc123/img/logo.png).
+
+    address[] memory indented = new address[](2);
 ";
         let out = rewrite_homepage_links(input, root, root, &map, repo, commit);
         assert_eq!(out, expected);


### PR DESCRIPTION
`rewrite_homepage_links` scanned the raw README for `](` without any awareness of code fences or inline code, so Solidity such as `new address[](2)` in a README code sample ended up as `new address[](https://github.com/.../blob/<sha>/2)` on the generated `forge doc` homepage. The `escape_mdx_outside_code_fences` pass that runs right after it is fence-aware, this one was not.

The rewriter now skips any `](` that falls inside a code region. Regions come from the crate's existing AST-based `code_regions` helper in `render.rs`, parsing the README as GitHub-flavored Markdown rather than MDX, since the raw README may still contain unescaped `{` or `<` that only `escape_mdx_outside_code_fences` neutralizes afterwards. This also covers indented code blocks and inline spans that cross a line break, and it does not treat a lone backtick as the start of a span. The URL scanner also clamps its cursor after a trailing backslash, which previously panicked on a README ending in an unclosed link target followed by `\`.

Takes over the original PR by @gomesalexandre; the follow-up commits replace the hand-rolled fence scanner with the shared helper, skip protected matches before scanning for a target, and turn the test into a full-output comparison. AI assistance was used.
