### PR TITLE
fix(lint): distinguish memory allocations

### DIFF
--- a/.changelog/lint-memory-allocations.md
+++ b/.changelog/lint-memory-allocations.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-lint: patch
+---
+
+Stop treating memory allocation as an external call in calls-loop and reentrancy-events, while preserving diagnostics for contract creation and external allocation-length calculations.

--- a/crates/lint/docs/calls-loop.md
+++ b/crates/lint/docs/calls-loop.md
@@ -12,6 +12,9 @@ Reports high-level contract calls, low-level `call`/`delegatecall`/`staticcall`,
 `send`/`transfer`, external self-calls through `this`, and contract creation inside a loop. Internal
 and private library calls and `super` dispatch are not treated as external calls.
 
+Memory allocations such as `new LedgerRow[](n)`, `new bytes(n)`, and `new string(n)` are not
+external calls. External calls used to calculate their lengths are still reported.
+
 ## Why is this bad?
 
 External calls inside loops can turn one reverting or gas-heavy callee into a denial-of-service for

--- a/crates/lint/src/sol/low/calls_loop.rs
+++ b/crates/lint/src/sol/low/calls_loop.rs
@@ -55,8 +55,9 @@ enum ExternalCall {
 /// dispatch run in this contract and are not external.
 fn classify<'gcx>(gcx: Gcx<'gcx>, callee: &Expr<'gcx>) -> Option<ExternalCall> {
     let callee = callee.peel_parens();
-    if matches!(callee.kind, ExprKind::New(_)) {
-        return Some(ExternalCall::Opaque);
+    if let ExprKind::New(ty) = &callee.kind {
+        return matches!(gcx.type_of_hir_ty(ty).kind, TyKind::Contract(_))
+            .then_some(ExternalCall::Opaque);
     }
     let ExprKind::Member(base, member) = &callee.kind else { return None };
     if matches!(

--- a/crates/lint/testdata/CallsLoopAllocations.sol
+++ b/crates/lint/testdata/CallsLoopAllocations.sol
@@ -1,0 +1,87 @@
+//@compile-flags: --only-lint calls-loop reentrancy-events
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+struct LedgerRow {
+    address wallet;
+    uint256 amount;
+}
+
+interface LengthSource {
+    function nextLength() external returns (uint256);
+    function length() external view returns (uint256);
+}
+
+contract Child {}
+
+contract CallsLoopAllocations {
+    event Allocated();
+    address[] wallets;
+
+    // Memory allocation does not interact with another contract, even for contract arrays.
+    function allocateInLoop(uint256 n) external returns (LedgerRow[] memory rows) {
+        for (uint256 i = 0; i < n; ++i) {
+            rows = new LedgerRow[](wallets.length);
+            uint256[] memory numbers = new uint256[](n);
+            bytes memory data = new bytes(n);
+            string memory text = new string(n);
+            Child[] memory children = new Child[](n);
+            LedgerRow[][] memory nested = new LedgerRow[][](n);
+            emit Allocated();
+        }
+    }
+
+    // The loop walker also follows allocations inside local helpers.
+    function allocateThroughHelper(uint256 n) external returns (LedgerRow[] memory rows) {
+        for (uint256 i = 0; i < n; ++i) {
+            rows = allocate(n);
+            emit Allocated();
+        }
+    }
+
+    function allocate(uint256 n) internal pure returns (LedgerRow[] memory) {
+        return new LedgerRow[](n);
+    }
+
+    // The shared reentrancy classifier must not treat a standalone allocation as an interaction.
+    function allocateThenEmit(uint256 n) external returns (bytes memory data) {
+        data = new bytes(n);
+        emit Allocated();
+    }
+
+    // Only the length calculation is an external call, not the enclosing allocation.
+    function externalLength(LengthSource source) external {
+        for (uint256 i = 0; i < 2; ++i) {
+            uint256[] memory numbers = new uint256[](source.nextLength()); //~WARN: external call inside a loop
+            emit Allocated(); //~WARN: event emitted after an external call
+        }
+    }
+
+    // A view call is still external, but cannot affect log ordering.
+    function viewLength(LengthSource source) external {
+        for (uint256 i = 0; i < 2; ++i) {
+            uint256[] memory numbers = new uint256[](source.length()); //~WARN: external call inside a loop
+            emit Allocated();
+        }
+    }
+
+    // An allocation must not erase an earlier real interaction.
+    function callThenAllocate(LengthSource source) external {
+        uint256 n = source.nextLength();
+        bytes memory data = new bytes(n);
+        emit Allocated(); //~WARN: event emitted after an external call
+    }
+
+    // Actual contract creation remains an external interaction, with or without a salt.
+    function createContracts() external {
+        for (uint256 i = 0; i < 2; ++i) {
+            new Child(); //~WARN: external call inside a loop
+            emit Allocated(); //~WARN: event emitted after an external call
+        }
+        for (uint256 i = 0; i < 2; ++i) {
+            new Child{salt: bytes32(i)}(); //~WARN: external call inside a loop
+            emit Allocated(); //~WARN: event emitted after an external call
+        }
+    }
+}

--- a/crates/lint/testdata/CallsLoopAllocations.stderr
+++ b/crates/lint/testdata/CallsLoopAllocations.stderr
@@ -1,0 +1,64 @@
+warning[calls-loop]: external call inside a loop
+   ╭▸ ROOT/testdata/CallsLoopAllocations.sol:LL:CC
+   │
+LL │             uint256[] memory numbers = new uint256[](source.nextLength());
+   │                                                      ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/calls-loop
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/CallsLoopAllocations.sol:LL:CC
+   │
+LL │             emit Allocated();
+   │             ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[calls-loop]: external call inside a loop
+   ╭▸ ROOT/testdata/CallsLoopAllocations.sol:LL:CC
+   │
+LL │             uint256[] memory numbers = new uint256[](source.length());
+   │                                                      ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/calls-loop
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/CallsLoopAllocations.sol:LL:CC
+   │
+LL │         emit Allocated();
+   │         ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[calls-loop]: external call inside a loop
+   ╭▸ ROOT/testdata/CallsLoopAllocations.sol:LL:CC
+   │
+LL │             new Child();
+   │             ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/calls-loop
+
+warning[calls-loop]: external call inside a loop
+   ╭▸ ROOT/testdata/CallsLoopAllocations.sol:LL:CC
+   │
+LL │             new Child{salt: bytes32(i)}();
+   │             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/calls-loop
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/CallsLoopAllocations.sol:LL:CC
+   │
+LL │             emit Allocated();
+   │             ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/CallsLoopAllocations.sol:LL:CC
+   │
+LL │             emit Allocated();
+   │             ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+


### PR DESCRIPTION
Memory allocation was classified as an external call because every `new` expression was treated as contract creation. Classify only allocated contract types as external interactions, removing false positives from `calls-loop` and `reentrancy-events` while preserving diagnostics for real deployments and external calls used to calculate allocation lengths.

Fixes #16665.
