### PR TITLE
fix(lint): analyze modifier bodies in arbitrary-send-erc20

### DIFF
--- a/.changelog/arbitrary-send-erc20-modifier-body.md
+++ b/.changelog/arbitrary-send-erc20-modifier-body.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+`arbitrary-send-erc20` now analyzes modifier bodies, so a `transferFrom` with an arbitrary `from` hidden inside a modifier is flagged the same way it already is when written inline.

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -1342,10 +1342,13 @@ fn seed_internal_callsite_facts<'hir>(
     }
 }
 
+/// Internal functions and modifiers are only reachable from within the contract hierarchy, so
+/// their parameters can be proven safe from their invocation sites.
 const fn is_internal_callsite_seed_candidate(func: &hir::Function<'_>) -> bool {
-    func.kind.is_function()
-        && matches!(func.visibility, ast::Visibility::Private | ast::Visibility::Internal)
-        && !func.parameters.is_empty()
+    let internal_only = matches!(func.kind, hir::FunctionKind::Modifier)
+        || (func.kind.is_function()
+            && matches!(func.visibility, ast::Visibility::Private | ast::Visibility::Internal));
+    internal_only && !func.parameters.is_empty()
 }
 
 thread_local! {
@@ -1387,7 +1390,14 @@ fn build_project_index<'hir>(
     let mut collector =
         InternalCallsiteCollector { gcx, hir, has_solady_lib, out: &mut index.internal_callsites };
     for fid in hir.function_ids() {
-        let Some(body) = hir.function(fid).body else { continue };
+        let func = hir.function(fid);
+        // Modifier invocations are the call sites of a modifier body.
+        for modifier in func.modifiers {
+            if let ItemId::Function(modifier_id) = modifier.id {
+                collector.record_call(modifier_id, &modifier.args);
+            }
+        }
+        let Some(body) = func.body else { continue };
         for stmt in body.stmts {
             let _ = collector.visit_stmt(stmt);
         }

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -1342,8 +1342,8 @@ fn seed_internal_callsite_facts<'hir>(
     }
 }
 
-/// Internal functions and modifiers are only reachable from within the contract hierarchy, so
-/// their parameters can be proven safe from their invocation sites.
+/// Internal functions and modifiers are only reachable from contracts in the compilation unit, so
+/// their parameters can be proven safe from the invocation sites seen there.
 const fn is_internal_callsite_seed_candidate(func: &hir::Function<'_>) -> bool {
     let internal_only = matches!(func.kind, hir::FunctionKind::Modifier)
         || (func.kind.is_function()

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -44,7 +44,7 @@ impl<'hir> LateLintPass<'hir> for ArbitrarySendErc20 {
         hir: &'hir hir::Hir<'hir>,
         func: &'hir hir::Function<'hir>,
     ) {
-        if !func.kind.is_function()
+        if matches!(func.kind, hir::FunctionKind::Constructor)
             || matches!(
                 func.state_mutability,
                 ast::StateMutability::Pure | ast::StateMutability::View

--- a/crates/lint/testdata/ArbitrarySendErc20.sol
+++ b/crates/lint/testdata/ArbitrarySendErc20.sol
@@ -733,6 +733,44 @@ contract ArbitrarySendErc20 {
         } while (false);
         token.transferFrom(x, to, a);
     }
+
+    // -- MODIFIER BODY SINKS --
+
+    modifier pullBad(address from, address to, uint256 a) {
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+        _;
+    }
+
+    function modifierSinkBad(address from, address to, uint256 a) public pullBad(from, to, a) {}
+
+    modifier guardedPullOk(address from, address to, uint256 a) {
+        require(from == msg.sender, "auth");
+        token.transferFrom(from, to, a);
+        _;
+    }
+
+    function modifierGuardedSinkOk(address from, address to, uint256 a) public guardedPullOk(from, to, a) {}
+
+    modifier pullBeforeGuardBad(address from, address to, uint256 a) {
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+        require(from == msg.sender, "auth");
+        _;
+    }
+
+    function modifierSinkBeforeGuardBad(address from, address to, uint256 a)
+        public
+        pullBeforeGuardBad(from, to, a)
+    {}
+
+    // -- FALLBACK / RECEIVE SINKS --
+    // `Fallback`/`Receive` are no longer excluded (only `Constructor` is); an unsafe sink
+    // reachable through either is a real finding, same as in an ordinary function.
+
+    fallback(bytes calldata data) external returns (bytes memory) {
+        address from = abi.decode(data, (address));
+        token.transferFrom(from, msg.sender, 1); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+        return "";
+    }
 }
 
 // Struct / array / mapping receivers.

--- a/crates/lint/testdata/ArbitrarySendErc20.sol
+++ b/crates/lint/testdata/ArbitrarySendErc20.sol
@@ -785,6 +785,26 @@ contract ArbitrarySendErc20 {
         pullFromMixedCallersBad(from, to, a)
     {}
 
+    // Statements after `_;` keep the prefix facts: parameters and locals cannot be changed by the
+    // wrapped function body, and mutable state is never trusted in the first place.
+    modifier guardedSuffixPullOk(address from, address to, uint256 a) {
+        require(from == msg.sender, "auth");
+        _;
+        token.transferFrom(from, to, a);
+    }
+
+    function modifierGuardedSuffixOk(address from, address to, uint256 a)
+        public
+        guardedSuffixPullOk(from, to, a)
+    {}
+
+    modifier suffixPullBad(address from, address to, uint256 a) {
+        _;
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+    }
+
+    function modifierSuffixSinkBad(address from, address to, uint256 a) public suffixPullBad(from, to, a) {}
+
     // -- FALLBACK SINKS --
     // Only constructors are excluded, so a sink reachable through `fallback`/`receive` is
     // reported like one in an ordinary function.
@@ -919,4 +939,25 @@ contract SafeERC721CallSites {
     function okSafeErc721ArbitraryFrom(address from, address to, uint256 tokenId) public {
         SafeERC721.safeTransferFrom(nft, from, to, tokenId);
     }
+}
+
+// A modifier declared in a base contract is seeded from the invocations in derived contracts.
+abstract contract PullModifierBase {
+    IERC20 internal token;
+
+    modifier pullFromCaller(address from, uint256 a) {
+        token.transferFrom(from, address(this), a);
+        _;
+    }
+
+    modifier pullFromAnyone(address from, uint256 a) {
+        token.transferFrom(from, address(this), a); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+        _;
+    }
+}
+
+contract PullModifierDerived is PullModifierBase {
+    function depositFromSender(uint256 a) external pullFromCaller(msg.sender, a) {}
+
+    function depositFrom(address from, uint256 a) external pullFromAnyone(from, a) {}
 }

--- a/crates/lint/testdata/ArbitrarySendErc20.sol
+++ b/crates/lint/testdata/ArbitrarySendErc20.sol
@@ -762,9 +762,32 @@ contract ArbitrarySendErc20 {
         pullBeforeGuardBad(from, to, a)
     {}
 
-    // -- FALLBACK / RECEIVE SINKS --
-    // `Fallback`/`Receive` are no longer excluded (only `Constructor` is); an unsafe sink
-    // reachable through either is a real finding, same as in an ordinary function.
+    // A modifier is only reachable through its invocations, so a `from` that is safe at every
+    // invocation site is not arbitrary.
+    modifier pullFromCallerOk(address from, address to, uint256 a) {
+        token.transferFrom(from, to, a);
+        _;
+    }
+
+    function modifierSenderInvocationOk(address to, uint256 a) public pullFromCallerOk(msg.sender, to, a) {}
+
+    function modifierSelfInvocationOk(address to, uint256 a) public pullFromCallerOk(address(this), to, a) {}
+
+    modifier pullFromMixedCallersBad(address from, address to, uint256 a) {
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+        _;
+    }
+
+    function modifierMixedSenderInvocation(address to, uint256 a) public pullFromMixedCallersBad(msg.sender, to, a) {}
+
+    function modifierMixedArbitraryInvocation(address from, address to, uint256 a)
+        public
+        pullFromMixedCallersBad(from, to, a)
+    {}
+
+    // -- FALLBACK SINKS --
+    // Only constructors are excluded, so a sink reachable through `fallback`/`receive` is
+    // reported like one in an ordinary function.
 
     fallback(bytes calldata data) external returns (bytes memory) {
         address from = abi.decode(data, (address));

--- a/crates/lint/testdata/ArbitrarySendErc20.stderr
+++ b/crates/lint/testdata/ArbitrarySendErc20.stderr
@@ -345,6 +345,30 @@ LL │ …     token.transferFrom(x, to, a);
 warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
    ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
    │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, msg.sender, 1);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
 LL │ …     cfg.token.transferFrom(from, to, a);
    │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ArbitrarySendErc20.stderr
+++ b/crates/lint/testdata/ArbitrarySendErc20.stderr
@@ -361,6 +361,14 @@ LL │ …     token.transferFrom(from, to, a);
 warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
    ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
    │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
 LL │ …     token.transferFrom(from, msg.sender, 1);
    │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ArbitrarySendErc20.stderr
+++ b/crates/lint/testdata/ArbitrarySendErc20.stderr
@@ -369,6 +369,14 @@ LL │ …     token.transferFrom(from, to, a);
 warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
    ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
    │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
 LL │ …     token.transferFrom(from, msg.sender, 1);
    │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -427,6 +435,14 @@ warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require 
    │
 LL │ …     SafeTransferLib.safeTransferFrom({token: token, from: from, to: to, amount: a});
    │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, address(this), a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
 


### PR DESCRIPTION
`arbitrary-send-erc20` returned early for every non-`Function` kind, so a `transferFrom` with an arbitrary `from` inside a modifier, `fallback`, or `receive` body was never reported, even though `arbitrary-send-eth` already analyzes those bodies. The filter now only excludes constructors, matching the sibling rule.

Because a modifier is only reachable through its invocations, the internal call-site seeding was extended to modifier invocations: a modifier parameter that receives `msg.sender` or `address(this)` at every invocation site is treated as safe, so `modifier pull(address from)` used only as `pull(msg.sender)` is not reported. The fixture covers unguarded and guarded modifier sinks, a sink before its guard, sinks after `_;`, all-safe and mixed invocation sites, a base-contract modifier invoked from a derived contract, and a `fallback` sink.

Takes over the original PR by @gomesalexandre; the follow-up commit adds the invocation-site seeding and its fixture cases. AI assistance was used.
