### PR TITLE
perf(lint): avoid repeated initializer walks

### DIFF
--- a/.changelog/initializer-lint-reachability.md
+++ b/.changelog/initializer-lint-reachability.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-lint: patch
+---
+
+Avoid redundant call-graph traversal in the unprotected-initializer lint, speeding up linting and builds with linting enabled.

--- a/crates/lint/src/sol/high/unprotected_initializer.rs
+++ b/crates/lint/src/sol/high/unprotected_initializer.rs
@@ -6,6 +6,7 @@ use crate::{
         analysis::{builtins, function_ids, is_builtin, runtime_entry_points},
     },
 };
+use alloy_primitives::map::HashSet;
 use solar::{
     ast::{ContractKind, DataLocation, StateMutability},
     interface::{kw, sym},
@@ -45,6 +46,9 @@ impl<'hir> LateLintPass<'hir> for UnprotectedInitializer {
         let upgradeable =
             bases.iter().any(|&cid| hir.contract(cid).name.as_str() == "Initializable")
                 || entries.iter().any(|&fid| has_initializer_modifier(hir, hir.function(fid)));
+        if !upgradeable {
+            return;
+        }
         let locked = bases.iter().filter_map(|&cid| hir.contract(cid).ctor).any(|ctor| {
             reaches(hir, bases, ctor, |expr| {
                 let ExprKind::Call(callee, ..) = &expr.kind else { return false };
@@ -55,11 +59,14 @@ impl<'hir> LateLintPass<'hir> for UnprotectedInitializer {
                 })
             })
         });
+        if locked {
+            return;
+        }
         let destructive = entries.iter().any(|&fid| {
             !has_modifier_named(hir, hir.function(fid), "onlyProxy")
                 && reaches(hir, bases, fid, is_destructive_call)
         });
-        if !upgradeable || locked || !destructive {
+        if !destructive {
             return;
         }
 
@@ -98,26 +105,24 @@ fn reaches<'hir>(
     fid: FunctionId,
     hit: impl FnMut(&'hir Expr<'hir>) -> bool,
 ) -> bool {
-    Reach { hir, bases, stack: Vec::new(), hit }.visit_function_body(fid).is_break()
+    Reach { hir, bases, visited: HashSet::default(), hit }.visit_function_body(fid).is_break()
 }
 
 struct Reach<'hir, F> {
     hir: &'hir hir::Hir<'hir>,
     bases: &'hir [ContractId],
-    stack: Vec<FunctionId>,
+    // The predicate and dispatch context are fixed for the entire reachability check.
+    visited: HashSet<FunctionId>,
     hit: F,
 }
 
 impl<'hir, F: FnMut(&'hir Expr<'hir>) -> bool> Reach<'hir, F> {
     fn visit_function_body(&mut self, fid: FunctionId) -> ControlFlow<()> {
-        if self.stack.contains(&fid) {
+        if !self.visited.insert(fid) {
             return ControlFlow::Continue(());
         }
         let Some(body) = self.hir.function(fid).body else { return ControlFlow::Continue(()) };
-        self.stack.push(fid);
-        let flow = body.stmts.iter().try_for_each(|stmt| self.visit_stmt(stmt));
-        self.stack.pop();
-        flow
+        body.stmts.iter().try_for_each(|stmt| self.visit_stmt(stmt))
     }
 }
 

--- a/crates/lint/testdata/UnprotectedInitializer.sol
+++ b/crates/lint/testdata/UnprotectedInitializer.sol
@@ -96,8 +96,17 @@ contract NoDestructiveSink is Initializable {
     address public owner;
 
     function initialize(address owner_) public initializer {
+        _shared();
+        _shared();
         owner = owner_;
     }
+
+    function _shared() internal pure {
+        _leaf();
+        _leaf();
+    }
+
+    function _leaf() internal pure {}
 }
 
 contract ProtectedDisableInitializers is Initializable {
@@ -313,5 +322,28 @@ contract StorageReturnInitializer is Initializable {
     function execute(address target, bytes calldata data) external {
         (bool ok,) = target.delegatecall(data);
         require(ok);
+    }
+}
+
+// Repeated edges and recursive calls must not hide a later state write.
+contract RepeatedInitializerCalls is Initializable, DangerousBase {
+    address public owner;
+
+    function initialize(address owner_) public initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        _left(owner_);
+        _right(owner_);
+    }
+
+    function _left(address owner_) internal {
+        _shared(owner_);
+    }
+
+    function _right(address owner_) internal {
+        _shared(owner_);
+        owner = owner_;
+    }
+
+    function _shared(address owner_) internal {
+        _left(owner_);
     }
 }

--- a/crates/lint/testdata/UnprotectedInitializer.stderr
+++ b/crates/lint/testdata/UnprotectedInitializer.stderr
@@ -86,3 +86,11 @@ LL │     function initializeConditional(bool useAlternate, address owner_) pub
    │
    ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
 
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initialize(address owner_) public initializer {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+


### PR DESCRIPTION
Short-circuit `unprotected-initializer` once a contract is known not to need a warning, and visit each function once per reachability check instead of repeatedly traversing shared call-graph branches. 

| Benchmark | master | this PR | Speedup |
| --- | ---: | ---: | ---: |
| `forge build test/DynamicArrayLib.t.sol` with cached compilation and linting | 823.7 ± 140.8 ms | 122.4 ± 14.7 ms | 6.73× (85.1% less time) |
