### PR TITLE
refactor(symbolic): simplify child state

### DIFF
--- a/.changelog/simplify-symbolic-child-state.md
+++ b/.changelog/simplify-symbolic-child-state.md
@@ -1,0 +1,5 @@
+---
+foundry-evm-symbolic: patch
+---
+
+Simplified symbolic child-state initialization without changing execution behavior.

--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -1056,7 +1056,7 @@ impl SymbolicExecutor {
         };
 
         let original_world = state.world.clone();
-        let mut child = state.external_call_child(frame);
+        let mut child = state.child(frame);
         if let Some((origin, origin_word)) = pranked_origin {
             child.origin = origin;
             child.origin_word = origin_word;

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -171,7 +171,7 @@ impl SymbolicExecutor {
             CallFrame::new(&mut self.cx, created, created, state.address, zero, false, calldata);
         frame.address_word = created_word.clone();
         frame.caller_word = state.address_word.clone();
-        let mut child = state.external_call_child(frame);
+        let mut child = state.child(frame);
         let pending_expected_creates = std::mem::take(&mut child.expected_creates);
         child.world = failure_world.clone();
         child.world.mark_current_transaction_created(created);

--- a/crates/evm/symbolic/src/executor/create.rs
+++ b/crates/evm/symbolic/src/executor/create.rs
@@ -110,7 +110,7 @@ impl SymbolicExecutor {
         );
         frame.address_word = created_word.clone();
         frame.caller_word = state.address_word.clone();
-        let mut child = state.external_call_child(frame);
+        let mut child = state.child(frame);
         let pending_expected_creates = std::mem::take(&mut child.expected_creates);
         child.world = failure_world.clone();
         child.world.mark_current_transaction_created(created);

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -209,18 +209,13 @@ impl PathState {
         // semantics unless the callee sets its own prank.
         child.prank = SymbolicPrank::default();
         child.loop_jumps.clear();
-        child
-    }
-
-    pub(crate) fn external_call_child(&self, frame: CallFrame) -> Self {
-        let mut child = self.child(frame);
         child.expected_revert = None;
         child.assume_no_revert_next_call = None;
         child
     }
 
     pub(crate) fn storage_hook_child(&self, frame: CallFrame) -> Self {
-        let mut child = self.external_call_child(frame);
+        let mut child = self.child(frame);
         child.storage_hook_active = true;
         child.recorded_logs = None;
         child.access_record = None;

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1808,12 +1808,14 @@ fn path_state_extracts_symbolic_usize_upper_bound() {
 }
 
 #[test]
-fn path_state_child_replaces_frame_and_resets_local_loop_state() {
+fn path_state_child_replaces_frame_and_resets_local_state() {
     let mut cx = SymCx::new();
     let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
     state.call_depth = 2;
     state.next_symbol = 7;
     state.loop_jumps.insert(3, 4);
+    state.expected_revert = Some(ExpectedRevert::new(ExpectedRevertData::Any, None, 1));
+    state.assume_no_revert_next_call = Some(AssumeNoRevert::Any);
 
     let parent_stack = SymExpr::constant(&mut cx, U256::from(0xab));
     state.stack.push(parent_stack).unwrap();
@@ -1847,7 +1849,11 @@ fn path_state_child_replaces_frame_and_resets_local_loop_state() {
     assert_eq!(child.world.cached_nonce(cached), Some(9));
     assert_eq!(child.address, child_address);
     assert!(child.loop_jumps.is_empty());
+    assert!(child.expected_revert.is_none());
+    assert!(child.assume_no_revert_next_call.is_none());
     assert_eq!(state.loop_jumps.get(&3), Some(&4));
+    assert!(state.expected_revert.is_some());
+    assert!(state.assume_no_revert_next_call.is_some());
     assert!(child.stack.peek(0).is_err());
 }
 


### PR DESCRIPTION
Moves the parent-scoped `expected_revert` and `assume_no_revert_next_call` resets into `PathState::child`, so every child-frame transition enforces the invariant in one place. This removes the redundant `external_call_child` constructor introduced by #16626 and extends the existing child-state test to cover both fields.

This PR was written with Codex, including code generation and validation.
