### PR TITLE
fix(lint): track struct fields in the ecrecover lint

### DIFF
--- a/.changelog/ecrecover-struct-fields.md
+++ b/.changelog/ecrecover-struct-fields.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed the `ecrecover` lint ignoring low-`s` guards on signature struct fields such as `sig.s`.

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -1372,6 +1372,11 @@ fn reference_args<'hir>(
     if !matches!(resolved.res, Res::Item(ItemId::Function(_))) {
         return Vec::new();
     }
+    let Some(ty) = gcx.type_of_expr(callee.id) else { return Vec::new() };
+    let TyKind::Fn(function_ty) = ty.kind else { return Vec::new() };
+    if !function_ty.is_internal() {
+        return Vec::new();
+    }
     let receiver = match &callee.kind {
         ExprKind::Member(base, _) if resolved.attached => Some(*base),
         _ => None,

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloy_primitives::{U256, uint};
 use solar::{
     ast::{BinOpKind, ElementaryType, UnOpKind},
-    interface::{Span, data_structures::Never},
+    interface::{Span, Symbol, data_structures::Never},
     sema::{
         Gcx,
         builtins::Builtin,
@@ -63,43 +63,25 @@ impl<'hir> LateLintPass<'hir> for Ecrecover {
     }
 }
 
-/// Identifies a trackable "place": either a whole variable, or a specific struct field
-/// reached from a variable (`sig` vs. `sig.s`). `Field` lets a malleability guard on
-/// `sig.s` be recorded and matched against a later `ecrecover(..., sig.s)` call, instead
-/// of falling back to an untracked `None` for any member expression.
+/// A tracked place: a whole variable, or a struct field reached from a variable (`sig.s`).
 ///
-/// The field variant carries an `epoch`, bumped by `FlowState::reset_var` whenever the
-/// whole base variable is reassigned/deleted/invalidated. Without it, a field that was
-/// only ever *read* (never explicitly written, e.g. via a `require` guard) has no entry
-/// in `values`, so it falls back to `ValueId::Initial(key)` - and since that fallback
-/// identity is purely structural (derived from `var` + field name), it would be *the
-/// same* identity before and after `sig = other;`, letting a stale low-s proof on the
-/// old struct silently survive onto the new one. Baking the epoch into the key ensures
-/// a post-reassignment read gets a fresh, previously-unproven identity instead.
+/// A field that is only ever read has no `values` entry and resolves to `ValueId::Initial(key)`,
+/// so the key carries an epoch that [`FlowState::reset_var`] bumps whenever the whole base
+/// variable is reassigned. Otherwise a guard on `sig.s` would survive `sig = other;`.
 ///
-/// Known limitation: a field is keyed by the *base variable's* id, with no alias
-/// tracking. Two storage/memory references to the same underlying struct (e.g.
-/// `Sig storage a = stored;` or `Sig memory a = sig;`) are different `VariableId`s, so a
-/// guard recorded through one does not follow a write made through the other. This can
-/// under-invalidate (a stale proof survives a write through an alias) as well as
-/// over-warn (a guard through an alias isn't visible to the other reference) - a
-/// pre-existing class of imprecision for this heuristic, best-effort analyzer, not
-/// something this field-tracking addition claims to solve.
+/// Fields are keyed by their base variable only, so aliases of the same struct are tracked
+/// independently.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum ValueKey {
     Var(hir::VariableId),
-    Field(hir::VariableId, solar::interface::Symbol, u32),
+    Field(hir::VariableId, Symbol, u32),
 }
 
 impl ValueKey {
     const fn var(&self) -> hir::VariableId {
         match self {
-            Self::Var(v) | Self::Field(v, _, _) => *v,
+            Self::Var(var) | Self::Field(var, _, _) => *var,
         }
-    }
-
-    fn touches(&self, v: hir::VariableId) -> bool {
-        self.var() == v
     }
 }
 
@@ -126,7 +108,7 @@ struct FlowState {
     values: HashMap<ValueKey, ValueId>,
     low_s: HashSet<ValueId>,
     pending: HashMap<ValueId, Vec<PendingRecovery>>,
-    /// Current field epoch per variable - see `ValueKey::Field`.
+    /// Current field epoch per variable, see [`ValueKey`].
     field_epoch: HashMap<hir::VariableId, u32>,
 }
 
@@ -154,15 +136,24 @@ impl FlowState {
         self.field_epoch.get(&var).copied().unwrap_or(0)
     }
 
-    fn field_key(&self, var: hir::VariableId, field: solar::interface::Symbol) -> ValueKey {
+    fn field_key(&self, var: hir::VariableId, field: Symbol) -> ValueKey {
         ValueKey::Field(var, field, self.field_epoch(var))
     }
 
-    /// Resets `var` to `value`, dropping every stale `Field(var, _, _)` fact and bumping
-    /// the field epoch so any subsequent, not-yet-rewritten field read gets a fresh
-    /// identity rather than reusing a pre-reset one that might already be proven low-s.
+    /// Sets the value of `key`, resetting the whole variable for a `Var` key.
+    fn set(&mut self, key: ValueKey, value: ValueId) {
+        match key {
+            ValueKey::Var(var) => self.reset_var(var, value),
+            ValueKey::Field(..) => {
+                self.values.insert(key, value);
+            }
+        }
+    }
+
+    /// Resets `var` to `value`, dropping every tracked field of `var` and starting a new field
+    /// epoch so that untracked fields no longer resolve to a possibly proven identity.
     fn reset_var(&mut self, var: hir::VariableId, value: ValueId) {
-        self.values.retain(|key, _| !key.touches(var));
+        self.values.retain(|key, _| key.var() != var);
         *self.field_epoch.entry(var).or_insert(0) += 1;
         self.values.insert(ValueKey::Var(var), value);
     }
@@ -212,8 +203,8 @@ impl<'hir> Analyzer<'hir> {
     }
 
     fn join(&mut self, left: FlowState, right: FlowState) -> FlowState {
-        // Take the max epoch per var from either branch so a field read after the join
-        // never coincides with an identity used pre-join in either branch.
+        // Keep the highest epoch so a field read after the join never reuses an identity that
+        // was reset in either branch.
         let mut field_epoch = left.field_epoch.clone();
         for (var, epoch) in &right.field_epoch {
             field_epoch.entry(*var).and_modify(|e| *e = (*e).max(*epoch)).or_insert(*epoch);
@@ -329,12 +320,7 @@ impl<'hir> Analyzer<'hir> {
                 args.exprs().next().and_then(|arg| self.current_value(arg))
             }
             ExprKind::Assign(lhs, None, _) => self.current_value(lhs),
-            // `sig.s`: a struct-field access. Without this arm every field read is
-            // untracked, so a guard like `require(uint256(sig.s) <= HALF_ORDER)` records
-            // no fact and the lint fires unconditionally on correctly-guarded code.
-            ExprKind::Member(base, field) => {
-                underlying_var(base).map(|var| self.state.value(self.state.field_key(var, field.name)))
-            }
+            ExprKind::Member(..) => self.place_key(expr).map(|key| self.state.value(key)),
             _ => None,
         }
     }
@@ -524,61 +510,23 @@ impl<'hir> Analyzer<'hir> {
         }
     }
 
-    fn assign_var_value(&mut self, var: hir::VariableId, assigned: AssignedValue) {
+    fn assign_value(&mut self, key: ValueKey, assigned: AssignedValue) {
         let value = assigned.value.unwrap_or_else(|| self.fresh_value());
         if assigned.low_s {
             self.state.low_s.insert(value);
         }
-        // A whole-value reassignment (`sig = newSig;`) supersedes any previously-tracked
-        // field (`sig.s`), so drop stale `Field(var, _, _)` facts along with the old `Var`
-        // entry - otherwise a guard on the old struct would incorrectly survive onto
-        // the new one. `reset_var` also bumps the field epoch, so even a field that was
-        // only ever *read* (never explicitly written, so never had a `values` entry to
-        // drop here) can't keep resolving to its pre-reassignment identity.
-        self.state.reset_var(var, value);
-    }
-
-    /// Handles a direct field write (`sig.s = value;`), which `collect_assignments`
-    /// cannot see since `underlying_var` never resolves a `Member` expression to a
-    /// variable. Without this, the stale fact from an earlier guard on `sig.s` would
-    /// survive the write, and a subsequent `ecrecover(..., sig.s)` would be judged safe
-    /// even though `sig.s` may now be attacker-controlled. Recurses through tuples the
-    /// same way `collect_assignments` does, so `(sig.s, sig.v) = (attackerS, newV);`
-    /// invalidates `sig.s` too, instead of only being visible to `assign_lhs` (which
-    /// skips a tuple element it can't resolve to a whole variable).
-    fn assign_member(&mut self, lhs: &'hir hir::Expr<'hir>, rhs: Option<&'hir hir::Expr<'hir>>) {
-        if let ExprKind::Tuple(lhs_elems) = &lhs.peel_parens().kind {
-            let rhs_elems = match rhs.map(|rhs| &rhs.peel_parens().kind) {
-                Some(ExprKind::Tuple(elems)) => Some(*elems),
-                _ => None,
-            };
-            for (index, elem) in lhs_elems.iter().enumerate() {
-                let Some(elem) = elem else { continue };
-                let elem_rhs = rhs_elems.and_then(|elems| elems.get(index)).copied().flatten();
-                self.assign_member(elem, elem_rhs);
-            }
-            return;
-        }
-        let ExprKind::Member(base, field) = &lhs.peel_parens().kind else { return };
-        let Some(var) = underlying_var(base) else { return };
-        let assigned = self.assigned_value(rhs);
-        let value = assigned.value.unwrap_or_else(|| self.fresh_value());
-        if assigned.low_s {
-            self.state.low_s.insert(value);
-        }
-        let key = self.state.field_key(var, field.name);
-        self.state.values.insert(key, value);
+        self.state.set(key, value);
     }
 
     fn assign_var(&mut self, var: hir::VariableId, rhs: Option<&'hir hir::Expr<'hir>>) {
-        self.assign_var_value(var, self.assigned_value(rhs));
+        self.assign_value(ValueKey::Var(var), self.assigned_value(rhs));
     }
 
     fn assign_lhs(&mut self, lhs: &'hir hir::Expr<'hir>, rhs: Option<&'hir hir::Expr<'hir>>) {
         let mut assignments = Vec::new();
         self.collect_assignments(lhs, rhs, &mut assignments);
-        for (var, assigned) in assignments {
-            self.assign_var_value(var, assigned);
+        for (key, assigned) in assignments {
+            self.assign_value(key, assigned);
         }
     }
 
@@ -586,7 +534,7 @@ impl<'hir> Analyzer<'hir> {
         &self,
         lhs: &'hir hir::Expr<'hir>,
         rhs: Option<&'hir hir::Expr<'hir>>,
-        assignments: &mut Vec<(hir::VariableId, AssignedValue)>,
+        assignments: &mut Vec<(ValueKey, AssignedValue)>,
     ) {
         if let ExprKind::Tuple(lhs_elems) = &lhs.peel_parens().kind {
             let rhs_elems = match rhs.map(|rhs| &rhs.peel_parens().kind) {
@@ -598,56 +546,44 @@ impl<'hir> Analyzer<'hir> {
                 let rhs = rhs_elems.and_then(|elems| elems.get(index)).copied().flatten();
                 self.collect_assignments(lhs, rhs, assignments);
             }
-        } else if let Some(var) = underlying_var(lhs) {
-            assignments.push((var, self.assigned_value(rhs)));
+        } else if let Some(key) = self.place_key(lhs) {
+            assignments.push((key, self.assigned_value(rhs)));
         }
+    }
+
+    /// Resolves an assignable expression to its tracked place, if any.
+    fn place_key(&self, expr: &hir::Expr<'_>) -> Option<ValueKey> {
+        if let Some(var) = underlying_var(expr) {
+            return Some(ValueKey::Var(var));
+        }
+        if let ExprKind::Member(base, field) = &expr.peel_parens().kind
+            && let Some(var) = underlying_var(base)
+        {
+            return Some(self.state.field_key(var, field.name));
+        }
+        None
     }
 
     fn mark_deleted(&mut self, target: &'hir hir::Expr<'hir>) {
-        if let Some(var) = underlying_var(target) {
-            let value = self.fresh_value();
-            self.state.reset_var(var, value);
-            self.state.low_s.insert(value);
-            return;
-        }
-        // `delete sig.s;` resets just that field to its zero value, which is trivially
-        // low-s - proven, same as the whole-variable case above.
-        if let ExprKind::Member(base, field) = &target.peel_parens().kind
-            && let Some(var) = underlying_var(base)
-        {
-            let value = self.fresh_value();
-            let key = self.state.field_key(var, field.name);
-            self.state.values.insert(key, value);
-            self.state.low_s.insert(value);
-        }
+        let Some(key) = self.place_key(target) else { return };
+        let value = self.fresh_value();
+        self.state.set(key, value);
+        self.state.low_s.insert(value);
     }
 
     fn invalidate(&mut self, target: &'hir hir::Expr<'hir>) {
-        if let Some(var) = underlying_var(target) {
-            self.invalidate_var(var);
-            return;
-        }
-        // `sig.s++`/`sig.s--` etc.: install a *fresh* value for the field, mirroring
-        // `invalidate_var` for a single field instead of the whole variable. Removing
-        // the entry instead of overwriting it would not be enough - a lookup miss falls
-        // back to `ValueId::Initial(field_key)`, the exact same structural identity the
-        // field held before this write, which may already sit in `low_s` from an earlier
-        // guard (e.g. `require(sig.s <= HALF_ORDER); sig.s++;` must not still read as
-        // proven).
-        if let ExprKind::Member(base, field) = &target.peel_parens().kind
-            && let Some(var) = underlying_var(base)
-        {
-            let key = self.state.field_key(var, field.name);
-            let value = self.fresh_value();
-            self.state.values.insert(key, value);
+        if let Some(key) = self.place_key(target) {
+            self.invalidate_key(key);
         }
     }
 
     fn invalidate_var(&mut self, var: hir::VariableId) {
+        self.invalidate_key(ValueKey::Var(var));
+    }
+
+    fn invalidate_key(&mut self, key: ValueKey) {
         let value = self.fresh_value();
-        // Drop any tracked field facts under `var` along with its own value - see
-        // `assign_var_value` for why a whole-variable write must invalidate both.
-        self.state.reset_var(var, value);
+        self.state.set(key, value);
     }
 
     fn tracked_vars(&self) -> HashSet<hir::VariableId> {
@@ -1351,7 +1287,6 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
                     );
                     self.deferred_calls = deferred_calls;
                     self.assign_lhs(lhs, Some(rhs));
-                    self.assign_member(lhs, Some(rhs));
                     for (var, recovery) in recoveries {
                         self.record_pending(var, recovery);
                     }
@@ -1364,7 +1299,6 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
                 }
                 let result = self.walk_expr(expr);
                 self.assign_lhs(lhs, None);
-                self.assign_member(lhs, None);
                 return result;
             }
             ExprKind::Delete(target) => {
@@ -1418,12 +1352,19 @@ fn underlying_var(expr: &hir::Expr<'_>) -> Option<hir::VariableId> {
 }
 
 fn collect_lhs_vars(expr: &hir::Expr<'_>, vars: &mut HashSet<hir::VariableId>) {
-    if let ExprKind::Tuple(exprs) = &expr.peel_parens().kind {
-        for expr in exprs.iter().flatten() {
-            collect_lhs_vars(expr, vars);
+    match &expr.peel_parens().kind {
+        ExprKind::Tuple(exprs) => {
+            for expr in exprs.iter().flatten() {
+                collect_lhs_vars(expr, vars);
+            }
         }
-    } else if let Some(var) = underlying_var(expr) {
-        vars.insert(var);
+        // A field write is attributed to its base variable.
+        ExprKind::Member(base, _) => collect_lhs_vars(base, vars),
+        _ => {
+            if let Some(var) = underlying_var(expr) {
+                vars.insert(var);
+            }
+        }
     }
 }
 

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -63,9 +63,49 @@ impl<'hir> LateLintPass<'hir> for Ecrecover {
     }
 }
 
+/// Identifies a trackable "place": either a whole variable, or a specific struct field
+/// reached from a variable (`sig` vs. `sig.s`). `Field` lets a malleability guard on
+/// `sig.s` be recorded and matched against a later `ecrecover(..., sig.s)` call, instead
+/// of falling back to an untracked `None` for any member expression.
+///
+/// The field variant carries an `epoch`, bumped by `FlowState::reset_var` whenever the
+/// whole base variable is reassigned/deleted/invalidated. Without it, a field that was
+/// only ever *read* (never explicitly written, e.g. via a `require` guard) has no entry
+/// in `values`, so it falls back to `ValueId::Initial(key)` - and since that fallback
+/// identity is purely structural (derived from `var` + field name), it would be *the
+/// same* identity before and after `sig = other;`, letting a stale low-s proof on the
+/// old struct silently survive onto the new one. Baking the epoch into the key ensures
+/// a post-reassignment read gets a fresh, previously-unproven identity instead.
+///
+/// Known limitation: a field is keyed by the *base variable's* id, with no alias
+/// tracking. Two storage/memory references to the same underlying struct (e.g.
+/// `Sig storage a = stored;` or `Sig memory a = sig;`) are different `VariableId`s, so a
+/// guard recorded through one does not follow a write made through the other. This can
+/// under-invalidate (a stale proof survives a write through an alias) as well as
+/// over-warn (a guard through an alias isn't visible to the other reference) - a
+/// pre-existing class of imprecision for this heuristic, best-effort analyzer, not
+/// something this field-tracking addition claims to solve.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum ValueKey {
+    Var(hir::VariableId),
+    Field(hir::VariableId, solar::interface::Symbol, u32),
+}
+
+impl ValueKey {
+    const fn var(&self) -> hir::VariableId {
+        match self {
+            Self::Var(v) | Self::Field(v, _, _) => *v,
+        }
+    }
+
+    fn touches(&self, v: hir::VariableId) -> bool {
+        self.var() == v
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum ValueId {
-    Initial(hir::VariableId),
+    Initial(ValueKey),
     Assigned(u32),
 }
 
@@ -83,9 +123,11 @@ struct PendingRecovery {
 
 #[derive(Clone, Default)]
 struct FlowState {
-    values: HashMap<hir::VariableId, ValueId>,
+    values: HashMap<ValueKey, ValueId>,
     low_s: HashSet<ValueId>,
     pending: HashMap<ValueId, Vec<PendingRecovery>>,
+    /// Current field epoch per variable - see `ValueKey::Field`.
+    field_epoch: HashMap<hir::VariableId, u32>,
 }
 
 #[derive(Clone, Default)]
@@ -104,8 +146,25 @@ impl LoopEffects {
 }
 
 impl FlowState {
-    fn value(&self, var: hir::VariableId) -> ValueId {
-        self.values.get(&var).copied().unwrap_or(ValueId::Initial(var))
+    fn value(&self, key: ValueKey) -> ValueId {
+        self.values.get(&key).copied().unwrap_or(ValueId::Initial(key))
+    }
+
+    fn field_epoch(&self, var: hir::VariableId) -> u32 {
+        self.field_epoch.get(&var).copied().unwrap_or(0)
+    }
+
+    fn field_key(&self, var: hir::VariableId, field: solar::interface::Symbol) -> ValueKey {
+        ValueKey::Field(var, field, self.field_epoch(var))
+    }
+
+    /// Resets `var` to `value`, dropping every stale `Field(var, _, _)` fact and bumping
+    /// the field epoch so any subsequent, not-yet-rewritten field read gets a fresh
+    /// identity rather than reusing a pre-reset one that might already be proven low-s.
+    fn reset_var(&mut self, var: hir::VariableId, value: ValueId) {
+        self.values.retain(|key, _| !key.touches(var));
+        *self.field_epoch.entry(var).or_insert(0) += 1;
+        self.values.insert(ValueKey::Var(var), value);
     }
 }
 
@@ -153,8 +212,15 @@ impl<'hir> Analyzer<'hir> {
     }
 
     fn join(&mut self, left: FlowState, right: FlowState) -> FlowState {
+        // Take the max epoch per var from either branch so a field read after the join
+        // never coincides with an identity used pre-join in either branch.
+        let mut field_epoch = left.field_epoch.clone();
+        for (var, epoch) in &right.field_epoch {
+            field_epoch.entry(*var).and_modify(|e| *e = (*e).max(*epoch)).or_insert(*epoch);
+        }
         let mut joined = FlowState {
             low_s: left.low_s.intersection(&right.low_s).copied().collect(),
+            field_epoch,
             ..FlowState::default()
         };
         let vars: HashSet<_> = left.values.keys().chain(right.values.keys()).copied().collect();
@@ -205,7 +271,7 @@ impl<'hir> Analyzer<'hir> {
     }
 
     fn record_pending(&mut self, var: hir::VariableId, recovery: PendingRecovery) {
-        let value = self.state.value(var);
+        let value = self.state.value(ValueKey::Var(var));
         let recoveries = self.state.pending.entry(value).or_default();
         if !recoveries.iter().any(|existing| {
             existing.span == recovery.span && existing.signature == recovery.signature
@@ -226,7 +292,8 @@ impl<'hir> Analyzer<'hir> {
     }
 
     fn use_return_values(&mut self) {
-        let values: Vec<_> = self.returns.iter().map(|var| self.state.value(*var)).collect();
+        let values: Vec<_> =
+            self.returns.iter().map(|var| self.state.value(ValueKey::Var(*var))).collect();
         for value in values {
             self.use_value(value);
         }
@@ -253,7 +320,7 @@ impl<'hir> Analyzer<'hir> {
     fn current_value(&self, expr: &'hir hir::Expr<'hir>) -> Option<ValueId> {
         match &expr.peel_parens().kind {
             ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
-                Res::Item(ItemId::Variable(var)) => Some(self.state.value(*var)),
+                Res::Item(ItemId::Variable(var)) => Some(self.state.value(ValueKey::Var(*var))),
                 _ => None,
             }),
             ExprKind::Call(callee, args, _)
@@ -262,6 +329,12 @@ impl<'hir> Analyzer<'hir> {
                 args.exprs().next().and_then(|arg| self.current_value(arg))
             }
             ExprKind::Assign(lhs, None, _) => self.current_value(lhs),
+            // `sig.s`: a struct-field access. Without this arm every field read is
+            // untracked, so a guard like `require(uint256(sig.s) <= HALF_ORDER)` records
+            // no fact and the lint fires unconditionally on correctly-guarded code.
+            ExprKind::Member(base, field) => {
+                underlying_var(base).map(|var| self.state.value(self.state.field_key(var, field.name)))
+            }
             _ => None,
         }
     }
@@ -371,7 +444,7 @@ impl<'hir> Analyzer<'hir> {
         let mut vars = HashSet::new();
         collect_lhs_vars(lhs, &mut vars);
         for var in vars {
-            self.ignored_reads.insert(self.state.value(var));
+            self.ignored_reads.insert(self.state.value(ValueKey::Var(var)));
         }
         let _ = self.visit_expr(lhs);
         self.ignored_reads = ignored_reads;
@@ -456,7 +529,45 @@ impl<'hir> Analyzer<'hir> {
         if assigned.low_s {
             self.state.low_s.insert(value);
         }
-        self.state.values.insert(var, value);
+        // A whole-value reassignment (`sig = newSig;`) supersedes any previously-tracked
+        // field (`sig.s`), so drop stale `Field(var, _, _)` facts along with the old `Var`
+        // entry - otherwise a guard on the old struct would incorrectly survive onto
+        // the new one. `reset_var` also bumps the field epoch, so even a field that was
+        // only ever *read* (never explicitly written, so never had a `values` entry to
+        // drop here) can't keep resolving to its pre-reassignment identity.
+        self.state.reset_var(var, value);
+    }
+
+    /// Handles a direct field write (`sig.s = value;`), which `collect_assignments`
+    /// cannot see since `underlying_var` never resolves a `Member` expression to a
+    /// variable. Without this, the stale fact from an earlier guard on `sig.s` would
+    /// survive the write, and a subsequent `ecrecover(..., sig.s)` would be judged safe
+    /// even though `sig.s` may now be attacker-controlled. Recurses through tuples the
+    /// same way `collect_assignments` does, so `(sig.s, sig.v) = (attackerS, newV);`
+    /// invalidates `sig.s` too, instead of only being visible to `assign_lhs` (which
+    /// skips a tuple element it can't resolve to a whole variable).
+    fn assign_member(&mut self, lhs: &'hir hir::Expr<'hir>, rhs: Option<&'hir hir::Expr<'hir>>) {
+        if let ExprKind::Tuple(lhs_elems) = &lhs.peel_parens().kind {
+            let rhs_elems = match rhs.map(|rhs| &rhs.peel_parens().kind) {
+                Some(ExprKind::Tuple(elems)) => Some(*elems),
+                _ => None,
+            };
+            for (index, elem) in lhs_elems.iter().enumerate() {
+                let Some(elem) = elem else { continue };
+                let elem_rhs = rhs_elems.and_then(|elems| elems.get(index)).copied().flatten();
+                self.assign_member(elem, elem_rhs);
+            }
+            return;
+        }
+        let ExprKind::Member(base, field) = &lhs.peel_parens().kind else { return };
+        let Some(var) = underlying_var(base) else { return };
+        let assigned = self.assigned_value(rhs);
+        let value = assigned.value.unwrap_or_else(|| self.fresh_value());
+        if assigned.low_s {
+            self.state.low_s.insert(value);
+        }
+        let key = self.state.field_key(var, field.name);
+        self.state.values.insert(key, value);
     }
 
     fn assign_var(&mut self, var: hir::VariableId, rhs: Option<&'hir hir::Expr<'hir>>) {
@@ -493,29 +604,59 @@ impl<'hir> Analyzer<'hir> {
     }
 
     fn mark_deleted(&mut self, target: &'hir hir::Expr<'hir>) {
-        let Some(var) = underlying_var(target) else { return };
-        let value = self.fresh_value();
-        self.state.values.insert(var, value);
-        self.state.low_s.insert(value);
+        if let Some(var) = underlying_var(target) {
+            let value = self.fresh_value();
+            self.state.reset_var(var, value);
+            self.state.low_s.insert(value);
+            return;
+        }
+        // `delete sig.s;` resets just that field to its zero value, which is trivially
+        // low-s - proven, same as the whole-variable case above.
+        if let ExprKind::Member(base, field) = &target.peel_parens().kind
+            && let Some(var) = underlying_var(base)
+        {
+            let value = self.fresh_value();
+            let key = self.state.field_key(var, field.name);
+            self.state.values.insert(key, value);
+            self.state.low_s.insert(value);
+        }
     }
 
     fn invalidate(&mut self, target: &'hir hir::Expr<'hir>) {
-        let Some(var) = underlying_var(target) else { return };
-        self.invalidate_var(var);
+        if let Some(var) = underlying_var(target) {
+            self.invalidate_var(var);
+            return;
+        }
+        // `sig.s++`/`sig.s--` etc.: install a *fresh* value for the field, mirroring
+        // `invalidate_var` for a single field instead of the whole variable. Removing
+        // the entry instead of overwriting it would not be enough - a lookup miss falls
+        // back to `ValueId::Initial(field_key)`, the exact same structural identity the
+        // field held before this write, which may already sit in `low_s` from an earlier
+        // guard (e.g. `require(sig.s <= HALF_ORDER); sig.s++;` must not still read as
+        // proven).
+        if let ExprKind::Member(base, field) = &target.peel_parens().kind
+            && let Some(var) = underlying_var(base)
+        {
+            let key = self.state.field_key(var, field.name);
+            let value = self.fresh_value();
+            self.state.values.insert(key, value);
+        }
     }
 
     fn invalidate_var(&mut self, var: hir::VariableId) {
         let value = self.fresh_value();
-        self.state.values.insert(var, value);
+        // Drop any tracked field facts under `var` along with its own value - see
+        // `assign_var_value` for why a whole-variable write must invalidate both.
+        self.state.reset_var(var, value);
     }
 
     fn tracked_vars(&self) -> HashSet<hir::VariableId> {
         self.state
             .values
             .keys()
-            .copied()
+            .map(ValueKey::var)
             .chain(self.state.low_s.iter().filter_map(|value| match value {
-                ValueId::Initial(var) => Some(*var),
+                ValueId::Initial(key) => Some(key.var()),
                 ValueId::Assigned(_) => None,
             }))
             .collect()
@@ -1210,18 +1351,20 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
                     );
                     self.deferred_calls = deferred_calls;
                     self.assign_lhs(lhs, Some(rhs));
+                    self.assign_member(lhs, Some(rhs));
                     for (var, recovery) in recoveries {
                         self.record_pending(var, recovery);
                     }
                     if let Some(target) = target
                         && !result_is_stored
                     {
-                        self.use_value(self.state.value(target));
+                        self.use_value(self.state.value(ValueKey::Var(target)));
                     }
                     return ControlFlow::Continue(());
                 }
                 let result = self.walk_expr(expr);
                 self.assign_lhs(lhs, None);
+                self.assign_member(lhs, None);
                 return result;
             }
             ExprKind::Delete(target) => {

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -69,9 +69,8 @@ impl<'hir> LateLintPass<'hir> for Ecrecover {
 /// so the key carries an epoch that [`FlowState::reset_var`] bumps whenever the whole base
 /// variable is reassigned. Otherwise a guard on `sig.s` would survive `sig = other;`.
 ///
-/// Fields are keyed by their base variable only, so aliases of the same struct are tracked
-/// independently: a write through one alias does not invalidate a guard recorded through another
-/// and can be missed.
+/// Fields are keyed by their base variable. Writes through memory or storage references
+/// conservatively invalidate field facts for other potentially aliasing variables.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum ValueKey {
     Var(hir::VariableId),
@@ -157,6 +156,12 @@ impl FlowState {
         self.values.retain(|key, _| key.var() != var);
         *self.field_epoch.entry(var).or_insert(0) += 1;
         self.values.insert(ValueKey::Var(var), value);
+    }
+
+    /// Drops tracked fields of `var` and starts a new field epoch.
+    fn reset_fields(&mut self, var: hir::VariableId) {
+        self.values.retain(|key, _| !matches!(key, ValueKey::Field(base, ..) if *base == var));
+        *self.field_epoch.entry(var).or_insert(0) += 1;
     }
 }
 
@@ -517,7 +522,7 @@ impl<'hir> Analyzer<'hir> {
         if assigned.low_s {
             self.state.low_s.insert(value);
         }
-        self.state.set(key, value);
+        self.set_value(key, value);
     }
 
     fn assign_var(&mut self, var: hir::VariableId, rhs: Option<&'hir hir::Expr<'hir>>) {
@@ -569,7 +574,7 @@ impl<'hir> Analyzer<'hir> {
     fn mark_deleted(&mut self, target: &'hir hir::Expr<'hir>) {
         let Some(key) = self.place_key(target) else { return };
         let value = self.fresh_value();
-        self.state.set(key, value);
+        self.set_value(key, value);
         self.state.low_s.insert(value);
     }
 
@@ -585,7 +590,39 @@ impl<'hir> Analyzer<'hir> {
 
     fn invalidate_key(&mut self, key: ValueKey) {
         let value = self.fresh_value();
+        self.set_value(key, value);
+    }
+
+    fn set_value(&mut self, key: ValueKey, value: ValueId) {
+        let ValueKey::Field(var, field, _) = key else {
+            self.state.set(key, value);
+            return;
+        };
+        self.invalidate_aliasable_fields(var);
+        let key = self.state.field_key(var, field);
         self.state.set(key, value);
+    }
+
+    fn invalidate_aliasable_fields(&mut self, written: hir::VariableId) {
+        let Some(location) = self.aliasable_location(written) else {
+            return;
+        };
+        for var in self.tracked_vars() {
+            if var != written && self.aliasable_location(var) == Some(location) {
+                self.state.reset_fields(var);
+            }
+        }
+    }
+
+    fn aliasable_location(&self, var: hir::VariableId) -> Option<hir::DataLocation> {
+        let var = self.hir.variable(var);
+        if var.kind.is_state() && !var.is_constant() && !var.is_immutable() {
+            Some(hir::DataLocation::Storage)
+        } else {
+            var.data_location.filter(|location| {
+                matches!(location, hir::DataLocation::Memory | hir::DataLocation::Storage)
+            })
+        }
     }
 
     fn tracked_vars(&self) -> HashSet<hir::VariableId> {
@@ -1368,17 +1405,17 @@ fn reference_args<'hir>(
     args: &'hir hir::CallArgs<'hir>,
 ) -> Vec<hir::VariableId> {
     let callee = callee.peel_parens();
-    let Some(resolved) = gcx.resolved_callee(callee.id) else { return Vec::new() };
-    if !matches!(resolved.res, Res::Item(ItemId::Function(_))) {
-        return Vec::new();
-    }
     let Some(ty) = gcx.type_of_expr(callee.id) else { return Vec::new() };
     let TyKind::Fn(function_ty) = ty.kind else { return Vec::new() };
     if !function_ty.is_internal() {
         return Vec::new();
     }
     let receiver = match &callee.kind {
-        ExprKind::Member(base, _) if resolved.attached => Some(*base),
+        ExprKind::Member(base, _)
+            if gcx.resolved_callee(callee.id).is_some_and(|resolved| resolved.attached) =>
+        {
+            Some(*base)
+        }
         _ => None,
     };
     receiver

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -70,7 +70,8 @@ impl<'hir> LateLintPass<'hir> for Ecrecover {
 /// variable is reassigned. Otherwise a guard on `sig.s` would survive `sig = other;`.
 ///
 /// Fields are keyed by their base variable only, so aliases of the same struct are tracked
-/// independently.
+/// independently: a write through one alias does not invalidate a guard recorded through another
+/// and can be missed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum ValueKey {
     Var(hir::VariableId),
@@ -204,7 +205,8 @@ impl<'hir> Analyzer<'hir> {
 
     fn join(&mut self, left: FlowState, right: FlowState) -> FlowState {
         // Keep the highest epoch so a field read after the join never reuses an identity that
-        // was reset in either branch.
+        // was reset in either branch. A field proven in both branches at different epochs is
+        // dropped by the intersection below, which over-warns rather than under-warns.
         let mut field_epoch = left.field_epoch.clone();
         for (var, epoch) in &right.field_epoch {
             field_epoch.entry(*var).and_modify(|e| *e = (*e).max(*epoch)).or_insert(*epoch);
@@ -604,7 +606,9 @@ impl<'hir> Analyzer<'hir> {
             .into_iter()
             .filter(|var| {
                 let var = self.hir.variable(*var);
-                var.kind.is_state() && !var.is_constant() && !var.is_immutable()
+                // Storage pointers alias mutable state.
+                (var.kind.is_state() && !var.is_constant() && !var.is_immutable())
+                    || var.data_location == Some(hir::DataLocation::Storage)
             })
             .collect();
         for var in vars {
@@ -829,6 +833,7 @@ impl<'hir> Analyzer<'hir> {
                     }
                 }
                 effects.mutable_state |= call_may_mutate_state(self.gcx, self.hir, callee);
+                effects.values.extend(reference_args(self.gcx, self.hir, callee, args));
             }
             ExprKind::Index(base, index) => {
                 self.add_expr_effects(base, effects);
@@ -1320,10 +1325,13 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
         }
 
         let result = self.walk_expr(expr);
-        if let ExprKind::Call(callee, _, _) = &expr.kind
-            && call_may_mutate_state(self.gcx, self.hir, callee)
-        {
-            self.invalidate_mutable_state();
+        if let ExprKind::Call(callee, args, _) = &expr.kind {
+            if call_may_mutate_state(self.gcx, self.hir, callee) {
+                self.invalidate_mutable_state();
+            }
+            for var in reference_args(self.gcx, self.hir, callee, args) {
+                self.invalidate_var(var);
+            }
         }
         if let Some(recovery) = self.pending_recovery(expr) {
             if self.deferred_calls.contains(&expr.peel_parens().id) {
@@ -1349,6 +1357,36 @@ fn underlying_var(expr: &hir::Expr<'_>) -> Option<hir::VariableId> {
         }
         _ => None,
     }
+}
+
+/// Memory and storage variables passed by reference to a user-defined function, including the
+/// receiver of a `using for` call, which the callee may write through.
+fn reference_args<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &hir::Hir<'hir>,
+    callee: &'hir hir::Expr<'hir>,
+    args: &'hir hir::CallArgs<'hir>,
+) -> Vec<hir::VariableId> {
+    let callee = callee.peel_parens();
+    let Some(resolved) = gcx.resolved_callee(callee.id) else { return Vec::new() };
+    if !matches!(resolved.res, Res::Item(ItemId::Function(_))) {
+        return Vec::new();
+    }
+    let receiver = match &callee.kind {
+        ExprKind::Member(base, _) if resolved.attached => Some(*base),
+        _ => None,
+    };
+    receiver
+        .into_iter()
+        .chain(args.exprs())
+        .filter_map(underlying_var)
+        .filter(|&var| {
+            matches!(
+                hir.variable(var).data_location,
+                Some(hir::DataLocation::Memory | hir::DataLocation::Storage)
+            )
+        })
+        .collect()
 }
 
 fn collect_lhs_vars(expr: &hir::Expr<'_>, vars: &mut HashSet<hir::VariableId>) {

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -17,6 +17,14 @@ contract Ecrecover {
     bytes32 private storedS;
     address private storedSigner;
 
+    struct Sig {
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+    }
+
+    Sig private storedSig;
+
     function mutateStoredS(bytes32 replacement) internal {
         storedS = replacement;
     }
@@ -706,6 +714,60 @@ contract Ecrecover {
         bytes32 s
     ) external pure returns (address) {
         return helper.ecrecover(hash, v, r, s);
+    }
+
+    function structMemberGuarded(bytes32 hash, Sig memory sig) external pure returns (address) {
+        require(uint256(sig.s) <= HALF_ORDER);
+        return ecrecover(hash, sig.v, sig.r, sig.s);
+    }
+
+    function structMemberUnguarded(bytes32 hash, Sig memory sig) external pure returns (address) {
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function structMemberReassigned(
+        bytes32 hash,
+        Sig memory sig,
+        Sig memory other
+    ) external pure returns (address) {
+        require(uint256(sig.s) <= HALF_ORDER);
+        sig = other;
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function structFieldReassigned(
+        bytes32 hash,
+        Sig memory sig,
+        bytes32 replacement
+    ) external pure returns (address) {
+        require(uint256(sig.s) <= HALF_ORDER);
+        sig.s = replacement;
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function stateStructMemberGuarded(bytes32 hash) external view returns (address) {
+        require(uint256(storedSig.s) <= HALF_ORDER);
+        return ecrecover(hash, storedSig.v, storedSig.r, storedSig.s);
+    }
+
+    function structMemberIncrementInvalidates(
+        bytes32 hash,
+        Sig memory sig
+    ) external pure returns (address) {
+        require(uint256(sig.s) <= HALF_ORDER);
+        sig.s++;
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function structMemberTupleAssignInvalidates(
+        bytes32 hash,
+        Sig memory sig,
+        bytes32 replacement,
+        uint8 newV
+    ) external pure returns (address) {
+        require(uint256(sig.s) <= HALF_ORDER);
+        (sig.s, sig.v) = (replacement, newV);
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
     }
 }
 

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -787,10 +787,18 @@ contract Ecrecover {
         sig.s = bytes32(type(uint256).max);
     }
 
+    function inspectSig(Sig memory) external pure {}
+
     function structMemberMutatedByCall(bytes32 hash, Sig memory sig) external pure returns (address) {
         require(uint256(sig.s) <= HALF_ORDER);
         normalizeSig(sig);
         return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function structMemberCopiedByExternalCall(bytes32 hash, Sig memory sig) external view returns (address) {
+        require(uint256(sig.s) <= HALF_ORDER);
+        this.inspectSig(sig);
+        return ecrecover(hash, sig.v, sig.r, sig.s);
     }
 
     function structMemberHashedOk(bytes32 hash, Sig memory sig) external pure returns (address) {

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -769,6 +769,19 @@ contract Ecrecover {
         (sig.s, sig.v) = (replacement, newV);
         return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
     }
+
+    function structMemberLoopCarried(
+        bytes32 hash,
+        Sig memory sig,
+        bytes32 replacement,
+        bool repeat
+    ) external pure returns (address signer) {
+        require(uint256(sig.s) <= HALF_ORDER);
+        while (repeat) {
+            signer = ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+            sig.s = replacement;
+        }
+    }
 }
 
 contract SameNameEcrecover {

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -745,6 +745,17 @@ contract Ecrecover {
         return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
     }
 
+    function structFieldReassignedThroughMemoryAlias(
+        bytes32 hash,
+        Sig memory sig,
+        bytes32 replacement
+    ) external pure returns (address) {
+        Sig memory aliasSig = sig;
+        require(uint256(sig.s) <= HALF_ORDER);
+        aliasSig.s = replacement;
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
+
     function stateStructMemberGuarded(bytes32 hash) external view returns (address) {
         require(uint256(storedSig.s) <= HALF_ORDER);
         return ecrecover(hash, storedSig.v, storedSig.r, storedSig.s);
@@ -795,6 +806,16 @@ contract Ecrecover {
         return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
     }
 
+    function structMemberMutatedByFunctionPointer(
+        bytes32 hash,
+        Sig memory sig
+    ) external pure returns (address) {
+        function(Sig memory) internal pure fn = normalizeSig;
+        require(uint256(sig.s) <= HALF_ORDER);
+        fn(sig);
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
+
     function structMemberCopiedByExternalCall(bytes32 hash, Sig memory sig) external view returns (address) {
         require(uint256(sig.s) <= HALF_ORDER);
         this.inspectSig(sig);
@@ -815,6 +836,17 @@ contract Ecrecover {
         Sig storage sig = storedSig;
         require(uint256(sig.s) <= HALF_ORDER);
         mutateStoredSig();
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function structFieldReassignedThroughStorageAlias(
+        bytes32 hash,
+        bytes32 replacement
+    ) external returns (address) {
+        Sig storage sig = storedSig;
+        Sig storage aliasSig = sig;
+        require(uint256(sig.s) <= HALF_ORDER);
+        aliasSig.s = replacement;
         return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
     }
 }

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -782,6 +782,33 @@ contract Ecrecover {
             sig.s = replacement;
         }
     }
+
+    function normalizeSig(Sig memory sig) internal pure {
+        sig.s = bytes32(type(uint256).max);
+    }
+
+    function structMemberMutatedByCall(bytes32 hash, Sig memory sig) external pure returns (address) {
+        require(uint256(sig.s) <= HALF_ORDER);
+        normalizeSig(sig);
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function structMemberHashedOk(bytes32 hash, Sig memory sig) external pure returns (address) {
+        require(uint256(sig.s) <= HALF_ORDER);
+        bytes32 digest = keccak256(abi.encode(hash, sig.v));
+        return ecrecover(digest, sig.v, sig.r, sig.s);
+    }
+
+    function mutateStoredSig() internal {
+        storedSig.s = bytes32(type(uint256).max);
+    }
+
+    function storagePointerMutatedByCall(bytes32 hash) external returns (address) {
+        Sig storage sig = storedSig;
+        require(uint256(sig.s) <= HALF_ORDER);
+        mutateStoredSig();
+        return ecrecover(hash, sig.v, sig.r, sig.s); //~WARN: ecrecover should reject malleable signatures
+    }
 }
 
 contract SameNameEcrecover {

--- a/crates/lint/testdata/Ecrecover.stderr
+++ b/crates/lint/testdata/Ecrecover.stderr
@@ -297,8 +297,32 @@ LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
 warning[ecrecover]: ecrecover should reject malleable signatures
    ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
    │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
 LL │             signer = ecrecover(hash, sig.v, sig.r, sig.s);
    │                      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/ecrecover
 

--- a/crates/lint/testdata/Ecrecover.stderr
+++ b/crates/lint/testdata/Ecrecover.stderr
@@ -294,3 +294,11 @@ LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
    │
    ╰ help: https://getfoundry.sh/forge/linting/ecrecover
 
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │             signer = ecrecover(hash, sig.v, sig.r, sig.s);
+   │                      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+

--- a/crates/lint/testdata/Ecrecover.stderr
+++ b/crates/lint/testdata/Ecrecover.stderr
@@ -254,3 +254,43 @@ LL │         return ecrecover(hash, v, r, s);
    │
    ╰ help: https://getfoundry.sh/forge/linting/ecrecover
 
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+

--- a/crates/lint/testdata/Ecrecover.stderr
+++ b/crates/lint/testdata/Ecrecover.stderr
@@ -302,3 +302,19 @@ LL │             signer = ecrecover(hash, sig.v, sig.r, sig.s);
    │
    ╰ help: https://getfoundry.sh/forge/linting/ecrecover
 
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, sig.v, sig.r, sig.s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+


### PR DESCRIPTION
The `ecrecover` lint's value tracker had no arm for member expressions, so a low-`s` guard on a struct-packed signature such as `require(uint256(sig.s) <= HALF_ORDER)` recorded nothing and `ecrecover(hash, sig.v, sig.r, sig.s)` was always reported.

Tracked places are now a `ValueKey` that is either a whole variable or a field of a variable. Field keys carry an epoch that is bumped whenever the whole base variable is reassigned, deleted, or invalidated, because a field that is only ever read has no stored value and would otherwise keep resolving to the same identity after `sig = other;`. Direct field writes, tuple destructuring into fields, increments, and `delete sig.s` update or reset the field's value like their whole-variable counterparts, and a field write inside a loop invalidates its base variable on the back edge like any other loop-carried write. Because a memory or storage struct can be rewritten by a callee, passing it by reference to a user-defined function (including as the receiver of a `using for` call) now invalidates it, and a state-mutating call also invalidates local storage pointers since they alias mutable state. Aliases of the same struct are otherwise tracked independently, which can miss a write through one alias after a guard through another.

Takes over the original PR by @gomesalexandre; the follow-up commits route every assignment, delete, and invalidation through one place resolver, add the loop-carried field write handling, trim the comments, and, after review, invalidate reference arguments and storage pointers. AI assistance was used.
