### PR TITLE
fix(cli): don't panic on a non-UTF-8 command-line argument

### DIFF
--- a/.changelog/nonutf8-arg-panic.md
+++ b/.changelog/nonutf8-arg-panic.md
@@ -1,0 +1,8 @@
+---
+cast: patch
+forge: patch
+anvil: patch
+chisel: patch
+---
+
+Fix all four binaries panicking on a non-UTF-8 command-line argument

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -85,6 +85,30 @@ Build Profile: [..]
 "#]]);
 });
 
+// tests that a non-UTF-8 command-line argument produces a clean error instead of an unrecovered
+// panic in `GlobalArgs::check_markdown_help` (which used to call `std::env::args()`, documented to
+// panic on invalid Unicode, as the very first statement of every binary's entry point)
+#[cfg(unix)]
+casttest!(non_utf8_argument_does_not_panic, |prj, _cmd| {
+    use std::os::unix::ffi::OsStrExt;
+
+    let bad_arg = std::ffi::OsStr::from_bytes(&[0xff]);
+    let output = prj.cast_bin().arg(bad_arg).output().unwrap();
+
+    assert_ne!(
+        output.status.code(),
+        Some(101),
+        "a non-UTF-8 argument must not cause an unrecovered panic (exit code 101); got status {:?}, stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked at"),
+        "a non-UTF-8 argument must not panic; stderr: {stderr}"
+    );
+});
+
 // tests `--help` is printed to std out
 casttest!(print_help, |_prj, cmd| {
     cmd.arg("--help").assert_success().stdout_eq(str![[r#"

--- a/crates/cli/src/opts/global.rs
+++ b/crates/cli/src/opts/global.rs
@@ -61,7 +61,7 @@ impl GlobalArgs {
     /// This must be called **before** parsing arguments, since commands with required
     /// subcommands would fail parsing before the flag is checked.
     pub fn check_markdown_help<C: clap::CommandFactory>() {
-        if std::env::args().take_while(|a| a != "--").any(|a| a == "--markdown-help") {
+        if std::env::args_os().take_while(|a| a != "--").any(|a| a == "--markdown-help") {
             // Pre-parse: `Shell` is not initialized yet, so `sh_*` is unavailable.
             foundry_cli_markdown::print_help_markdown::<C>();
             std::process::exit(0);


### PR DESCRIPTION
`cast`, `forge`, `anvil`, and `chisel` all panic on a single non-UTF-8 command-line argument:

```
$ cast   $(printf '\xff')
$ forge  $(printf '\xff')
$ anvil  $(printf '\xff')
$ chisel $(printf '\xff')
```

All four crash with:

```
Message:  called `Result::unwrap()` on an `Err` value: "\xFF"
Location: library/std/src/env.rs:864

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry
```

## Root cause

`GlobalArgs::check_markdown_help` is called as the *first statement* in every binary's entry point (`cast/src/args.rs`, `forge/src/args.rs`, `anvil/src/args.rs`, `chisel/src/args.rs`), before clap ever sees argv:

```rust
pub fn check_markdown_help<C: clap::CommandFactory>() {
    if std::env::args().take_while(|a| a != "--").any(|a| a == "--markdown-help") {
```

`std::env::args()` is documented to panic if any argument isn't valid Unicode (`args_os()` is the non-panicking variant). Since this runs before anything is initialized, there's no error path to fall back to, so the panic surfaces raw with a backtrace instead of a usage error.

Confirmed via a control test: putting `--markdown-help` *before* the bad argument does NOT panic (prints markdown help, exits 0), because `any()` short-circuits before reaching the invalid element - that pins the panic to this specific iteration.

## Not exotic

On Linux/macOS, filenames are arbitrary byte sequences, so this triggers via `forge fmt *` in a directory containing a non-UTF-8-named file, `forge script <path>` on such a path, anything piped through `find | xargs`, or a mistyped multibyte paste in a terminal with a mismatched locale. The user gets a crash banner literally asking them to file a bug report, with no indication the real issue is one bad byte in a filename.

Introduced with the CLI markdown-docs feature (#13291) - not longstanding.

## Fix

`args()` -> `args_os()`. `OsString`'s `PartialEq<str>` impl means the existing `!=`/`==` comparisons against string literals need no other changes.

I also checked the `--` separator boundary directly against a built binary (not just by reading the iterator-adapter chain): `cast -- $(printf '\xff')` and `cast to-hex -- $(printf '\xff')` both already produce a clean clap usage error (exit 2) rather than a panic, both before and after this fix - `take_while` correctly stops consuming once it hits `--`, so the bad byte after it is never touched by this function; clap's own parsing (which already uses `args_os()` internally) handles it as a normal invalid-UTF-8 argument error.

## Testing

- Manually verified against built `cast` and `forge` binaries: the panic reproduces on unfixed code and is gone after the fix, for the trivial case, the `--`-separated case, and a case with a subcommand before `--`.
- Added a regression test (`crates/cast/tests/cli/main.rs`, unix-only since it needs `OsStr::from_bytes` via `std::os::unix::ffi::OsStrExt`) that invokes the actual `cast` binary with a raw non-UTF-8 byte argument and asserts it does not exit with code 101 (Rust's default panic exit code) and stderr doesn't contain "panicked at". Verified real red-before-green: fails with the actual panic on unfixed code, passes after the fix.
- Coverage gap disclosed: the test is unix-only. Windows has the mirror-image problem (unpaired UTF-16 surrogates rather than invalid bytes) and would need a different construction; I didn't add a Windows-specific test.
- Not a security issue - a crash on malformed input in a local dev tool, not a vulnerability.

## receipts

no runtime UI change - this is a CLI-argument-handling fix; the regression test invoking the actual built binary is the receipt.
