### PR TITLE
fix(anvil): default omitted state blocks

### DIFF
--- a/.changelog/anvil-default-state-block.md
+++ b/.changelog/anvil-default-state-block.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Defaulted omitted state query block parameters to the latest block.

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -90,7 +90,7 @@ pub enum EthRequest {
     EthCoinbase(()),
 
     #[serde(rename = "eth_getBalance")]
-    EthGetBalance(Address, Option<BlockId>),
+    EthGetBalance(Address, #[serde(default)] Option<BlockId>),
 
     #[serde(rename = "eth_getAccount")]
     EthGetAccount(Address, Option<BlockId>),
@@ -99,11 +99,11 @@ pub enum EthRequest {
     EthGetAccountInfo(Address, Option<BlockId>),
 
     #[serde(rename = "eth_getStorageAt")]
-    EthGetStorageAt(Address, U256, Option<BlockId>),
+    EthGetStorageAt(Address, U256, #[serde(default)] Option<BlockId>),
 
     /// Returns storage values for multiple accounts and slots in a single call.
     #[serde(rename = "eth_getStorageValues")]
-    EthGetStorageValues(HashMap<Address, Vec<B256>>, Option<BlockId>),
+    EthGetStorageValues(HashMap<Address, Vec<B256>>, #[serde(default)] Option<BlockId>),
 
     #[serde(rename = "eth_getBlockByHash")]
     EthGetBlockByHash(B256, bool),
@@ -139,7 +139,7 @@ pub enum EthRequest {
     EthGetBlockAccessListRaw(BlockId),
 
     #[serde(rename = "eth_getTransactionCount")]
-    EthGetTransactionCount(Address, Option<BlockId>),
+    EthGetTransactionCount(Address, #[serde(default)] Option<BlockId>),
 
     #[serde(rename = "eth_getBlockTransactionCountByHash", with = "sequence")]
     EthGetTransactionCountByHash(B256),
@@ -160,12 +160,12 @@ pub enum EthRequest {
     EthGetUnclesCountByNumber(BlockNumber),
 
     #[serde(rename = "eth_getCode")]
-    EthGetCodeAt(Address, Option<BlockId>),
+    EthGetCodeAt(Address, #[serde(default)] Option<BlockId>),
 
     /// Returns the account and storage values of the specified account including the Merkle-proof.
     /// This call can be used to verify that the data you are pulling from is not tampered with.
     #[serde(rename = "eth_getProof")]
-    EthGetProof(Address, Vec<B256>, Option<BlockId>),
+    EthGetProof(Address, Vec<B256>, #[serde(default)] Option<BlockId>),
 
     /// The sign method calculates an Ethereum specific signature with:
     #[serde(rename = "eth_sign")]
@@ -2075,6 +2075,30 @@ true}]}"#;
 ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x0", "latest"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_state_requests_without_block() {
+        let requests = [
+            r#"{"method":"eth_getBalance","params":["0x295a70b2de5e3953354a6a8344e616ed314d7251"]}"#,
+            r#"{"method":"eth_getCode","params":["0x295a70b2de5e3953354a6a8344e616ed314d7251"]}"#,
+            r#"{"method":"eth_getStorageAt","params":["0x295a70b2de5e3953354a6a8344e616ed314d7251","0x0"]}"#,
+            r#"{"method":"eth_getStorageValues","params":[{"0x295a70b2de5e3953354a6a8344e616ed314d7251":["0x0000000000000000000000000000000000000000000000000000000000000000"]}]}"#,
+            r#"{"method":"eth_getTransactionCount","params":["0x295a70b2de5e3953354a6a8344e616ed314d7251"]}"#,
+            r#"{"method":"eth_getProof","params":["0x295a70b2de5e3953354a6a8344e616ed314d7251",[]]}"#,
+        ];
+
+        for request in requests {
+            assert!(matches!(
+                serde_json::from_str::<EthRequest>(request).unwrap(),
+                EthRequest::EthGetBalance(_, None)
+                    | EthRequest::EthGetCodeAt(_, None)
+                    | EthRequest::EthGetStorageAt(_, _, None)
+                    | EthRequest::EthGetStorageValues(_, None)
+                    | EthRequest::EthGetTransactionCount(_, None)
+                    | EthRequest::EthGetProof(_, _, None)
+            ));
+        }
     }
 
     #[test]

--- a/crates/anvil/tests/it/storage_values.rs
+++ b/crates/anvil/tests/it/storage_values.rs
@@ -164,24 +164,13 @@ async fn test_fork_storage_values_skips_upstream_for_local_state() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn storage_values_requires_an_explicit_block_parameter() {
+async fn storage_values_defaults_to_latest_block() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
-    // Like `eth_getStorageAt`, the trailing block parameter has to be present, even as `null`.
     let requests =
         HashMap::<Address, Vec<B256>>::from_iter([(Address::repeat_byte(0x07), vec![slot(0)])]);
-    let err = provider
-        .client()
-        .request::<_, HashMap<Address, Vec<B256>>>("eth_getStorageValues", (requests.clone(),))
-        .await
-        .unwrap_err();
-    assert!(err.to_string().contains("expected tuple variant"), "unexpected error: {err}");
-
-    let values: HashMap<Address, Vec<B256>> = provider
-        .client()
-        .request("eth_getStorageValues", (requests, Option::<BlockId>::None))
-        .await
-        .unwrap();
+    let values: HashMap<Address, Vec<B256>> =
+        provider.client().request("eth_getStorageValues", (requests,)).await.unwrap();
     assert_eq!(values[&Address::repeat_byte(0x07)], vec![B256::ZERO]);
 }


### PR DESCRIPTION
Defaults omitted block parameters to `latest` for state query methods, allowing requests to use the optional parameter behavior defined by the Execution API.
