### PR TITLE
fix(anvil): restore backwards compatibility for state dumps missing block/best_block_number keys

### DIFF
--- a/.changelog/anvil-loadstate-missing-keys.md
+++ b/.changelog/anvil-loadstate-missing-keys.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Restored backwards compatibility for `anvil_loadState` / `--load-state` when a state dump file omits the `block` or `best_block_number` keys entirely (rather than carrying them with an explicit `null`). Both fields are documented as optional for backwards compatibility but were missing `#[serde(default)]`, making them hard-required by serde despite the deserializer being written to accept `None`.

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -706,11 +706,11 @@ pub struct SerializableState {
     /// The block number of the state
     ///
     /// Note: This is an Option for backwards compatibility: <https://github.com/foundry-rs/foundry/issues/5460>
-    #[serde(deserialize_with = "deserialize_block_env_compat")]
+    #[serde(default, deserialize_with = "deserialize_block_env_compat")]
     pub block: Option<BlockEnv>,
     pub accounts: BTreeMap<Address, SerializableAccountRecord>,
     /// The best block number of the state, can be different from block number (Arbitrum chain).
-    #[serde(deserialize_with = "deserialize_best_block_number_compat")]
+    #[serde(default, deserialize_with = "deserialize_best_block_number_compat")]
     pub best_block_number: Option<u64>,
     #[serde(default)]
     pub blocks: Vec<SerializableBlock>,

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -1043,6 +1043,68 @@ async fn test_backward_compatibility_optional_fields_deserialization_v1_2() {
     assert!(state.transactions.is_empty());
 }
 
+// `block` and `best_block_number` are documented as `Option`al for backwards compatibility, but
+// `#[serde(deserialize_with = "...")]` alone doesn't default a missing key to `None` - the custom
+// deserializer never runs if the key is absent. Without `#[serde(default)]` an old dump file that
+// simply lacks these keys (as opposed to carrying them with an explicit `null`) fails to parse.
+#[test]
+fn test_backward_compatibility_missing_block_and_best_block_number_v1_2() {
+    let old_format_missing_keys = json!({
+        "accounts": {}
+        // `block` and `best_block_number` keys are entirely absent, not null.
+    });
+
+    let state: SerializableState =
+        serde_json::from_str(&old_format_missing_keys.to_string()).unwrap();
+    assert_eq!(state.block, None);
+    assert_eq!(state.best_block_number, None);
+
+    // Same file with the keys present-and-null must parse identically - proves this is purely an
+    // absent-key issue, not a difference in the compat deserializers themselves.
+    let old_format_null_keys = json!({
+        "block": null,
+        "accounts": {},
+        "best_block_number": null
+    });
+    let state_null: SerializableState =
+        serde_json::from_str(&old_format_null_keys.to_string()).unwrap();
+    assert_eq!(state_null.block, None);
+    assert_eq!(state_null.best_block_number, None);
+}
+
+// End-to-end: Anvil must actually boot off a state file that lacks the `block` and
+// `best_block_number` keys entirely, the same code path `anvil --load-state <file>` /
+// `anvil_loadState` use.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_load_state_missing_block_and_best_block_number_v1_2() {
+    let tmp = tempfile::tempdir().unwrap();
+    let old_state_file = tmp.path().join("old_state_missing_keys.json");
+
+    let old_state_json = json!({
+        "accounts": {
+            "0x0000000000000000000000000000000000000001": {
+                "nonce": 0,
+                "balance": "0x1234",
+                "code": "0x",
+                "storage": {}
+            }
+        }
+        // `block` and `best_block_number` keys entirely absent.
+    });
+
+    foundry_common::fs::write_json_file(&old_state_file, &old_state_json).unwrap();
+
+    let (api, _handle) = spawn(NodeConfig::test().with_init_state_path(&old_state_file)).await;
+
+    // Boots fine and the account balance from the dump was applied.
+    let addr = "0x0000000000000000000000000000000000000001".parse().unwrap();
+    let provider = _handle.http_provider();
+    let balance = provider.get_balance(addr).await.unwrap();
+    assert_eq!(balance, U256::from(0x1234));
+
+    api.mine_one().await.unwrap();
+}
+
 // <https://github.com/foundry-rs/foundry/issues/11176>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_backward_compatibility_state_dump_deserialization_v1_2() {


### PR DESCRIPTION
\`SerializableState\` (\`crates/anvil/src/eth/backend/db.rs\`) has two fields documented as "Option for backwards compatibility" that are actually hard-required by serde, while a third field with the identical doc comment correctly isn't:

\`\`\`rust
/// Note: This is an Option for backwards compatibility: <https://github.com/foundry-rs/foundry/issues/5460>
#[serde(deserialize_with = "deserialize_block_env_compat")]      // <- missing #[serde(default)]
pub block: Option<BlockEnv>,

#[serde(deserialize_with = "deserialize_best_block_number_compat")]  // <- missing #[serde(default)]
pub best_block_number: Option<u64>,

/// Note: This is an Option for backwards compatibility.
#[serde(default)]                                                 // <- has it
pub historical_states: Option<SerializableHistoricalStates>,
\`\`\`

serde's missing-field-defaults-to-\`None\` behavior only applies automatically when a field uses its own plain \`Deserialize\` impl. Adding \`#[serde(deserialize_with = "...")]\` without \`#[serde(default)]\` makes the field hard-required — the custom deserializer never runs if the key is absent, so you get a hard parse error instead of graceful \`None\`-defaulting.

## Live-verified consequence

Loading an older state-dump JSON file that lacks the \`block\`/\`best_block_number\` keys entirely fails hard via both \`anvil --load-state <file>\` and the \`anvil_loadState\` RPC method (\`error: failed to parse json file: missing field \`block\` at line 1 column 115\`). The decisive control: the same file with the keys present-but-\`null\` loads fine — this is purely "absent key" vs "key present with default", nothing to do with the compat deserializers themselves.

The consumer is already written to expect \`None\`: \`crates/anvil/src/eth/backend/mem/mod.rs\`'s \`load_state\` does \`let mut block_env = state.block.take();\` then \`if let Some(block) = &mut block_env { ... }\`, and defaults \`best_number\` via \`state.best_block_number.unwrap_or(...)\`.

## Regression origin

\`#[serde(deserialize_with = "...")]\` landed in #11179 ("v1.2 state load compatibility") whose explicit goal was to *widen* compatibility with old dump formats — but it didn't also add \`#[serde(default)]\`, the opposite of the PR's own intent. Pre-#11179 these fields were bare \`pub block: Option<BlockEnv>\` with no custom deserializer, which correctly defaulted to \`None\` on a missing key.

## Precedent

#8501 ("\`anvil_loadState\` fails to decode state dump after upgrading") → #8752 ("fix(anvil): backwards compatible dumps"), merged — same bug class (an older dump file failing to load after an anvil upgrade), different field.

## Why no test caught it

The closest existing test (\`test_backward_compatibility_optional_fields_deserialization_v1_2\`) deliberately omits three *other* fields to test compat, but always supplies \`block\` and \`best_block_number\` — and every \`test-data/state-dump*.json\` fixture carries both keys too.

## Fix

Add \`#[serde(default)]\` to both fields, restoring the pre-#11179 graceful-degrade behavior the doc comments already claim exists.

**Honest trade-off**: this restores a silent partial load (rather than a loud parse error) if someone typos or truncates the \`block\` key in a hand-edited/corrupted dump file. This is exactly the pre-#11179 behavior, so precedent supports it as acceptable, but it's worth stating explicitly rather than presenting this as a risk-free one-word diff.

## Testing

- \`test_backward_compatibility_missing_block_and_best_block_number_v1_2\`: direct deserialization test proving a truly-absent-key document parses to \`None\`/\`None\`, identical to the present-and-\`null\` control case.
- \`test_load_state_missing_block_and_best_block_number_v1_2\`: end-to-end test spawning a real Anvil node via \`with_init_state_path\` off a missing-keys dump file, verifying it boots and applies account state correctly — the real \`load_state\` code path, not just isolated deserialization.
- Verified real red→green: reverted just the fix, confirmed both new tests fail on unfixed code (panic on missing field), restored the fix, confirmed both pass.
- All 5 \`backward_compatibility_*\` tests and all 31 \`state::\` tests pass.
- \`cargo check -p anvil --tests\` clean. \`cargo fmt --check\` clean on stable (nightly unavailable in this environment to verify against, same disclosure as prior PRs in this campaign).
- Note: \`cargo clippy -p anvil -- -D warnings\` fails on a completely unmodified \`master\` checkout too (two pre-existing \`missing_const_for_fn\` findings in \`mem/mod.rs\`'s monad-feature shim functions, unrelated to this diff) — confirmed via \`git stash\` before touching anything, so not a regression introduced here.

## receipts

no runtime UI change — this is a backend/RPC-level bug; the added integration test (spawning a real Anvil node off a hand-crafted missing-keys state file and verifying it boots + applies account state) is the receipt.