### PR TITLE
fix(anvil): validate Tempo transaction expiry

### DIFF
--- a/.changelog/anvil-tempo-expiring-nonce-window.md
+++ b/.changelog/anvil-tempo-expiring-nonce-window.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Enforced Tempo's hardfork-specific expiring nonce validity window during Anvil transaction pool admission.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -8766,6 +8766,20 @@ where
                     }
                     .into());
                 }
+
+                let hardfork = self.tempo_hardfork();
+                if hardfork.is_t1() && tempo_tx.is_expiring_nonce_tx() {
+                    let max_expiry_secs = hardfork.expiring_nonce_max_expiry_secs();
+                    let max_allowed = current_time.saturating_add(max_expiry_secs);
+                    if valid_before > max_allowed {
+                        return Err(InvalidTransactionError::TempoValidBeforeTooFar {
+                            valid_before,
+                            max_expiry_secs,
+                            max_allowed,
+                        }
+                        .into());
+                    }
+                }
             }
 
             // Reject if valid_after is too far in the future (> 1 hour)

--- a/crates/anvil/src/eth/error/mod.rs
+++ b/crates/anvil/src/eth/error/mod.rs
@@ -350,6 +350,11 @@ pub enum InvalidTransactionError {
     /// Tempo transaction valid_before is expired or too close to current time
     #[error("Tempo tx valid_before ({valid_before}) must be > current time + 3s ({min_allowed})")]
     TempoValidBeforeExpired { valid_before: u64, min_allowed: u64 },
+    /// Tempo expiring nonce transaction valid_before is too far in the future.
+    #[error(
+        "Tempo expiring nonce tx valid_before ({valid_before}) must be <= current time + {max_expiry_secs}s ({max_allowed})"
+    )]
+    TempoValidBeforeTooFar { valid_before: u64, max_expiry_secs: u64, max_allowed: u64 },
     /// Tempo transaction valid_after is too far in the future
     #[error("Tempo tx valid_after ({valid_after}) must be <= current time + 1h ({max_allowed})")]
     TempoValidAfterTooFar { valid_after: u64, max_allowed: u64 },

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -4743,6 +4743,67 @@ async fn test_tempo_aa_transaction_expiring_nonce() {
     assert!(receipt.status(), "Tempo AA transaction with expiring nonce should succeed");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_expiring_nonce_valid_before_pool_limits() {
+    for (hardfork, max_expiry_secs, enforce_limit) in [
+        (TempoHardfork::T0, 30, false),
+        (TempoHardfork::T1, 30, true),
+        (TempoHardfork::T10, 30, true),
+        (TempoHardfork::T11, 300, true),
+    ] {
+        let (api, handle) = spawn(
+            NodeConfig::test_tempo().with_hardfork(Some(hardfork.into())).with_no_mining(true),
+        )
+        .await;
+        let provider = handle.http_provider();
+        let accounts: Vec<Address> = handle.dev_accounts().collect();
+        let token = IERC20::new(PATH_USD, &provider);
+        let chain_id = provider.get_chain_id().await.unwrap();
+        let base_fee = provider.get_gas_price().await.unwrap();
+        let block = provider.get_block(BlockNumberOrTag::Latest.into()).await.unwrap().unwrap();
+        let pool_time = block.header.timestamp + 1;
+        api.evm_set_next_block_timestamp(pool_time).unwrap();
+        let calldata: Bytes = token.transfer(accounts[1], U256::from(1)).calldata().clone();
+
+        for (offset, accepted) in [(max_expiry_secs, true), (max_expiry_secs + 1, !enforce_limit)] {
+            let tempo_tx = TempoTransaction {
+                chain_id,
+                fee_token: Some(ALPHA_USD),
+                max_priority_fee_per_gas: base_fee / 10,
+                max_fee_per_gas: base_fee * 2,
+                gas_limit: TIP20_TRANSFER_GAS,
+                calls: vec![Call {
+                    to: TxKind::Call(PATH_USD),
+                    value: U256::ZERO,
+                    input: calldata.clone(),
+                }],
+                access_list: Default::default(),
+                nonce_key: U256::MAX,
+                nonce: 0,
+                fee_payer_signature: None,
+                valid_before: NonZeroU64::new(pool_time + offset),
+                valid_after: None,
+                key_authorization: None,
+                tempo_authorization_list: vec![],
+            };
+            let signature = dev_key(0).sign_hash(&tempo_tx.signature_hash()).await.unwrap();
+            let signed_tx = AASigned::new_unhashed(
+                tempo_tx,
+                TempoSignature::Primitive(PrimitiveSignature::Secp256k1(signature)),
+            );
+            let mut encoded = Vec::new();
+            TempoTxEnvelope::AA(signed_tx).encode_2718(&mut encoded);
+
+            let result = provider.send_raw_transaction(&encoded).await;
+            assert_eq!(
+                result.is_ok(),
+                accepted,
+                "unexpected pool admission at {hardfork} with valid_before offset {offset}: {result:?}"
+            );
+        }
+    }
+}
+
 // ============================================================================
 // Tempo AA: Expiring Nonce Replay
 // ============================================================================


### PR DESCRIPTION
Tempo expiring-nonce transactions may remain valid for up to 30 seconds before T11 and 300 seconds from T11 onward. TIP-1093 requires transactions exceeding this limit to be rejected during pool validation.

Anvil currently accepts these transactions into its pool and returns a transaction hash, leaving Tempo REVM to reject them during execution. This change validates the active limit before pool admission while preserving pre-T1 behavior.