### PR TITLE
fix(anvil): handle zero-count fee history

### DIFF
--- a/.changelog/anvil-zero-block-fee-history.md
+++ b/.changelog/anvil-zero-block-fee-history.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Return an empty fee history when zero blocks are requested.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1232,6 +1232,9 @@ impl<N: Network> EthApi<N> {
         {
             return Err(FeeHistoryError::InvalidRewardPercentiles.into());
         }
+        if block_count.is_zero() {
+            return Ok(FeeHistory::default());
+        }
 
         // max number of blocks in the requested range
 

--- a/crates/anvil/tests/it/gas.rs
+++ b/crates/anvil/tests/it/gas.rs
@@ -191,6 +191,20 @@ async fn test_tip_above_fee_cap() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_zero_block_fee_history_is_empty() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+
+    let history = api.fee_history(U256::ZERO, BlockNumberOrTag::Latest, vec![50.0]).await.unwrap();
+
+    assert_eq!(history.oldest_block, 0);
+    assert!(history.base_fee_per_gas.is_empty());
+    assert!(history.gas_used_ratio.is_empty());
+    assert!(history.reward.is_none());
+    assert!(history.base_fee_per_blob_gas.is_empty());
+    assert!(history.blob_gas_used_ratio.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_can_use_fee_history() {
     let base_fee = 50u128;
     let (_api, handle) = spawn(NodeConfig::test().with_base_fee(Some(base_fee as u64))).await;


### PR DESCRIPTION
Returns empty fee history when `blockCount` is zero, ensuring the response reflects the requested empty block range.