### PR TITLE
chore(ci): restrict automations to upstream

### DIFF
--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   run-benchmarks:
     name: Run Nightly Benchmarks
+    if: github.event_name != 'schedule' || github.repository == 'foundry-rs/foundry'
     runs-on: depot-ubuntu-24.04-32
     permissions:
       contents: read

--- a/.github/workflows/bump-forge-std.yml
+++ b/.github/workflows/bump-forge-std.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   update-tag:
     name: update forge-std tag
+    if: github.repository == 'foundry-rs/foundry'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/bump-tempo.yml
+++ b/.github/workflows/bump-tempo.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   bump-tempo:
+    if: github.repository == 'foundry-rs/foundry'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -41,9 +41,10 @@ jobs:
   tempo-check:
     # Skip on PRs from forks and Dependabot, which cannot access the RPC secrets.
     if: |
-      github.event_name != 'pull_request' ||
+      (github.event_name != 'schedule' || github.repository == 'foundry-rs/foundry') &&
+      (github.event_name != 'pull_request' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]')
+      github.event.pull_request.user.login != 'dependabot[bot]'))
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/crate-checks.yml
+++ b/.github/workflows/crate-checks.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   crate-checks:
+    if: github.event_name != 'schedule' || github.repository == 'foundry-rs/foundry'
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   prepare:
     name: Prepare release
+    if: github.event_name != 'schedule' || github.repository == 'foundry-rs/foundry'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/stable-version-pr.yml
+++ b/.github/workflows/stable-version-pr.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   prepare:
-    if: github.ref == 'refs/heads/master'
+    if: github.repository == 'foundry-rs/foundry' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test-deploy-verify.yml
+++ b/.github/workflows/test-deploy-verify.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   test:
     name: deploy + verify
+    if: github.event_name != 'schedule' || github.repository == 'foundry-rs/foundry'
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   test:
     name: flaky tests
+    if: github.event_name != 'schedule' || github.repository == 'foundry-rs/foundry'
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
Prevents repository-maintenance workflows from running automatically in forks, to reduce noise for external contributors. Dependency and release-version PR generation is restricted to `foundry-rs/foundry`, while scheduled benchmarks, release jobs, and nightly checks are skipped in forks without disabling their manual dispatch paths.
