### PR TITLE
perf(cli): avoid repeated import walks

### DIFF
--- a/.changelog/avoid-repeated-import-walks.md
+++ b/.changelog/avoid-repeated-import-walks.md
@@ -1,0 +1,6 @@
+---
+foundry-cli: patch
+forge: patch
+---
+
+Avoid repeated transitive import walks when preparing Solidity sources, reducing build preparation work for deep dependency graphs.

--- a/crates/cli/src/opts/build/utils.rs
+++ b/crates/cli/src/opts/build/utils.rs
@@ -13,7 +13,7 @@ use solar::{interface::MIN_SOLIDITY_VERSION, sema::ParsingContext};
 #[cfg(windows)]
 use std::os::windows::ffi::OsStrExt as _;
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::HashSet,
     path::{Path, PathBuf},
 };
 
@@ -197,21 +197,19 @@ pub fn get_solar_sources_from_compile_output(
         && !targets.is_empty()
     {
         let mut source_paths = HashSet::new();
-        let mut queue: VecDeque<PathBuf> = targets
-            .iter()
-            .filter_map(|path| {
-                is_solidity_file(path).then(|| dunce::canonicalize(path).ok()).flatten()
-            })
-            .collect();
-
-        while let Some(path) = queue.pop_front() {
+        for path in targets.iter().filter_map(|path| {
+            is_solidity_file(path).then(|| dunce::canonicalize(path).ok()).flatten()
+        }) {
             if source_paths.insert(path.clone()) {
-                for import in output.graph().imports(path.as_path()) {
-                    // Skip ignored imports to prevent solar from trying to compile them
-                    if !is_ignored(import) {
-                        queue.push_back(import.to_path_buf());
-                    }
-                }
+                // `imports` already includes transitive dependencies.
+                source_paths.extend(
+                    output
+                        .graph()
+                        .imports(&path)
+                        .into_iter()
+                        .filter(|import| !is_ignored(import))
+                        .map(Path::to_path_buf),
+                );
             }
         }
 


### PR DESCRIPTION
`GraphEdges::imports()` already returns transitive imports, but source preparation queued those imports and expanded them again. Consume that closure directly, preserving explicit roots and ignored-import filtering while removing the redundant queue and dependency walks. Public APIs are unchanged. Implementation and PR text were AI-assisted, with Omp Oracle consulted during the investigation.

### Results

Local `foundry-bench`, profiling builds against master `e7c8e8fb0`, Solc 0.8.30, M5 Pro, one worker, cached builds with linting enabled. Each binary had two warmups and five samples in each of two reversed-order batches. The generated chains contain one empty contract per source, each importing the next; these are scaling stress cases, not claims about typical project structure.

| Workload | Master wall time | Candidate wall time | Change | User CPU, master → candidate |
| --- | ---: | ---: | --- | ---: |
| 1,024-file import chain (synthetic) | 1.428 ± 0.075 s | 1.276 ± 0.068 s | 10.6% lower | 1.098 → 0.964 s |
| 2,048-file import chain (synthetic) | 4.769 ± 0.297 s | 3.657 ± 0.146 s | 23.3% lower | 3.940 → 3.051 s |
| Solady v0.1.26 ERC4626 | 0.124 ± 0.013 s | 0.121 ± 0.007 s | Neutral (overlapping ranges) | 0.101 → 0.100 s |

The real Solady workload is neutral; this targets deep import graphs, not a general Forge test speedup.
