### PR TITLE
fix(cast): tighten ERC-4626 inspection

### DIFF
--- a/.changelog/fix-erc4626-inspection.md
+++ b/.changelog/fix-erc4626-inspection.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fixed ERC-4626 compatibility checks and native-asset amount formatting.

--- a/crates/cast/src/cmd/erc4626.rs
+++ b/crates/cast/src/cmd/erc4626.rs
@@ -24,6 +24,8 @@ use foundry_common::shell;
 use serde::Serialize;
 
 const NATIVE_ASSET: Address = address!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
+/// ERC-7535 asset quantities are denominated in wei.
+const NATIVE_ASSET_DECIMALS: u8 = 18;
 const ERC7540_ASYNC_DEPOSIT_INTERFACE: FixedBytes<4> = FixedBytes::new([0xce, 0x3b, 0xbe, 0x50]);
 const ERC7540_ASYNC_REDEEM_INTERFACE: FixedBytes<4> = FixedBytes::new([0x62, 0x0e, 0xe8, 0xe4]);
 
@@ -766,7 +768,7 @@ async fn show_info(
     let mut warnings = Vec::new();
     let (asset_name, asset_symbol, asset_decimals) = if asset == NATIVE_ASSET {
         warnings.push(native_asset_warning());
-        (None, None, None)
+        (None, None, Some(NATIVE_ASSET_DECIMALS))
     } else {
         let asset_contract = IERC20Metadata::new(asset, &provider);
         let name_call = asset_contract.name().block(block);
@@ -865,7 +867,7 @@ async fn show_position(
     let mut warnings = Vec::new();
     let (asset_symbol, asset_decimals) = if asset == NATIVE_ASSET {
         warnings.push(native_asset_warning());
-        (None, None)
+        (None, Some(NATIVE_ASSET_DECIMALS))
     } else {
         let asset_contract = IERC20Metadata::new(asset, &provider);
         let symbol_call = asset_contract.symbol().block(block);
@@ -1071,9 +1073,9 @@ async fn check_compatibility(
     record_preview(&mut checks, "previewWithdraw(0)", "redeem", async_redeem, preview_withdraw);
     record_required(&mut checks, "maxRedeem(address)", max_redeem);
     record_preview(&mut checks, "previewRedeem(0)", "redeem", async_redeem, preview_redeem);
-    record_optional(&mut checks, "name()", name);
-    record_optional(&mut checks, "symbol()", symbol);
-    record_optional(&mut checks, "decimals()", decimals);
+    record_required(&mut checks, "name()", name);
+    record_required(&mut checks, "symbol()", symbol);
+    record_required(&mut checks, "decimals()", decimals);
 
     let passed = checks.iter().filter(|check| matches!(check.status, CheckStatus::Pass)).count();
     let warnings = checks.iter().filter(|check| matches!(check.status, CheckStatus::Warn)).count();
@@ -1266,19 +1268,6 @@ fn record_required<T, E>(
         (CheckStatus::Pass, "call succeeded")
     } else {
         (CheckStatus::Fail, "call failed or returned incompatible data")
-    };
-    push_check(checks, name, status, detail);
-}
-
-fn record_optional<T, E>(
-    checks: &mut Vec<CompatibilityCheck>,
-    name: &str,
-    result: std::result::Result<T, E>,
-) {
-    let (status, detail) = if result.is_ok() {
-        (CheckStatus::Pass, "call succeeded")
-    } else {
-        (CheckStatus::Warn, "optional ERC-20 metadata is unavailable")
     };
     push_check(checks, name, status, detail);
 }

--- a/crates/cast/tests/cli/erc4626.rs
+++ b/crates/cast/tests/cli/erc4626.rs
@@ -454,6 +454,44 @@ forgetest_async!(erc4626_check_warns_for_known_extensions, |prj, cmd| {
     deploy_test_contract(&mut cmd, &rpc, anvil_const::PK1, "TestAsyncVault");
 
     cmd.cast_fuse()
+        .args(["erc4626", "info", anvil_const::VAULT, "--human", "--rpc-url", &rpc])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Vault                0x5FbDB2315678afecb367f032d93F642f64180aa3
+Name                 Test Async Vault
+Symbol               TAV
+Decimals             18
+Asset                0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
+Asset name           <unavailable>
+Asset symbol         <unavailable>
+Asset decimals       18
+Total assets         1
+Total supply         0 TAV
+Assets per share     1
+Shares per asset     1 TAV
+
+"#]]);
+
+    let output = cmd
+        .cast_fuse()
+        .args([
+            "erc4626",
+            "position",
+            anvil_const::VAULT,
+            anvil_const::ADDR1,
+            "--json",
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+    let output: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(output["data"]["asset_decimals"], 18);
+    assert_eq!(output["data"]["assets_equivalent"]["formatted"], "0");
+
+    cmd.cast_fuse()
         .args(["erc4626", "check", anvil_const::VAULT, "--rpc-url", &rpc])
         .assert_success()
         .stdout_eq(str![[r#"
@@ -484,13 +522,13 @@ Summary: 14 passed, 5 warnings, 0 failed
 "#]]);
 });
 
-forgetest_async!(erc4626_check_fails_for_missing_interface, |prj, cmd| {
+forgetest_async!(erc4626_check_fails_for_missing_metadata, |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;
     let rpc = handle.http_endpoint();
 
     foundry_test_utils::util::initialize(prj.root());
     prj.add_source("TestVault.sol", include_str!("../fixtures/TestVault.sol"));
-    deploy_test_contract(&mut cmd, &rpc, anvil_const::PK1, "TestInvalidVault");
+    deploy_test_contract(&mut cmd, &rpc, anvil_const::PK1, "TestMissingMetadataVault");
 
     cmd.cast_fuse()
         .args(["erc4626", "check", anvil_const::VAULT, "--rpc-url", &rpc])
@@ -500,25 +538,25 @@ Vault                0x5FbDB2315678afecb367f032d93F642f64180aa3
 Account              0x0000000000000000000000000000000000000000
 Note: This probes read-call behavior only; it does not prove state-changing selector coverage or semantic ERC-4626 compliance.
 PASS contract code            contract bytecode is present
-FAIL asset()                  call failed or returned incompatible data
-FAIL totalAssets()            call failed or returned incompatible data
-FAIL totalSupply()            call failed or returned incompatible data
-FAIL balanceOf(address)       call failed or returned incompatible data
-FAIL allowance(address,address) call failed or returned incompatible data
-FAIL convertToShares(0)       call failed or returned incompatible data
-FAIL convertToAssets(0)       call failed or returned incompatible data
-FAIL maxDeposit(address)      call failed or returned incompatible data
-FAIL previewDeposit(0)        call failed or returned incompatible data without advertised ERC-7540 support
-FAIL maxMint(address)         call failed or returned incompatible data
-FAIL previewMint(0)           call failed or returned incompatible data without advertised ERC-7540 support
-FAIL maxWithdraw(address)     call failed or returned incompatible data
-FAIL previewWithdraw(0)       call failed or returned incompatible data without advertised ERC-7540 support
-FAIL maxRedeem(address)       call failed or returned incompatible data
-FAIL previewRedeem(0)         call failed or returned incompatible data without advertised ERC-7540 support
-WARN name()                   optional ERC-20 metadata is unavailable
-WARN symbol()                 optional ERC-20 metadata is unavailable
-WARN decimals()               optional ERC-20 metadata is unavailable
-Summary: 1 passed, 3 warnings, 15 failed
+WARN asset()                  returned the ERC-7535 native-asset sentinel
+PASS totalAssets()            call succeeded
+PASS totalSupply()            call succeeded
+PASS balanceOf(address)       call succeeded
+PASS allowance(address,address) call succeeded
+PASS convertToShares(0)       returned zero
+PASS convertToAssets(0)       returned zero
+PASS maxDeposit(address)      call succeeded
+WARN previewDeposit(0)        reverted as required by advertised asynchronous ERC-7540 deposit support
+PASS maxMint(address)         call succeeded
+WARN previewMint(0)           reverted as required by advertised asynchronous ERC-7540 deposit support
+PASS maxWithdraw(address)     call succeeded
+WARN previewWithdraw(0)       reverted as required by advertised asynchronous ERC-7540 redeem support
+PASS maxRedeem(address)       call succeeded
+WARN previewRedeem(0)         reverted as required by advertised asynchronous ERC-7540 redeem support
+FAIL name()                   call failed or returned incompatible data
+FAIL symbol()                 call failed or returned incompatible data
+FAIL decimals()               call failed or returned incompatible data
+Summary: 11 passed, 5 warnings, 3 failed
 
 "#]]);
 
@@ -532,7 +570,7 @@ Summary: 1 passed, 3 warnings, 15 failed
     let output: serde_json::Value = serde_json::from_slice(&output).unwrap();
     assert_eq!(output["success"], false);
     assert_eq!(output["data"]["read_compatible"], false);
-    assert_eq!(output["data"]["failed"], 15);
+    assert_eq!(output["data"]["failed"], 3);
     assert_eq!(output["errors"][0]["code"], "erc4626.compatibility_failed");
 });
 

--- a/crates/cast/tests/fixtures/TestVault.sol
+++ b/crates/cast/tests/fixtures/TestVault.sol
@@ -176,13 +176,22 @@ contract TestVault {
 }
 
 contract TestAsyncVault {
-    string public name = "Test Async Vault";
-    string public symbol = "TAV";
-    uint8 public decimals = 18;
     uint256 public totalSupply;
 
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping(address => uint256)) public allowance;
+
+    function name() external pure virtual returns (string memory) {
+        return "Test Async Vault";
+    }
+
+    function symbol() external pure virtual returns (string memory) {
+        return "TAV";
+    }
+
+    function decimals() external pure virtual returns (uint8) {
+        return 18;
+    }
 
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return interfaceId == 0xce3bbe50 || interfaceId == 0x620ee8e4;
@@ -193,7 +202,7 @@ contract TestAsyncVault {
     }
 
     function totalAssets() external pure returns (uint256) {
-        return 0;
+        return 1 ether;
     }
 
     function convertToShares(uint256 assets) external pure returns (uint256) {
@@ -237,4 +246,16 @@ contract TestAsyncVault {
     }
 }
 
-contract TestInvalidVault {}
+contract TestMissingMetadataVault is TestAsyncVault {
+    function name() external pure override returns (string memory) {
+        revert();
+    }
+
+    function symbol() external pure override returns (string memory) {
+        revert();
+    }
+
+    function decimals() external pure override returns (uint8) {
+        revert();
+    }
+}


### PR DESCRIPTION
## Summary

- require ERC-20 metadata calls in `cast erc4626 check`, as required by ERC-4626
- format ERC-7535 native-asset quantities with 18 decimals
- cover native `info`/`position` output and missing metadata regressions

Follow-up to #16605.

## Testing

- `cargo test -p cast@1.8.1 --test cli erc4626 --no-fail-fast`
- `cargo clippy -p cast@1.8.1 --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 .github/scripts/validate_changelog.py --base origin/master --head HEAD`
