### PR TITLE
fix(lint): restore numeric-cast peeling for underlying_var in arbitrary-send-erc20

### DIFF
--- a/.changelog/lint-underlying-var-numeric-cast.md
+++ b/.changelog/lint-underlying-var-numeric-cast.md
@@ -1,0 +1,5 @@
+---
+forge-lint: patch
+---
+
+Fixed a false positive in `arbitrary-send-erc20` where a `permit`/`transferFrom` owner correlated through a numeric cast round-trip (e.g. `address(uint160(rawToken))`) was no longer recognized as the same variable, a regression from the `sol/analysis` consolidation. The peeling now only applies to casts that cannot truncate an address value, so amount/fee correlation in flash-loan repayment tracking stays conservative.

--- a/crates/lint/src/sol/analysis/exprs.rs
+++ b/crates/lint/src/sol/analysis/exprs.rs
@@ -102,6 +102,22 @@ pub fn is_address_like_cast(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
     is_address_cast(callee) || is_contract_cast(gcx, callee)
 }
 
+/// `uintN(..)` / `intN(..)` cast head at least as wide as `address` (20 bytes), or a `bytes(..)`
+/// cast head - the non-address-like casts that still legitimately wrap an underlying address
+/// value (e.g. `address(uint160(rawAddr))`). The width floor matters: peeling through a narrower
+/// cast (e.g. `uint8`) would treat a value-truncating round-trip as identity-preserving, which is
+/// unsound for any caller trying to prove two expressions reference the same value.
+pub fn is_numeric_or_bytes_cast(callee: &Expr<'_>) -> bool {
+    match &callee.peel_parens().kind {
+        ExprKind::Type(hir::Type {
+            kind: TypeKind::Elementary(ElementaryType::Int(size) | ElementaryType::UInt(size)),
+            ..
+        }) => size.bytes() >= 20,
+        ExprKind::Type(hir::Type { kind: TypeKind::Elementary(ElementaryType::Bytes), .. }) => true,
+        _ => false,
+    }
+}
+
 /// `address(this)`, `payable(this)`, `IFoo(this)`, `IFoo(address(this))`, or bare `this`.
 pub fn is_address_self(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let expr = expr.peel_parens();
@@ -123,6 +139,26 @@ pub fn underlying_var(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<VariableId> {
             args.exprs().next().and_then(|arg| underlying_var(gcx, arg))
         }
         ExprKind::Payable(inner) => underlying_var(gcx, inner),
+        _ => None,
+    }
+}
+
+/// Like [`underlying_var`], but also looks through `uintN(x)`, `intN(x)` and `bytes(x)` cast
+/// heads. Only for callers that correlate two independently-cast references to the *same*
+/// address-typed variable (e.g. matching a `permit` owner against a later `transferFrom` `from`) -
+/// NOT a general-purpose replacement for `underlying_var`, since peeling an arbitrary numeric cast
+/// chain can silently accept a value-truncating round-trip (`uint160 -> uint8 -> uint160`) as if
+/// it were identity-preserving, which is exactly what a recipient/target-tracking lint like
+/// `unsafe-oz-erc721-mint` must NOT do.
+pub fn underlying_var_through_numeric_casts(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<VariableId> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(_) => gcx.resolved_variable(expr),
+        ExprKind::Call(callee, args, _)
+            if is_address_like_cast(gcx, callee) || is_numeric_or_bytes_cast(callee) =>
+        {
+            args.exprs().next().and_then(|arg| underlying_var_through_numeric_casts(gcx, arg))
+        }
+        ExprKind::Payable(inner) => underlying_var_through_numeric_casts(gcx, inner),
         _ => None,
     }
 }

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -7,7 +7,7 @@ use crate::{
             arg_for_param, branch_always_exits, expr_is_address, is_address_like_cast,
             is_address_self, is_address_type, is_elementary, is_msg_sender, is_require_or_assert,
             loop_update, modifier_prefix, receiver_contract_id, state_lhs_vars, tuple_elems,
-            underlying_var,
+            underlying_var, underlying_var_through_numeric_casts,
         },
     },
 };
@@ -261,7 +261,7 @@ impl<'gcx> Analyzer<'gcx> {
             // A fact about a rewritten parameter says nothing about the caller's variable.
             if !a.written.contains(&param)
                 && let Some(caller) = arg_for_param(self.gcx, fid, param, &m.args)
-                    .and_then(|expr| underlying_var(self.gcx, expr))
+                    .and_then(|expr| underlying_var_through_numeric_casts(self.gcx, expr))
                 && self.is_safe_target(caller)
             {
                 if a.state.safe_vars.contains(&param) {
@@ -326,7 +326,7 @@ impl<'gcx> Analyzer<'gcx> {
         Rhs {
             safe: self.is_safe(rhs),
             is_self: self.is_self_expr(rhs),
-            alias: underlying_var(self.gcx, rhs).map(|v| self.canonical(v)),
+            alias: underlying_var_through_numeric_casts(self.gcx, rhs).map(|v| self.canonical(v)),
             sum: sum_operands(self.gcx, rhs),
         }
     }
@@ -357,7 +357,7 @@ impl<'gcx> Analyzer<'gcx> {
     fn assign_lhs(&mut self, lhs: &Expr<'_>, rhs: Option<&Expr<'_>>) {
         // Writing `cfg.token` drops permits keyed on that field.
         if let ExprKind::Member(base, ident) = &lhs.peel_parens().kind
-            && let Some(base) = underlying_var(self.gcx, base)
+            && let Some(base) = underlying_var_through_numeric_casts(self.gcx, base)
         {
             let key = TokenKey::Field(self.canonical(base), ident.name);
             self.state.permits.retain(|p| p.token != key);
@@ -402,7 +402,7 @@ impl<'gcx> Analyzer<'gcx> {
                     self.state = after_lhs.meet(&self.state);
                 } else if op.kind == eq {
                     for (a, b) in [(lhs, rhs), (rhs, lhs)] {
-                        if let Some(v) = underlying_var(self.gcx, b)
+                        if let Some(v) = underlying_var_through_numeric_casts(self.gcx, b)
                             && self.is_safe_target(v)
                         {
                             if self.is_safe(a) {
@@ -447,12 +447,14 @@ impl<'gcx> Analyzer<'gcx> {
         }
         Some(PermitRecord {
             token: self.canonical_key(token_key(self.gcx, token)?),
-            owner: self.canonical(underlying_var(self.gcx, owner)?),
+            owner: self.canonical(underlying_var_through_numeric_casts(self.gcx, owner)?),
         })
     }
 
     fn permit_covers(&self, sink: &Sink<'_>) -> bool {
-        let (Some(token), Some(owner)) = (sink.token, underlying_var(self.gcx, sink.from)) else {
+        let (Some(token), Some(owner)) =
+            (sink.token, underlying_var_through_numeric_casts(self.gcx, sink.from))
+        else {
             return false;
         };
         self.state.permits.contains(&PermitRecord {
@@ -473,7 +475,7 @@ impl<'gcx> Analyzer<'gcx> {
     /// receiver back to `address(this)`.
     fn consume_repayment(&mut self, sink: &Sink<'_>) -> bool {
         let (Some(from), Some(TokenKey::Var(token))) =
-            (underlying_var(self.gcx, sink.from), sink.token)
+            (underlying_var_through_numeric_casts(self.gcx, sink.from), sink.token)
         else {
             return false;
         };
@@ -710,12 +712,12 @@ fn sum_operands(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<(VariableId, VariableId
 
 /// `token` or `cfg.token` receiver key, through casts and `payable(..)`.
 fn token_key(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<TokenKey> {
-    if let Some(v) = underlying_var(gcx, expr) {
+    if let Some(v) = underlying_var_through_numeric_casts(gcx, expr) {
         return Some(TokenKey::Var(v));
     }
     match &expr.peel_parens().kind {
         ExprKind::Member(base, ident) => {
-            Some(TokenKey::Field(underlying_var(gcx, base)?, ident.name))
+            Some(TokenKey::Field(underlying_var_through_numeric_casts(gcx, base)?, ident.name))
         }
         _ => None,
     }
@@ -754,8 +756,8 @@ fn match_flash_loan_call<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> Option<Pend
         return None;
     }
     Some(PendingRepayment {
-        receiver: underlying_var(gcx, recv)?,
-        token: underlying_var(gcx, a[1])?,
+        receiver: underlying_var_through_numeric_casts(gcx, recv)?,
+        token: underlying_var_through_numeric_casts(gcx, a[1])?,
         amount: underlying_var(gcx, a[2])?,
         fee: underlying_var(gcx, a[3])?,
     })

--- a/crates/lint/src/sol/high/controlled_delegatecall.rs
+++ b/crates/lint/src/sol/high/controlled_delegatecall.rs
@@ -5,8 +5,9 @@ use crate::{
         Severity, SolLint,
         analysis::{
             arg_for_param, branch_always_exits, count_placeholders, do_while_user_stmts,
-            has_side_effect, is_address_like_cast, is_loop_termination_if, is_require_or_assert,
-            loop_update, stmts_before_placeholder, stmts_break_or_continue, tuple_elems,
+            has_side_effect, is_address_like_cast, is_loop_termination_if,
+            is_numeric_or_bytes_cast, is_require_or_assert, loop_update, stmts_before_placeholder,
+            stmts_break_or_continue, tuple_elems, underlying_var_through_numeric_casts,
             var_is_address_like,
         },
     },
@@ -18,8 +19,8 @@ use solar::{
         Gcx,
         builtins::Builtin,
         hir::{
-            self, ElementaryType, Expr, ExprKind, FunctionKind, ItemId, LoopSource, Res, Stmt,
-            StmtKind, TypeKind, VariableId, Visit,
+            self, Expr, ExprKind, FunctionKind, ItemId, LoopSource, Res, Stmt, StmtKind,
+            VariableId, Visit,
         },
     },
 };
@@ -105,7 +106,9 @@ impl<'gcx> Analyzer<'gcx> {
                 }
                 _ => false,
             }),
-            ExprKind::Call(callee, args, _) if is_cast(self.gcx, callee) => {
+            ExprKind::Call(callee, args, _)
+                if is_address_like_cast(self.gcx, callee) || is_numeric_or_bytes_cast(callee) =>
+            {
                 args.exprs().next().is_some_and(|arg| self.is_trusted_target_inner(arg, depth))
             }
             ExprKind::Payable(inner) => self.is_trusted_target_inner(inner, depth),
@@ -141,7 +144,7 @@ impl<'gcx> Analyzer<'gcx> {
     }
 
     fn assign_expr(&mut self, lhs: &'gcx Expr<'gcx>, rhs: Option<&'gcx Expr<'gcx>>) {
-        if let Some(var) = underlying_var(self.gcx, lhs) {
+        if let Some(var) = underlying_var_through_numeric_casts(self.gcx, lhs) {
             self.assign(var, rhs.is_some_and(|rhs| self.is_trusted_target(rhs)));
         }
     }
@@ -199,7 +202,8 @@ impl<'gcx> Analyzer<'gcx> {
                 } else if op.kind == eq {
                     for (safe, candidate) in [(lhs, rhs), (rhs, lhs)] {
                         if self.is_trusted_target(safe)
-                            && let Some(var) = underlying_var(self.gcx, candidate)
+                            && let Some(var) =
+                                underlying_var_through_numeric_casts(self.gcx, candidate)
                             && self.is_trusted_fact_target(var)
                         {
                             self.safe_vars.insert(var);
@@ -382,7 +386,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
             }
             ExprKind::Delete(target) => {
                 // `delete` zeroes the target, and the zero address is trusted.
-                if let Some(var) = underlying_var(self.gcx, target) {
+                if let Some(var) = underlying_var_through_numeric_casts(self.gcx, target) {
                     self.assign(var, true);
                 }
                 self.walk_expr(expr)
@@ -390,33 +394,6 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
             _ => self.walk_expr(expr),
         }
     }
-}
-
-/// The variable a bare identifier refers to, looking through parens, `payable(...)` and
-/// address-like or numeric casts.
-fn underlying_var(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<VariableId> {
-    match &expr.peel_parens().kind {
-        ExprKind::Ident(_) => gcx.resolved_variable(expr),
-        ExprKind::Call(callee, args, _) if is_cast(gcx, callee) => {
-            args.exprs().next().and_then(|expr| underlying_var(gcx, expr))
-        }
-        ExprKind::Payable(inner) => underlying_var(gcx, inner),
-        _ => None,
-    }
-}
-
-/// `address(..)`, `IFoo(..)`, `uintN(..)`, `intN(..)` or `bytes(..)` cast head.
-fn is_cast(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
-    is_address_like_cast(gcx, callee)
-        || matches!(
-            &callee.peel_parens().kind,
-            ExprKind::Type(hir::Type {
-                kind: TypeKind::Elementary(
-                    ElementaryType::Int(_) | ElementaryType::UInt(_) | ElementaryType::Bytes
-                ),
-                ..
-            })
-        )
 }
 
 /// The expression returned by a non-virtual, non-overriding, parameterless helper whose body is a
@@ -442,7 +419,8 @@ fn no_arg_helper_return<'gcx>(
         StmtKind::Return(Some(expr)) => Some(expr),
         StmtKind::Expr(expr) => match &expr.peel_parens().kind {
             ExprKind::Assign(lhs, None, rhs)
-                if func.returns.len() == 1 && underlying_var(gcx, lhs) == Some(func.returns[0]) =>
+                if func.returns.len() == 1
+                    && underlying_var_through_numeric_casts(gcx, lhs) == Some(func.returns[0]) =>
             {
                 Some(rhs)
             }
@@ -473,7 +451,7 @@ fn modifier_safe_vars<'gcx>(
         .iter()
         .filter_map(|&param| {
             let arg = arg_for_param(gcx, fid, param, &invocation.args)?;
-            Some((param, underlying_var(gcx, arg)?))
+            Some((param, underlying_var_through_numeric_casts(gcx, arg)?))
         })
         .collect();
     if bindings.is_empty() {

--- a/crates/lint/testdata/ArbitrarySendErc20.sol
+++ b/crates/lint/testdata/ArbitrarySendErc20.sol
@@ -475,6 +475,36 @@ contract ArbitrarySendErc20 {
         token.transferFrom(from, to, a);
     }
 
+    // `from` round-tripped through a numeric cast (address -> uint160 -> address) must still
+    // resolve back to the same underlying variable so the permit correlates with the pull.
+    function okPermitNumericCastFrom(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(address(uint160(from)), address(this), a, deadline, v, r, s);
+        token.transferFrom(address(uint160(from)), to, a);
+    }
+
+    // Same numeric-cast round-trip, but the pull uses a *different* raw variable - must still warn.
+    function badPermitNumericCastFromMismatch(
+        address from,
+        address other_,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(address(uint160(from)), address(this), a, deadline, v, r, s);
+        token.transferFrom(address(uint160(other_)), to, a); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+    }
+
     // ERC721 same-named methods must NOT trigger this lint.
     function okErc721TransferFrom(address from, address to, uint256 id) public {
         nft.transferFrom(from, to, id);
@@ -598,6 +628,45 @@ contract ArbitrarySendErc20 {
     ) public {
         receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
         token.transferFrom(address(receiver), address(this), other); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+    }
+
+    // The callback commits to a truncated amount (via a narrowing cast); the pull-back still
+    // claims the full untruncated `amount + fee`. Peeling the numeric cast for amount/fee must
+    // stay narrow (no cast-peeling at all), or this would be wrongly treated as matching.
+    function badFlashLoanCallbackAmountTruncated(
+        IERC3156FlashBorrower receiver,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data
+    ) public {
+        receiver.onFlashLoan(msg.sender, address(token), uint160(amount), fee, data);
+        token.transferFrom(address(receiver), address(this), amount + fee); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+    }
+
+    // Same hazard, mirrored: full callback amount, but the pull-back sums a locally truncated
+    // stand-in for the fee.
+    function badFlashLoanPullFeeTruncated(
+        IERC3156FlashBorrower receiver,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data
+    ) public {
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        token.transferFrom(address(receiver), address(this), amount + uint256(uint160(fee))); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+    }
+
+    // Same hazard again, but through the `sum_of` local-alias fallback rather than a direct
+    // `amount + fee` expression: the pull-back passes a truncated stand-in for the local that
+    // holds the real sum.
+    function badFlashLoanSumOfLocalTruncated(
+        IERC3156FlashBorrower receiver,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data
+    ) public {
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        uint256 total = amount + fee;
+        token.transferFrom(address(receiver), address(this), uint256(uint160(total))); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
     }
 
     // Second pull-back after the obligation has been consumed.

--- a/crates/lint/testdata/ArbitrarySendErc20.stderr
+++ b/crates/lint/testdata/ArbitrarySendErc20.stderr
@@ -225,6 +225,14 @@ LL │ …     token.transferFrom(owner, to, a);
 warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
    ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
    │
+LL │ …     token.transferFrom(address(uint160(other_)), to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
 LL │ …     token.transferFrom(x, to, a);
    │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -275,6 +283,30 @@ warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require 
    │
 LL │ …     token.transferFrom(address(receiver), address(this), other);
    │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
+LL │ …     token.transferFrom(address(receiver), address(this), amount + fee);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
+LL │ …     token.transferFrom(address(receiver), address(this), amount + uint256(uint160(fee)));
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
+LL │ …     token.transferFrom(address(receiver), address(this), uint256(uint160(total)));
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
 

--- a/crates/lint/testdata/ControlledDelegatecall.sol
+++ b/crates/lint/testdata/ControlledDelegatecall.sol
@@ -236,6 +236,13 @@ contract ControlledDelegatecall {
         (ok,) = address(uint160(0x000000000000000000000000000000000000dEaD)).delegatecall(data);
     }
 
+    // A narrowing cast (uint8) inside an otherwise-trusted numeric chain stops the peel, even
+    // though the whole expression is a provably-constant zero address. Accepted false positive:
+    // rejecting narrowing casts is what keeps a genuinely truncating chain from being trusted.
+    function delegateToNarrowedConstant(bytes calldata data) external returns (bool ok) {
+        (ok,) = address(uint160(uint8(0))).delegatecall(data); //~WARN: `delegatecall` target is not provably trusted
+    }
+
     function delegateToDeleted(address target, bytes calldata data) external returns (bool ok) {
         address localTarget = target;
         delete localTarget;

--- a/crates/lint/testdata/ControlledDelegatecall.stderr
+++ b/crates/lint/testdata/ControlledDelegatecall.stderr
@@ -177,6 +177,14 @@ LL │         (ok,) = localTarget.delegatecall(data);
 warning[controlled-delegatecall]: `delegatecall` target is not provably trusted
    ╭▸ ROOT/testdata/ControlledDelegatecall.sol:LL:CC
    │
+LL │         (ok,) = address(uint160(uint8(0))).delegatecall(data);
+   │                 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/controlled-delegatecall
+
+warning[controlled-delegatecall]: `delegatecall` target is not provably trusted
+   ╭▸ ROOT/testdata/ControlledDelegatecall.sol:LL:CC
+   │
 LL │         (ok,) = target.delegatecall(data);
    │                 ━━━━━━━━━━━━━━━━━━━━━━━━━
    │


### PR DESCRIPTION
`underlying_var()` (`crates/lint/src/sol/analysis/exprs.rs`) only peels address-like casts (`address(x)`, `IFoo(x)`) after the `sol/analysis` consolidation (#16615). Before that refactor, `arbitrary_send_erc20.rs` had its own copy of this logic that ALSO peeled numeric casts (`uintN`/`intN`/`bytes`), specifically to correlate a `permit()` owner with a later `transferFrom()`'s `from` across a cast round-trip like `address(uint160(rawToken))`. The refactor silently dropped that:

```solidity
IERC20 token = IERC20(address(uint160(rawToken)));
token.permit(from, address(this), amt, deadline, v, r, s);
token.transferFrom(from, address(this), amt);   // guarded, but now flagged - underlying_var can't
                                                  // resolve address(uint160(rawToken)) back to rawToken
```

`controlled_delegatecall.rs` still carries its own private duplicate with the broader (numeric-cast-peeling) behavior - that's the evidence the drop from the shared helper was accidental, not deliberate: the refactor kept the narrower helper in the new shared module, let one caller opt out with a local duplicate, and silently moved every other consumer (including `arbitrary-send-erc20`) onto the weaker version.

## Fix

Adds `underlying_var_through_numeric_casts()` alongside the original `underlying_var()` (left untouched). The new function peels `uintN`/`intN` casts that are **at least 20 bytes wide** (i.e. can hold a full address without truncation), plus `bytes(..)`.

The width floor matters, and cost me an iteration: my first draft peeled through *any* numeric cast width, which broke `unsafe_oz_erc721_mint.rs`'s `TruncatedRecipientNft` test - that test specifically checks that a `uint160 -> uint8 -> uint160` truncating cast chain must NOT be treated as identity-preserving. Caught via the full UI suite (not just the target fixture), confirmed against unfixed `master` that it wasn't a pre-existing flake.

`underlying_var_through_numeric_casts()` is used only where two expressions are correlated as the *same address-typed value* (permit owner, `transferFrom` `from`, token identity, flash-loan `receiver`/`token`). Value-typed correlation (flash-loan `amount`/`fee`, `sum_operands`, the `sum_of` lookup) stays on the original narrow `underlying_var()` - a width floor that's sound for addresses is **not** sound for arbitrary `uint256` values. An earlier draft that widened every call site uniformly introduced a real false negative here (a truncated flash-loan callback amount silently treated as matching the untruncated repayment pull), caught by a synchronous Codex adversarial review before this shipped - see the two `badFlashLoan*Truncated` fixtures below, which reproduce exactly that.

Also consolidates `controlled_delegatecall.rs`'s private `underlying_var()`/`is_cast()` duplicate into the shared helpers (deleting the duplicate) instead of leaving two copies to drift apart again, which is what caused this regression in the first place.

## Known, disclosed limitation (not introduced by this diff)

`address(bytes20(x))` still false-positives - `ElementaryType::Bytes` is dynamic `bytes`, not `bytesN`, and this diff doesn't add `FixedBytes` handling. This gap existed identically before the diff too (the pre-refactor code's `bytes(..)` branch matched dynamic `Bytes`, which doesn't apply to a real `address(bytes20(x))` cast either - matching a valid `bytesN` cast head would need new logic). Codex specifically cautioned against a naive "accept all `FixedBytes >= 20`" fix here, since mixed fixed-byte/integer resizing has different padding semantics that can shift which 160 bits survive a chain - left out of scope rather than risk introducing an under-tested new correctness gap.

Also disclosed and documented with a regression test: a narrowing cast inside an otherwise-trusted chain (`address(uint160(uint8(0)))`) is a conservative false positive in `controlled-delegatecall`, since rejecting narrowing casts is exactly what keeps a genuinely truncating chain from being wrongly trusted.

## Testing

- Real red-before/green-after: confirmed the false-positive on unfixed `master` via `token.permit`/`token.transferFrom` correlated through a numeric-cast round-trip; confirmed the two flash-loan truncation false-negatives Codex found also reproduce against an earlier draft of this diff (widen-everywhere) but not against the final version.
- Full lint UI fixture suite: 97/97 passing, including `UnsafeOzErc721Mint.sol` and `ControlledDelegatecall.sol` with zero unintended diff on either's `.stderr` snapshot (confirmed non-regressive on both prior consumers of the duplicated/shared logic).
- Added 6 new fixture cases to `ArbitrarySendErc20.sol`: the false-positive fix (numeric-cast round-trip correctly correlates), a mismatched-round-trip regression check (still warns), 3 flash-loan truncation false-negative regression checks (callback-side truncation, pull-side sum truncation, `sum_of`-local-alias truncation), and 1 new fixture in `ControlledDelegatecall.sol` documenting the accepted narrowing-cast conservative false positive.
- `forge-lint` unit tests pass.
- Clippy clean (`-D warnings`). `cargo fmt --check` clean on stable - nightly (used by this repo's CI) wasn't available in this environment to verify against.
- Two rounds of synchronous Codex adversarial review: first pass found the flash-loan amount/fee false-negative (High) and the `bytes20` gap (Medium), both addressed above; second pass on the revised diff found no blocking issues.

## receipts

no runtime UI change - `forge-lint`'s own test suite is the receipt for this PR (static-analysis fixture corpus, not a runnable app).