### PR TITLE
refactor(traces): carry execution context

### DIFF
--- a/.changelog/carry-trace-context.md
+++ b/.changelog/carry-trace-context.md
@@ -1,0 +1,8 @@
+---
+cast: patch
+forge-verify: patch
+foundry-evm: patch
+foundry-evm-traces: patch
+---
+
+Carried trace network and hardfork context through local execution and decoding instead of passing the values independently.

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -57,7 +57,7 @@ use foundry_evm::{
     },
     executors::{ExecutorBuilder, TracingExecutor},
     opts::EvmOpts,
-    traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements},
+    traces::{InternalTraceMode, SparsedTraceArena, TraceContext, TraceRequirements},
 };
 use foundry_evm_networks::NetworkConfigs;
 use foundry_wallets::{BrowserWalletOpts, WalletOpts};
@@ -618,13 +618,11 @@ impl CallArgs {
             handle_traces(
                 result,
                 &config,
-                chain,
+                TraceContext::new(chain, endpoint_identity.network_profile, resolved_hardfork),
                 &contracts_bytecode,
                 &tracing,
                 with_local_artifacts,
                 false,
-                resolved_hardfork,
-                endpoint_identity.network_profile,
             )
             .await?;
 
@@ -639,35 +637,24 @@ impl CallArgs {
 
             let create2_deployer = evm_opts.create2_deployer;
             let verbosity = tracing.verbosity;
-            let (mut evm_env, tx_env, fork, chain, networks, endpoint_hardfork) =
-                TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts).await?;
-            let context_block_number = evm_env.block_env.number().saturating_to();
+            let mut fork = TracingExecutor::<FEN>::get_fork(&mut config, evm_opts).await?;
+            let context_block_number = fork.evm_env.block_env.number().saturating_to();
             // Modify settings usually set in eth_call while keeping execution gas bounded.
-            evm_env.cfg_env.disable_block_gas_limit = true;
-            evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+            fork.evm_env.cfg_env.disable_block_gas_limit = true;
+            fork.evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
 
             // Apply the block overrides.
             if let Some(block_overrides) = block_overrides {
                 if let Some(number) = block_overrides.number {
-                    evm_env.block_env.set_number(number.to());
+                    fork.evm_env.block_env.set_number(number.to());
                 }
                 if let Some(time) = block_overrides.time {
-                    evm_env.block_env.set_timestamp(U256::from(time));
+                    fork.evm_env.block_env.set_timestamp(U256::from(time));
                 }
             }
-            let resolved_hardfork = TracingExecutor::<FEN>::resolve_spec_for_chain(
-                &config,
-                networks,
-                chain.id(),
-                endpoint_hardfork,
-                &mut evm_env,
-                evm_version,
-            );
-            TracingExecutor::<FEN>::extend_precompile_labels(
-                &mut config,
-                networks,
-                resolved_hardfork,
-            );
+            fork.resolve_spec(&config, evm_version);
+            fork.extend_precompile_labels(&mut config);
+            let context = fork.context();
 
             let trace_requirements = TraceRequirements::none()
                 .with_calls(true)
@@ -678,13 +665,10 @@ impl CallArgs {
                     InternalTraceMode::None
                 })
                 .with_state_changes(verbosity > 4);
-            let mut executor = TracingExecutor::<FEN>::new(
+            let mut executor = fork.into_executor(
                 executor_builder,
-                (evm_env, tx_env),
-                fork,
                 None,
                 trace_requirements,
-                networks,
                 create2_deployer,
                 state_overrides,
             )?;
@@ -742,7 +726,7 @@ impl CallArgs {
                 &provider,
                 context_block_number,
                 &context_tx,
-                networks,
+                context.networks(),
             )
             .await?;
 
@@ -762,13 +746,11 @@ impl CallArgs {
             handle_traces(
                 trace,
                 &config,
-                chain,
+                context,
                 &contracts_bytecode,
                 &tracing,
                 with_local_artifacts,
                 debug,
-                resolved_hardfork,
-                networks,
             )
             .await?;
 

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -35,7 +35,7 @@ use foundry_cli::{
 use foundry_common::{
     FoundryTransactionBuilder,
     abi::{encode_function_args, get_func},
-    provider::{ProviderBuilder, curl_transport::generate_curl_command},
+    provider::{ProviderBuilder, RetryProvider, curl_transport::generate_curl_command},
     sh_println, shell,
 };
 use foundry_compilers::artifacts::EvmVersion;
@@ -52,8 +52,8 @@ use foundry_evm::core::evm::MonadEvmNetwork;
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
     core::{
-        FoundryBlock, FoundryTransaction,
-        evm::{EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, context_for_child_transaction},
+        FoundryBlock, FoundryChain, FoundryTransaction,
+        evm::{ChainFor, EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
     },
     executors::{ExecutorBuilder, TracingExecutor},
     opts::EvmOpts,
@@ -63,6 +63,44 @@ use foundry_evm_networks::NetworkConfigs;
 use foundry_wallets::{BrowserWalletOpts, WalletOpts};
 use revm::context::Block;
 use std::str::FromStr;
+
+struct StatelessChildContext;
+
+#[cfg(feature = "monad")]
+struct MonadChildContext;
+
+trait ChildTransactionContext<FEN: FoundryEvmNetwork> {
+    async fn build(
+        &self,
+        provider: &RetryProvider<FEN::Network>,
+        block_number: u64,
+        tx: &TxEnvFor<FEN>,
+    ) -> Result<ChainFor<FEN>>;
+}
+
+impl<FEN: FoundryEvmNetwork> ChildTransactionContext<FEN> for StatelessChildContext {
+    async fn build(
+        &self,
+        _provider: &RetryProvider<FEN::Network>,
+        _block_number: u64,
+        tx: &TxEnvFor<FEN>,
+    ) -> Result<ChainFor<FEN>> {
+        Ok(ChainFor::<FEN>::for_transaction(tx))
+    }
+}
+
+#[cfg(feature = "monad")]
+impl ChildTransactionContext<MonadEvmNetwork> for MonadChildContext {
+    async fn build(
+        &self,
+        provider: &RetryProvider<<MonadEvmNetwork as FoundryEvmNetwork>::Network>,
+        block_number: u64,
+        tx: &TxEnvFor<MonadEvmNetwork>,
+    ) -> Result<ChainFor<MonadEvmNetwork>> {
+        foundry_evm::core::evm::monad_context_for_child_transaction(provider, block_number, tx)
+            .await
+    }
+}
 
 /// CLI arguments for `cast call`.
 ///
@@ -280,6 +318,7 @@ impl CallArgs {
                     evm_opts,
                     auth_preflight,
                     ExecutorBuilder::<TempoEvmNetwork>::new(),
+                    StatelessChildContext,
                 )
                 .await;
         }
@@ -292,6 +331,7 @@ impl CallArgs {
                     evm_opts,
                     auth_preflight,
                     ExecutorBuilder::<MonadEvmNetwork>::new(),
+                    MonadChildContext,
                 )
                 .await;
         }
@@ -304,6 +344,7 @@ impl CallArgs {
                     evm_opts,
                     auth_preflight,
                     ExecutorBuilder::<OpEvmNetwork>::new(),
+                    StatelessChildContext,
                 )
                 .await;
         }
@@ -313,6 +354,7 @@ impl CallArgs {
             evm_opts,
             auth_preflight,
             ExecutorBuilder::<EthEvmNetwork>::new(),
+            StatelessChildContext,
         )
         .await
     }
@@ -370,6 +412,7 @@ impl CallArgs {
         evm_opts: EvmOpts,
         auth_preflight: AuthDisclosurePreflight,
         executor_builder: ExecutorBuilder<FEN>,
+        child_context: impl ChildTransactionContext<FEN>,
     ) -> Result<()> {
         config.networks = evm_opts.networks;
         let mut state_overrides = self.get_state_overrides()?;
@@ -667,7 +710,6 @@ impl CallArgs {
                 .with_state_changes(verbosity > 4);
             let mut executor = fork.into_executor(
                 executor_builder,
-                None,
                 trace_requirements,
                 create2_deployer,
                 state_overrides,
@@ -722,13 +764,8 @@ impl CallArgs {
             context_tx.set_kind(tx_kind);
             context_tx.set_data(input.clone());
             context_tx.set_value(value);
-            let chain_context = context_for_child_transaction::<FEN, _>(
-                &provider,
-                context_block_number,
-                &context_tx,
-                context.networks(),
-            )
-            .await?;
+            let chain_context =
+                child_context.build(&provider, context_block_number, &context_tx).await?;
 
             let trace = match tx_kind {
                 TxKind::Create => {

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -35,7 +35,7 @@ use foundry_cli::{
 use foundry_common::{
     FoundryTransactionBuilder,
     abi::{encode_function_args, get_func},
-    provider::{ProviderBuilder, RetryProvider, curl_transport::generate_curl_command},
+    provider::{ProviderBuilder, curl_transport::generate_curl_command},
     sh_println, shell,
 };
 use foundry_compilers::artifacts::EvmVersion;
@@ -52,8 +52,8 @@ use foundry_evm::core::evm::MonadEvmNetwork;
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
     core::{
-        FoundryBlock, FoundryChain, FoundryTransaction,
-        evm::{ChainFor, EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
+        FoundryBlock, FoundryTransaction,
+        evm::{EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork},
     },
     executors::{ExecutorBuilder, TracingExecutor},
     opts::EvmOpts,
@@ -61,46 +61,7 @@ use foundry_evm::{
 };
 use foundry_evm_networks::NetworkConfigs;
 use foundry_wallets::{BrowserWalletOpts, WalletOpts};
-use revm::context::Block;
 use std::str::FromStr;
-
-struct StatelessChildContext;
-
-#[cfg(feature = "monad")]
-struct MonadChildContext;
-
-trait ChildTransactionContext<FEN: FoundryEvmNetwork> {
-    async fn build(
-        &self,
-        provider: &RetryProvider<FEN::Network>,
-        block_number: u64,
-        tx: &TxEnvFor<FEN>,
-    ) -> Result<ChainFor<FEN>>;
-}
-
-impl<FEN: FoundryEvmNetwork> ChildTransactionContext<FEN> for StatelessChildContext {
-    async fn build(
-        &self,
-        _provider: &RetryProvider<FEN::Network>,
-        _block_number: u64,
-        tx: &TxEnvFor<FEN>,
-    ) -> Result<ChainFor<FEN>> {
-        Ok(ChainFor::<FEN>::for_transaction(tx))
-    }
-}
-
-#[cfg(feature = "monad")]
-impl ChildTransactionContext<MonadEvmNetwork> for MonadChildContext {
-    async fn build(
-        &self,
-        provider: &RetryProvider<<MonadEvmNetwork as FoundryEvmNetwork>::Network>,
-        block_number: u64,
-        tx: &TxEnvFor<MonadEvmNetwork>,
-    ) -> Result<ChainFor<MonadEvmNetwork>> {
-        foundry_evm::core::evm::monad_context_for_child_transaction(provider, block_number, tx)
-            .await
-    }
-}
 
 /// CLI arguments for `cast call`.
 ///
@@ -318,7 +279,6 @@ impl CallArgs {
                     evm_opts,
                     auth_preflight,
                     ExecutorBuilder::<TempoEvmNetwork>::new(),
-                    StatelessChildContext,
                 )
                 .await;
         }
@@ -331,7 +291,6 @@ impl CallArgs {
                     evm_opts,
                     auth_preflight,
                     ExecutorBuilder::<MonadEvmNetwork>::new(),
-                    MonadChildContext,
                 )
                 .await;
         }
@@ -344,7 +303,6 @@ impl CallArgs {
                     evm_opts,
                     auth_preflight,
                     ExecutorBuilder::<OpEvmNetwork>::new(),
-                    StatelessChildContext,
                 )
                 .await;
         }
@@ -354,7 +312,6 @@ impl CallArgs {
             evm_opts,
             auth_preflight,
             ExecutorBuilder::<EthEvmNetwork>::new(),
-            StatelessChildContext,
         )
         .await
     }
@@ -412,7 +369,6 @@ impl CallArgs {
         evm_opts: EvmOpts,
         auth_preflight: AuthDisclosurePreflight,
         executor_builder: ExecutorBuilder<FEN>,
-        child_context: impl ChildTransactionContext<FEN>,
     ) -> Result<()> {
         config.networks = evm_opts.networks;
         let mut state_overrides = self.get_state_overrides()?;
@@ -681,7 +637,6 @@ impl CallArgs {
             let create2_deployer = evm_opts.create2_deployer;
             let verbosity = tracing.verbosity;
             let mut fork = TracingExecutor::<FEN>::get_fork(&mut config, evm_opts).await?;
-            let context_block_number = fork.evm_env.block_env.number().saturating_to();
             // Modify settings usually set in eth_call while keeping execution gas bounded.
             fork.evm_env.cfg_env.disable_block_gas_limit = true;
             fork.evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
@@ -759,22 +714,13 @@ impl CallArgs {
                 env_tx.set_signed_authorization(auth);
             }
 
-            let mut context_tx = executor.tx_env().clone();
-            context_tx.set_caller(from);
-            context_tx.set_kind(tx_kind);
-            context_tx.set_data(input.clone());
-            context_tx.set_value(value);
-            let chain_context =
-                child_context.build(&provider, context_block_number, &context_tx).await?;
-
             let trace = match tx_kind {
                 TxKind::Create => {
-                    let deploy_result =
-                        executor.deploy_with_context(from, input, value, chain_context, None);
+                    let deploy_result = executor.deploy(from, input, value, None);
                     TraceResult::try_from(deploy_result)?
                 }
                 TxKind::Call(to) => TraceResult::from_raw(
-                    executor.transact_raw_with_context(from, to, input, value, chain_context)?,
+                    executor.transact_raw(from, to, input, value)?,
                     TraceKind::Execution,
                 ),
             };

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -539,7 +539,6 @@ impl RunArgs {
         let mut evm_env = fork.evm_env.clone();
         let mut executor = fork.into_executor(
             executor_builder,
-            evm_version,
             TraceRequirements::none(),
             create2_deployer,
             None,

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -10,7 +10,6 @@ use crate::{
         apply_chain_specific_tx_replay_env_changes_for_chain, block_env_from_header,
     },
 };
-use alloy_chains::Chain;
 use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
 use alloy_eips::BlockNumHash;
 use alloy_network::{
@@ -58,7 +57,7 @@ use foundry_evm::{
     executors::{Executor, ExecutorBuilder, TracingExecutor},
     hardforks::FoundryHardfork,
     opts::EvmOpts,
-    traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
+    traces::{InternalTraceMode, SparsedTraceArena, TraceContext, TraceRequirements, Traces},
 };
 use foundry_evm_networks::NetworkConfigs;
 use futures::{StreamExt, TryFutureExt};
@@ -173,9 +172,7 @@ struct PreparedRun<FEN: FoundryEvmNetwork> {
     block: Option<AnyRpcBlock>,
     evm_env: EvmEnvFor<FEN>,
     executor: TracingExecutor<FEN>,
-    chain: Chain,
-    networks: NetworkConfigs,
-    resolved_hardfork: Option<FoundryHardfork>,
+    trace_context: TraceContext,
     verbosity: u8,
     prestate_applied: bool,
     #[cfg(feature = "monad")]
@@ -465,13 +462,11 @@ impl RunArgs {
             handle_traces(
                 result,
                 &config,
-                chain,
+                TraceContext::new(chain, endpoint_identity.network_profile, resolved_hardfork),
                 &contracts_bytecode,
                 &tracing,
                 with_local_artifacts,
                 false,
-                resolved_hardfork,
-                endpoint_identity.network_profile,
             )
             .await?;
 
@@ -487,31 +482,33 @@ impl RunArgs {
 
         let create2_deployer = evm_opts.create2_deployer;
         let verbosity = tracing.verbosity;
-        let (block, (mut evm_env, tx_env, fork, chain, networks, endpoint_hardfork)) = tokio::try_join!(
+        let (block, mut fork) = tokio::try_join!(
             // fetch the block the transaction was mined in
             provider.get_block(tx_block_number.into()).full().into_future().map_err(Into::into),
-            TracingExecutor::<FEN>::get_fork_material(&mut config, evm_opts)
+            TracingExecutor::<FEN>::get_fork(&mut config, evm_opts)
         )?;
+        let chain = fork.context().chain();
+        let networks = fork.context().networks();
 
         let mut evm_version = self.evm_version;
         // Mined transactions already passed the block gas limit check their chain applies, and
         // some chains admit transactions whose gas limit exceeds it: BSC validator transactions
         // carry a gas limit of `i64::MAX`. Re-applying the check can only reject a transaction
         // the chain accepted.
-        evm_env.cfg_env.disable_block_gas_limit = true;
+        fork.evm_env.cfg_env.disable_block_gas_limit = true;
 
         // By default do not enforce transaction gas limits imposed by Osaka (EIP-7825).
         // Users can opt-in to enable these limits by setting `enable_tx_gas_limit` to true.
         if !self.enable_tx_gas_limit {
-            evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+            fork.evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
         }
 
-        evm_env.cfg_env.limit_contract_code_size = None;
-        evm_env.block_env.set_number(U256::from(tx_block_number));
+        fork.evm_env.cfg_env.limit_contract_code_size = None;
+        fork.evm_env.block_env.set_number(U256::from(tx_block_number));
 
         let mut parent_beacon_block_root = None;
         if let Some(block) = &block {
-            evm_env.block_env = block_env_from_header(block.header());
+            fork.evm_env.block_env = block_env_from_header(block.header());
             parent_beacon_block_root = block.header().parent_beacon_block_root();
 
             // Unless explicitly configured, resolve the correct spec for the block using the same
@@ -527,31 +524,23 @@ impl RunArgs {
                 evm_version = Some(EvmVersion::Cancun);
             }
             apply_chain_and_block_specific_env_changes_for_chain::<AnyNetwork, _, _>(
-                &mut evm_env,
+                &mut fork.evm_env,
                 block,
                 chain.id(),
                 config.networks,
             );
         }
-        let resolved_hardfork = TracingExecutor::<FEN>::resolve_spec_for_chain(
-            &config,
-            networks,
-            chain.id(),
-            endpoint_hardfork,
-            &mut evm_env,
-            evm_version,
-        );
-        TracingExecutor::<FEN>::extend_precompile_labels(&mut config, networks, resolved_hardfork);
+        fork.resolve_spec(&config, evm_version);
+        fork.extend_precompile_labels(&mut config);
 
-        apply_chain_specific_tx_replay_env_changes_for_chain(&mut evm_env, chain.id());
+        apply_chain_specific_tx_replay_env_changes_for_chain(&mut fork.evm_env, chain.id());
 
-        let mut executor = TracingExecutor::<FEN>::new(
+        let trace_context = fork.context();
+        let mut evm_env = fork.evm_env.clone();
+        let mut executor = fork.into_executor(
             executor_builder,
-            (evm_env.clone(), tx_env),
-            fork,
             evm_version,
             TraceRequirements::none(),
-            networks,
             create2_deployer,
             None,
         )?;
@@ -606,9 +595,7 @@ impl RunArgs {
             block,
             evm_env,
             executor,
-            chain,
-            networks,
-            resolved_hardfork,
+            trace_context,
             verbosity,
             prestate_applied,
             #[cfg(feature = "monad")]
@@ -719,13 +706,11 @@ impl<FEN: FoundryEvmNetwork> PreparedRun<FEN> {
         handle_traces(
             result,
             &self.config,
-            self.chain,
+            self.trace_context,
             &contracts_bytecode,
             &self.tracing,
             self.args.with_local_artifacts,
             self.args.debug,
-            self.resolved_hardfork,
-            self.networks,
         )
         .await
     }

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -1,4 +1,3 @@
-use alloy_chains::Chain;
 #[cfg(test)]
 use alloy_primitives::B256;
 use alloy_primitives::{Bytes, map::AddressHashMap};
@@ -8,15 +7,14 @@ use foundry_compilers::artifacts::output_selection::ContractOutputSelection;
 use foundry_config::{Config, FoundryHardfork, TracingConfig};
 use foundry_debugger::Debugger;
 use foundry_evm::{
-    hardforks::TempoHardfork,
     opts::ForkEndpointIdentity,
     traces::{
-        CallTraceDecoderBuilder, DebugTraceIdentifier,
+        CallTraceDecoderBuilder, DebugTraceIdentifier, TraceContext,
         debug::ContractSources,
         identifier::{SignaturesIdentifier, TraceIdentifiers},
     },
 };
-use foundry_evm_networks::{NetworkConfigs, NetworkVariant};
+use foundry_evm_networks::NetworkVariant;
 
 pub(crate) fn select_remote_trace_hardfork(
     configured: Option<FoundryHardfork>,
@@ -43,17 +41,14 @@ pub(crate) fn ensure_remote_trace_context_unchanged(
 }
 
 /// labels the traces, conditionally prints them or opens the debugger
-#[expect(clippy::too_many_arguments)]
 pub(crate) async fn handle_traces(
     mut result: TraceResult,
     config: &Config,
-    chain: Chain,
+    context: TraceContext,
     contracts_bytecode: &AddressHashMap<Bytes>,
     tracing: &TracingConfig,
     with_local_artifacts: bool,
     debug: bool,
-    hardfork: Option<FoundryHardfork>,
-    networks: NetworkConfigs,
 ) -> eyre::Result<()> {
     let (known_contracts, mut sources) = if with_local_artifacts {
         // Status prose goes to stderr so `--json` output on stdout stays machine-readable.
@@ -81,25 +76,13 @@ pub(crate) async fn handle_traces(
         (None, ContractSources::default())
     };
 
-    let execution_network = networks.execution_network();
-    let mut resolved_hardfork = hardfork
-        .or(config.hardfork)
-        .filter(|hardfork| hardfork.namespace() == execution_network.hardfork_namespace());
-    if resolved_hardfork.is_none() && execution_network.is_tempo() {
-        resolved_hardfork = Some(config.evm_spec_id::<TempoHardfork>().into());
-    }
-    #[cfg(feature = "monad")]
-    if resolved_hardfork.is_none() && execution_network.is_monad() {
-        resolved_hardfork =
-            Some(config.evm_spec_id::<foundry_evm::hardforks::MonadHardfork>().into());
-    }
     let mut builder = CallTraceDecoderBuilder::new()
         .with_tracing_config(tracing)
         .with_signature_identifier(SignaturesIdentifier::from_config(config)?)
-        .with_networks(networks)
-        .with_chain_id(Some(chain.id()))
-        .with_hardfork(resolved_hardfork);
-    let mut identifier = TraceIdentifiers::new().with_external(config, Some(chain))?;
+        .with_networks(context.networks())
+        .with_chain_id(Some(context.chain().id()))
+        .with_hardfork(context.decoding_hardfork(config));
+    let mut identifier = TraceIdentifiers::new().with_external(config, Some(context.chain()))?;
     if let Some(contracts) = &known_contracts {
         builder = builder.with_known_contracts(contracts);
         identifier = identifier.with_local_and_bytecodes(contracts, contracts_bytecode);

--- a/crates/evm/core/src/evm/block_context.rs
+++ b/crates/evm/core/src/evm/block_context.rs
@@ -2,10 +2,13 @@ use alloy_consensus::BlockHeader;
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{BlockResponse, TransactionResponse};
 use alloy_provider::Provider;
-use alloy_rpc_types::{BlockNumberOrTag, BlockTransactions};
+#[cfg(feature = "monad")]
+use alloy_rpc_types::BlockNumberOrTag;
+use alloy_rpc_types::BlockTransactions;
 use eyre::{Result, WrapErr};
-use foundry_evm_networks::NetworkConfigs;
 
+#[cfg(feature = "monad")]
+use super::MonadEvmNetwork;
 use super::{BlockResponseFor, ChainFor, FoundryEvmNetwork, TxEnvFor};
 use crate::FoundryChain;
 
@@ -91,31 +94,29 @@ impl<FEN: FoundryEvmNetwork> BlockContext<FEN> {
     }
 }
 
-/// Builds context for a synthetic transaction executed on top of `block_number`.
-pub async fn context_for_child_transaction<FEN, P>(
+/// Builds Monad context for a synthetic transaction executed on top of `block_number`.
+#[cfg(feature = "monad")]
+pub async fn monad_context_for_child_transaction<P>(
     provider: &P,
     block_number: u64,
-    tx: &TxEnvFor<FEN>,
-    networks: NetworkConfigs,
-) -> Result<ChainFor<FEN>>
+    tx: &TxEnvFor<MonadEvmNetwork>,
+) -> Result<ChainFor<MonadEvmNetwork>>
 where
-    FEN: FoundryEvmNetwork,
-    P: Provider<FEN::Network>,
+    P: Provider<<MonadEvmNetwork as FoundryEvmNetwork>::Network>,
 {
-    if !networks.is_monad() {
-        return Ok(ChainFor::<FEN>::for_transaction(tx));
-    }
-
     let block = provider
         .get_block(BlockNumberOrTag::Number(block_number).into())
         .full()
         .await?
         .ok_or_else(|| eyre::eyre!("block {block_number} not found while building EVM context"))?;
-    let parent = fetch_parent::<FEN, P>(provider, &block).await?;
-    let current = transaction_envs::<FEN>(&block)?;
-    let parent = parent.as_ref().map(transaction_envs::<FEN>).transpose()?.unwrap_or_default();
+    let parent = fetch_parent::<MonadEvmNetwork, P>(provider, &block).await?;
+    let current = transaction_envs::<MonadEvmNetwork>(&block)?;
+    let parent =
+        parent.as_ref().map(transaction_envs::<MonadEvmNetwork>).transpose()?.unwrap_or_default();
 
-    Ok(BlockContext::<FEN>::new(Vec::new(), parent, current).into_child().next_transaction(tx))
+    Ok(BlockContext::<MonadEvmNetwork>::new(Vec::new(), parent, current)
+        .into_child()
+        .next_transaction(tx))
 }
 
 async fn fetch_parent<FEN, P>(

--- a/crates/evm/core/src/evm/block_context.rs
+++ b/crates/evm/core/src/evm/block_context.rs
@@ -2,13 +2,9 @@ use alloy_consensus::BlockHeader;
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{BlockResponse, TransactionResponse};
 use alloy_provider::Provider;
-#[cfg(feature = "monad")]
-use alloy_rpc_types::BlockNumberOrTag;
 use alloy_rpc_types::BlockTransactions;
 use eyre::{Result, WrapErr};
 
-#[cfg(feature = "monad")]
-use super::MonadEvmNetwork;
 use super::{BlockResponseFor, ChainFor, FoundryEvmNetwork, TxEnvFor};
 use crate::FoundryChain;
 
@@ -92,31 +88,6 @@ impl<FEN: FoundryEvmNetwork> BlockContext<FEN> {
         self.grandparent = std::mem::take(&mut self.parent);
         self.parent = std::mem::take(&mut self.current);
     }
-}
-
-/// Builds Monad context for a synthetic transaction executed on top of `block_number`.
-#[cfg(feature = "monad")]
-pub async fn monad_context_for_child_transaction<P>(
-    provider: &P,
-    block_number: u64,
-    tx: &TxEnvFor<MonadEvmNetwork>,
-) -> Result<ChainFor<MonadEvmNetwork>>
-where
-    P: Provider<<MonadEvmNetwork as FoundryEvmNetwork>::Network>,
-{
-    let block = provider
-        .get_block(BlockNumberOrTag::Number(block_number).into())
-        .full()
-        .await?
-        .ok_or_else(|| eyre::eyre!("block {block_number} not found while building EVM context"))?;
-    let parent = fetch_parent::<MonadEvmNetwork, P>(provider, &block).await?;
-    let current = transaction_envs::<MonadEvmNetwork>(&block)?;
-    let parent =
-        parent.as_ref().map(transaction_envs::<MonadEvmNetwork>).transpose()?.unwrap_or_default();
-
-    Ok(BlockContext::<MonadEvmNetwork>::new(Vec::new(), parent, current)
-        .into_child()
-        .next_transaction(tx))
 }
 
 async fn fetch_parent<FEN, P>(

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -95,7 +95,7 @@ pub use showmap::{
     ShowmapDomain, ShowmapOpts, ShowmapReplayTarget, ShowmapStats, replay_corpus_to_showmap,
     replay_sequence_for_minimization,
 };
-pub use trace::TracingExecutor;
+pub use trace::{TracingExecutor, TracingFork};
 
 const DURATION_BETWEEN_METRICS_REPORT: Duration = Duration::from_secs(5);
 

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -60,7 +60,6 @@ impl<FEN: FoundryEvmNetwork> TracingFork<FEN> {
     pub fn into_executor(
         self,
         builder: ExecutorBuilder<FEN>,
-        version: Option<EvmVersion>,
         trace_requirements: TraceRequirements,
         create2_deployer: Address,
         state_overrides: Option<StateOverride>,
@@ -69,7 +68,7 @@ impl<FEN: FoundryEvmNetwork> TracingFork<FEN> {
             builder,
             (self.evm_env, self.tx_env),
             self.fork,
-            version,
+            None,
             trace_requirements,
             self.context.networks(),
             create2_deployer,

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -12,13 +12,84 @@ use foundry_evm_core::{
 };
 use foundry_evm_hardforks::{FoundryHardfork, TempoHardfork};
 use foundry_evm_networks::NetworkConfigs;
-use foundry_evm_traces::TraceRequirements;
+use foundry_evm_traces::{TraceContext, TraceRequirements};
 use revm::state::Bytecode;
 use std::ops::{Deref, DerefMut};
 
 /// A default executor with tracing enabled
 pub struct TracingExecutor<FEN: FoundryEvmNetwork> {
     executor: Executor<FEN>,
+}
+
+/// Fork state and network context used to construct a tracing executor.
+pub struct TracingFork<FEN: FoundryEvmNetwork> {
+    pub evm_env: EvmEnvFor<FEN>,
+    pub tx_env: TxEnvFor<FEN>,
+    fork: CreateFork,
+    context: TraceContext,
+}
+
+impl<FEN: FoundryEvmNetwork> TracingFork<FEN> {
+    pub const fn context(&self) -> TraceContext {
+        self.context
+    }
+
+    /// Resolves the execution spec and carries it into the trace decoding context.
+    pub fn resolve_spec(&mut self, config: &Config, evm_version: Option<EvmVersion>) {
+        let hardfork = TracingExecutor::<FEN>::resolve_spec_for_chain(
+            config,
+            self.context.networks(),
+            self.context.chain().id(),
+            self.context.hardfork(),
+            &mut self.evm_env,
+            evm_version,
+        );
+        self.context = self.context.with_hardfork(hardfork);
+    }
+
+    /// Adds labels for precompiles active in this trace context.
+    pub fn extend_precompile_labels(&self, config: &mut Config) {
+        TracingExecutor::<FEN>::extend_precompile_labels(
+            config,
+            self.context.networks(),
+            self.context.hardfork(),
+        );
+    }
+
+    /// Builds a tracing executor from this resolved fork.
+    pub fn into_executor(
+        self,
+        builder: ExecutorBuilder<FEN>,
+        version: Option<EvmVersion>,
+        trace_requirements: TraceRequirements,
+        create2_deployer: Address,
+        state_overrides: Option<StateOverride>,
+    ) -> eyre::Result<TracingExecutor<FEN>> {
+        TracingExecutor::new(
+            builder,
+            (self.evm_env, self.tx_env),
+            self.fork,
+            version,
+            trace_requirements,
+            self.context.networks(),
+            create2_deployer,
+            state_overrides,
+        )
+    }
+
+    fn into_parts(
+        self,
+    ) -> (EvmEnvFor<FEN>, TxEnvFor<FEN>, CreateFork, Chain, NetworkConfigs, Option<FoundryHardfork>)
+    {
+        (
+            self.evm_env,
+            self.tx_env,
+            self.fork,
+            self.context.chain(),
+            self.context.networks(),
+            self.context.hardfork(),
+        )
+    }
 }
 
 impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
@@ -103,18 +174,11 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         config.labels.extend(networks.precompiles_label(resolved_hardfork));
     }
 
-    /// uses the fork block number from the config
-    pub async fn get_fork_material(
+    /// Resolves the fork state and trace context using the fork block number from the config.
+    pub async fn get_fork(
         config: &mut Config,
         mut evm_opts: EvmOpts,
-    ) -> eyre::Result<(
-        EvmEnvFor<FEN>,
-        TxEnvFor<FEN>,
-        CreateFork,
-        Chain,
-        NetworkConfigs,
-        Option<FoundryHardfork>,
-    )> {
+    ) -> eyre::Result<TracingFork<FEN>> {
         evm_opts.fork_url = Some(config.get_rpc_url_or_localhost_http()?.into_owned());
         evm_opts.fork_block_number = config.fork_block_number;
         evm_opts.infer_network_from_fork().await?;
@@ -128,7 +192,27 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         let fork_context = resolved.context();
 
         let chain = fork_context.source_chain_id.into();
-        Ok((evm_env, tx_env, fork, chain, networks, fork_context.hardfork))
+        Ok(TracingFork {
+            evm_env,
+            tx_env,
+            fork,
+            context: TraceContext::new(chain, networks, fork_context.hardfork),
+        })
+    }
+
+    /// Returns the tracing fork as its legacy tuple representation.
+    pub async fn get_fork_material(
+        config: &mut Config,
+        evm_opts: EvmOpts,
+    ) -> eyre::Result<(
+        EvmEnvFor<FEN>,
+        TxEnvFor<FEN>,
+        CreateFork,
+        Chain,
+        NetworkConfigs,
+        Option<FoundryHardfork>,
+    )> {
+        Ok(Self::get_fork(config, evm_opts).await?.into_parts())
     }
 }
 

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -15,6 +15,9 @@ use foundry_common::{
     contracts::{ContractsByAddress, ContractsByArtifact},
     shell,
 };
+use foundry_config::{Chain, Config};
+use foundry_evm_hardforks::{FoundryHardfork, TempoHardfork};
+use foundry_evm_networks::NetworkConfigs;
 use revm::bytecode::opcode::OpCode;
 use revm_inspectors::tracing::{OpcodeFilter, types::DecodedTraceStep};
 use serde::{Deserialize, Serialize};
@@ -27,6 +30,58 @@ use std::{
 
 use alloy_primitives::{Address, U256, map::HashMap};
 use tempo_contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
+
+/// Network context used to identify and decode execution traces.
+#[derive(Clone, Copy, Debug)]
+pub struct TraceContext {
+    chain: Chain,
+    networks: NetworkConfigs,
+    hardfork: Option<FoundryHardfork>,
+}
+
+impl TraceContext {
+    pub const fn new(
+        chain: Chain,
+        networks: NetworkConfigs,
+        hardfork: Option<FoundryHardfork>,
+    ) -> Self {
+        Self { chain, networks, hardfork }
+    }
+
+    pub const fn chain(self) -> Chain {
+        self.chain
+    }
+
+    pub const fn networks(self) -> NetworkConfigs {
+        self.networks
+    }
+
+    pub const fn hardfork(self) -> Option<FoundryHardfork> {
+        self.hardfork
+    }
+
+    pub const fn with_hardfork(mut self, hardfork: Option<FoundryHardfork>) -> Self {
+        self.hardfork = hardfork;
+        self
+    }
+
+    /// Returns the hardfork to use while decoding this context's traces.
+    pub fn decoding_hardfork(self, config: &Config) -> Option<FoundryHardfork> {
+        let execution_network = self.networks.execution_network();
+        let mut hardfork = self
+            .hardfork
+            .or(config.hardfork)
+            .filter(|hardfork| hardfork.namespace() == execution_network.hardfork_namespace());
+        if hardfork.is_none() && execution_network.is_tempo() {
+            hardfork = Some(config.evm_spec_id::<TempoHardfork>().into());
+        }
+        #[cfg(feature = "monad")]
+        if hardfork.is_none() && execution_network.is_monad() {
+            hardfork = Some(config.evm_spec_id::<foundry_evm_hardforks::MonadHardfork>().into());
+        }
+        hardfork
+    }
+}
 
 pub use revm_inspectors::tracing::{
     CallTraceArena, FourByteInspector, GethTraceBuilder, ParityTraceBuilder, StackSnapshotType,
@@ -672,8 +727,26 @@ impl TraceRequirements {
 mod tests {
     use super::*;
     use alloy_primitives::Bytes;
+    use foundry_config::NamedChain;
     use revm::interpreter::InstructionResult;
     use revm_inspectors::tracing::types::{CallTraceStep, StorageChange, StorageChangeReason};
+
+    #[test]
+    fn trace_context_uses_the_execution_network_hardfork_namespace() {
+        let config = Config {
+            hardfork: Some(FoundryHardfork::Ethereum(
+                foundry_evm_hardforks::EthereumHardfork::Cancun,
+            )),
+            ..Default::default()
+        };
+        let context = TraceContext::new(
+            Chain::from_named(NamedChain::Tempo),
+            NetworkConfigs::with_tempo(),
+            None,
+        );
+
+        assert!(matches!(context.decoding_hardfork(&config), Some(FoundryHardfork::Tempo(_))));
+    }
 
     #[test]
     fn trace_depth_projection_removes_and_reindexes_nodes() {

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -385,7 +385,6 @@ where
     let tx_env = fork.tx_env.clone();
     let executor = fork.into_executor(
         executor_builder,
-        None,
         TraceRequirements::none().with_calls(true),
         create2_deployer,
         None,

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -23,7 +23,9 @@ use foundry_compilers::{
     multi::{MultiCompilerLanguage, MultiCompilerParser},
     utils::canonicalize,
 };
-use foundry_config::{Config, FoundryHardfork};
+use foundry_config::Config;
+#[cfg(all(test, feature = "monad"))]
+use foundry_config::FoundryHardfork;
 use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
     core::{
@@ -364,29 +366,27 @@ where
     fork_config.fork_block_number = Some(fork_blk_num);
 
     let create2_deployer = evm_opts.create2_deployer;
-    let (mut evm_env, tx_env, fork, chain, networks, endpoint_hardfork) =
-        TracingExecutor::<FEN>::get_fork_material(fork_config, evm_opts).await?;
+    let mut fork = TracingExecutor::<FEN>::get_fork(fork_config, evm_opts).await?;
+    let context = fork.context();
 
-    evm_env.block_env.set_number(U256::from(execution_blk_num));
+    fork.evm_env.block_env.set_number(U256::from(execution_blk_num));
     if let Some(block) = execution_block {
-        configure_env_block::<FEN>(&mut evm_env, block, chain.id(), networks);
+        configure_env_block::<FEN>(
+            &mut fork.evm_env,
+            block,
+            context.chain().id(),
+            context.networks(),
+        );
     }
-    let resolved_hardfork = resolve_runtime_spec::<FEN>(
-        fork_config,
-        networks,
-        chain.id(),
-        endpoint_hardfork,
-        &mut evm_env,
-    );
-    TracingExecutor::<FEN>::extend_precompile_labels(fork_config, networks, resolved_hardfork);
+    fork.resolve_spec(fork_config, None);
+    fork.extend_precompile_labels(fork_config);
 
-    let executor = TracingExecutor::<FEN>::new(
+    let evm_env = fork.evm_env.clone();
+    let tx_env = fork.tx_env.clone();
+    let executor = fork.into_executor(
         executor_builder,
-        (evm_env.clone(), tx_env.clone()),
-        fork,
         None,
         TraceRequirements::none().with_calls(true),
-        networks,
         create2_deployer,
         None,
     )?;
@@ -394,6 +394,7 @@ where
     Ok((evm_env, tx_env, executor))
 }
 
+#[cfg(all(test, feature = "monad"))]
 fn resolve_runtime_spec<FEN>(
     config: &Config,
     networks: NetworkConfigs,


### PR DESCRIPTION
## Summary

- carry chain, network profile, and hardfork through tracing as one `TraceContext`
- carry resolved fork state through `TracingFork` into executor construction and trace decoding
- preserve the existing tracing constructor and tuple-returning API as compatibility wrappers

## Testing

- `cargo check -p foundry-evm-traces -p foundry-evm -p cast@1.8.1 -p forge-verify`
- `cargo test -p foundry-evm-traces trace_context_uses_the_execution_network_hardfork_namespace`
- `cargo test -p cast@1.8.1 remote_trace_context`
- `cargo test -p forge-verify --features monad runtime_spec`
- `cargo clippy -p foundry-evm-traces -p foundry-evm -p cast@1.8.1 -p forge-verify --all-targets --no-deps -- -D warnings`