### PR TITLE
fix: clean workspace build warnings

### DIFF
--- a/.changelog/clean-default-build-warnings.md
+++ b/.changelog/clean-default-build-warnings.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+foundry-macros: patch
+---
+
+Removed stale manifests, an unmaintained macro dependency, and a benign macOS linker diagnostic that produced warnings during workspace builds with recent Rust versions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6254,7 +6254,6 @@ dependencies = [
 name = "foundry-macros"
 version = "1.8.1"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9396,16 +9395,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "proc-macro-error-attr3"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9413,18 +9402,6 @@ checksum = "82366fd7d8b7a440d66d13418820c69df9b3908bcb1a0476d7f5ce5d12f5a04d"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,9 +298,6 @@ alloy-json-abi.opt-level = "s"
 
 [workspace.dependencies]
 anvil = { path = "crates/anvil", default-features = false }
-cast = { path = "crates/cast", default-features = false }
-chisel = { path = "crates/chisel", default-features = false }
-forge = { path = "crates/forge", default-features = false }
 
 forge-doc = { path = "crates/doc", default-features = false }
 forge-fmt = { path = "crates/fmt", default-features = false }
@@ -369,14 +366,8 @@ alloy-rpc-types-eth = { version = "2.4.0", default-features = false }
 alloy-rpc-types-mev = { version = "2.4.0", default-features = false }
 alloy-serde = { version = "2.4.0", default-features = false }
 alloy-signer = { version = "2.4.0", default-features = false }
-alloy-signer-aws = { version = "2.4.0", default-features = false }
-alloy-signer-gcp = { version = "2.4.0", default-features = false }
-alloy-signer-ledger = { version = "2.4.0", default-features = false }
 alloy-signer-local = { version = "2.4.0", default-features = false }
-alloy-signer-trezor = { version = "2.4.0", default-features = false }
-alloy-signer-turnkey = { version = "2.4.0", default-features = false }
 alloy-transport = { version = "2.4.0", default-features = false }
-alloy-transport-http = { version = "2.4.0", default-features = false }
 alloy-transport-ipc = { version = "2.4.0", default-features = false }
 alloy-transport-ws = { version = "2.4.0", default-features = false }
 alloy-hardforks = { version = "0.4.8", default-features = false }
@@ -495,7 +486,6 @@ soldeer-core = { version = "=0.11.0", features = ["serde"] }
 strum = "0.28"
 tempfile = "3.23"
 tokio = "1"
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 toml = "1.1"
 toml_edit = "0.25"
 tower = "0.5"

--- a/crates/evm/symbolic/Cargo.toml
+++ b/crates/evm/symbolic/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "foundry-evm-symbolic"
 description = "Foundry symbolic EVM executor"
-readme = "README.md"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -1,6 +1,14 @@
 //! The `forge` CLI: build, test, fuzz, debug and deploy Solidity contracts, like Hardhat, Brownie,
 //! Ape.
 
+#![cfg_attr(
+    target_os = "macos",
+    allow(
+        linker_messages,
+        reason = "Apple ld cannot encode Forge's large unwind table in its compact format"
+    )
+)]
+
 use forge::args::run;
 
 #[global_allocator]

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -22,4 +22,3 @@ doc = false
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
-proc-macro-error2 = "2"

--- a/crates/macros/src/cheatcodes.rs
+++ b/crates/macros/src/cheatcodes.rs
@@ -2,31 +2,35 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{Attribute, Data, DataStruct, DeriveInput, Error, Result};
 
-// TODO: `proc_macro_error2` only emits warnings when feature "nightly" is enabled, which we can't
-// practically enable.
+// Stable proc macros cannot emit warnings, so treat validation diagnostics as errors.
 macro_rules! emit_warning {
-    ($($t:tt)*) => {
-        proc_macro_error2::emit_error! { $($t)* }
+    ($errors:expr, $span:expr, $($t:tt)*) => {
+        $errors.push(Error::new($span, format!($($t)*)))
     };
 }
 
-pub fn derive_cheatcode(input: &DeriveInput) -> Result<TokenStream> {
+pub fn derive_cheatcode(input: &DeriveInput, errors: &mut Vec<Error>) -> Result<TokenStream> {
     let name = &input.ident;
     let name_s = name.to_string();
     match &input.data {
-        Data::Struct(s) if name_s.ends_with("Call") => derive_call(name, s, &input.attrs),
+        Data::Struct(s) if name_s.ends_with("Call") => derive_call(name, s, &input.attrs, errors),
         Data::Struct(_) if name_s.ends_with("Return") => Ok(TokenStream::new()),
-        Data::Struct(s) => derive_struct(name, s, &input.attrs),
+        Data::Struct(s) => derive_struct(name, s, &input.attrs, errors),
         Data::Enum(e) if name_s.ends_with("Calls") => derive_calls_enum(e),
         Data::Enum(e) if name_s.ends_with("Errors") => derive_errors_events_enum(e, false),
         Data::Enum(e) if name_s.ends_with("Events") => derive_errors_events_enum(e, true),
-        Data::Enum(e) => derive_enum(name, e, &input.attrs),
+        Data::Enum(e) => derive_enum(name, e, &input.attrs, errors),
         Data::Union(_) => Err(Error::new(name.span(), "unions are not supported")),
     }
 }
 
 /// Implements `CheatcodeDef` for a function call struct.
-fn derive_call(name: &Ident, data: &DataStruct, attrs: &[Attribute]) -> Result<TokenStream> {
+fn derive_call(
+    name: &Ident,
+    data: &DataStruct,
+    attrs: &[Attribute],
+    errors: &mut Vec<Error>,
+) -> Result<TokenStream> {
     let mut group = None::<Ident>;
     let mut status = None::<TokenStream>;
     let mut safety = None::<Ident>;
@@ -58,7 +62,7 @@ fn derive_call(name: &Ident, data: &DataStruct, attrs: &[Attribute]) -> Result<T
         }
     };
 
-    check_named_fields(data, name);
+    check_named_fields(data, name, errors);
 
     let id = name.to_string();
     let id = id.strip_suffix("Call").expect("function struct ends in Call");
@@ -72,6 +76,7 @@ fn derive_call(name: &Ident, data: &DataStruct, attrs: &[Attribute]) -> Result<T
     }
     if params.contains(" memory ") {
         emit_warning!(
+            errors,
             name.span(),
             "parameter data locations must be `calldata` instead of `memory`"
         );
@@ -82,7 +87,7 @@ fn derive_call(name: &Ident, data: &DataStruct, attrs: &[Attribute]) -> Result<T
     let mutability = Ident::new(mutability, Span::call_site());
 
     if description.is_empty() {
-        emit_warning!(name.span(), "missing documentation for a cheatcode")
+        emit_warning!(errors, name.span(), "missing documentation for a cheatcode")
     }
     let description = description.replace("\n ", "\n");
 
@@ -160,6 +165,7 @@ fn derive_struct(
     name: &Ident,
     input: &syn::DataStruct,
     attrs: &[Attribute],
+    errors: &mut Vec<Error>,
 ) -> Result<TokenStream> {
     let name_s = name.to_string();
 
@@ -189,11 +195,11 @@ fn derive_struct(
             StructKind::Event => "n",
             StructKind::Struct => "",
         };
-        emit_warning!(name.span(), "missing documentation for a{n} {}", kind.as_str());
+        emit_warning!(errors, name.span(), "missing documentation for a{n} {}", kind.as_str());
     }
 
     if kind == StructKind::Struct {
-        check_named_fields(input, name);
+        check_named_fields(input, name, errors);
     }
 
     let def = match kind {
@@ -272,20 +278,25 @@ impl StructKind {
     }
 }
 
-fn derive_enum(name: &Ident, input: &syn::DataEnum, attrs: &[Attribute]) -> Result<TokenStream> {
+fn derive_enum(
+    name: &Ident,
+    input: &syn::DataEnum,
+    attrs: &[Attribute],
+    errors: &mut Vec<Error>,
+) -> Result<TokenStream> {
     let name_s = name.to_string();
     let doc = get_docstring(attrs);
     let doc_end = doc.find("```solidity").expect("bad docstring");
     let doc = doc[..doc_end].trim();
     if doc.is_empty() {
-        emit_warning!(name.span(), "missing documentation for an enum");
+        emit_warning!(errors, name.span(), "missing documentation for an enum");
     }
     let variants = input.variants.iter().filter(|v| v.discriminant.is_none()).map(|v| {
         let name = v.ident.to_string();
         let doc = get_docstring(&v.attrs);
         let doc = doc.trim();
         if doc.is_empty() {
-            emit_warning!(v.ident.span(), "missing documentation for a variant");
+            emit_warning!(errors, v.ident.span(), "missing documentation for a variant");
         }
         quote! {
             EnumVariant {
@@ -306,10 +317,10 @@ fn derive_enum(name: &Ident, input: &syn::DataEnum, attrs: &[Attribute]) -> Resu
     })
 }
 
-fn check_named_fields(data: &DataStruct, ident: &Ident) {
+fn check_named_fields(data: &DataStruct, ident: &Ident, errors: &mut Vec<Error>) {
     for field in &data.fields {
         if field.ident.is_none() {
-            emit_warning!(ident, "all params must be named");
+            emit_warning!(errors, ident.span(), "all params must be named");
         }
     }
 }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -5,9 +5,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[macro_use]
-extern crate proc_macro_error2;
-
 use proc_macro::TokenStream;
 use syn::{DeriveInput, Error, parse_macro_input};
 
@@ -21,8 +18,11 @@ pub fn console_fmt(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(Cheatcode, attributes(cheatcode))]
-#[proc_macro_error]
 pub fn cheatcode(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    cheatcodes::derive_cheatcode(&input).unwrap_or_else(Error::into_compile_error).into()
+    let mut errors = Vec::new();
+    let mut output =
+        cheatcodes::derive_cheatcode(&input, &mut errors).unwrap_or_else(Error::into_compile_error);
+    output.extend(errors.into_iter().map(Error::into_compile_error));
+    output.into()
 }


### PR DESCRIPTION
Recent Cargo and Rust versions make a plain workspace build noisy for three independent reasons: Cargo surfaces stale unused workspace dependencies and a redundant explicit README, `proc-macro-error2` has a future-incompatibility, and rustc now reports Apple ld's compact-unwind size diagnostic.

This removes the unused manifest entries, relies on Cargo's README inference, and replaces `proc-macro-error2` with a small `syn::Error` collector that preserves aggregated `Cheatcode` derive diagnostics. On macOS, Forge allows the known `linker_messages` diagnostic at the binary crate boundary; it does not change linker output or unwind behavior.

This PR was authored with Codex, including code generation and validation.
