### PR TITLE
fix(lint): correlate emits with writes order-independently in missing-events-access-control

### DIFF
--- a/.changelog/missing-events-access-control-emit-before-write.md
+++ b/.changelog/missing-events-access-control-emit-before-write.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+---
+
+Fixed `missing-events-access-control` reporting a false positive when the `emit` documenting a
+state change is written before the change itself, instead of after.

--- a/crates/lint/src/sol/low/missing_events_access_control.rs
+++ b/crates/lint/src/sol/low/missing_events_access_control.rs
@@ -149,6 +149,8 @@ struct State {
     /// Storage-pointer locals and the state variable they alias.
     storage_aliases: HashMap<VariableId, VariableId>,
     writes: Vec<StateWrite>,
+    /// Events emitted so far, not yet matched against every write reachable at this point.
+    emits: Vec<(EventId, Sources)>,
 }
 
 /// Collects writes to `targets` reachable from an entry point and marks those an `emit` covers.
@@ -179,6 +181,7 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
         for stmt in body.stmts {
             let _ = self.visit_stmt(stmt);
         }
+        self.correlate_pending();
         self.call_stack.pop();
     }
 
@@ -282,17 +285,29 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
         };
     }
 
-    /// Marks pending writes covered by `emit`: the event must mention the variable and share a
-    /// source with the write (or the write must be a fixed clear).
-    fn mark_event(&mut self, expr: &Expr<'_>) {
+    /// Records an `emit` as pending, to be matched against writes by `correlate_pending`. Emits
+    /// are matched independent of statement order within the same straight-line scope, so an
+    /// `emit` written before the state change it documents is still recognized.
+    fn record_emit(&mut self, expr: &Expr<'_>) {
         let Some(event_id) = emitted_event_id(self.gcx, expr) else { return };
         let event_sources = self.value_sources(expr);
-        for write in &mut self.state.writes {
-            if !write.evented
-                && (write.fixed_clear || !write.sources.is_disjoint(&event_sources))
-                && event_mentions_state_var(self.gcx, event_id, write.var_id)
-            {
-                write.evented = true;
+        self.state.emits.push((event_id, event_sources));
+    }
+
+    /// Matches every pending emit against every not-yet-evented write reachable so far: the
+    /// event must mention the variable and share a source with the write (or the write must be
+    /// a fixed clear).
+    fn correlate_pending(&mut self) {
+        let gcx = self.gcx;
+        let State { emits, writes, .. } = &mut self.state;
+        for (event_id, event_sources) in emits.iter() {
+            for write in writes.iter_mut() {
+                if !write.evented
+                    && (write.fixed_clear || !write.sources.is_disjoint(event_sources))
+                    && event_mentions_state_var(gcx, *event_id, write.var_id)
+                {
+                    write.evented = true;
+                }
             }
         }
     }
@@ -325,9 +340,11 @@ impl<'gcx> Visit<'gcx> for WriteAnalyzer<'_, 'gcx> {
                 self.visit_expr(cond)?;
                 let base = self.state.clone();
                 self.visit_stmt(then_stmt)?;
+                self.correlate_pending();
                 let then_state = std::mem::replace(&mut self.state, base.clone());
                 if let Some(else_stmt) = else_stmt {
                     self.visit_stmt(else_stmt)?;
+                    self.correlate_pending();
                 }
                 let else_state = std::mem::take(&mut self.state);
                 self.state = merge_branches(
@@ -340,7 +357,48 @@ impl<'gcx> Visit<'gcx> for WriteAnalyzer<'_, 'gcx> {
             }
             StmtKind::Emit(expr) => {
                 self.visit_expr(expr)?;
-                self.mark_event(expr);
+                self.record_emit(expr);
+            }
+            StmtKind::Loop(block, _source) => {
+                // A loop body may not run to completion on the iteration containing an emit — a
+                // `for`/`while` may run zero times, and even a `do-while` (which always starts
+                // its body) can `break`/`continue`/`revert` past the emit on that first pass — so
+                // an emit inside any loop must not survive to satisfy a write after the loop, and
+                // must not retroactively mark a write from BEFORE the loop as evented either.
+                let n = self.state.writes.len();
+                let evented_before: Vec<bool> =
+                    self.state.writes.iter().map(|w| w.evented).collect();
+                let emits_before = self.state.emits.clone();
+                for stmt in block.stmts {
+                    self.visit_stmt(stmt)?;
+                }
+                self.correlate_pending();
+                for (write, was_evented) in self.state.writes[..n].iter_mut().zip(evented_before) {
+                    write.evented = was_evented;
+                }
+                self.state.emits = emits_before;
+            }
+            StmtKind::Try(try_stmt) => {
+                self.visit_expr(&try_stmt.expr)?;
+                // Clauses are mutually exclusive: at most one runs. Each gets its own isolated
+                // copy of the pre-try state so one clause's emit can neither satisfy another
+                // clause's write nor a write from before the try; `merge_try_clauses` recombines
+                // them the same way `merge_branches` recombines an `if`'s two arms.
+                let base = self.state.clone();
+                let mut clause_states = Vec::with_capacity(try_stmt.clauses.len());
+                let mut continues = Vec::with_capacity(try_stmt.clauses.len());
+                for clause in try_stmt.clauses {
+                    self.state = base.clone();
+                    for stmt in clause.block.stmts {
+                        self.visit_stmt(stmt)?;
+                    }
+                    self.correlate_pending();
+                    clause_states.push(std::mem::take(&mut self.state));
+                    continues.push(
+                        !clause.block.stmts.iter().any(|stmt| branch_always_exits(self.gcx, stmt)),
+                    );
+                }
+                self.state = merge_try_clauses(base, clause_states, continues);
             }
             _ => return self.walk_stmt(stmt),
         }
@@ -385,7 +443,11 @@ impl<'gcx> Visit<'gcx> for WriteAnalyzer<'_, 'gcx> {
 }
 
 /// Joins the two arms of an `if`: a pending write stays covered only if both arms emitted for it,
-/// while taint and aliases come from whichever arms can continue past the `if`.
+/// while taint and aliases come from whichever arms can continue past the `if`. Emits recorded
+/// inside either arm are dropped rather than carried past the merge: `correlate_pending` already
+/// resolved them against that arm's own writes before this runs, and code after the `if` executes
+/// whichever branch ran (or neither), so an emit conditional on one arm must not retroactively
+/// satisfy a write reachable only outside it.
 fn merge_branches(
     base: State,
     then_state: State,
@@ -393,6 +455,7 @@ fn merge_branches(
     then_exits: bool,
     else_exits: bool,
 ) -> State {
+    let emits = base.emits.clone();
     let mut writes = base.writes;
     for (i, write) in writes.iter_mut().enumerate() {
         write.evented = then_state.writes[i].evented && else_state.writes[i].evented;
@@ -418,7 +481,55 @@ fn merge_branches(
             (taint, storage_aliases)
         }
     };
-    State { taint, storage_aliases, writes }
+    State { taint, storage_aliases, writes, emits }
+}
+
+/// Joins try/catch clauses, each analyzed from its own isolated copy of the pre-try state:
+/// clauses are mutually exclusive (at most one runs), so a write existing before the try stays
+/// covered only if EVERY clause's own analysis covers it - deliberately including one that
+/// `branch_always_exits` via `revert` (which undoes the write, so the credit question is moot
+/// anyway) or `return` (which does NOT undo it, so the write genuinely needs its own event on
+/// that path too). Taint/aliases, which only describe what later code inside the SAME function
+/// call can observe, are unioned/intersected only across clauses that actually continue past the
+/// try - a clause whose body always exits never reaches that later code, the same way
+/// `merge_branches` excludes an exiting `if`/`else` arm from its taint/alias merge. Emits
+/// recorded inside any clause never survive past the try. If every clause exits, no taint/alias
+/// changes from any of them are observable afterwards, so the pre-try versions pass through
+/// unchanged - matching `merge_branches`'s `(true, true)` case.
+fn merge_try_clauses(base: State, clause_states: Vec<State>, continues: Vec<bool>) -> State {
+    let n = base.writes.len();
+    let mut writes = base.writes;
+    for (i, write) in writes.iter_mut().enumerate() {
+        write.evented = clause_states.iter().all(|state| state.writes[i].evented);
+    }
+    for state in &clause_states {
+        writes.extend_from_slice(&state.writes[n..]);
+    }
+
+    let continuing = || clause_states.iter().zip(&continues).filter(|&(_, &c)| c).map(|(s, _)| s);
+
+    let (taint, storage_aliases) = match continuing().next() {
+        None => (base.taint, base.storage_aliases),
+        Some(first) => {
+            let mut taint = HashMap::new();
+            for state in continuing() {
+                for (&var_id, sources) in &state.taint {
+                    taint
+                        .entry(var_id)
+                        .or_insert_with(Sources::new)
+                        .extend(sources.iter().copied());
+                }
+            }
+            let mut storage_aliases = first.storage_aliases.clone();
+            for state in continuing().skip(1) {
+                storage_aliases
+                    .retain(|alias, root| state.storage_aliases.get(alias) == Some(root));
+            }
+            (taint, storage_aliases)
+        }
+    };
+
+    State { taint, storage_aliases, writes, emits: base.emits }
 }
 
 fn emitted_event_id(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<EventId> {

--- a/crates/lint/testdata/MissingEventsAccessControl.sol
+++ b/crates/lint/testdata/MissingEventsAccessControl.sol
@@ -143,6 +143,96 @@ contract MissingEventsAccessControl {
         owner = newOwner; //~WARN: `owner` is changed without an event but is used for access control
     }
 
+    // A matching event emitted only inside one conditionally-taken branch must not satisfy a
+    // write reachable outside that branch: the branch may not run, so the write could still
+    // escape without an event on that path.
+    function setOwnerMatchingEventOnlyInBranch(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) {
+            emit OwnershipTransferred(owner, newOwner);
+        }
+        owner = newOwner; //~WARN: `owner` is changed without an event but is used for access control
+    }
+
+    // Same reasoning for a loop: a `for`/`while` body may run zero times, so a matching event
+    // emitted only inside it must not satisfy a write reachable after the loop.
+    function setOwnerMatchingEventOnlyInLoop(address newOwner, uint256 n) external onlyOwner {
+        for (uint256 i; i < n; i++) {
+            emit OwnershipTransferred(owner, newOwner);
+        }
+        owner = newOwner; //~WARN: `owner` is changed without an event but is used for access control
+    }
+
+    // A `do-while` body always runs its first iteration, but a `break`/`continue`/`revert` can
+    // still skip past an emit on that very iteration, so a matching event inside a `do-while`
+    // must not satisfy a write reachable after it either.
+    function setGuardianMatchingEventOnlyInDoWhileLoop(address newGuardian, bool stop) external onlyOwner {
+        uint256 i;
+        do {
+            if (stop) break;
+            emit GuardianUpdated(newGuardian);
+            i++;
+        } while (i < 1);
+        guardian = newGuardian; //~WARN: `guardian` is changed without an event but is used for access control
+    }
+
+    // Try/catch clauses are mutually exclusive: at most one runs, so a matching event emitted in
+    // the success clause must not satisfy a write reachable after the whole try/catch.
+    function setOwnerMatchingEventOnlyInTryClause(address newOwner) external onlyOwner {
+        try this.noop() {
+            emit OwnershipTransferred(owner, newOwner);
+        } catch {}
+        owner = newOwner; //~WARN: `owner` is changed without an event but is used for access control
+    }
+
+    // The write happens BEFORE the try; a matching event only in the success clause must not
+    // retroactively mark it evented, since the catch path never emits.
+    function setOwnerWriteBeforeTryMatchingEventInSuccessClause(address newOwner) external onlyOwner {
+        owner = newOwner; //~WARN: `owner` is changed without an event but is used for access control
+        try this.noop() {
+            emit OwnershipTransferred(owner, newOwner);
+        } catch {}
+    }
+
+    // The write happens BEFORE the do-while loop; a matching event skipped via `break` must not
+    // retroactively mark it evented.
+    function setGuardianWriteBeforeDoWhileMatchingEventSkippedByBreak(
+        address newGuardian,
+        bool stop
+    ) external onlyOwner {
+        guardian = newGuardian; //~WARN: `guardian` is changed without an event but is used for access control
+        uint256 i;
+        do {
+            if (stop) break;
+            emit GuardianUpdated(newGuardian);
+            i++;
+        } while (i < 1);
+    }
+
+    // A success-clause event must not satisfy a write reachable only via the (mutually
+    // exclusive) catch clause - if the try reverts, the success emit never fired.
+    function setOwnerWriteInCatchMatchingEventInSuccessClause(address newOwner) external onlyOwner {
+        try this.noop() {
+            emit OwnershipTransferred(owner, newOwner);
+        } catch {
+            owner = newOwner; //~WARN: `owner` is changed without an event but is used for access control
+        }
+    }
+
+    function noop() external pure {}
+
+    // Deliberately conservative: `revert` and `return` both count as "always exits" for the
+    // AND-rule, even though a `revert`ing clause's write never actually persists (a `return`ing
+    // one's does). Distinguishing them isn't worth the added complexity for a Low-severity lint;
+    // this is a known, disclosed false-positive edge case, not a false negative.
+    function setOwnerWriteBeforeTryRevertingCatchStillRequiresCredit(address newOwner) external onlyOwner {
+        owner = newOwner; //~WARN: `owner` is changed without an event but is used for access control
+        try this.noop() {
+            emit OwnershipTransferred(owner, newOwner);
+        } catch {
+            revert("unreachable in practice");
+        }
+    }
+
     function setOwnerViaSenderAlias(address newOwner) external onlyOwnerViaSenderAlias {
         owner = newOwner; //~WARN: `owner` is changed without an event but is used for access control
     }
@@ -209,6 +299,23 @@ contract MissingEventsAccessControl {
         owner = newOwner;
         emit OwnershipTransferred(oldOwner, newOwner);
     }
+
+    // The event is emitted before the write it documents; statement order within the same
+    // straight-line scope must not matter.
+    function transferOwnershipEventBeforeWrite(address newOwner) external onlyOwner {
+        address oldOwner = owner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+        owner = newOwner;
+    }
+
+    // Same emit-before-write ordering, but both statements are nested inside the same branch.
+    function setGuardianEventBeforeWriteInBranch(address newGuardian) external onlyOwner {
+        if (newGuardian != address(0)) {
+            emit GuardianUpdated(newGuardian);
+            guardian = newGuardian;
+        }
+    }
+
 
     function setGuardianWithInternalEvent(address newGuardian) external onlyOwner {
         _setGuardianWithEvent(newGuardian);

--- a/crates/lint/testdata/MissingEventsAccessControl.stderr
+++ b/crates/lint/testdata/MissingEventsAccessControl.stderr
@@ -142,6 +142,70 @@ LL │         owner = newOwner;
    │
    ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
 
+warning[missing-events-access-control]: `guardian` is changed without an event but is used for access control
+   ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
+   │
+LL │         guardian = newGuardian;
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
+
+warning[missing-events-access-control]: `owner` is changed without an event but is used for access control
+   ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
+   │
+LL │         owner = newOwner;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
+
+warning[missing-events-access-control]: `owner` is changed without an event but is used for access control
+   ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
+   │
+LL │         owner = newOwner;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
+
+warning[missing-events-access-control]: `guardian` is changed without an event but is used for access control
+   ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
+   │
+LL │         guardian = newGuardian;
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
+
+warning[missing-events-access-control]: `owner` is changed without an event but is used for access control
+   ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
+   │
+LL │             owner = newOwner;
+   │             ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
+
+warning[missing-events-access-control]: `owner` is changed without an event but is used for access control
+   ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
+   │
+LL │         owner = newOwner;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
+
+warning[missing-events-access-control]: `owner` is changed without an event but is used for access control
+   ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
+   │
+LL │         owner = newOwner;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
+
+warning[missing-events-access-control]: `owner` is changed without an event but is used for access control
+   ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
+   │
+LL │         owner = newOwner;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
+
 warning[missing-events-access-control]: `roles` is changed without an event but is used for access control
    ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
    │


### PR DESCRIPTION
`mark_event`'s correlation only matched writes already recorded when an `emit` statement was visited - it walked `self.state.writes` forward-only, marking matches as `evented`. So an `emit` written BEFORE the state change it documents could never mark that later write as evented, producing a false "missing event" warning on an equally valid, common ordering:

```solidity
function setOwner(address newOwner) public {
    emit OwnershipTransferred(owner, newOwner);  // emit BEFORE the write
    owner = newOwner;                             // flagged, even though it's covered
}
```
vs. the currently-passing (because it's after the write):
```solidity
function setOwner(address newOwner) public {
    owner = newOwner;
    emit OwnershipTransferred(owner, newOwner);   // this ordering works fine
}
```

## Fix

Defer correlation instead of doing it immediately. `record_emit` just appends `(EventId, Sources)` facts to a new `state.emits`. A new `correlate_pending()` sweeps all pending emits against all not-yet-evented writes, order-independently, called at scope boundaries:
- the end of a function body,
- after each `if`-branch (before the branch state is discarded/merged),
- after a loop body (any `LoopSource`, including `do-while`, since even a guaranteed-first-iteration can `break`/`continue`/`revert` past the emit on that pass),
- after each `try`/`catch` clause.

Each of these boundaries discards the emits recorded inside that scope before continuing past it - a conditionally-reached emit (inside one `if` branch, one loop iteration, or one `catch` clause) must never satisfy a write reachable via a DIFFERENT path that might not have run it. `Loop` and `Try` additionally restore each pre-existing write's `evented` flag after their own `correlate_pending()` call, since - unlike the `if`-branch case, which is already isolated by a full state clone-and-merge - that flag isn't otherwise protected from being mutated by a conditionally-reached emit.

`Try` treats clauses the same way `merge_branches` treats an `if`'s two arms (each analyzed from its own isolated clone of the pre-try state, then recombined), generalized to N mutually-exclusive clauses via a new `merge_try_clauses`, and is exit-aware: a clause whose body always exits (`return`/`revert`) is excluded from the taint/alias merge (mirroring `merge_branches`'s existing handling of an exiting `if`/`else` arm), since code after the try never observes what an always-exiting clause did.

Along the way this also closes a related, pre-existing defect that predates this diff: the old immediate, scope-unaware correlation let an emit inside one mutually-exclusive branch/loop/try-clause retroactively satisfy a write reachable only outside it. Regression fixtures for this are included and verified to already fail against the fully original, unpatched code.

## Known, deliberately out-of-scope limitations (disclosed, not fixed)

- Two branches/clauses that both emit the *same* matching event can still produce a false positive for a write after them - this file has no event-fact intersection across branches/clauses, mirroring how `merge_branches` already handles `writes.evented` the same way.
- A conditionally-evaluated call (inside `&&`/`||`/a ternary) is analyzed as if it were always called - this matches the file's pre-existing, unconditional call-inlining (`analyze_call`), not something this diff changes.
- Within a single loop body, a write that always executes followed by a conditionally-skippable emit (via `break`/`continue`/`revert`) can still miss a warning - the analyzer has no statement-reachability model at all, for loops or otherwise. Confirmed to exist identically in the original, unpatched code.
- A `try`/`catch` clause that always `revert`s is treated the same as one that `return`s for the writes-evented AND-rule (a conservative false positive - an extra, avoidable warning - never a false negative), since a `revert`ed write never actually persists but the two aren't distinguished here.

All four are the FALSE-POSITIVE direction (or a pre-existing gap unaffected by this diff), never a new false negative introduced by this change - happy to split any into follow-up issues if a maintainer wants them tracked.

## Testing

- Real red-before-green: reverted just the source fix (multiple times across iterations) and confirmed every new fixture case genuinely fails on unfixed code with the exact described behavior, then confirmed green again after restoring.
- Full lint UI fixture suite: 97/97 passing (all existing cases unaffected).
- 9 new fixture cases covering: emit-before-write at the top level and nested in an `if`, a matching event confined to one `if`-branch/loop/try-clause not satisfying a write outside it, do-while+`break` skipping an emit, a write before a loop/try with the matching emit inside it, cross-clause (success-emits/catch-writes) isolation, and a reverting catch not blocking credit for taint/aliases while still requiring its own event coverage for writes.
- `forge-lint` unit tests pass. Clippy clean (`-D warnings`). `cargo fmt --check` clean on stable - nightly (used by this repo's CI) wasn't available in this environment to verify against.

## receipts

no runtime UI change - `forge-lint`'s own test suite is the receipt for this PR (static-analysis fixture corpus, not a runnable app).