### PR TITLE
fix(cast): don't discard sign in from-wei/format-units for negative input

### DIFF
--- a/.changelog/cast-from-wei-negative.md
+++ b/.changelog/cast-from-wei-negative.md
@@ -1,0 +1,6 @@
+---
+cast: patch
+---
+
+Fix `cast from-wei` and `cast format-units` silently returning a garbage ~1.157e59 value for
+negative input instead of the correct signed result.

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1589,7 +1589,7 @@ impl SimpleCast {
             .wrap_err("Could not convert to uint")?
             .0;
         let unit = unit.parse().wrap_err("could not parse units")?;
-        Ok(Self::format_unit_as_string(value, unit))
+        Ok(Self::format_unit_as_string(ParseUnits::U256(value), unit))
     }
 
     /// Convert a number into a uint with arbitrary decimals.
@@ -1626,19 +1626,39 @@ impl SimpleCast {
     /// assert_eq!(Cast::format_units("2500000", 6)?, "2.500000");
     /// assert_eq!(Cast::format_units("1000000000000", 12)?, "1"); // 12 decimals
     /// assert_eq!(Cast::format_units("1230", 3)?, "1.230"); // 3 decimals
+    /// assert_eq!(Cast::format_units("-1000000", 6)?, "-1"); // negative value
     ///
     /// # Ok(())
     /// # }
     /// ```
     pub fn format_units(value: &str, unit: u8) -> Result<String> {
-        let value = NumberWithBase::parse_int(value, None)?.number();
+        let value = NumberWithBase::parse_int(value, None)?;
         let unit = Unit::new(unit).ok_or_else(|| eyre::eyre!("invalid unit"))?;
-        Ok(Self::format_unit_as_string(value, unit))
+        let parsed = Self::signed_parse_units(&value)?;
+        Ok(Self::format_unit_as_string(parsed, unit))
+    }
+
+    /// Converts a parsed, possibly-negative [`NumberWithBase`] into a [`ParseUnits`], preserving
+    /// its sign.
+    ///
+    /// `NumberWithBase::number()` returns the two's-complement bits of a negative value modulo
+    /// 2^256, which is a wider range than [`I256`] can represent (magnitudes up to 2^255 only).
+    /// A magnitude beyond that range would silently reinterpret as a small *positive* [`I256`]
+    /// if constructed unconditionally via [`I256::from_raw`] -- reject it instead.
+    fn signed_parse_units(value: &NumberWithBase) -> Result<ParseUnits> {
+        if value.is_nonnegative() {
+            return Ok(ParseUnits::U256(value.number()));
+        }
+        let signed = I256::from_raw(value.number());
+        if !signed.is_negative() {
+            eyre::bail!("value out of range for a signed 256-bit integer");
+        }
+        Ok(ParseUnits::I256(signed))
     }
 
     // Helper function to format units as a string
-    fn format_unit_as_string(value: U256, unit: Unit) -> String {
-        let mut formatted = ParseUnits::U256(value).format_units(unit);
+    fn format_unit_as_string(value: ParseUnits, unit: Unit) -> String {
+        let mut formatted = value.format_units(unit);
         // Trim empty fractional part.
         if let Some(dot) = formatted.find('.') {
             let fractional = &formatted[dot + 1..];
@@ -1661,11 +1681,13 @@ impl SimpleCast {
     /// assert_eq!(Cast::from_wei("10", "ether")?, "0.000000000000000010");
     /// assert_eq!(Cast::from_wei("100", "eth")?, "0.000000000000000100");
     /// assert_eq!(Cast::from_wei("17", "ether")?, "0.000000000000000017");
+    /// assert_eq!(Cast::from_wei("-1000000000000000000", "ether")?, "-1.000000000000000000");
     /// # Ok::<_, eyre::Report>(())
     /// ```
     pub fn from_wei(value: &str, unit: &str) -> Result<String> {
-        let value = NumberWithBase::parse_int(value, None)?.number();
-        Ok(ParseUnits::U256(value).format_units(unit.parse()?))
+        let value = NumberWithBase::parse_int(value, None)?;
+        let parsed = Self::signed_parse_units(&value)?;
+        Ok(parsed.format_units(unit.parse()?))
     }
 
     /// Converts an eth amount into wei

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -5845,6 +5845,63 @@ casttest!(format_units, |_prj, cmd| {
 1.230
 
 "#]]);
+
+    // Negative values must round-trip correctly instead of wrapping to a huge unsigned garbage
+    // value (regression test).
+    cmd.cast_fuse().args(["format-units", "--", "-1000000", "6"]).assert_success().stdout_eq(str![
+        [r#"
+-1
+
+"#]
+    ]);
+});
+
+// <https://github.com/foundry-rs/foundry/issues> negative wei/unit values must round-trip
+// through from-wei/format-units instead of silently wrapping to U256::MAX-derived garbage.
+casttest!(from_wei_negative, |_prj, cmd| {
+    cmd.args(["from-wei", "--", "-1000000000000000000"]).assert_success().stdout_eq(str![[r#"
+-1.000000000000000000
+
+"#]]);
+
+    // Round-trip against the documented inverse command.
+    cmd.cast_fuse().args(["to-wei", "-1", "ether"]).assert_success().stdout_eq(str![[r#"
+-1000000000000000000
+
+"#]]);
+
+    cmd.cast_fuse().args(["from-wei", "--", "-1000000000000000000"]).assert_success().stdout_eq(
+        str![[r#"
+-1.000000000000000000
+
+"#]],
+    );
+
+    // In-binary oracle: to-fixed-point performs the same underlying arithmetic and must agree.
+    cmd.cast_fuse()
+        .args(["to-fixed-point", "18", "--", "-1000000000000000000"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+-1.000000000000000000
+
+"#]]);
+});
+
+// A negative magnitude whose absolute value exceeds I256::MIN (2^255) cannot be represented as a
+// signed 256-bit integer -- must error cleanly, not silently reinterpret as a small positive
+// value (regression test for a review finding on the negative-value fix above).
+casttest!(from_wei_rejects_magnitude_beyond_i256_range, |_prj, cmd| {
+    cmd.args([
+        "from-wei",
+        "--",
+        "-57896044618658097711785492504343953926634992332820282019728792003956564819969",
+        "wei",
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+Error: value out of range for a signed 256-bit integer
+
+"#]]);
 });
 
 // tests that fetches a sample contract creation code


### PR DESCRIPTION
`cast from-wei` and `cast format-units` silently return a garbage ~1.157e59 value for any negative input, instead of the correct signed result.

## The round-trip receipt

```
$ cast to-wei -1 ether
-1000000000000000000                                                              <- correct, sign preserved

$ cast from-wei -- -1000000000000000000
115792089237316195423570985008687907853269984665640564039456.584007913129639936   <- WRONG, expected -1
```

Same defect in `cast format-units`:

```
$ cast format-units -- -1000000 6
115792089237316195423570985008687907853269984665640564039457584007913128.639936   <- WRONG, expected -1
```

## In-binary oracle for the correct answer

`cast to-fixed-point` does the exact same underlying arithmetic in the same binary and gets it right, no external reference needed:

```
$ cast to-fixed-point 18 -- -1000000000000000000
-1.000000000000000000
```

## Why this isn't user error

`FromWei.value` carries an explicit `#[arg(allow_hyphen_values = true)]` -- negatives are a deliberately supported input on this exact command. That attribute was added (#10123) to a hand-picked set of four commands: `FromFixedPoint`, `ToFixedPoint`, `ToWei`, `FromWei`. Three of the four are sign-correct; `from-wei` is the odd one out.

## Root cause

`from_wei`/`format_units` parse a signed literal via `NumberWithBase::parse_int` (which correctly returns the two's-complement `U256` bits and a separate sign flag), then discard the sign and unconditionally construct `ParseUnits::U256(...)`. The sibling `to_wei` correctly routes through `ParseUnits::parse_units`, which returns the `I256` arm for negatives.

Fix: branch on `NumberWithBase::is_nonnegative()` and construct the `I256` arm for negative input, mirroring `to_wei`'s existing behavior. `format_unit_as_string`'s signature changed from taking `U256` to taking the already-existing `ParseUnits` enum so both `format_units` and `to_unit` route through the same correctly-signed path (`to_unit`'s own input is always non-negative, parsed via `DynSolType::Uint(256)` which already rejects negatives, so its behavior is unchanged).

## Hardening from adversarial review

A synchronous Codex review of the first draft found a real edge case: `NumberWithBase::number()` returns two's-complement bits modulo 2^256 (a wider range than `I256` can represent, which tops out at magnitude 2^255). A magnitude beyond that range was silently reinterpreted as a small *positive* `I256` via an unconditional `I256::from_raw`, e.g.:

```
cast from-wei -- -57896044618658097711785492504343953926634992332820282019728792003956564819969 wei
```
previously printed a positive garbage value instead of erroring. Fixed by validating the reinterpreted `I256` is actually negative before accepting it, erroring cleanly otherwise. Added a regression test for this case.

## Known limitation, not fixed here

The review also found that `Unit::MAX` (77) is off-by-one for negative values specifically: alloy's own `ParseUnits::format_units_with` substitutes unit 76 for unit 77 whenever the value is signed (to avoid a `10^77` overflow converting into `I256`), so e.g. `cast from-wei -- -1 76` and `cast from-wei -- -1 77` currently print the same value. This is inherited from alloy's own signed-formatting logic (`alloy_primitives::utils::units`), not introduced by this diff, and is an extreme edge case (unit 77 is essentially never used in practice). Not fixed in this PR; flagging in case a maintainer wants it tracked as a separate alloy-level issue.

## Not bundled

`cast to-unit` has a separate, weaker, adjacent issue -- it fails with a truncated, unhelpful `Error: parser error:` on negative input rather than returning garbage, since its input path already rejects negatives via `DynSolType::coerce_str`. Worth a follow-up at most, not fixed here.

## Testing

- Real red-before-green: reverted just the source fix via `git stash`, confirmed the exact garbage output reproduces on unfixed code (~1.157e59 for both `from-wei` and `format-units`), restored, confirmed green.
- Added CLI integration tests: `format_units` extended with a negative case, new `from_wei_negative` covering the round-trip receipt and the `to-fixed-point` oracle comparison, new `from_wei_rejects_magnitude_beyond_i256_range` for the out-of-range case found by review.
- All 60 existing doctests pass, including two new negative-value assertions added to `from_wei`'s and `format_units`' doc examples.
- 322/322 relevant `cast` lib unit tests pass. A pre-existing, unrelated stack-overflow in `opts::tests::parse_call_data` (and sibling tests in that module) reproduces identically on unmodified master -- confirmed via `git stash` before disclosing, not caused by this diff.
- `clippy --all-targets -D warnings` on the full crate hits pre-existing, unrelated failures in `crates/anvil` (missing-const-fn on `monad`-feature code) and `crates/cast/src/cmd/erc4626.rs` (large-stack-frames) -- both confirmed present on unmodified master via `git stash`. Clippy on just the touched region of `lib.rs` is clean.
- `rustfmt --check` clean on stable (nightly-only options unavailable in this environment, matching this repo's CI toolchain).

## receipts

no runtime UI change -- `cast`'s own CLI test suite (real binary invocations) is the receipt for this PR.
