### PR TITLE
fix(ci): remove stale cooldown ref comments

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Enforce baseline Cargo dependency cooldown
         if: steps.prep.outputs.is_source_comparison == 'true'
-        uses: tempoxyz/gh-actions/actions/cargo-cooldown@0aa93238d85fd085d7901320b670cc6adb7a02f3 # main
+        uses: tempoxyz/gh-actions/actions/cargo-cooldown@0aa93238d85fd085d7901320b670cc6adb7a02f3
         env:
           RUSTC_WRAPPER: ""
         with:

--- a/.github/workflows/cargo-cooldown.yml
+++ b/.github/workflows/cargo-cooldown.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           toolchain: stable
       - name: Enforce Cargo dependency cooldown
-        uses: tempoxyz/gh-actions/actions/cargo-cooldown@0aa93238d85fd085d7901320b670cc6adb7a02f3 # main
+        uses: tempoxyz/gh-actions/actions/cargo-cooldown@0aa93238d85fd085d7901320b670cc6adb7a02f3
         with:
           strict-project-config: true


### PR DESCRIPTION
Remove the stale `# main` comments from both Cargo cooldown action pins. Upstream `main` has moved, so zizmor reports `ref-version-mismatch` and fails [workflow validation](https://github.com/foundry-rs/foundry/actions/runs/33922124956/job/101184303350?pr=16645). The action remains pinned to the same commit; upstream publishes no release tags to use as version comments.

This is a CI-only change; a maintainer must apply `L-ignore` for the changelog exemption.

This PR was authored and checked by Centaur with AI assistance.

Prompted by: @DaniPopes
