### PR TITLE
fix(anvil): apply genesis header

### DIFF
--- a/.changelog/anvil-genesis-header.md
+++ b/.changelog/anvil-genesis-header.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Applied `genesis.json` header fields and allocation state root to Anvil's genesis block.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -60,6 +60,7 @@ use alloy_eips::{
     eip7685::EMPTY_REQUESTS_HASH,
     eip7840::BlobParams,
     eip7910::SystemContract,
+    eip7928::EMPTY_BLOCK_ACCESS_LIST_HASH,
 };
 use alloy_evm::{
     Database, EthEvmFactory, Evm, EvmEnv, EvmFactory, FromTxWithEncoded,
@@ -68,6 +69,7 @@ use alloy_evm::{
     overrides::{OverrideBlockHashes, apply_state_overrides},
     precompiles::{DynPrecompile, MovePrecompileError, Precompile, PrecompilesMap},
 };
+use alloy_genesis::Genesis;
 use alloy_network::{
     AnyHeader, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction, AnyTxEnvelope, AnyTxType,
     BlockResponse, Network, NetworkTransactionBuilder, ReceiptResponse, UnknownTxEnvelope,
@@ -111,7 +113,7 @@ use alloy_rpc_types_eth::{AccountInfo as RpcAccountInfo, Bundle, EthCallResponse
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use alloy_serde::{OtherFields, WithOtherFields};
 use alloy_sol_types::SolCall;
-use alloy_trie::{HashBuilder, Nibbles, proof::ProofRetainer};
+use alloy_trie::{HashBuilder, Nibbles, proof::ProofRetainer, root::state_root_ref_unhashed};
 use anvil_core::eth::{
     block::{Block, BlockInfo, canonical_block, create_block},
     transaction::{MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo},
@@ -3928,12 +3930,16 @@ impl<N: Network> Backend<N> {
             trace!(target: "backend", "using forked blockchain at {}", fork.block_number());
             Blockchain::forked(fork.block_number(), fork.block_hash(), fork.total_difficulty())
         } else {
-            let header = genesis_header(
-                &env.read(),
-                fees.is_eip1559().then(|| fees.base_fee()),
-                genesis.timestamp,
-                genesis.number,
-            );
+            let header = if let Some(genesis) = genesis.genesis_init.as_ref() {
+                genesis_json_header(genesis)
+            } else {
+                genesis_header(
+                    &env.read(),
+                    fees.is_eip1559().then(|| fees.base_fee()),
+                    genesis.timestamp,
+                    genesis.number,
+                )
+            };
             Blockchain::new(foundry_header(&networks, header))
         };
 
@@ -9425,6 +9431,44 @@ fn genesis_header(
         parent_beacon_block_root: (spec_id >= SpecId::CANCUN).then_some(Default::default()),
         withdrawals_root: (spec_id >= SpecId::SHANGHAI).then_some(EMPTY_WITHDRAWALS),
         requests_hash: (spec_id >= SpecId::PRAGUE).then_some(EMPTY_REQUESTS_HASH),
+        ..Default::default()
+    }
+}
+
+/// Creates an Ethereum header from a `genesis.json` configuration.
+fn genesis_json_header(genesis: &Genesis) -> Header {
+    let number = genesis.number.unwrap_or_default();
+    let timestamp = genesis.timestamp;
+    let is_london = genesis.config.is_london_active_at_block(number);
+    let is_shanghai = genesis.config.is_shanghai_active_at_block_and_timestamp(number, timestamp);
+    let is_cancun = genesis.config.is_cancun_active_at_block_and_timestamp(number, timestamp);
+    let is_prague = genesis.config.prague_time.is_some_and(|fork| fork <= timestamp);
+    let is_amsterdam = genesis.config.amsterdam_time.is_some_and(|fork| fork <= timestamp);
+
+    Header {
+        number,
+        parent_hash: genesis.parent_hash.unwrap_or_default(),
+        gas_limit: genesis.gas_limit,
+        difficulty: genesis.difficulty,
+        nonce: genesis.nonce.into(),
+        extra_data: genesis.extra_data.clone(),
+        state_root: state_root_ref_unhashed(&genesis.alloc),
+        timestamp,
+        mix_hash: genesis.mix_hash,
+        beneficiary: genesis.coinbase,
+        base_fee_per_gas: is_london.then(|| {
+            genesis
+                .base_fee_per_gas
+                .map(|fee| fee as u64)
+                .unwrap_or(crate::eth::fees::INITIAL_BASE_FEE)
+        }),
+        withdrawals_root: is_shanghai.then_some(EMPTY_WITHDRAWALS),
+        parent_beacon_block_root: is_cancun.then_some(B256::ZERO),
+        blob_gas_used: is_cancun.then_some(genesis.blob_gas_used.unwrap_or_default()),
+        excess_blob_gas: is_cancun.then_some(genesis.excess_blob_gas.unwrap_or_default()),
+        requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
+        block_access_list_hash: is_amsterdam.then_some(EMPTY_BLOCK_ACCESS_LIST_HASH),
+        slot_number: is_amsterdam.then_some(genesis.slot_number.unwrap_or_default()),
         ..Default::default()
     }
 }

--- a/crates/anvil/tests/it/genesis.rs
+++ b/crates/anvil/tests/it/genesis.rs
@@ -2,8 +2,9 @@
 
 use crate::fork::fork_config;
 use alloy_genesis::Genesis;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::Provider;
+use alloy_rpc_types::BlockNumberOrTag;
 use anvil::{NodeConfig, spawn};
 use std::str::FromStr;
 
@@ -35,6 +36,41 @@ const GENESIS: &str = r#"{
 }
 "#;
 
+const GENESIS_HEADER: &str = r#"{
+  "config": {
+    "chainId": 19763,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "terminalTotalDifficulty": 0,
+    "mergeNetsplitBlock": 0,
+    "ethash": {}
+  },
+  "nonce": "0x42",
+  "timestamp": "0x123",
+  "extraData": "0x1234",
+  "gasLimit": "0x989680",
+  "difficulty": "0x20000",
+  "mixHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+  "coinbase": "0x2222222222222222222222222222222222222222",
+  "alloc": {
+    "3333333333333333333333333333333333333333": {
+      "balance": "0x1",
+      "nonce": "0x2",
+      "code": "0x6000"
+    }
+  },
+  "baseFeePerGas": "0x7"
+}
+"#;
+
 #[tokio::test(flavor = "multi_thread")]
 async fn can_apply_genesis() {
     let genesis: Genesis = serde_json::from_str(GENESIS).unwrap();
@@ -52,6 +88,30 @@ async fn can_apply_genesis() {
 
     let block_number = provider.get_block_number().await.unwrap();
     assert_eq!(block_number, 73u64);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn applies_genesis_header() {
+    let genesis: Genesis = serde_json::from_str(GENESIS_HEADER).unwrap();
+    let (_api, handle) = spawn(NodeConfig::test().with_genesis(Some(genesis))).await;
+
+    let block = handle
+        .http_provider()
+        .get_block_by_number(BlockNumberOrTag::Earliest)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        block.header.hash,
+        B256::from_str("0x0a6ab47aa1672305a6d2fe01c7e4245b2e80ff8f20da2079c2a62a506410a46d")
+            .unwrap()
+    );
+    assert_eq!(
+        block.header.state_root,
+        B256::from_str("0x5b0bc9e85c26ad3ecafbea8de25cf99fca0f65c73572b24aacb5a781fb61815a")
+            .unwrap()
+    );
 }
 
 // <https://github.com/foundry-rs/foundry/issues/10059>


### PR DESCRIPTION
Apply header fields and the allocation-derived state root from `genesis.json`. This makes `anvil --init` produce the same genesis block hash as Execution clients while preserving default Anvil initialization.