### PR TITLE
feat(forge): support pure Yul tests

### DIFF
--- a/.changelog/yul-test-modules.md
+++ b/.changelog/yul-test-modules.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added support for running bare Yul test modules with `forge test --strict-assembly`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=1e313aa20ae3185eabafdaa7f0dac22d277f0348#1e313aa20ae3185eabafdaa7f0dac22d277f0348"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=1e313aa20ae3185eabafdaa7f0dac22d277f0348#1e313aa20ae3185eabafdaa7f0dac22d277f0348"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5824,7 +5824,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.15.0",
+ "itertools 0.13.0",
  "path-slash",
  "rand 0.10.2",
  "rayon",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=1e313aa20ae3185eabafdaa7f0dac22d277f0348#1e313aa20ae3185eabafdaa7f0dac22d277f0348"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=1e313aa20ae3185eabafdaa7f0dac22d277f0348#1e313aa20ae3185eabafdaa7f0dac22d277f0348"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=1e313aa20ae3185eabafdaa7f0dac22d277f0348#1e313aa20ae3185eabafdaa7f0dac22d277f0348"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=1e313aa20ae3185eabafdaa7f0dac22d277f0348#1e313aa20ae3185eabafdaa7f0dac22d277f0348"
 dependencies = [
  "alloy-primitives",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=f7d93bbf7c021dd711463d58354f9d50869cc3af#f7d93bbf7c021dd711463d58354f9d50869cc3af"
 dependencies = [
  "alloy-primitives",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -563,8 +563,8 @@ solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "0b8a4f83b383
 
 ## foundry-core
 foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "f7d93bbf7c021dd711463d58354f9d50869cc3af" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "f7d93bbf7c021dd711463d58354f9d50869cc3af" }
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
 
 ## alloy-core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -563,8 +563,8 @@ solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "0b8a4f83b383
 
 ## foundry-core
 foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "f7d93bbf7c021dd711463d58354f9d50869cc3af" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "f7d93bbf7c021dd711463d58354f9d50869cc3af" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "1e313aa20ae3185eabafdaa7f0dac22d277f0348" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "1e313aa20ae3185eabafdaa7f0dac22d277f0348" }
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
 
 ## alloy-core

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -16,7 +16,8 @@ use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{
     Artifact, Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, SolcConfig,
     artifacts::{
-        BytecodeObject, Contract, Source, output_selection::OutputSelection, remappings::Remapping,
+        BytecodeObject, Contract, Source, Sources, output_selection::OutputSelection,
+        remappings::Remapping,
     },
     compilers::{
         Compiler,
@@ -83,9 +84,6 @@ pub struct ProjectCompiler {
 
     /// Whether to compile with dynamic linking tests and scripts.
     dynamic_test_linking: bool,
-
-    /// Whether to compile bare `.t.yul` modules as test contracts.
-    yul_tests: bool,
 }
 
 impl Default for ProjectCompiler {
@@ -110,7 +108,6 @@ impl ProjectCompiler {
             size_limits: ContractSizeLimits::default(),
             files: Vec::new(),
             dynamic_test_linking: false,
-            yul_tests: false,
         }
     }
 
@@ -178,22 +175,50 @@ impl ProjectCompiler {
         self
     }
 
-    /// Sets whether bare `.t.yul` modules should be compiled as test contracts.
-    #[inline]
-    pub const fn yul_tests(mut self, preprocess: bool) -> Self {
-        self.yul_tests = preprocess;
-        self
-    }
-
     /// Compiles the project.
     #[instrument(target = "forge::compile", skip_all)]
     pub fn compile<C: Compiler<CompilerContract = Contract>>(
-        mut self,
+        self,
         project: &Project<C>,
     ) -> Result<ProjectCompileOutput<C>>
     where
         DynamicTestLinkingPreprocessor: Preprocessor<C>,
-        YulTestPreprocessor: Preprocessor<C>,
+    {
+        self.compile_project(project, |sources, preprocess| {
+            let mut compiler =
+                foundry_compilers::project::ProjectCompiler::with_sources(project, sources)?;
+            if preprocess {
+                compiler = compiler.with_preprocessor(DynamicTestLinkingPreprocessor);
+            }
+            compiler.compile().map_err(Into::into)
+        })
+    }
+
+    /// Compiles a multi-compiler project with bare `.t.yul` modules enabled as test contracts.
+    #[instrument(target = "forge::compile", skip_all)]
+    pub fn compile_yul_tests(
+        self,
+        project: &Project<MultiCompiler>,
+    ) -> Result<ProjectCompileOutput<MultiCompiler>> {
+        self.compile_project(project, |sources, preprocess| {
+            let mut compiler =
+                foundry_compilers::project::ProjectCompiler::with_sources(project, sources)?
+                    .with_preprocessor(YulTestPreprocessor::default());
+            if preprocess {
+                compiler = compiler.with_additional_preprocessor(DynamicTestLinkingPreprocessor);
+            }
+            compiler.compile().map_err(Into::into)
+        })
+    }
+
+    fn compile_project<C, F>(
+        mut self,
+        project: &Project<C>,
+        f: F,
+    ) -> Result<ProjectCompileOutput<C>>
+    where
+        C: Compiler<CompilerContract = Contract>,
+        F: FnOnce(Sources, bool) -> Result<ProjectCompileOutput<C>>,
     {
         self.project_root = project.root().to_path_buf();
 
@@ -208,26 +233,15 @@ impl ProjectCompiler {
             std::process::exit(0);
         }
 
-        // Taking is fine since we don't need these in `compile_with`.
         let files = std::mem::take(&mut self.files);
         let preprocess = self.dynamic_test_linking;
-        let yul_tests = self.yul_tests;
         self.compile_with(|| {
             let sources = if files.is_empty() {
                 project.paths.read_input_files()?
             } else {
                 Source::read_all(files)?
             };
-
-            let mut compiler =
-                foundry_compilers::project::ProjectCompiler::with_sources(project, sources)?;
-            if yul_tests {
-                compiler = compiler.with_preprocessor(YulTestPreprocessor::default());
-            }
-            if preprocess {
-                compiler = compiler.with_preprocessor(DynamicTestLinkingPreprocessor);
-            }
-            compiler.compile().map_err(Into::into)
+            f(sources, preprocess)
         })
     }
 
@@ -709,7 +723,6 @@ pub fn compile_target<C: Compiler<CompilerContract = Contract>>(
 ) -> Result<ProjectCompileOutput<C>>
 where
     DynamicTestLinkingPreprocessor: Preprocessor<C>,
-    YulTestPreprocessor: Preprocessor<C>,
 {
     ProjectCompiler::new().quiet(quiet).files([target_path.into()]).compile(project)
 }
@@ -721,13 +734,23 @@ pub fn compile_abi_project<C: Compiler<CompilerContract = Contract>>(
 ) -> Result<ProjectCompileOutput<C>>
 where
     DynamicTestLinkingPreprocessor: Preprocessor<C>,
-    YulTestPreprocessor: Preprocessor<C>,
 {
     project.update_output_selection(|selection| {
         // Request ABI so compilers populate `contracts` without producing bytecode outputs.
         *selection = OutputSelection::common_output_selection(["abi".to_string()]);
     });
     compiler.compile(project)
+}
+
+/// Compiles a multi-compiler project requesting only ABI output, with Yul tests enabled.
+pub fn compile_abi_project_with_yul_tests(
+    project: &mut Project<MultiCompiler>,
+    compiler: ProjectCompiler,
+) -> Result<ProjectCompileOutput<MultiCompiler>> {
+    project.update_output_selection(|selection| {
+        *selection = OutputSelection::common_output_selection(["abi".to_string()]);
+    });
+    compiler.compile_yul_tests(project)
 }
 
 /// Compiles the target contract requesting only ABI output and returns its ABI.

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -1,7 +1,10 @@
 //! Support for compiling [foundry_compilers::Project]
 
 use crate::{
-    TestFunctionExt, preprocessor::DynamicTestLinkingPreprocessor, shell, term::SpinnerReporter,
+    TestFunctionExt,
+    preprocessor::{DynamicTestLinkingPreprocessor, YulTestPreprocessor},
+    shell,
+    term::SpinnerReporter,
 };
 use alloy_json_abi::JsonAbi;
 use comfy_table::{
@@ -80,6 +83,9 @@ pub struct ProjectCompiler {
 
     /// Whether to compile with dynamic linking tests and scripts.
     dynamic_test_linking: bool,
+
+    /// Whether to compile bare `.t.yul` modules as test contracts.
+    yul_tests: bool,
 }
 
 impl Default for ProjectCompiler {
@@ -104,6 +110,7 @@ impl ProjectCompiler {
             size_limits: ContractSizeLimits::default(),
             files: Vec::new(),
             dynamic_test_linking: false,
+            yul_tests: false,
         }
     }
 
@@ -171,6 +178,13 @@ impl ProjectCompiler {
         self
     }
 
+    /// Sets whether bare `.t.yul` modules should be compiled as test contracts.
+    #[inline]
+    pub const fn yul_tests(mut self, preprocess: bool) -> Self {
+        self.yul_tests = preprocess;
+        self
+    }
+
     /// Compiles the project.
     #[instrument(target = "forge::compile", skip_all)]
     pub fn compile<C: Compiler<CompilerContract = Contract>>(
@@ -179,6 +193,7 @@ impl ProjectCompiler {
     ) -> Result<ProjectCompileOutput<C>>
     where
         DynamicTestLinkingPreprocessor: Preprocessor<C>,
+        YulTestPreprocessor: Preprocessor<C>,
     {
         self.project_root = project.root().to_path_buf();
 
@@ -196,6 +211,7 @@ impl ProjectCompiler {
         // Taking is fine since we don't need these in `compile_with`.
         let files = std::mem::take(&mut self.files);
         let preprocess = self.dynamic_test_linking;
+        let yul_tests = self.yul_tests;
         self.compile_with(|| {
             let sources = if files.is_empty() {
                 project.paths.read_input_files()?
@@ -205,6 +221,9 @@ impl ProjectCompiler {
 
             let mut compiler =
                 foundry_compilers::project::ProjectCompiler::with_sources(project, sources)?;
+            if yul_tests {
+                compiler = compiler.with_preprocessor(YulTestPreprocessor::default());
+            }
             if preprocess {
                 compiler = compiler.with_preprocessor(DynamicTestLinkingPreprocessor);
             }
@@ -690,6 +709,7 @@ pub fn compile_target<C: Compiler<CompilerContract = Contract>>(
 ) -> Result<ProjectCompileOutput<C>>
 where
     DynamicTestLinkingPreprocessor: Preprocessor<C>,
+    YulTestPreprocessor: Preprocessor<C>,
 {
     ProjectCompiler::new().quiet(quiet).files([target_path.into()]).compile(project)
 }
@@ -701,6 +721,7 @@ pub fn compile_abi_project<C: Compiler<CompilerContract = Contract>>(
 ) -> Result<ProjectCompileOutput<C>>
 where
     DynamicTestLinkingPreprocessor: Preprocessor<C>,
+    YulTestPreprocessor: Preprocessor<C>,
 {
     project.update_output_selection(|selection| {
         // Request ABI so compilers populate `contracts` without producing bytecode outputs.

--- a/crates/common/src/preprocessor/mod.rs
+++ b/crates/common/src/preprocessor/mod.rs
@@ -20,6 +20,9 @@ use data::{collect_preprocessor_data, create_deploy_helpers};
 mod deps;
 use deps::{PreprocessorDependencies, remove_bytecode_dependencies};
 
+mod yul;
+pub use yul::YulTestPreprocessor;
+
 /// Preprocessor that replaces static bytecode linking in tests and scripts (`new Contract`) with
 /// dynamic linkage through (`Vm.create*`).
 ///
@@ -118,6 +121,10 @@ impl Preprocessor<MultiCompiler> for DynamicTestLinkingPreprocessor {
     ) -> Result<()> {
         // Preprocess only Solc compilers.
         let MultiCompilerInput::Solc(input) = input else { return Ok(()) };
+
+        if input.input.language != SolcLanguage::Solidity {
+            return Ok(());
+        }
 
         let Some(solc) = &compiler.solc else { return Ok(()) };
 

--- a/crates/common/src/preprocessor/yul.rs
+++ b/crates/common/src/preprocessor/yul.rs
@@ -1,0 +1,490 @@
+use alloy_json_abi::{Function, JsonAbi, StateMutability};
+use alloy_primitives::keccak256;
+use foundry_compilers::{
+    Compiler, ProjectPathsConfig,
+    artifacts::{Contract, SolcLanguage, Source, Sources},
+    error::{Result, SolcError},
+    multi::{MultiCompiler, MultiCompilerInput, MultiCompilerLanguage},
+    project::Preprocessor,
+    solc::{SolcCompiler, SolcVersionedInput},
+};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Write,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+
+#[derive(Debug, Default)]
+pub struct YulTestPreprocessor {
+    tests: Mutex<HashMap<PathBuf, Vec<String>>>,
+}
+
+impl Preprocessor<SolcCompiler> for YulTestPreprocessor {
+    fn preprocess(
+        &self,
+        _compiler: &SolcCompiler,
+        _input: &mut SolcVersionedInput,
+        _paths: &ProjectPathsConfig<SolcLanguage>,
+        _mocks: &mut HashSet<PathBuf>,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl Preprocessor<MultiCompiler> for YulTestPreprocessor {
+    fn preprocess(
+        &self,
+        _compiler: &MultiCompiler,
+        _input: &mut MultiCompilerInput,
+        _paths: &ProjectPathsConfig<MultiCompilerLanguage>,
+        _mocks: &mut HashSet<PathBuf>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn preprocess_inputs(
+        &self,
+        _compiler: &MultiCompiler,
+        input: MultiCompilerInput,
+        paths: &ProjectPathsConfig<MultiCompilerLanguage>,
+        _mocks: &mut HashSet<PathBuf>,
+    ) -> Result<Vec<MultiCompilerInput>> {
+        let MultiCompilerInput::Solc(input) = input else { return Ok(vec![input]) };
+        if input.input.language != SolcLanguage::Yul {
+            return Ok(vec![MultiCompilerInput::Solc(input)]);
+        }
+
+        let test_paths = input
+            .input
+            .sources
+            .keys()
+            .filter(|path| is_yul_test(path, paths))
+            .cloned()
+            .collect::<Vec<_>>();
+        if test_paths.is_empty() {
+            return Ok(vec![MultiCompilerInput::Solc(input)]);
+        }
+
+        let mut inputs = Vec::with_capacity(test_paths.len());
+        for test_path in test_paths {
+            let mut visited = HashSet::new();
+            let mut modules = Vec::new();
+            collect_modules(
+                &test_path,
+                &input.input.sources,
+                paths,
+                &mut visited,
+                &mut HashSet::new(),
+                &mut modules,
+            )?;
+
+            let mut definitions = String::new();
+            let mut names = HashSet::new();
+            let mut entrypoints = Vec::new();
+            for (path, content) in modules {
+                if path != test_path
+                    && path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.ends_with(".t.yul"))
+                {
+                    return Err(SolcError::msg(format!(
+                        "Yul test suite `{}` cannot import another test suite `{}`",
+                        test_path.display(),
+                        path.display()
+                    )));
+                }
+                let functions = parse_module(&content).map_err(|error| {
+                    SolcError::msg(format!("invalid Yul module `{}`: {error}", path.display()))
+                })?;
+                for function in &functions {
+                    if !names.insert(function.name.to_string()) {
+                        return Err(SolcError::msg(format!(
+                            "duplicate Yul function `{}` in test suite `{}`",
+                            function.name,
+                            test_path.display()
+                        )));
+                    }
+                    if path == test_path
+                        && (function.name.starts_with("test") || function.name == "setUp")
+                    {
+                        if function.name.starts_with("testFail") {
+                            return Err(SolcError::msg(format!(
+                                "legacy `testFail*` Yul tests are not supported; use an explicit assertion in `{}`",
+                                function.name
+                            )));
+                        }
+                        if !function.parameters.is_empty() || !function.returns.is_empty() {
+                            return Err(SolcError::msg(format!(
+                                "Yul test entrypoint `{}` must not have parameters or return values",
+                                function.name
+                            )));
+                        }
+                        entrypoints.push(function.name.to_string());
+                    }
+                }
+                definitions.push_str(&without_imports(&content));
+                definitions.push('\n');
+            }
+
+            if entrypoints.iter().all(|name| name == "setUp") {
+                return Err(SolcError::msg(format!(
+                    "no test functions found in `{}`",
+                    test_path.display()
+                )));
+            }
+            if entrypoints.iter().filter(|name| name.as_str() == "setUp").count() > 1 {
+                return Err(SolcError::msg(format!(
+                    "multiple `setUp` functions found in `{}`",
+                    test_path.display()
+                )));
+            }
+
+            let suite_name = suite_name(&test_path)?;
+            let generated = generate_harness(&suite_name, &entrypoints, &definitions)?;
+            self.tests
+                .lock()
+                .map_err(|_| SolcError::msg("Yul test metadata lock poisoned"))?
+                .insert(test_path.clone(), entrypoints);
+
+            let mut split = (*input).clone();
+            split.input.sources = Sources::from_iter([(test_path, Source::new(generated))]);
+            // Solc emits no contract entry for Yul when only ABI output is requested. Forge's
+            // filtered discovery and `--list` paths use ABI-only compilation, so request the
+            // smallest real Yul output needed for postprocessing to attach the synthetic ABI.
+            let outputs = split
+                .input
+                .settings
+                .output_selection
+                .0
+                .entry("*".to_string())
+                .or_default()
+                .entry("*".to_string())
+                .or_default();
+            if !outputs.iter().any(|output| output == "evm.bytecode.object") {
+                outputs.push("evm.bytecode.object".to_string());
+            }
+            inputs.push(MultiCompilerInput::Solc(Box::new(split)));
+        }
+        Ok(inputs)
+    }
+
+    fn postprocess(
+        &self,
+        _input: &MultiCompilerInput,
+        output: &mut foundry_compilers::CompilerOutput<
+            <MultiCompiler as Compiler>::CompilationError,
+            Contract,
+        >,
+    ) -> Result<()> {
+        let tests =
+            self.tests.lock().map_err(|_| SolcError::msg("Yul test metadata lock poisoned"))?;
+        for (path, contracts) in &mut output.contracts {
+            let Some(entrypoints) = tests.get(path) else { continue };
+            let mut abi = JsonAbi::new();
+            for name in entrypoints {
+                abi.functions.entry(name.clone()).or_default().push(Function {
+                    name: name.clone(),
+                    inputs: Vec::new(),
+                    outputs: Vec::new(),
+                    state_mutability: StateMutability::NonPayable,
+                });
+            }
+            for contract in contracts.values_mut() {
+                contract.abi = Some(abi.clone());
+            }
+        }
+        Ok(())
+    }
+}
+
+fn is_yul_test(path: &Path, paths: &ProjectPathsConfig<MultiCompilerLanguage>) -> bool {
+    path.file_name().and_then(|name| name.to_str()).is_some_and(|name| name.ends_with(".t.yul"))
+        && paths.is_test(&paths.root.join(path))
+}
+
+fn suite_name(path: &Path) -> Result<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_suffix(".t.yul"))
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| SolcError::msg(format!("invalid Yul test path `{}`", path.display())))
+}
+
+fn collect_modules(
+    path: &Path,
+    sources: &Sources,
+    paths: &ProjectPathsConfig<MultiCompilerLanguage>,
+    visited: &mut HashSet<PathBuf>,
+    visiting: &mut HashSet<PathBuf>,
+    modules: &mut Vec<(PathBuf, String)>,
+) -> Result<()> {
+    if visited.contains(path) {
+        return Ok(());
+    }
+    if !visiting.insert(path.to_path_buf()) {
+        return Err(SolcError::msg(format!("cyclic Yul import involving `{}`", path.display())));
+    }
+    let source = sources.get(path).ok_or_else(|| {
+        SolcError::msg(format!("Yul import `{}` is not present in compiler input", path.display()))
+    })?;
+    for import in foundry_compilers::utils::find_yul_imports(&source.content) {
+        let absolute = if path.is_absolute() { path.to_path_buf() } else { paths.root.join(path) };
+        let parent = absolute.parent().unwrap_or(&paths.root);
+        let resolved = paths.resolve_import(parent, Path::new(import.path))?;
+        let resolved =
+            resolved.strip_prefix(&paths.root).map(Path::to_path_buf).unwrap_or(resolved);
+        collect_modules(&resolved, sources, paths, visited, visiting, modules)?;
+    }
+    visiting.remove(path);
+    visited.insert(path.to_path_buf());
+    modules.push((path.to_path_buf(), source.content.to_string()));
+    Ok(())
+}
+
+fn without_imports(source: &str) -> String {
+    let mut output = source.to_string();
+    for import in foundry_compilers::utils::find_yul_imports(source).into_iter().rev() {
+        output.replace_range(import.statement, "");
+    }
+    output
+}
+
+fn generate_harness(name: &str, entrypoints: &[String], definitions: &str) -> Result<String> {
+    let mut selectors = HashSet::new();
+    let mut dispatch = String::new();
+    for entrypoint in entrypoints {
+        let hash = keccak256(format!("{entrypoint}()"));
+        let selector = &hash[..4];
+        if !selectors.insert(selector.to_vec()) {
+            return Err(SolcError::msg(format!("selector collision for `{entrypoint}()`")));
+        }
+        writeln!(
+            dispatch,
+            "            case 0x{} {{ {entrypoint}() stop() }}",
+            alloy_primitives::hex::encode(selector)
+        )
+        .unwrap();
+    }
+
+    Ok(format!(
+        r#"object "{name}" {{
+    code {{
+        datacopy(0, dataoffset("runtime"), datasize("runtime"))
+        return(0, datasize("runtime"))
+    }}
+    object "runtime" {{
+        code {{
+            if lt(calldatasize(), 4) {{ revert(0, 0) }}
+            switch shr(224, calldataload(0))
+{dispatch}            default {{ revert(0, 0) }}
+{definitions}
+        }}
+    }}
+}}
+"#
+    ))
+}
+
+#[derive(Debug)]
+struct YulFunction<'a> {
+    name: &'a str,
+    parameters: &'a str,
+    returns: &'a str,
+}
+
+fn parse_module(source: &str) -> std::result::Result<Vec<YulFunction<'_>>, String> {
+    let imports = foundry_compilers::utils::find_yul_imports(source);
+    let mut functions = Vec::new();
+    let mut cursor = 0;
+    loop {
+        cursor = skip_trivia(source, cursor)?;
+        if cursor == source.len() {
+            break;
+        }
+        if let Some(import) = imports.iter().find(|import| import.statement.start == cursor) {
+            cursor = import.statement.end;
+            continue;
+        }
+        let (keyword, next) = identifier(source, cursor)?;
+        if keyword != "function" {
+            return Err(format!("expected `function` or `import` at byte {cursor}"));
+        }
+        cursor = skip_trivia(source, next)?;
+        let (name, next) = identifier(source, cursor)?;
+        cursor = skip_trivia(source, next)?;
+        let (parameters, next) = delimited(source, cursor, b'(', b')')?;
+        cursor = skip_trivia(source, next)?;
+        let returns = if source[cursor..].starts_with("->") {
+            cursor = skip_trivia(source, cursor + 2)?;
+            let body = find_unquoted(source, cursor, b'{')?;
+            let returns = source[cursor..body].trim();
+            cursor = body;
+            returns
+        } else {
+            ""
+        };
+        let (_, next) = delimited(source, cursor, b'{', b'}')?;
+        functions.push(YulFunction { name, parameters: parameters.trim(), returns });
+        cursor = next;
+    }
+    Ok(functions)
+}
+
+fn skip_trivia(source: &str, mut cursor: usize) -> std::result::Result<usize, String> {
+    let bytes = source.as_bytes();
+    loop {
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        if bytes.get(cursor..cursor + 2) == Some(b"//") {
+            cursor += 2;
+            while bytes.get(cursor).is_some_and(|byte| *byte != b'\n') {
+                cursor += 1;
+            }
+        } else if bytes.get(cursor..cursor + 2) == Some(b"/*") {
+            let Some(end) = source[cursor + 2..].find("*/") else {
+                return Err("unterminated block comment".to_string());
+            };
+            cursor += end + 4;
+        } else {
+            return Ok(cursor);
+        }
+    }
+}
+
+fn identifier(source: &str, start: usize) -> std::result::Result<(&str, usize), String> {
+    let bytes = source.as_bytes();
+    if !bytes.get(start).is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_') {
+        return Err(format!("expected identifier at byte {start}"));
+    }
+    let mut end = start + 1;
+    while bytes.get(end).is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_') {
+        end += 1;
+    }
+    Ok((&source[start..end], end))
+}
+
+fn delimited(
+    source: &str,
+    start: usize,
+    open: u8,
+    close: u8,
+) -> std::result::Result<(&str, usize), String> {
+    let bytes = source.as_bytes();
+    if bytes.get(start) != Some(&open) {
+        return Err(format!("expected `{}` at byte {start}", open as char));
+    }
+    let mut depth = 1usize;
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'/' if bytes.get(cursor + 1) == Some(&b'/') => {
+                cursor += 2;
+                while bytes.get(cursor).is_some_and(|byte| *byte != b'\n') {
+                    cursor += 1;
+                }
+            }
+            b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
+                let Some(end) = source[cursor + 2..].find("*/") else {
+                    return Err("unterminated block comment".to_string());
+                };
+                cursor += end + 4;
+            }
+            b'"' | b'\'' => cursor = skip_string(source, cursor)?,
+            byte if byte == open => {
+                depth += 1;
+                cursor += 1;
+            }
+            byte if byte == close => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok((&source[start + 1..cursor], cursor + 1));
+                }
+                cursor += 1;
+            }
+            _ => cursor += 1,
+        }
+    }
+    Err(format!("unterminated `{}`", open as char))
+}
+
+fn find_unquoted(
+    source: &str,
+    mut cursor: usize,
+    needle: u8,
+) -> std::result::Result<usize, String> {
+    let bytes = source.as_bytes();
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'/' if bytes.get(cursor + 1) == Some(&b'/') => {
+                cursor += 2;
+                while bytes.get(cursor).is_some_and(|byte| *byte != b'\n') {
+                    cursor += 1;
+                }
+            }
+            b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
+                let Some(end) = source[cursor + 2..].find("*/") else {
+                    return Err("unterminated block comment".to_string());
+                };
+                cursor += end + 4;
+            }
+            b'"' | b'\'' => cursor = skip_string(source, cursor)?,
+            byte if byte == needle => return Ok(cursor),
+            _ => cursor += 1,
+        }
+    }
+    Err(format!("expected `{}`", needle as char))
+}
+
+fn skip_string(source: &str, start: usize) -> std::result::Result<usize, String> {
+    let bytes = source.as_bytes();
+    let quote = bytes[start];
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'\\' => cursor += 2,
+            byte if byte == quote => return Ok(cursor + 1),
+            _ => cursor += 1,
+        }
+    }
+    Err("unterminated string".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_functions_without_comment_false_positives() {
+        let functions = parse_module(
+            r#"
+import "Math.yul"
+// function test_ignored() {}
+function helper(a, b) -> result { result := add(a, b) }
+function test_example() { let value := "function test_fake() {}" }
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            functions.iter().map(|function| function.name).collect::<Vec<_>>(),
+            ["helper", "test_example"]
+        );
+        assert_eq!(functions[0].parameters, "a, b");
+        assert_eq!(functions[0].returns, "result");
+    }
+
+    #[test]
+    fn generates_dispatcher() {
+        let harness = generate_harness(
+            "Example",
+            &["setUp".to_string(), "test_example".to_string()],
+            "function setUp() {} function test_example() {}",
+        )
+        .unwrap();
+        assert!(harness.contains("case 0x0a9254e4 { setUp() stop() }"));
+        assert!(harness.contains("case 0x22c34ba7 { test_example() stop() }"));
+    }
+}

--- a/crates/common/src/preprocessor/yul.rs
+++ b/crates/common/src/preprocessor/yul.rs
@@ -6,7 +6,6 @@ use foundry_compilers::{
     error::{Result, SolcError},
     multi::{MultiCompiler, MultiCompilerInput, MultiCompilerLanguage},
     project::Preprocessor,
-    solc::{SolcCompiler, SolcVersionedInput},
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -20,27 +19,13 @@ pub struct YulTestPreprocessor {
     tests: Mutex<HashMap<PathBuf, Vec<String>>>,
 }
 
-impl Preprocessor<SolcCompiler> for YulTestPreprocessor {
-    fn preprocess(
-        &self,
-        _compiler: &SolcCompiler,
-        _input: &mut SolcVersionedInput,
-        _paths: &ProjectPathsConfig<SolcLanguage>,
-        _mocks: &mut HashSet<PathBuf>,
-    ) -> Result<()> {
-        Ok(())
-    }
-}
-
 impl Preprocessor<MultiCompiler> for YulTestPreprocessor {
-    fn preprocess(
-        &self,
-        _compiler: &MultiCompiler,
-        _input: &mut MultiCompilerInput,
-        _paths: &ProjectPathsConfig<MultiCompilerLanguage>,
-        _mocks: &mut HashSet<PathBuf>,
-    ) -> Result<()> {
-        Ok(())
+    fn supports_interface_only_invalidation(&self) -> bool {
+        false
+    }
+
+    fn cache_key(&self) -> Option<&'static str> {
+        Some("foundry-yul-tests-v1")
     }
 
     fn preprocess_inputs(
@@ -62,11 +47,8 @@ impl Preprocessor<MultiCompiler> for YulTestPreprocessor {
             .filter(|path| is_yul_test(path, paths))
             .cloned()
             .collect::<Vec<_>>();
-        if test_paths.is_empty() {
-            return Ok(vec![MultiCompilerInput::Solc(input)]);
-        }
-
-        let mut inputs = Vec::with_capacity(test_paths.len());
+        let mut inputs = Vec::with_capacity(input.input.sources.len());
+        let mut consumed = HashSet::new();
         for test_path in test_paths {
             let mut visited = HashSet::new();
             let mut modules = Vec::new();
@@ -78,6 +60,7 @@ impl Preprocessor<MultiCompiler> for YulTestPreprocessor {
                 &mut HashSet::new(),
                 &mut modules,
             )?;
+            consumed.extend(visited);
 
             let mut definitions = String::new();
             let mut names = HashSet::new();
@@ -115,7 +98,7 @@ impl Preprocessor<MultiCompiler> for YulTestPreprocessor {
                                 function.name
                             )));
                         }
-                        if !function.parameters.is_empty() || !function.returns.is_empty() {
+                        if has_tokens(function.parameters) || has_tokens(function.returns) {
                             return Err(SolcError::msg(format!(
                                 "Yul test entrypoint `{}` must not have parameters or return values",
                                 function.name
@@ -134,13 +117,6 @@ impl Preprocessor<MultiCompiler> for YulTestPreprocessor {
                     test_path.display()
                 )));
             }
-            if entrypoints.iter().filter(|name| name.as_str() == "setUp").count() > 1 {
-                return Err(SolcError::msg(format!(
-                    "multiple `setUp` functions found in `{}`",
-                    test_path.display()
-                )));
-            }
-
             let suite_name = suite_name(&test_path)?;
             let generated = generate_harness(&suite_name, &entrypoints, &definitions)?;
             self.tests
@@ -153,18 +129,17 @@ impl Preprocessor<MultiCompiler> for YulTestPreprocessor {
             // Solc emits no contract entry for Yul when only ABI output is requested. Forge's
             // filtered discovery and `--list` paths use ABI-only compilation, so request the
             // smallest real Yul output needed for postprocessing to attach the synthetic ABI.
-            let outputs = split
-                .input
-                .settings
-                .output_selection
-                .0
-                .entry("*".to_string())
-                .or_default()
-                .entry("*".to_string())
-                .or_default();
-            if !outputs.iter().any(|output| output == "evm.bytecode.object") {
-                outputs.push("evm.bytecode.object".to_string());
+            ensure_yul_bytecode_output(&mut split);
+            inputs.push(MultiCompilerInput::Solc(Box::new(split)));
+        }
+
+        for (path, source) in &input.input.sources {
+            if consumed.contains(path) {
+                continue;
             }
+            let mut split = (*input).clone();
+            split.input.sources = Sources::from_iter([(path.clone(), source.clone())]);
+            ensure_yul_bytecode_output(&mut split);
             inputs.push(MultiCompilerInput::Solc(Box::new(split)));
         }
         Ok(inputs)
@@ -196,6 +171,21 @@ impl Preprocessor<MultiCompiler> for YulTestPreprocessor {
             }
         }
         Ok(())
+    }
+}
+
+fn ensure_yul_bytecode_output(input: &mut foundry_compilers::solc::SolcVersionedInput) {
+    let outputs = input
+        .input
+        .settings
+        .output_selection
+        .0
+        .entry("*".to_string())
+        .or_default()
+        .entry("*".to_string())
+        .or_default();
+    if !outputs.iter().any(|output| output == "evm.bytecode.object") {
+        outputs.push("evm.bytecode.object".to_string());
     }
 }
 
@@ -234,9 +224,20 @@ fn collect_modules(
         let absolute = if path.is_absolute() { path.to_path_buf() } else { paths.root.join(path) };
         let parent = absolute.parent().unwrap_or(&paths.root);
         let resolved = paths.resolve_import(parent, Path::new(import.path))?;
-        let resolved =
-            resolved.strip_prefix(&paths.root).map(Path::to_path_buf).unwrap_or(resolved);
-        collect_modules(&resolved, sources, paths, visited, visiting, modules)?;
+        let source_key = sources
+            .keys()
+            .find(|candidate| {
+                foundry_compilers::utils::normalize_solidity_import_path(&paths.root, candidate)
+                    .is_ok_and(|absolute| absolute == resolved)
+            })
+            .cloned()
+            .ok_or_else(|| {
+                SolcError::msg(format!(
+                    "resolved Yul import `{}` is not present in compiler input",
+                    resolved.display()
+                ))
+            })?;
+        collect_modules(&source_key, sources, paths, visited, visiting, modules)?;
     }
     visiting.remove(path);
     visited.insert(path.to_path_buf());
@@ -357,14 +358,24 @@ fn skip_trivia(source: &str, mut cursor: usize) -> std::result::Result<usize, St
 
 fn identifier(source: &str, start: usize) -> std::result::Result<(&str, usize), String> {
     let bytes = source.as_bytes();
-    if !bytes.get(start).is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_') {
+    if !bytes
+        .get(start)
+        .is_some_and(|byte| byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$'))
+    {
         return Err(format!("expected identifier at byte {start}"));
     }
     let mut end = start + 1;
-    while bytes.get(end).is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_') {
+    while bytes
+        .get(end)
+        .is_some_and(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$' | b'.'))
+    {
         end += 1;
     }
     Ok((&source[start..end], end))
+}
+
+fn has_tokens(source: &str) -> bool {
+    skip_trivia(source, 0).is_ok_and(|cursor| cursor != source.len())
 }
 
 fn delimited(
@@ -464,16 +475,19 @@ mod tests {
 import "Math.yul"
 // function test_ignored() {}
 function helper(a, b) -> result { result := add(a, b) }
+function $helper.name(/* no parameters */) -> /* no returns */ { }
 function test_example() { let value := "function test_fake() {}" }
 "#,
         )
         .unwrap();
         assert_eq!(
             functions.iter().map(|function| function.name).collect::<Vec<_>>(),
-            ["helper", "test_example"]
+            ["helper", "$helper.name", "test_example"]
         );
         assert_eq!(functions[0].parameters, "a, b");
         assert_eq!(functions[0].returns, "result");
+        assert!(!has_tokens(functions[1].parameters));
+        assert!(!has_tokens(functions[1].returns));
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -108,6 +108,10 @@ const DEBUGGER_MATCHING_TESTS_DISPLAY_LIMIT: usize = 12;
 const AUTO_FUZZ_FAILURE_DIR: &str = "fuzz";
 const AUTO_CORPUS_DIR: &str = "corpus";
 
+fn is_yul_test_path(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()).is_some_and(|name| name.ends_with(".t.yul"))
+}
+
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(TestArgs, build, evm);
 
@@ -512,6 +516,10 @@ pub struct TestArgs {
     /// The contract file you want to test, it's a shortcut for --match-path.
     #[arg(value_hint = ValueHint::FilePath)]
     pub path: Option<GlobMatcher>,
+
+    /// Compile bare `.t.yul` modules as strict-assembly test contracts.
+    #[arg(long)]
+    strict_assembly: bool,
 
     /// Run a single test in the debugger.
     ///
@@ -1489,7 +1497,9 @@ impl TestArgs {
             .chain(
                 // Preserve path-filter behavior for conventional test files while still
                 // scanning non-test fixtures under the test root.
-                test_files().filter(|path| !path.is_sol_test() || test_filter.matches_path(path)),
+                test_files().filter(|path| {
+                    !path.is_sol_test() && !is_yul_test_path(path) || test_filter.matches_path(path)
+                }),
             )
             .collect::<BTreeSet<_>>();
         let output = compile_abi_project(
@@ -1497,6 +1507,7 @@ impl TestArgs {
             ProjectCompiler::new()
                 .files(sources.iter().cloned())
                 .dynamic_test_linking(config.dynamic_test_linking)
+                .yul_tests(self.strict_assembly)
                 .quiet(true),
         )?;
         if output.has_compiler_errors() {
@@ -1648,6 +1659,7 @@ impl TestArgs {
 
         let compiler = ProjectCompiler::new()
             .dynamic_test_linking(config.dynamic_test_linking)
+            .yul_tests(self.strict_assembly)
             .quiet(shell::is_json() || self.junit);
         let (output, selected_sources, inline_config) = if self.list {
             // Only the ABI is needed to list tests, so skip the full compile when possible.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -39,7 +39,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     ContractsByArtifact, EmptyTestFilter, TestFilter, TestFunctionExt, TestFunctionKind,
-    compile::{ProjectCompiler, compile_abi_project},
+    compile::{ProjectCompiler, compile_abi_project, compile_abi_project_with_yul_tests},
     fs, sh_status, sh_warn, shell,
 };
 use foundry_compilers::{
@@ -1502,14 +1502,15 @@ impl TestArgs {
                 }),
             )
             .collect::<BTreeSet<_>>();
-        let output = compile_abi_project(
-            &mut project,
-            ProjectCompiler::new()
-                .files(sources.iter().cloned())
-                .dynamic_test_linking(config.dynamic_test_linking)
-                .yul_tests(self.strict_assembly)
-                .quiet(true),
-        )?;
+        let compiler = ProjectCompiler::new()
+            .files(sources.iter().cloned())
+            .dynamic_test_linking(config.dynamic_test_linking)
+            .quiet(true);
+        let output = if self.strict_assembly {
+            compile_abi_project_with_yul_tests(&mut project, compiler)?
+        } else {
+            compile_abi_project(&mut project, compiler)?
+        };
         if output.has_compiler_errors() {
             sh_println!("{output}")?;
             bail!("Compilation failed");
@@ -1659,7 +1660,6 @@ impl TestArgs {
 
         let compiler = ProjectCompiler::new()
             .dynamic_test_linking(config.dynamic_test_linking)
-            .yul_tests(self.strict_assembly)
             .quiet(shell::is_json() || self.junit);
         let (output, selected_sources, inline_config) = if self.list {
             // Only the ABI is needed to list tests, so skip the full compile when possible.
@@ -1677,11 +1677,21 @@ impl TestArgs {
             } else {
                 compiler
             };
-            (compile_abi_project(&mut project, compiler)?, BTreeSet::new(), None)
+            let output = if self.strict_assembly {
+                compile_abi_project_with_yul_tests(&mut project, compiler)?
+            } else {
+                compile_abi_project(&mut project, compiler)?
+            };
+            (output, BTreeSet::new(), None)
         } else {
             let (files, inline_config) =
                 self.get_sources_to_compile(&config, &filter, replay_symbolic_artifact.as_ref())?;
-            let output = compiler.files(files.clone()).compile(&project);
+            let compiler = compiler.files(files.clone());
+            let output = if self.strict_assembly {
+                compiler.compile_yul_tests(&project)
+            } else {
+                compiler.compile(&project)
+            };
             let output = if should_mutate {
                 output.wrap_err(
                     "Mutation testing compiler profile failed to compile before applying mutations",

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -38,6 +38,7 @@ mod verify;
 mod verify_bytecode;
 mod version;
 mod watch;
+mod yul;
 
 mod ext_integration;
 mod fmt;

--- a/crates/forge/tests/cli/yul.rs
+++ b/crates/forge/tests/cli/yul.rs
@@ -15,8 +15,14 @@ function min(a, b) -> minimum {
         r#"
 import "../src/MathUtil.yul"
 
+function setUp() { sstore(0, 42) }
+
 function test_min() {
     if iszero(eq(2, min(4, 2))) { revert(0, 0) }
+}
+
+function test_set_up_state() {
+    if iszero(eq(sload(0), 42)) { revert(0, 0) }
 }
 "#,
     );
@@ -28,6 +34,7 @@ Compiler run successful!
 test/MathUtil.t.yul
   MathUtil
     test_min
+    test_set_up_state
 
 
 "#]]);
@@ -37,13 +44,89 @@ test/MathUtil.t.yul
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
-Ran 1 test for test/MathUtil.t.yul:MathUtil
+Ran 2 tests for test/MathUtil.t.yul:MathUtil
 [PASS] test_min() ([GAS])
-Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+[PASS] test_set_up_state() ([GAS])
+Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
-Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 
 "#]]);
+});
+
+forgetest!(strict_assembly_preserves_independent_yul_objects, |prj, cmd| {
+    prj.create_file("test/Suite.t.yul", "function test_ok() {}\n");
+    for object in ["First", "Second"] {
+        prj.create_file(
+            format!("src/{object}.yul"),
+            &format!(
+                r#"object "{object}" {{
+    code {{ mstore(0, 1) return(0, 32) }}
+}}"#
+            ),
+        );
+    }
+
+    cmd.args(["test", "--strict-assembly", "--list"]).assert_success();
+    for object in ["First", "Second"] {
+        assert!(prj.artifacts().join(format!("{object}.yul/{object}.json")).exists());
+    }
+
+    cmd.forge_fuse().args(["test", "--strict-assembly"]).assert_success();
+    for object in ["First", "Second"] {
+        prj.create_file(
+            format!("src/{object}.yul"),
+            &format!(
+                r#"object "{object}" {{
+    code {{ mstore(0, 2) return(0, 32) }}
+}}"#
+            ),
+        );
+    }
+    cmd.forge_fuse().args(["test", "--strict-assembly"]).assert_success();
+});
+
+forgetest!(strict_assembly_invalidates_solidity_body_changes, |prj, cmd| {
+    prj.create_file(
+        "src/Value.sol",
+        "contract Value { function value() external pure returns (uint256) { return 1; } }",
+    );
+    prj.create_file(
+        "test/Value.t.sol",
+        r#"
+import {Value} from "../src/Value.sol";
+contract ValueTest {
+    function test_value() external { require(new Value().value() == 1); }
+}
+"#,
+    );
+    prj.create_file("test/Suite.t.yul", "function test_ok() {}\n");
+
+    cmd.args(["test", "--strict-assembly"]).assert_success();
+    prj.create_file(
+        "src/Value.sol",
+        "contract Value { function value() external pure returns (uint256) { return 2; } }",
+    );
+    let output = cmd
+        .forge_fuse()
+        .args(["test", "--strict-assembly"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(output.contains("ValueTest"));
+    assert!(output.contains("[FAIL") && output.contains("test_value()"));
+
+    prj.update_config(|config| config.dynamic_test_linking = true);
+    prj.create_file(
+        "src/Value.sol",
+        "contract Value { function value() external pure returns (uint256) { return 1; } }",
+    );
+    cmd.forge_fuse().args(["test", "--strict-assembly"]).assert_success();
+    prj.create_file(
+        "src/Value.sol",
+        "contract Value { function value() external pure returns (uint256) { return 2; } }",
+    );
+    cmd.forge_fuse().args(["test", "--strict-assembly"]).assert_failure();
 });
 
 forgetest!(strict_assembly_test_failure_reverts, |prj, cmd| {
@@ -75,6 +158,17 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
 Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
+});
+
+forgetest!(strict_assembly_cache_is_not_reused_without_flag, |prj, cmd| {
+    prj.create_file("test/Cache.t.yul", "function test_cache_identity() {}\n");
+
+    cmd.args(["test", "--strict-assembly"]).assert_success();
+    cmd.forge_fuse().arg("test").assert_failure();
+
+    prj.update_config(|config| config.dynamic_test_linking = true);
+    cmd.forge_fuse().args(["test", "--strict-assembly"]).assert_success();
+    cmd.forge_fuse().arg("test").assert_failure();
 });
 
 forgetest!(strict_assembly_splits_suites_and_invalidates_imports, |prj, cmd| {

--- a/crates/forge/tests/cli/yul.rs
+++ b/crates/forge/tests/cli/yul.rs
@@ -1,0 +1,110 @@
+use foundry_test_utils::util::OutputExt;
+
+forgetest!(can_run_strict_assembly_tests, |prj, cmd| {
+    prj.create_file(
+        "src/MathUtil.yul",
+        r#"
+function min(a, b) -> minimum {
+    minimum := a
+    if lt(b, a) { minimum := b }
+}
+"#,
+    );
+    prj.create_file(
+        "test/MathUtil.t.yul",
+        r#"
+import "../src/MathUtil.yul"
+
+function test_min() {
+    if iszero(eq(2, min(4, 2))) { revert(0, 0) }
+}
+"#,
+    );
+
+    cmd.args(["test", "--strict-assembly", "--list"]).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+test/MathUtil.t.yul
+  MathUtil
+    test_min
+
+
+"#]]);
+
+    cmd.forge_fuse().args(["test", "--strict-assembly"]).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/MathUtil.t.yul:MathUtil
+[PASS] test_min() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+});
+
+forgetest!(strict_assembly_test_failure_reverts, |prj, cmd| {
+    prj.create_file(
+        "test/Failure.t.yul",
+        r#"
+function test_failure() { revert(0, 0) }
+"#,
+    );
+
+    cmd.args(["test", "--strict-assembly"]).assert_failure().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/Failure.t.yul:Failure
+[FAIL: EvmError: Revert] test_failure() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/Failure.t.yul:Failure
+[FAIL: EvmError: Revert] test_failure() ([GAS])
+
+Encountered a total of 1 failing tests, 0 tests succeeded
+
+Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
+
+"#]]);
+});
+
+forgetest!(strict_assembly_splits_suites_and_invalidates_imports, |prj, cmd| {
+    prj.create_file("src/Shared.yul", "function shared() -> value { value := 1 }");
+    for suite in ["First", "Second"] {
+        prj.create_file(
+            format!("test/{suite}.t.yul"),
+            &format!(
+                r#"
+import "../src/Shared.yul"
+function test_{suite}() {{
+    if iszero(eq(shared(), 1)) {{ revert(0, 0) }}
+}}
+"#
+            ),
+        );
+    }
+
+    let output =
+        cmd.args(["test", "--strict-assembly"]).assert_success().get_output().stdout_lossy();
+    assert!(output.contains("test_First()"));
+    assert!(output.contains("test_Second()"));
+
+    prj.create_file("src/Shared.yul", "function shared() -> value { value := 2 }");
+    let output = cmd
+        .forge_fuse()
+        .args(["test", "--strict-assembly"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(output.contains("[FAIL: EvmError: Revert] test_First()"));
+    assert!(output.contains("[FAIL: EvmError: Revert] test_Second()"));
+});


### PR DESCRIPTION
## Summary

- add `forge test --strict-assembly` for function-only `.t.yul` test suites
- resolve and inline Yul imports, generate deployable selector dispatchers, and attach synthetic test ABIs
- support `setUp`, test filtering, fresh `--list`, cached artifacts, multiple suites, and imported-helper invalidation
- reject unsupported parameterized entrypoints, imported test suites, duplicate functions, and legacy `testFail*` tests with clear errors

Closes #11059.

Depends on foundry-rs/foundry-core#177. The dependency pins in this PR reference that prerequisite branch commit and should be refreshed after it merges.

## Testing

- cargo test -p foundry-common preprocessor::yul --lib
- cargo test -p forge --test cli yul:: -- --nocapture
- cargo check -p foundry-common -p forge
- cargo clippy -p foundry-common -p forge --lib -- -D warnings
- cargo +nightly fmt --all -- --check