### PR TITLE
fix(anvil): include simulated block size

### DIFF
--- a/.changelog/anvil-simulated-block-size.md
+++ b/.changelog/anvil-simulated-block-size.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Included the encoded block size in `eth_simulateV1` responses.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -46,7 +46,7 @@ use crate::{
 };
 use alloy_chains::NamedChain;
 use alloy_consensus::{
-    Blob, BlockHeader, EnvKzgSettings, Header, Signed, Transaction as TransactionTrait,
+    Blob, BlockBody, BlockHeader, EnvKzgSettings, Header, Signed, Transaction as TransactionTrait,
     TransactionEnvelope, TrieAccount, TxEip4844Variant, TxEnvelope, TxReceipt, Typed2718,
     constants::EMPTY_WITHDRAWALS,
     proofs::{calculate_receipt_root, calculate_transaction_root},
@@ -8426,6 +8426,16 @@ impl Backend<FoundryNetwork> {
                     ..Default::default()
                 };
                 let block_hash = header.hash_slow();
+                let withdrawals = (spec_id >= SpecId::SHANGHAI).then_some(Default::default());
+                let size = U256::from(
+                    BlockBody {
+                        transactions: transaction_envelopes,
+                        ommers: vec![],
+                        withdrawals: withdrawals.clone(),
+                    }
+                    .into_block(header.clone())
+                    .length(),
+                );
                 for (transaction_index, transaction) in transactions.iter_mut().enumerate() {
                     transaction.block_hash = Some(block_hash);
                     transaction.block_number = Some(header.number);
@@ -8437,11 +8447,11 @@ impl Backend<FoundryNetwork> {
                         hash: block_hash,
                         inner: header.into(),
                         total_difficulty: None,
-                        size: None,
+                        size: Some(size),
                     },
                     uncles: vec![],
                     transactions: BlockTransactions::Full(transactions),
-                    withdrawals: (spec_id >= SpecId::SHANGHAI).then_some(Default::default()),
+                    withdrawals,
                 };
 
                 if !return_full_transactions {

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -63,6 +63,20 @@ fn deposit_event_runtime(event: DepositEvent) -> Bytes {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_includes_block_size_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{"blockStateCalls": [{}]}, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert!(quantity(&response["result"][0]["size"]) > 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fork_simulate_native_transfers_rpc() {
     crate::init_tracing();
     let (_, handle) = spawn(


### PR DESCRIPTION
Include the canonical encoded block size in `eth_simulateV1` responses, as required by the Execution API block schema. This aligns simulated block responses with standard block responses without changing simulation execution.