### PR TITLE
refactor(tempo): centralize transaction preparation

### DIFF
--- a/.changelog/centralize-tempo-transaction-preparation.md
+++ b/.changelog/centralize-tempo-transaction-preparation.md
@@ -1,0 +1,8 @@
+---
+cast: patch
+forge: patch
+forge-script: patch
+foundry-common: patch
+---
+
+Centralized Tempo fee-token and sponsor preparation so outgoing transaction paths share the same ordering around gas estimation and signing.

--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -22,9 +22,7 @@ use foundry_cli::{
     utils::{self, LoadConfig, maybe_print_resolved_lane, resolve_lane},
 };
 use foundry_common::{
-    FoundryTransactionBuilder,
-    provider::ProviderBuilder,
-    tempo::{maybe_print_fee_token, resolve_and_set_fee_token},
+    FoundryTransactionBuilder, provider::ProviderBuilder, tempo::prepare_tempo_transaction,
 };
 use foundry_wallets::{TempoAccountsWallet, WalletOpts, WalletSigner};
 use tempo_alloy::TempoNetwork;
@@ -145,14 +143,14 @@ impl BatchMakeTxArgs {
             }
             let (mut tx, _) = tx_builder.build(from).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            let fee_token = resolve_and_set_fee_token(
+            prepare_tempo_transaction(
+                None,
                 (!config.eth_rpc_curl).then_some(&provider),
                 Some(chain),
                 &mut tx,
-                Some(from),
+                from,
             )
             .await?;
-            maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token).await?;
             let raw_tx =
                 alloy_primitives::hex::encode_prefixed(tx.build_unsigned()?.encoded_for_signing());
             sh_println!("{raw_tx}")?;
@@ -166,14 +164,14 @@ impl BatchMakeTxArgs {
             }
             let (mut tx, _) = tx_builder.build(config.sender).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            let fee_token = resolve_and_set_fee_token(
+            prepare_tempo_transaction(
+                None,
                 (!config.eth_rpc_curl).then_some(&provider),
                 Some(chain),
                 &mut tx,
-                Some(config.sender),
+                config.sender,
             )
             .await?;
-            maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token).await?;
             let signed_tx = provider.sign_transaction(tx).await?;
             sh_println!("{signed_tx}")?;
             return Ok(());
@@ -186,14 +184,14 @@ impl BatchMakeTxArgs {
             }
             let (mut tx, _, prepared) = tx_builder.build_with_tempo_wallet(access_key).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            let fee_token = resolve_and_set_fee_token(
+            prepare_tempo_transaction(
+                None,
                 (!config.eth_rpc_curl).then_some(&provider),
                 Some(chain),
                 &mut tx,
-                Some(prepared.account()),
+                prepared.account(),
             )
             .await?;
-            maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token).await?;
             let raw_tx = tx.sign_with_tempo_wallet(&prepared).await?;
             alloy_primitives::hex::encode(raw_tx)
         } else {
@@ -207,14 +205,14 @@ impl BatchMakeTxArgs {
             }
             let (mut tx, _) = tx_builder.build(&signer).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            let fee_token = resolve_and_set_fee_token(
+            prepare_tempo_transaction(
+                None,
                 (!config.eth_rpc_curl).then_some(&provider),
                 Some(chain),
                 &mut tx,
-                Some(Signer::address(&signer)),
+                Signer::address(&signer),
             )
             .await?;
-            maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token).await?;
             let envelope = tx.build(&EthereumWallet::new(signer)).await?;
             alloy_primitives::hex::encode(envelope.encoded_2718())
         };

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -32,7 +32,7 @@ use foundry_common::{
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::{ProviderBuilder, RetryProviderWithSigner},
     shell,
-    tempo::{maybe_print_fee_token, resolve_and_set_fee_token},
+    tempo::{prepare_tempo_sponsor_hash, prepare_tempo_transaction},
 };
 #[doc(hidden)]
 pub use foundry_config::{Chain, Eip1559FeeEstimatePreset, utils::*};
@@ -421,39 +421,26 @@ impl Erc20Subcommand {
                     .await?;
                     if needs_sponsor_payload {
                         if print_sponsor_hash {
-                            if let Some(fee_payer) = sponsor_fee_payer {
-                                resolve_and_set_fee_token(
-                                    (!config.eth_rpc_curl).then_some(&$provider),
-                                    Some(chain),
-                                    &mut tx,
-                                    Some(fee_payer),
-                                )
-                                .await?;
-                            }
-                            let hash = tx
-                                .compute_sponsor_hash(prepared_access_key.account())
-                                .ok_or_else(|| {
-                                    eyre::eyre!(
-                                        "This network does not support sponsored transactions"
-                                    )
-                                })?;
+                            let hash = prepare_tempo_sponsor_hash(
+                                (!config.eth_rpc_curl).then_some(&$provider),
+                                Some(chain),
+                                &mut tx,
+                                prepared_access_key.account(),
+                                sponsor_fee_payer,
+                            )
+                            .await?;
                             sh_println!("{hash:?}")?;
                             return Ok(());
                         }
                         if let Some(sponsor) = &tempo_sponsor {
-                            sponsor
-                                .resolve_and_set_fee_token(
-                                    (!config.eth_rpc_curl).then_some(&$provider),
-                                    Some(chain),
-                                    &mut tx,
-                                )
-                                .await?;
-                            sponsor
-                                .attach_and_print::<TempoNetwork>(
-                                    &mut tx,
-                                    prepared_access_key.account(),
-                                )
-                                .await?;
+                            prepare_tempo_transaction(
+                                Some(sponsor),
+                                (!config.eth_rpc_curl).then_some(&$provider),
+                                Some(chain),
+                                &mut tx,
+                                prepared_access_key.account(),
+                            )
+                            .await?;
                         }
                     }
                     if let Some(sponsor_url) = sponsor_url.as_deref() {
@@ -502,44 +489,25 @@ impl Erc20Subcommand {
                     )
                     .await?;
                     if print_sponsor_hash {
-                        if let Some(fee_payer) = sponsor_fee_payer {
-                            resolve_and_set_fee_token(
-                                (!config.eth_rpc_curl).then_some(&$provider),
-                                Some(chain),
-                                &mut tx,
-                                Some(fee_payer),
-                            )
-                            .await?;
-                        }
-                        let hash = tx.compute_sponsor_hash(browser.address()).ok_or_else(|| {
-                            eyre::eyre!("This network does not support sponsored transactions")
-                        })?;
-                        sh_println!("{hash:?}")?;
-                        return Ok(());
-                    }
-                    if let Some(sponsor) = &tempo_sponsor {
-                        sponsor
-                            .resolve_and_set_fee_token(
-                                (!config.eth_rpc_curl).then_some(&$provider),
-                                Some(chain),
-                                &mut tx,
-                            )
-                            .await?;
-                        sponsor.attach_and_print::<N>(&mut tx, browser.address()).await?;
-                    } else {
-                        let fee_token = resolve_and_set_fee_token(
+                        let hash = prepare_tempo_sponsor_hash(
                             (!config.eth_rpc_curl).then_some(&$provider),
                             Some(chain),
                             &mut tx,
-                            Some(browser.address()),
+                            browser.address(),
+                            sponsor_fee_payer,
                         )
                         .await?;
-                        maybe_print_fee_token(
-                            (!config.eth_rpc_curl).then_some(&$provider),
-                            fee_token,
-                        )
-                        .await?;
+                        sh_println!("{hash:?}")?;
+                        return Ok(());
                     }
+                    prepare_tempo_transaction(
+                        tempo_sponsor.as_ref(),
+                        (!config.eth_rpc_curl).then_some(&$provider),
+                        Some(chain),
+                        &mut tx,
+                        browser.address(),
+                    )
+                    .await?;
                     let tx_hash = browser.send_transaction_via_browser(tx).await?;
                     CastTxSender::new(&$provider)
                         .print_tx_result(
@@ -573,30 +541,26 @@ impl Erc20Subcommand {
                         )
                         .await?;
                         if print_sponsor_hash {
-                            if let Some(fee_payer) = sponsor_fee_payer {
-                                resolve_and_set_fee_token(
-                                    (!config.eth_rpc_curl).then_some(&$provider),
-                                    Some(chain),
-                                    &mut tx,
-                                    Some(fee_payer),
-                                )
-                                .await?;
-                            }
-                            let hash = tx.compute_sponsor_hash(from).ok_or_else(|| {
-                                eyre::eyre!("This network does not support sponsored transactions")
-                            })?;
+                            let hash = prepare_tempo_sponsor_hash(
+                                (!config.eth_rpc_curl).then_some(&$provider),
+                                Some(chain),
+                                &mut tx,
+                                from,
+                                sponsor_fee_payer,
+                            )
+                            .await?;
                             sh_println!("{hash:?}")?;
                             return Ok(());
                         }
                         if let Some(sponsor) = &tempo_sponsor {
-                            sponsor
-                                .resolve_and_set_fee_token(
-                                    (!config.eth_rpc_curl).then_some(&$provider),
-                                    Some(chain),
-                                    &mut tx,
-                                )
-                                .await?;
-                            sponsor.attach_and_print::<N>(&mut tx, from).await?;
+                            prepare_tempo_transaction(
+                                Some(sponsor),
+                                (!config.eth_rpc_curl).then_some(&$provider),
+                                Some(chain),
+                                &mut tx,
+                                from,
+                            )
+                            .await?;
                         }
                     } else {
                         // Fill only the fees; the provider fills nonce and gas limit.

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -20,12 +20,11 @@ use foundry_cli::{
     utils::{LoadConfig, maybe_print_resolved_lane, parse_fee_token_address, resolve_lane},
 };
 use foundry_common::{
-    FoundryTransactionBuilder,
     provider::{ProviderBuilder, is_rpc_method_not_found},
     sh_warn, shell,
     tempo::{
-        self, AccountsStoreView, KeyType, maybe_print_fee_token, read_tempo_accounts_store,
-        resolve_and_set_fee_token, tempo_accounts_store_path,
+        self, AccountsStoreView, KeyType, prepare_tempo_sponsor_hash, prepare_tempo_transaction,
+        read_tempo_accounts_store, tempo_accounts_store_path,
     },
 };
 use foundry_evm::hardfork::TempoHardfork;
@@ -3649,18 +3648,14 @@ pub(crate) async fn send_keychain_tx_with_root_signer(
         let from = root_signer.address();
         let chain = builder.chain();
         let (mut tx, _) = builder.build(root_signer.sender()).await?;
-        if let Some(fee_payer) = sponsor_fee_payer {
-            resolve_and_set_fee_token(
-                (!config.eth_rpc_curl).then_some(&provider),
-                Some(chain),
-                &mut tx,
-                Some(fee_payer),
-            )
-            .await?;
-        }
-        let hash = tx
-            .compute_sponsor_hash(from)
-            .ok_or_else(|| eyre::eyre!("This network does not support sponsored transactions"))?;
+        let hash = prepare_tempo_sponsor_hash(
+            (!config.eth_rpc_curl).then_some(&provider),
+            Some(chain),
+            &mut tx,
+            from,
+            sponsor_fee_payer,
+        )
+        .await?;
         if shell::is_json() {
             sh_println!("{}", serde_json::json!({ "sponsor_hash": format!("{hash:?}") }))?;
         } else {
@@ -3675,26 +3670,14 @@ pub(crate) async fn send_keychain_tx_with_root_signer(
         KeychainRootSigner::Browser(browser) => {
             let chain = builder.chain();
             let (mut tx, _) = builder.with_browser_wallet().build(browser.address()).await?;
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<TempoNetwork>(&mut tx, browser.address()).await?;
-            } else {
-                let fee_token = resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(browser.address()),
-                )
-                .await?;
-                maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token)
-                    .await?;
-            }
+            prepare_tempo_transaction(
+                tempo_sponsor.as_ref(),
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                browser.address(),
+            )
+            .await?;
 
             before_submit()?;
             let tx_hash = browser.send_transaction_via_browser(tx).await?;
@@ -3707,26 +3690,14 @@ pub(crate) async fn send_keychain_tx_with_root_signer(
             let chain = builder.chain();
             let (mut tx, _) = builder.build(signer.as_ref()).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<TempoNetwork>(&mut tx, from).await?;
-            } else {
-                let fee_token = resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(from),
-                )
-                .await?;
-                maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token)
-                    .await?;
-            }
+            prepare_tempo_transaction(
+                tempo_sponsor.as_ref(),
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                from,
+            )
+            .await?;
 
             before_submit()?;
             let wallet = EthereumWallet::from(*signer);

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -22,7 +22,7 @@ use foundry_cli::{
 use foundry_common::{
     FoundryTransactionBuilder,
     provider::ProviderBuilder,
-    tempo::{maybe_print_fee_token, resolve_and_set_fee_token},
+    tempo::{prepare_tempo_sponsor_hash, prepare_tempo_transaction},
 };
 use foundry_wallets::{TempoAccountsWallet, WalletSigner};
 use std::{path::PathBuf, str::FromStr};
@@ -222,18 +222,14 @@ impl MakeTxArgs {
                 let (tx, _) = tx_builder.build(&signer).await?;
                 (tx, from)
             };
-            if let Some(fee_payer) = sponsor_fee_payer {
-                resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(fee_payer),
-                )
-                .await?;
-            }
-            let hash = tx.compute_sponsor_hash(from).ok_or_else(|| {
-                eyre::eyre!("This network does not support sponsored transactions")
-            })?;
+            let hash = prepare_tempo_sponsor_hash(
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                from,
+                sponsor_fee_payer,
+            )
+            .await?;
             print_scalar(format!("{hash:?}"))?;
             return Ok(());
         }
@@ -265,26 +261,14 @@ impl MakeTxArgs {
             }
             let (mut tx, _) = tx_builder.build(from).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<N>(&mut tx, from).await?;
-            } else {
-                let fee_token = resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(from),
-                )
-                .await?;
-                maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token)
-                    .await?;
-            }
+            prepare_tempo_transaction(
+                tempo_sponsor.as_ref(),
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                from,
+            )
+            .await?;
             let raw_tx = hex::encode_prefixed(tx.build_unsigned()?.encoded_for_signing());
 
             print_scalar(raw_tx)?;
@@ -299,26 +283,14 @@ impl MakeTxArgs {
             }
             let (mut tx, _) = tx_builder.build(from).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<N>(&mut tx, from).await?;
-            } else {
-                let fee_token = resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(from),
-                )
-                .await?;
-                maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token)
-                    .await?;
-            }
+            prepare_tempo_transaction(
+                tempo_sponsor.as_ref(),
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                from,
+            )
+            .await?;
 
             let tx = tx.build_unsigned()?;
             let recovered = signature.recover_address_from_prehash(&tx.signature_hash())?;
@@ -342,26 +314,14 @@ impl MakeTxArgs {
             }
             let (mut tx, _) = tx_builder.build(config.sender).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<N>(&mut tx, config.sender).await?;
-            } else {
-                let fee_token = resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(config.sender),
-                )
-                .await?;
-                maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token)
-                    .await?;
-            }
+            prepare_tempo_transaction(
+                tempo_sponsor.as_ref(),
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                config.sender,
+            )
+            .await?;
             let signed_tx = provider.sign_transaction(tx).await?;
 
             print_scalar(signed_tx)?;
@@ -376,26 +336,14 @@ impl MakeTxArgs {
             }
             let (mut tx, _, prepared) = tx_builder.build_with_tempo_wallet(&access_key).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<N>(&mut tx, prepared.account()).await?;
-            } else {
-                let fee_token = resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(prepared.account()),
-                )
-                .await?;
-                maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token)
-                    .await?;
-            }
+            prepare_tempo_transaction(
+                tempo_sponsor.as_ref(),
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                prepared.account(),
+            )
+            .await?;
             tx.sign_with_tempo_wallet(&prepared).await?
         } else {
             // Get the signer from the wallet, and fail if it can't be constructed.
@@ -412,26 +360,14 @@ impl MakeTxArgs {
             }
             let (mut tx, _) = tx_builder.build(&signer).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<N>(&mut tx, from).await?;
-            } else {
-                let fee_token = resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(from),
-                )
-                .await?;
-                maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token)
-                    .await?;
-            }
+            prepare_tempo_transaction(
+                tempo_sponsor.as_ref(),
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                from,
+            )
+            .await?;
 
             tx.build(&EthereumWallet::new(signer)).await?.encoded_2718()
         };

--- a/crates/cast/src/cmd/safe/transaction.rs
+++ b/crates/cast/src/cmd/safe/transaction.rs
@@ -11,9 +11,7 @@ use foundry_cli::{
     utils::{LoadConfig, resolve_lane},
 };
 use foundry_common::{
-    FoundryTransactionBuilder,
-    provider::ProviderBuilder,
-    tempo::{maybe_print_fee_token, resolve_and_set_fee_token},
+    FoundryTransactionBuilder, provider::ProviderBuilder, tempo::prepare_tempo_transaction,
 };
 use foundry_wallets::WalletOpts;
 use serde::Serialize;
@@ -133,14 +131,14 @@ where
         .await?;
     let chain = builder.chain();
     let (mut request, _) = builder.build(from).await?;
-    let fee_token = resolve_and_set_fee_token(
+    prepare_tempo_transaction(
+        None,
         (!config.eth_rpc_curl).then_some(&provider),
         Some(chain),
         &mut request,
-        Some(from),
+        from,
     )
     .await?;
-    maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token).await?;
 
     let receipt = provider
         .send_transaction(request)

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -17,7 +17,7 @@ use foundry_common::{
     FoundryTransactionBuilder,
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::ProviderBuilder,
-    tempo::{maybe_print_fee_token, resolve_and_set_fee_token},
+    tempo::{TempoTransactionPreparation, prepare_tempo_sponsor_hash, prepare_tempo_transaction},
 };
 use foundry_config::Chain;
 use foundry_wallets::{TempoAccountsWallet, WalletSigner};
@@ -297,18 +297,14 @@ impl SendTxArgs {
                 let (tx, _) = builder.build(signer).await?;
                 (tx, from)
             };
-            if let Some(fee_payer) = sponsor_fee_payer {
-                resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(fee_payer),
-                )
-                .await?;
-            }
-            let hash = tx
-                .compute_sponsor_hash(from)
-                .ok_or_else(|| eyre!("This network does not support sponsored transactions"))?;
+            let hash = prepare_tempo_sponsor_hash(
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                from,
+                sponsor_fee_payer,
+            )
+            .await?;
             sh_println!("{hash:?}")?;
             return Ok(());
         }
@@ -368,14 +364,14 @@ impl SendTxArgs {
                 tx_request.nonce().unwrap_or_default(),
             )?;
             if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx_request,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<N>(&mut tx_request, config.sender).await?;
+                prepare_tempo_transaction(
+                    Some(sponsor),
+                    (!config.eth_rpc_curl).then_some(&provider),
+                    Some(chain),
+                    &mut tx_request,
+                    config.sender,
+                )
+                .await?;
             }
 
             cast_send(
@@ -404,26 +400,14 @@ impl SendTxArgs {
                 tx_request.nonce().unwrap_or_default(),
             )?;
 
-            if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx_request,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<N>(&mut tx_request, browser.address()).await?;
-            } else {
-                let fee_token = resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx_request,
-                    Some(browser.address()),
-                )
-                .await?;
-                maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token)
-                    .await?;
-            }
+            prepare_tempo_transaction(
+                tempo_sponsor.as_ref(),
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx_request,
+                browser.address(),
+            )
+            .await?;
 
             if chain.id() != browser.chain_id() {
                 sh_warn!("Switching browser wallet to chain {}", chain)?;
@@ -447,14 +431,14 @@ impl SendTxArgs {
                 tx_request.nonce().unwrap_or_default(),
             )?;
             if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx_request,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<N>(&mut tx_request, prepared.account()).await?;
+                prepare_tempo_transaction(
+                    Some(sponsor),
+                    (!config.eth_rpc_curl).then_some(&provider),
+                    Some(chain),
+                    &mut tx_request,
+                    prepared.account(),
+                )
+                .await?;
             }
             if let Some(sponsor_url) = sponsor_url.as_deref() {
                 cast_send_with_tempo_wallet_via_sponsor(
@@ -549,14 +533,14 @@ impl SendTxArgs {
             )?;
 
             if let Some(sponsor) = &tempo_sponsor {
-                sponsor
-                    .resolve_and_set_fee_token(
-                        (!config.eth_rpc_curl).then_some(&provider),
-                        Some(chain),
-                        &mut tx_request,
-                    )
-                    .await?;
-                sponsor.attach_and_print::<N>(&mut tx_request, from).await?;
+                prepare_tempo_transaction(
+                    Some(sponsor),
+                    (!config.eth_rpc_curl).then_some(&provider),
+                    Some(chain),
+                    &mut tx_request,
+                    from,
+                )
+                .await?;
             }
 
             let wallet = EthereumWallet::from(signer);
@@ -598,14 +582,15 @@ where
     N::TransactionRequest: Default + FoundryTransactionBuilder<N>,
     N::ReceiptResponse: UIfmt + UIfmtReceiptExt,
 {
-    let fee_token = resolve_and_set_fee_token(
+    let preparation = TempoTransactionPreparation::resolve(
+        None,
         resolve_unknown_fee_token_symbol.then_some(&provider),
         chain,
         &mut tx,
         fee_payer,
     )
     .await?;
-    maybe_print_fee_token(resolve_unknown_fee_token_symbol.then_some(&provider), fee_token).await?;
+    preparation.finish(resolve_unknown_fee_token_symbol.then_some(&provider), &mut tx).await?;
     let cast = CastTxSender::new(provider);
 
     if sync {
@@ -659,14 +644,15 @@ where
     N::TransactionRequest: Default + FoundryTransactionBuilder<N>,
     N::ReceiptResponse: UIfmt + UIfmtReceiptExt,
 {
-    let fee_token = resolve_and_set_fee_token(
+    let preparation = TempoTransactionPreparation::resolve(
+        None,
         resolve_unknown_fee_token_symbol.then_some(provider),
         chain,
         &mut tx,
         fee_payer,
     )
     .await?;
-    maybe_print_fee_token(resolve_unknown_fee_token_symbol.then_some(provider), fee_token).await?;
+    preparation.finish(resolve_unknown_fee_token_symbol.then_some(provider), &mut tx).await?;
     let raw_tx = tx.sign_with_tempo_wallet(wallet).await?;
     let cast = CastTxSender::new(provider);
     let (tx_hash, receipt) = cast_send_raw(provider, &raw_tx, sync).await?;

--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -14,9 +14,8 @@ use alloy_signer::Signer;
 use clap::Parser;
 use foundry_cli::utils::{LoadConfig, get_chain, maybe_print_resolved_lane, resolve_lane};
 use foundry_common::{
-    FoundryTransactionBuilder,
     provider::ProviderBuilder,
-    tempo::{maybe_print_fee_token, resolve_and_set_fee_token},
+    tempo::{prepare_tempo_sponsor_hash, prepare_tempo_transaction},
 };
 use foundry_wallets::{TempoAccountsWallet, WalletSigner};
 use std::{str::FromStr, time::Duration};
@@ -251,18 +250,14 @@ pub(crate) async fn send_tip20_transaction(
                 let (tx, _) = builder.build(signer).await?;
                 (tx, from)
             };
-            if let Some(fee_payer) = sponsor_fee_payer {
-                resolve_and_set_fee_token(
-                    (!config.eth_rpc_curl).then_some(&provider),
-                    Some(chain),
-                    &mut tx,
-                    Some(fee_payer),
-                )
-                .await?;
-            }
-            let hash = tx.compute_sponsor_hash(from).ok_or_else(|| {
-                eyre::eyre!("This network does not support sponsored transactions")
-            })?;
+            let hash = prepare_tempo_sponsor_hash(
+                (!config.eth_rpc_curl).then_some(&provider),
+                Some(chain),
+                &mut tx,
+                from,
+                sponsor_fee_payer,
+            )
+            .await?;
             sh_println!("{hash:?}")?;
             eyre::Ok(())
         })
@@ -278,25 +273,14 @@ pub(crate) async fn send_tip20_transaction(
     if let Some(browser) = send_tx.browser.run::<TempoNetwork>().await? {
         let (mut tx, _) = Box::pin(builder.with_browser_wallet().build(browser.address())).await?;
         maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-        if let Some(sponsor) = &tempo_sponsor {
-            attach_sponsor(
-                sponsor,
-                (!config.eth_rpc_curl).then_some(&provider),
-                chain,
-                &mut tx,
-                browser.address(),
-            )
-            .await?;
-        } else {
-            let fee_token = resolve_and_set_fee_token(
-                (!config.eth_rpc_curl).then_some(&provider),
-                Some(chain),
-                &mut tx,
-                Some(browser.address()),
-            )
-            .await?;
-            maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token).await?;
-        }
+        prepare_tempo_transaction(
+            tempo_sponsor.as_ref(),
+            (!config.eth_rpc_curl).then_some(&provider),
+            Some(chain),
+            &mut tx,
+            browser.address(),
+        )
+        .await?;
         let tx_hash = browser.send_transaction_via_browser(tx).await?;
         CastTxSender::new(&provider)
             .print_tx_result(tx_hash, send_tx.cast_async, send_tx.confirmations, timeout)
@@ -305,10 +289,10 @@ pub(crate) async fn send_tip20_transaction(
         let (mut tx, _, prepared) = Box::pin(builder.build_with_tempo_wallet(&ak)).await?;
         maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
         if let Some(sponsor) = &tempo_sponsor {
-            attach_sponsor(
-                sponsor,
+            prepare_tempo_transaction(
+                Some(sponsor),
                 (!config.eth_rpc_curl).then_some(&provider),
-                chain,
+                Some(chain),
                 &mut tx,
                 prepared.account(),
             )
@@ -372,10 +356,10 @@ pub(crate) async fn send_tip20_transaction(
         let (mut tx, _) = builder.build(&signer).await?;
         maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
         if let Some(sponsor) = &tempo_sponsor {
-            attach_sponsor(
-                sponsor,
+            prepare_tempo_transaction(
+                Some(sponsor),
                 (!config.eth_rpc_curl).then_some(&provider),
-                chain,
+                Some(chain),
                 &mut tx,
                 from,
             )
@@ -416,26 +400,4 @@ async fn resolve_send_signer(
     let from = signer.address();
     crate::tx::validate_from_address(eth.wallet.from, from)?;
     Ok((signer, from))
-}
-
-/// Resolves the sponsored fee token and attaches the sponsor signature preview for `payer`.
-async fn attach_sponsor<P>(
-    sponsor: &crate::tempo::TempoSponsor,
-    provider: Option<&P>,
-    chain: foundry_config::Chain,
-    tx: &mut <TempoNetwork as alloy_network::Network>::TransactionRequest,
-    payer: Address,
-) -> eyre::Result<()>
-where
-    P: Provider<TempoNetwork>,
-{
-    sponsor
-        .resolve_and_set_fee_token(
-            provider.map(|p| p as &dyn Provider<TempoNetwork>),
-            Some(chain),
-            tx,
-        )
-        .await?;
-    sponsor.attach_and_print::<TempoNetwork>(tx, payer).await?;
-    Ok(())
 }

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -21,7 +21,7 @@ use foundry_common::{
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::ProviderBuilder,
     shell,
-    tempo::{maybe_print_fee_token, resolve_and_set_fee_token},
+    tempo::prepare_tempo_transaction,
 };
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use serde_json::json;
@@ -201,14 +201,14 @@ async fn register(
         .await?;
         if shell::is_json() {
             // JSON mode bypasses `cast_send_with_tempo_wallet`, so report the selection here.
-            let fee_token = resolve_and_set_fee_token(
+            prepare_tempo_transaction(
+                None,
                 (!config.eth_rpc_curl).then_some(&provider),
                 Some(chain),
                 &mut tx,
-                Some(prepared.account()),
+                prepared.account(),
             )
             .await?;
-            maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token).await?;
             let raw_tx = tx.sign_with_tempo_wallet(&prepared).await?;
             let (tx_hash, _) = cast_send_raw(&provider, &raw_tx, send_tx.sync).await?;
             if !send_tx.sync {
@@ -250,14 +250,14 @@ async fn register(
         .await?;
         if shell::is_json() {
             // JSON mode bypasses `cast_send`, so report the selection here.
-            let fee_token = resolve_and_set_fee_token(
+            prepare_tempo_transaction(
+                None,
                 (!config.eth_rpc_curl).then_some(&provider),
                 Some(chain),
                 &mut tx,
-                Some(sender),
+                sender,
             )
             .await?;
-            maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token).await?;
             let cast = CastTxSender::new(&provider);
             if send_tx.sync {
                 cast.send_sync(tx).await.map(|(tx_hash, _)| tx_hash)

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -250,6 +250,104 @@ pub async fn resolve_tempo_sponsor_signer(spec: &str) -> Result<WalletSigner> {
     }
 }
 
+/// Tempo transaction state resolved before gas estimation and finalized before signing.
+///
+/// Fee-token resolution must happen before estimating gas, while sponsor signatures must be
+/// attached afterwards because their digest commits to the completed transaction.
+#[must_use = "Tempo transaction preparation must be finalized before signing"]
+#[derive(Debug)]
+pub struct TempoTransactionPreparation<'a>(TempoTransactionPreparationKind<'a>);
+
+#[derive(Debug)]
+enum TempoTransactionPreparationKind<'a> {
+    Sponsored { sponsor: &'a TempoSponsor, sender: Option<Address> },
+    FeeToken(Option<Address>),
+}
+
+impl<'a> TempoTransactionPreparation<'a> {
+    /// Resolves the fee token and remembers the transaction account needed for finalization.
+    pub async fn resolve<N>(
+        sponsor: Option<&'a TempoSponsor>,
+        provider: Option<&dyn Provider<N>>,
+        chain: Option<Chain>,
+        tx: &mut N::TransactionRequest,
+        account: Option<Address>,
+    ) -> Result<Self>
+    where
+        N: Network,
+        N::TransactionRequest: Default + FoundryTransactionBuilder<N>,
+    {
+        if let Some(sponsor) = sponsor {
+            sponsor.resolve_and_set_fee_token(provider, chain, tx).await?;
+            Ok(Self(TempoTransactionPreparationKind::Sponsored { sponsor, sender: account }))
+        } else {
+            let fee_token = resolve_and_set_fee_token(provider, chain, tx, account).await?;
+            Ok(Self(TempoTransactionPreparationKind::FeeToken(fee_token)))
+        }
+    }
+
+    /// Attaches the sponsor signature or prints the resolved fee token.
+    pub async fn finish<N>(
+        self,
+        provider: Option<&dyn Provider<N>>,
+        tx: &mut N::TransactionRequest,
+    ) -> Result<()>
+    where
+        N: Network,
+        N::TransactionRequest: Default + FoundryTransactionBuilder<N>,
+    {
+        match self.0 {
+            TempoTransactionPreparationKind::Sponsored { sponsor, sender } => {
+                let sender = sender.ok_or_else(|| {
+                    eyre::eyre!("missing transaction sender for Tempo sponsor signature")
+                })?;
+                sponsor.attach_and_print::<N>(tx, sender).await?;
+            }
+            TempoTransactionPreparationKind::FeeToken(fee_token) => {
+                maybe_print_fee_token(provider, fee_token).await?
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolves and finalizes Tempo-specific transaction fields when no intervening gas estimation is
+/// required.
+pub async fn prepare_tempo_transaction<N>(
+    sponsor: Option<&TempoSponsor>,
+    provider: Option<&dyn Provider<N>>,
+    chain: Option<Chain>,
+    tx: &mut N::TransactionRequest,
+    sender: Address,
+) -> Result<()>
+where
+    N: Network,
+    N::TransactionRequest: Default + FoundryTransactionBuilder<N>,
+{
+    let preparation =
+        TempoTransactionPreparation::resolve(sponsor, provider, chain, tx, Some(sender)).await?;
+    preparation.finish(provider, tx).await
+}
+
+/// Resolves the fee token selected for a sponsor digest and computes the digest.
+pub async fn prepare_tempo_sponsor_hash<N>(
+    provider: Option<&dyn Provider<N>>,
+    chain: Option<Chain>,
+    tx: &mut N::TransactionRequest,
+    sender: Address,
+    fee_payer: Option<Address>,
+) -> Result<B256>
+where
+    N: Network,
+    N::TransactionRequest: Default + FoundryTransactionBuilder<N>,
+{
+    if let Some(fee_payer) = fee_payer {
+        resolve_and_set_fee_token(provider, chain, tx, Some(fee_payer)).await?;
+    }
+    tx.compute_sponsor_hash(sender)
+        .ok_or_else(|| eyre::eyre!("This network does not support sponsored transactions"))
+}
+
 /// Placeholder rendered by `Debug` impls in place of secret key material.
 fn redacted_debug(value: &str) -> &'static str {
     if value.trim().is_empty() { "<empty>" } else { "<redacted>" }
@@ -424,7 +522,7 @@ async fn resolve_fee_token_symbol<N, P>(provider: &P, fee_token: Address) -> Opt
 where
     N: Network,
     N::TransactionRequest: Default + NetworkTransactionBuilder<N>,
-    P: Provider<N>,
+    P: Provider<N> + ?Sized,
 {
     if let Some(symbol) = known_fee_token_symbol(fee_token) {
         return Some(symbol.to_string());
@@ -449,7 +547,7 @@ pub async fn maybe_print_fee_token<N, P>(
 where
     N: Network,
     N::TransactionRequest: Default + NetworkTransactionBuilder<N>,
-    P: Provider<N>,
+    P: Provider<N> + ?Sized,
 {
     if let Some(fee_token) = fee_token {
         let symbol = if let Some(symbol) = known_fee_token_symbol(fee_token) {

--- a/crates/common/src/tempo/tests.rs
+++ b/crates/common/src/tempo/tests.rs
@@ -20,8 +20,8 @@ use tempo_primitives::transaction::{Call, SignatureType};
 
 use super::{
     ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
-    TIP_FEE_MANAGER_ADDRESS, TempoSponsor, known_fee_token_symbol, resolve_and_set_fee_token,
-    resolve_fee_token_symbol,
+    TIP_FEE_MANAGER_ADDRESS, TempoSponsor, TempoTransactionPreparation, known_fee_token_symbol,
+    resolve_and_set_fee_token, resolve_fee_token_symbol,
 };
 
 #[test]
@@ -310,16 +310,14 @@ async fn sponsor_fee_token_resolution_uses_sponsor_address() -> eyre::Result<()>
 
     asserter.push_success(&BETA_USD_ADDRESS.abi_encode());
 
-    assert_eq!(
-        sponsor
-            .resolve_and_set_fee_token::<TempoNetwork>(
-                Some(&provider),
-                Some(Chain::from_named(NamedChain::Tempo)),
-                &mut tx,
-            )
-            .await?,
-        Some(BETA_USD_ADDRESS)
-    );
+    let _preparation = TempoTransactionPreparation::resolve(
+        Some(&sponsor),
+        Some(&provider),
+        Some(Chain::from_named(NamedChain::Tempo)),
+        &mut tx,
+        Some(sender),
+    )
+    .await?;
     assert_eq!(tx.fee_token, Some(BETA_USD_ADDRESS));
     Ok(())
 }

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -26,7 +26,7 @@ use foundry_common::{
         fee::{estimate_eip1559_fees, resolve_broadcast_eip1559_fees},
     },
     shell,
-    tempo::{maybe_print_fee_token, resolve_and_set_fee_token},
+    tempo::prepare_tempo_transaction,
 };
 use foundry_compilers::{
     ArtifactId, artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize,
@@ -606,26 +606,14 @@ impl CreateArgs {
         }
 
         let tempo_sponsor = self.tx.tempo.sponsor_config().await?;
-        if let Some(sponsor) = &tempo_sponsor {
-            sponsor
-                .resolve_and_set_fee_token(
-                    resolve_unknown_fee_token_symbol.then_some(&provider),
-                    Some(chain),
-                    &mut deployer.tx,
-                )
-                .await?;
-            sponsor.attach_and_print::<N>(&mut deployer.tx, deployer_address).await?;
-        } else {
-            let fee_token = resolve_and_set_fee_token(
-                resolve_unknown_fee_token_symbol.then_some(&provider),
-                Some(chain),
-                &mut deployer.tx,
-                Some(deployer_address),
-            )
-            .await?;
-            maybe_print_fee_token(resolve_unknown_fee_token_symbol.then_some(&provider), fee_token)
-                .await?;
-        }
+        prepare_tempo_transaction(
+            tempo_sponsor.as_ref(),
+            resolve_unknown_fee_token_symbol.then_some(&provider),
+            Some(chain),
+            &mut deployer.tx,
+            deployer_address,
+        )
+        .await?;
 
         // Deploy the actual contract
         let (deployed_contract, receipt) = if let Some(browser) = browser_signer {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -37,7 +37,7 @@ use foundry_common::{
         fee::{estimate_eip1559_fees, resolve_broadcast_eip1559_fees},
     },
     shell,
-    tempo::{TempoSponsor, maybe_print_fee_token, resolve_and_set_fee_token},
+    tempo::{TempoSponsor, TempoTransactionPreparation},
 };
 use foundry_config::Config;
 use foundry_evm::core::{
@@ -130,12 +130,14 @@ where
             **wallet = tx.prepare_with_tempo_wallet(provider, wallet).await?;
         }
 
-        let fee_token = if let Some(sponsor) = tempo_sponsor {
-            sponsor.resolve_and_set_fee_token(Some(provider), chain, tx).await?;
-            None
-        } else {
-            resolve_and_set_fee_token(Some(provider), chain, tx, tx.from()).await?
-        };
+        let preparation = TempoTransactionPreparation::resolve(
+            tempo_sponsor,
+            Some(provider),
+            chain,
+            tx,
+            tx.from(),
+        )
+        .await?;
 
         // A fee token, sponsor, validity window, or other Tempo field selects
         // the AA transaction type. AA requests carry CREATE as their first
@@ -148,12 +150,7 @@ where
             estimate_gas(tx, provider, estimate_multiplier, tempo_browser).await?;
         }
 
-        if let Some(sponsor) = tempo_sponsor {
-            let from = tx.from().expect("no sender");
-            sponsor.attach_and_print::<N>(tx, from).await?;
-        } else {
-            maybe_print_fee_token(Some(provider), fee_token).await?;
-        }
+        preparation.finish(Some(provider), tx).await?;
 
         Ok(())
     }
@@ -1139,24 +1136,14 @@ impl BundledState<TempoEvmNetwork> {
             ..Default::default()
         };
         self.script_config.tempo.apply::<TempoNetwork>(&mut batch_tx, None);
-        let fee_token = if let Some(sponsor) = &tempo_sponsor {
-            sponsor
-                .resolve_and_set_fee_token(
-                    Some(provider.as_ref()),
-                    Some(Chain::from_named(NamedChain::Tempo)),
-                    &mut batch_tx,
-                )
-                .await?;
-            None
-        } else {
-            resolve_and_set_fee_token(
-                Some(provider.as_ref()),
-                Some(Chain::from_named(NamedChain::Tempo)),
-                &mut batch_tx,
-                Some(sender),
-            )
-            .await?
-        };
+        let preparation = TempoTransactionPreparation::resolve(
+            tempo_sponsor.as_ref(),
+            Some(provider.as_ref()),
+            Some(Chain::from_named(NamedChain::Tempo)),
+            &mut batch_tx,
+            Some(sender),
+        )
+        .await?;
 
         if let BatchSigner::TempoKeychain(wallet) = &mut batch_signer {
             **wallet = batch_tx.prepare_with_tempo_wallet(provider.as_ref(), wallet).await?;
@@ -1168,11 +1155,7 @@ impl BundledState<TempoEvmNetwork> {
 
         sh_println!("Estimated gas: {}", batch_tx.inner.gas.unwrap_or(0))?;
 
-        if let Some(sponsor) = &tempo_sponsor {
-            sponsor.attach_and_print::<TempoNetwork>(&mut batch_tx, sender).await?;
-        } else {
-            maybe_print_fee_token(Some(provider.as_ref()), fee_token).await?;
-        }
+        preparation.finish(Some(provider.as_ref()), &mut batch_tx).await?;
 
         // Sign and send.
         let tx_hash = match batch_signer {


### PR DESCRIPTION
## Summary

- introduce a two-phase Tempo transaction preparation context around gas estimation and signing
- route Cast, Forge Create, and Forge Script transaction paths through shared preparation helpers
- centralize sponsor-hash fee-token preparation while retaining the low-level public APIs for compatibility

## Testing

- `cargo check -p foundry-common -p cast@1.8.1 -p forge-script -p forge`
- `cargo test -p foundry-common tempo::tests`
- `cargo clippy -p foundry-common -p cast@1.8.1 -p forge-script -p forge --all-targets --no-deps -- -D warnings`