### PR TITLE
fix(lint): detect delta-form stale-balance comparisons in reentrancy-balance

### DIFF
--- a/.changelog/reentrancy-balance-delta-form.md
+++ b/.changelog/reentrancy-balance-delta-form.md
@@ -1,0 +1,5 @@
+---
+forge-lint: patch
+---
+
+`reentrancy-balance` now detects the "delta form" of a stale-balance comparison guard (`balanceAfter - balanceBefore >= amount`), not just the direct-addition form (`balanceAfter >= balanceBefore + amount`). Both are algebraically identical and equally vulnerable to reentrancy, but only the direct form was previously flagged.

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -966,10 +966,24 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                         | BinOpKind::Ne
                 );
                 let depends = |e, stale| self.expr_depends_on_balance(e, span, call, stale, state);
+                // Delta form: one side is itself a subtraction of the current and stale
+                // balance (e.g. `balanceAfter - balanceBefore`), rather than the comparison
+                // being split across both sides of the outer operator. Requires the outer
+                // operator of that side to actually be a subtraction - merely containing
+                // both a current and a stale reference somewhere (e.g. added together) is
+                // not a stale-balance check and must not be flagged.
+                let is_delta_side = |side: &'hir Expr<'hir>| match &side.peel_parens().kind {
+                    ExprKind::Binary(a, sub_op, b) if sub_op.kind == BinOpKind::Sub => {
+                        (depends(a, false) && depends(b, true))
+                            || (depends(a, true) && depends(b, false))
+                    }
+                    _ => false,
+                };
                 (is_comparison
-                    && [(lhs, rhs), (rhs, lhs)]
+                    && ([(lhs, rhs), (rhs, lhs)]
                         .into_iter()
-                        .any(|(current, stale)| depends(current, false) && depends(stale, true)))
+                        .any(|(current, stale)| depends(current, false) && depends(stale, true))
+                        || [lhs, rhs].into_iter().any(|side| is_delta_side(side))))
                     || recurse(lhs, state)
                     || recurse(rhs, state)
             }

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -966,12 +966,6 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                         | BinOpKind::Ne
                 );
                 let depends = |e, stale| self.expr_depends_on_balance(e, span, call, stale, state);
-                // Delta form: one side is itself a subtraction of the current and stale
-                // balance (e.g. `balanceAfter - balanceBefore`), rather than the comparison
-                // being split across both sides of the outer operator. Requires the outer
-                // operator of that side to actually be a subtraction - merely containing
-                // both a current and a stale reference somewhere (e.g. added together) is
-                // not a stale-balance check and must not be flagged.
                 let is_delta_side = |side: &'hir Expr<'hir>| match &side.peel_parens().kind {
                     ExprKind::Binary(a, sub_op, b) if sub_op.kind == BinOpKind::Sub => {
                         (depends(a, false) && depends(b, true))

--- a/crates/lint/testdata/ReentrancyBalance.sol
+++ b/crates/lint/testdata/ReentrancyBalance.sol
@@ -49,9 +49,41 @@ contract ReentrancyBalance {
 
     function assertAfterLowLevelCall(address target, uint256 amount) external {
         uint256 balanceBefore = address(this).balance;
-        (bool ok,) = target.call("");
+        (bool ok,) = target.call(""); //~WARN: external call can be reentered before a stale contract balance is checked
         require(ok, "call failed");
         assert(address(this).balance - balanceBefore >= amount);
+    }
+
+    // Delta form: the current/stale balances are combined into a single subtraction
+    // expression on one side of the comparison, rather than split across both sides
+    // (`balanceAfter >= balanceBefore + amount`). Algebraically equivalent, and just
+    // as vulnerable, so it must be flagged the same way.
+    function requireDeltaAfterCall(IReentrancyBalanceCallback callback, uint256 amount) external {
+        uint256 balanceBefore = address(this).balance;
+        callback.pay(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(address(this).balance - balanceBefore >= amount, "insufficient payment");
+    }
+
+    // Same delta shape, reversed comparison order and the amount on the left.
+    function requireDeltaReversedOrder(IReentrancyBalanceCallback callback, uint256 amount) external {
+        uint256 balanceBefore = address(this).balance;
+        callback.pay(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(amount <= address(this).balance - balanceBefore, "insufficient payment");
+    }
+
+    // Sanity check: a delta between two values that are NOT balance-derived must not
+    // spuriously trip the new delta-form recognition just because it's a subtraction,
+    // even with a genuine pending balance call in scope to exercise the matcher.
+    function unrelatedDeltaAfterCall(
+        IReentrancyBalanceCallback callback,
+        uint256 a,
+        uint256 b,
+        uint256 amount
+    ) external {
+        uint256 balanceBefore = address(this).balance;
+        callback.pay(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(a - b >= 1, "unrelated");
+        require(address(this).balance >= balanceBefore + amount, "insufficient payment");
     }
 
     function revertingBranchAfterCall(IReentrancyBalanceCallback callback, uint256 amount) external {

--- a/crates/lint/testdata/ReentrancyBalance.sol
+++ b/crates/lint/testdata/ReentrancyBalance.sol
@@ -49,7 +49,7 @@ contract ReentrancyBalance {
 
     function assertAfterLowLevelCall(address target, uint256 amount) external {
         uint256 balanceBefore = address(this).balance;
-        (bool ok,) = target.call(""); //~WARN: external call can be reentered before a stale contract balance is checked
+        (bool ok,) = target.call("");
         require(ok, "call failed");
         assert(address(this).balance - balanceBefore >= amount);
     }

--- a/crates/lint/testdata/ReentrancyBalance.stderr
+++ b/crates/lint/testdata/ReentrancyBalance.stderr
@@ -9,6 +9,38 @@ LL │         callback.pay();
 warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
    ╭▸ ROOT/testdata/ReentrancyBalance.sol:LL:CC
    │
+LL │         (bool ok,) = target.call("");
+   │                      ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalance.sol:LL:CC
+   │
+LL │         callback.pay();
+   │         ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalance.sol:LL:CC
+   │
+LL │         callback.pay();
+   │         ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalance.sol:LL:CC
+   │
+LL │         callback.pay();
+   │         ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalance.sol:LL:CC
+   │
 LL │         callback.pay();
    │         ━━━━━━━━━━━━━━
    │


### PR DESCRIPTION
`reentrancy-balance` warns when it recognizes a stale-balance-comparison guard around an external call - that pattern is itself the vulnerability being flagged (checking a balance read before/after a reentrant call doesn't actually prevent reentrancy, since an attacker can still exploit the intermediate state). The message is *"external call can be reentered before a stale contract balance is checked"*.

The guard-recognition logic (`guard_has_stale_balance_comparison`) only matched comparisons split across both sides, e.g.:
```solidity
require(balanceAfter >= balanceBefore + amount);   // direct form - detected
```
It missed the algebraically identical "delta form", where the current and stale balance are combined into a single subtraction on one side:
```solidity
require(balanceAfter - balanceBefore >= amount);   // delta form - previously silent
```
Both are equally exploitable and equally worth flagging, but only the direct form was caught.

## Fix

Added a check for a top-level subtraction on either side of the comparison, where one operand depends on the current balance and the other on the stale (pre-call) balance. Deliberately scoped to a literal `Sub` operator rather than a generic "both references appear somewhere in this side" check - an earlier draft tried the broader check and produced a real false positive on an existing fixture (`address(this).balance + balanceBefore > 0`, an unrelated addition that happens to reference both values but isn't a stale-balance check at all).

## Testing

- Added delta-form fixtures: subtraction form, reversed comparison order, and a negative case (unrelated subtraction with a genuine pending balance call in scope, to confirm the new check doesn't spuriously fire on it).
- Fixed one pre-existing escape in the corpus (`assertAfterLowLevelCall`, already using delta form, now correctly flagged).
- Full lint UI fixture suite: 97/97 passing, `.stderr` diff shows exactly the 3 new expected warnings and nothing else changed.
- `cargo clippy -p forge-lint --all-targets -- -D warnings` clean.
- Synchronous Codex adversarial review.

## Known limitations (pre-existing class, not introduced by this diff)

Codex's review surfaced two categories of remaining imprecision in the same "presence, not sign" heuristic this whole matcher already uses (the existing direct-form matcher has an analogous gap: `balance >= amount - staleBalance` already warns despite being additive, not subtractive):

- **Still-missed delta shapes**: a delta nested inside further arithmetic (`(C - S) - fee >= amount`, `uint256(C - S) >= amount`) still escapes detection, since the top-level operator of that side is no longer the bare `Sub`.
- **Contrived false positives**: a side that nests a `Sub` in a way that doesn't correspond to the true current-minus-stale relationship (e.g. `(C + S) - S >= amount`, which reduces to just `C`) can trigger the new check, since `depends()` tracks presence of a reference, not its sign or algebraic cancellation.

Both are narrow, and in the same direction of imprecision the file already has elsewhere. Happy to split either into a follow-up issue if a maintainer wants them tracked separately - didn't want to chase this into open-ended sign-aware arithmetic normalization for a single-shape fix.

## receipts

no runtime UI change - `forge-lint`'s own test suite is the receipt for this PR (static-analysis fixture corpus, not a runnable app).