### PR TITLE
fix(symbolic): re-registering an identical vm.mockCall replaces the stale entry

### DIFF
--- a/.changelog/symbolic-mockcall-remock-replace.md
+++ b/.changelog/symbolic-mockcall-remock-replace.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `vm.mockCall`/`vm.mockCalls` under `--symbolic` appending a duplicate mock instead of replacing the prior one when re-registering the same `(callee, value, calldata)`, diverging from concrete-mode's replace semantics.

--- a/.changelog/symbolic-mockcall-remock-replace.md
+++ b/.changelog/symbolic-mockcall-remock-replace.md
@@ -2,4 +2,4 @@
 forge: patch
 ---
 
-Fixed `vm.mockCall`/`vm.mockCalls` under `--symbolic` appending a duplicate mock instead of replacing the prior one when re-registering the same `(callee, value, calldata)`, diverging from concrete-mode's replace semantics.
+Fixed symbolic `vm.mockCall`/`vm.mockCalls` to replace mocks with the same callee, value, and calldata.

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -409,7 +409,21 @@ impl SymbolicExecutor {
         returns: Vec<SymReturnData>,
         reverts: bool,
     ) -> CheatcodeOutcome {
-        state.call_mocks.push(CallMock::new(callee, value, data, returns, reverts));
+        // Re-registering the same (callee, value, calldata) mock must REPLACE the prior
+        // entry, matching the concrete cheatcode's map-insert semantics
+        // (`cheatcodes/src/evm/mock.rs`'s `mocked_calls.entry(..).insert(..)`), not append
+        // a second entry behind it. Selection resolves ties on `specificity()` by keeping
+        // the earliest-inserted candidate (see `calls.rs`), so an unconditional push here
+        // would leave the stale mock permanently winning over its own replacement.
+        if let Some(existing) = state
+            .call_mocks
+            .iter_mut()
+            .find(|mock| mock.matches_definition(&mut self.cx, &callee, value, &data))
+        {
+            *existing = CallMock::new(callee, value, data, returns, reverts);
+        } else {
+            state.call_mocks.push(CallMock::new(callee, value, data, returns, reverts));
+        }
         CheatcodeOutcome::Continue(Vec::new())
     }
 

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -409,17 +409,12 @@ impl SymbolicExecutor {
         returns: Vec<SymReturnData>,
         reverts: bool,
     ) -> CheatcodeOutcome {
-        // Re-registering the same (callee, value, calldata) mock must REPLACE the prior
-        // entry, matching the concrete cheatcode's map-insert semantics
-        // (`cheatcodes/src/evm/mock.rs`'s `mocked_calls.entry(..).insert(..)`), not append
-        // a second entry behind it. Selection resolves ties on `specificity()` by keeping
-        // the earliest-inserted candidate (see `calls.rs`), so an unconditional push here
-        // would leave the stale mock permanently winning over its own replacement.
-        if let Some(existing) = state
-            .call_mocks
-            .iter_mut()
-            .find(|mock| mock.matches_definition(&mut self.cx, &callee, value, &data))
-        {
+        // Replace identical definitions in place to preserve mock precedence.
+        if let Some(existing) = state.call_mocks.iter_mut().find(|mock| {
+            mock.callee == callee
+                && mock.value() == value
+                && mock.data.same_bytes(&mut self.cx, &data)
+        }) {
             *existing = CallMock::new(callee, value, data, returns, reverts);
         } else {
             state.call_mocks.push(CallMock::new(callee, value, data, returns, reverts));

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -1162,6 +1162,20 @@ impl CallMock {
         self.value
     }
 
+    /// Structural-equality check used to dedupe re-registrations of the same mock at
+    /// insert time (mirrors the concrete cheatcode's `BTreeMap`-keyed replace semantics,
+    /// see `add_call_mock`). Only recognizes syntactically identical `callee`/`data`; two
+    /// semantically-equal-but-differently-expressed symbolic expressions won't dedupe.
+    pub(crate) fn matches_definition(
+        &self,
+        cx: &mut SymCx,
+        callee: &SymExpr,
+        value: Option<U256>,
+        data: &SymBytes,
+    ) -> bool {
+        self.callee == *callee && self.value == value && self.data.same_bytes(cx, data)
+    }
+
     pub(crate) fn specificity(&self) -> (usize, bool) {
         (self.data.len(), self.value.is_some())
     }

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -1139,9 +1139,9 @@ impl ExpectedCall {
 
 #[derive(Clone, Debug)]
 pub(crate) struct CallMock {
-    callee: SymExpr,
+    pub(crate) callee: SymExpr,
     value: Option<U256>,
-    data: SymBytes,
+    pub(crate) data: SymBytes,
     returns: Vec<SymReturnData>,
     reverts: bool,
     calls: usize,
@@ -1160,20 +1160,6 @@ impl CallMock {
 
     pub(crate) const fn value(&self) -> Option<U256> {
         self.value
-    }
-
-    /// Structural-equality check used to dedupe re-registrations of the same mock at
-    /// insert time (mirrors the concrete cheatcode's `BTreeMap`-keyed replace semantics,
-    /// see `add_call_mock`). Only recognizes syntactically identical `callee`/`data`; two
-    /// semantically-equal-but-differently-expressed symbolic expressions won't dedupe.
-    pub(crate) fn matches_definition(
-        &self,
-        cx: &mut SymCx,
-        callee: &SymExpr,
-        value: Option<U256>,
-        data: &SymBytes,
-    ) -> bool {
-        self.callee == *callee && self.value == value && self.data.same_bytes(cx, data)
     }
 
     pub(crate) fn specificity(&self) -> (usize, bool) {

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -2936,6 +2936,29 @@ contract SymbolicMockCall is Test {
         assertEq(IMockedTarget(target).value(input), input + 2);
         assertEq(IMockedTarget(target).value(input), input + 2);
     }
+
+    function checkMockCallRemockReplacesStaleValue(uint256) public {
+        address target = address(0x1234);
+
+        vm.mockCall(
+            target,
+            abi.encodeWithSelector(IMockedTarget.value.selector, uint256(1)),
+            abi.encode(uint256(10))
+        );
+        assertEq(IMockedTarget(target).value(1), 10);
+
+        // Re-mock the IDENTICAL (callee, calldata) pair with a new return value -- this
+        // must REPLACE the prior registration, matching the concrete cheatcode's
+        // map-insert semantics (see `testMockCallWithValue` in `MockCall.t.sol`), not
+        // stack a second entry that a specificity tie then resolves in favor of the
+        // first-inserted (stale) one.
+        vm.mockCall(
+            target,
+            abi.encodeWithSelector(IMockedTarget.value.selector, uint256(1)),
+            abi.encode(uint256(20))
+        );
+        assertEq(IMockedTarget(target).value(1), 20);
+    }
 }
 "#,
     );
@@ -3011,6 +3034,22 @@ contract SymbolicMockCall is Test {
 checkSymbolicCalleeMockMismatch(address)
 "#]],
     );
+    assert!(!stdout.contains("symbolic vm.mockCall"), "{stdout}");
+
+    let stdout = prj
+        .forge_command()
+        .args(["test", "--symbolic", "--match-test", "checkMockCallRemockReplacesStaleValue"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkMockCallRemockReplacesStaleValue(uint256)
+"#]],
+    );
+    assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
     assert!(!stdout.contains("symbolic vm.mockCall"), "{stdout}");
 });
 

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -2947,11 +2947,7 @@ contract SymbolicMockCall is Test {
         );
         assertEq(IMockedTarget(target).value(1), 10);
 
-        // Re-mock the IDENTICAL (callee, calldata) pair with a new return value -- this
-        // must REPLACE the prior registration, matching the concrete cheatcode's
-        // map-insert semantics (see `testMockCallWithValue` in `MockCall.t.sol`), not
-        // stack a second entry that a specificity tie then resolves in favor of the
-        // first-inserted (stale) one.
+        // Re-registering the same mock replaces its return value.
         vm.mockCall(
             target,
             abi.encodeWithSelector(IMockedTarget.value.selector, uint256(1)),


### PR DESCRIPTION
## tl;dr

Under `--symbolic`, re-registering the exact same `vm.mockCall`/`vm.mockCalls` (identical `callee`/`value`/`calldata`) left the stale mock winning forever, instead of replacing it like concrete mode does.

## The bug

`add_call_mock` (`crates/evm/symbolic/src/executor/cheatcodes.rs`) unconditionally `push`ed onto `state.call_mocks: Vec<CallMock>` on every `vm.mockCall`/`vm.mockCalls` call. Re-registering the same `(callee, value, calldata)` therefore left BOTH the old and new entry in the vec.

Selection (`executor/calls.rs`, untouched by this diff) resolves ties on `specificity()` -- `(data.len(), value.is_some())` -- by keeping the FIRST-inserted candidate on a strict `>` comparison. So the stale mock always won over its own replacement, diverging from the concrete cheatcode's `BTreeMap`-keyed map-insert (replace) semantics, which are already pinned by `testMockCallWithValue` in `testdata/default/cheats/MockCall.t.sol`.

## The fix

Dedupe at insert time, not at selection: `add_call_mock` now searches `call_mocks` for an existing entry whose `(callee, value, data)` structurally matches (new `CallMock::matches_definition`, mirroring the already-correct sibling `set_function_mock`/`FunctionMock::matches_definition` pattern in the same file) and replaces it in place; otherwise it pushes as before.

Deliberately does **not** touch the specificity-based tie-break in `calls.rs` -- that logic is relied on by other tests for genuinely-distinct overlapping mocks, and changing it would risk disturbing that unrelated precedence behavior.

**Known limitation (by design, out of scope):** dedup is exact structural equality, not solver-level equivalence. Two symbolic expressions that are equal only under a `vm.assume` constraint won't dedupe. This matches how the rest of the mock-matching machinery already works and is a safe, conservative choice -- it never merges two definitions that aren't syntactically identical.

## Testing

- Added `checkMockCallRemockReplacesStaleValue` to `symbolic_cheatcodes.rs`, exercising the exact repro (mock a value, re-mock the identical callee/calldata with a new return, assert the new value wins). Verified genuinely red against the old push-only logic (`[FAIL: symbolic counterexample did not replay...]`), green after the fix (`[PASS] checkMockCallRemockReplacesStaleValue`).
- Full `symbolic_cheatcodes` CLI suite: 60/61 passed. The one failure (`symbolic_mapping_storage_hooks`, a `fuzz.runs must be greater than 0` config panic) is pre-existing and unrelated -- confirmed identical against unmodified master via `git stash`.
- `cargo clippy -p foundry-evm-symbolic -- -D warnings`: clean.
- `cargo fmt --check`: clean (only the usual nightly-only-feature notices, no diff on stable).
- Synchronous adversarial Codex review of the diff: no correctness or borrow-safety issues found. It flagged two pre-existing, out-of-scope limitations (solver-equivalent-but-syntactically-distinct keys don't dedupe; empty-`mockCalls`-array fallthrough behavior differs from concrete mode) -- both predate this diff and aren't touched by it.

closes nothing (no tracked issue -- found via direct code inspection comparing concrete vs. symbolic mock-call semantics)