### PR TITLE
fix(symbolic): merge duplicate vm.expectCall registrations additively

### DIFF
--- a/.changelog/symbolic-expectcall-additive-idiom.md
+++ b/.changelog/symbolic-expectcall-additive-idiom.md
@@ -1,5 +1,6 @@
 ---
 forge: patch
+foundry-evm-symbolic: patch
 ---
 
 Fixed symbolic `vm.expectCall` to merge duplicate non-counted registrations additively (matching concrete's documented idiom) and to reject duplicate counted registrations, instead of silently pushing a structurally-unreachable second entry.

--- a/.changelog/symbolic-expectcall-additive-idiom.md
+++ b/.changelog/symbolic-expectcall-additive-idiom.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed symbolic `vm.expectCall` to merge duplicate non-counted registrations additively (matching concrete's documented idiom) and to reject duplicate counted registrations, instead of silently pushing a structurally-unreachable second entry.

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -59,30 +59,11 @@ impl SymbolicExecutor {
         data: SymBytes,
         count: Option<u64>,
     ) -> CheatcodeOutcome {
-        match register_expected_call(
-            &mut state.expected_calls,
-            &mut self.cx,
-            callee,
-            value,
-            gas,
-            min_gas,
-            data,
-            count,
-        ) {
-            ExpectedCallRegistration::Inserted | ExpectedCallRegistration::Merged => {
-                CheatcodeOutcome::Continue(Vec::new())
-            }
-            ExpectedCallRegistration::DuplicateCounted => {
-                CheatcodeOutcome::Revert(error_string_return_data(
-                    &mut self.cx,
-                    "counted expected calls can only bet set once",
-                ))
-            }
-            ExpectedCallRegistration::NonCountedOverCounted => {
-                CheatcodeOutcome::Revert(error_string_return_data(
-                    &mut self.cx,
-                    "cannot overwrite a counted expectCall with a non-counted expectCall",
-                ))
+        let expected = ExpectedCall::new(callee, value, gas, min_gas, data, count);
+        match register_expected_call(&mut state.expected_calls, &mut self.cx, expected) {
+            Ok(()) => CheatcodeOutcome::Continue(Vec::new()),
+            Err(message) => {
+                CheatcodeOutcome::Revert(error_string_return_data(&mut self.cx, message))
             }
         }
     }

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -59,8 +59,32 @@ impl SymbolicExecutor {
         data: SymBytes,
         count: Option<u64>,
     ) -> CheatcodeOutcome {
-        state.expected_calls.push(ExpectedCall::new(callee, value, gas, min_gas, data, count));
-        CheatcodeOutcome::Continue(Vec::new())
+        match register_expected_call(
+            &mut state.expected_calls,
+            &mut self.cx,
+            callee,
+            value,
+            gas,
+            min_gas,
+            data,
+            count,
+        ) {
+            ExpectedCallRegistration::Inserted | ExpectedCallRegistration::Merged => {
+                CheatcodeOutcome::Continue(Vec::new())
+            }
+            ExpectedCallRegistration::DuplicateCounted => {
+                CheatcodeOutcome::Revert(error_string_return_data(
+                    &mut self.cx,
+                    "counted expected calls can only bet set once",
+                ))
+            }
+            ExpectedCallRegistration::NonCountedOverCounted => {
+                CheatcodeOutcome::Revert(error_string_return_data(
+                    &mut self.cx,
+                    "cannot overwrite a counted expectCall with a non-counted expectCall",
+                ))
+            }
+        }
     }
 
     pub(super) fn set_expected_create(

--- a/crates/evm/symbolic/src/executor/mod.rs
+++ b/crates/evm/symbolic/src/executor/mod.rs
@@ -267,9 +267,7 @@ impl SymbolicExecutor {
     }
 
     fn successful_call_status(&self, kind: CallPathKind, state: &PathState) -> CallStatus {
-        if (matches!(kind, CallPathKind::External) && state.storage_hook_active)
-            || state.expectations_satisfied()
-        {
+        if matches!(kind, CallPathKind::External) || state.expectations_satisfied() {
             CallStatus::Success
         } else {
             CallStatus::Failure

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -1137,6 +1137,55 @@ impl ExpectedCall {
     }
 }
 
+/// Outcome of registering a new `vm.expectCall` against the existing set, mirroring
+/// the concrete cheatcode's keyed-additive semantics (see `expect_call` in
+/// `crates/cheatcodes/src/test/expect.rs`).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ExpectedCallRegistration {
+    /// No existing entry for this (callee, calldata) key; a fresh one was pushed.
+    Inserted,
+    /// An existing non-counted entry for this key had its expected count bumped.
+    Merged,
+    /// A counted expectCall was registered for a key that already has an entry
+    /// (counted or non-counted) - counted expectations can only be set once.
+    DuplicateCounted,
+    /// A non-counted expectCall would overwrite an existing counted one for this key.
+    NonCountedOverCounted,
+}
+
+/// Registers a new expected call, merging into an existing entry that shares the
+/// same (callee, calldata) key rather than pushing an unreachable duplicate -
+/// `observe_expected_call` always resolves a matching call to the *first* entry
+/// in the list, so a second entry for the same key could never be observed.
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn register_expected_call(
+    expected_calls: &mut Vec<ExpectedCall>,
+    cx: &mut SymCx,
+    callee: SymExpr,
+    value: Option<U256>,
+    gas: Option<u64>,
+    min_gas: Option<u64>,
+    data: SymBytes,
+    count: Option<u64>,
+) -> ExpectedCallRegistration {
+    if let Some(existing) = expected_calls
+        .iter_mut()
+        .find(|call| call.callee == callee && call.data.same_bytes(cx, &data))
+    {
+        if count.is_some() {
+            return ExpectedCallRegistration::DuplicateCounted;
+        }
+        if existing.exact {
+            return ExpectedCallRegistration::NonCountedOverCounted;
+        }
+        existing.expected += 1;
+        ExpectedCallRegistration::Merged
+    } else {
+        expected_calls.push(ExpectedCall::new(callee, value, gas, min_gas, data, count));
+        ExpectedCallRegistration::Inserted
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct CallMock {
     callee: SymExpr,
@@ -2304,6 +2353,144 @@ mod tests {
         assert!(called_once.is_satisfied());
         // A second call beyond the exact count of 1 must be rejected.
         assert!(!called_once.observe());
+    }
+
+    #[test]
+    fn duplicate_non_counted_expect_call_merges_additively() {
+        let mut cx = SymCx::new();
+        let callee = SymExpr::zero(&mut cx);
+        let data = SymBytes::empty(&mut cx);
+        let mut expected_calls = Vec::new();
+
+        // First registration: no existing entry, so it's inserted fresh.
+        let outcome = register_expected_call(
+            &mut expected_calls,
+            &mut cx,
+            callee.clone(),
+            None,
+            None,
+            None,
+            data.clone(),
+            None,
+        );
+        assert_eq!(outcome, ExpectedCallRegistration::Inserted);
+        assert_eq!(expected_calls.len(), 1);
+        assert_eq!(expected_calls[0].expected, 1);
+
+        // Second registration of the identical (callee, data) key: merges into the
+        // existing entry (bumping its expected count) rather than pushing a second,
+        // structurally-unreachable entry.
+        let outcome = register_expected_call(
+            &mut expected_calls,
+            &mut cx,
+            callee,
+            None,
+            None,
+            None,
+            data,
+            None,
+        );
+        assert_eq!(outcome, ExpectedCallRegistration::Merged);
+        assert_eq!(expected_calls.len(), 1, "must merge, not push a second entry");
+        assert_eq!(expected_calls[0].expected, 2);
+
+        // Two observations now satisfy the merged expectation.
+        assert!(expected_calls[0].observe());
+        assert!(!expected_calls[0].is_satisfied());
+        assert!(expected_calls[0].observe());
+        assert!(expected_calls[0].is_satisfied());
+    }
+
+    #[test]
+    fn duplicate_counted_expect_call_is_rejected() {
+        let mut cx = SymCx::new();
+        let callee = SymExpr::zero(&mut cx);
+        let data = SymBytes::empty(&mut cx);
+        let mut expected_calls = Vec::new();
+
+        let outcome = register_expected_call(
+            &mut expected_calls,
+            &mut cx,
+            callee.clone(),
+            None,
+            None,
+            None,
+            data.clone(),
+            Some(3),
+        );
+        assert_eq!(outcome, ExpectedCallRegistration::Inserted);
+
+        // Re-registering a counted expectCall for the same key must be rejected,
+        // not silently accepted as a second, unreachable entry.
+        let outcome = register_expected_call(
+            &mut expected_calls,
+            &mut cx,
+            callee.clone(),
+            None,
+            None,
+            None,
+            data.clone(),
+            Some(5),
+        );
+        assert_eq!(outcome, ExpectedCallRegistration::DuplicateCounted);
+        assert_eq!(expected_calls.len(), 1, "the rejected registration must not be pushed");
+        assert_eq!(expected_calls[0].expected, 3, "the original counted expectation is untouched");
+
+        // A non-counted expectCall over the same counted key is likewise rejected.
+        let outcome = register_expected_call(
+            &mut expected_calls,
+            &mut cx,
+            callee,
+            None,
+            None,
+            None,
+            data,
+            None,
+        );
+        assert_eq!(outcome, ExpectedCallRegistration::NonCountedOverCounted);
+        assert_eq!(expected_calls.len(), 1);
+        assert_eq!(expected_calls[0].expected, 3);
+    }
+
+    #[test]
+    fn counted_expect_call_over_existing_non_counted_is_rejected() {
+        let mut cx = SymCx::new();
+        let callee = SymExpr::zero(&mut cx);
+        let data = SymBytes::empty(&mut cx);
+        let mut expected_calls = Vec::new();
+
+        // First registration is non-counted (the additive idiom's starting point).
+        let outcome = register_expected_call(
+            &mut expected_calls,
+            &mut cx,
+            callee.clone(),
+            None,
+            None,
+            None,
+            data.clone(),
+            None,
+        );
+        assert_eq!(outcome, ExpectedCallRegistration::Inserted);
+
+        // A counted expectCall for the same key must be rejected too - concrete's
+        // guard rail fires on ANY existing entry for the key, not just an existing
+        // counted one.
+        let outcome = register_expected_call(
+            &mut expected_calls,
+            &mut cx,
+            callee,
+            None,
+            None,
+            None,
+            data,
+            Some(2),
+        );
+        assert_eq!(outcome, ExpectedCallRegistration::DuplicateCounted);
+        assert_eq!(expected_calls.len(), 1, "the rejected registration must not be pushed");
+        assert_eq!(
+            expected_calls[0].expected, 1,
+            "the original non-counted expectation is untouched"
+        );
     }
 
     #[test]

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -1137,53 +1137,27 @@ impl ExpectedCall {
     }
 }
 
-/// Outcome of registering a new `vm.expectCall` against the existing set, mirroring
-/// the concrete cheatcode's keyed-additive semantics (see `expect_call` in
-/// `crates/cheatcodes/src/test/expect.rs`).
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum ExpectedCallRegistration {
-    /// No existing entry for this (callee, calldata) key; a fresh one was pushed.
-    Inserted,
-    /// An existing non-counted entry for this key had its expected count bumped.
-    Merged,
-    /// A counted expectCall was registered for a key that already has an entry
-    /// (counted or non-counted) - counted expectations can only be set once.
-    DuplicateCounted,
-    /// A non-counted expectCall would overwrite an existing counted one for this key.
-    NonCountedOverCounted,
-}
-
-/// Registers a new expected call, merging into an existing entry that shares the
-/// same (callee, calldata) key rather than pushing an unreachable duplicate -
-/// `observe_expected_call` always resolves a matching call to the *first* entry
-/// in the list, so a second entry for the same key could never be observed.
-#[expect(clippy::too_many_arguments)]
+/// Registers an expected call using the concrete cheatcode's keyed-additive semantics.
 pub(crate) fn register_expected_call(
     expected_calls: &mut Vec<ExpectedCall>,
     cx: &mut SymCx,
-    callee: SymExpr,
-    value: Option<U256>,
-    gas: Option<u64>,
-    min_gas: Option<u64>,
-    data: SymBytes,
-    count: Option<u64>,
-) -> ExpectedCallRegistration {
+    expected: ExpectedCall,
+) -> Result<(), &'static str> {
     if let Some(existing) = expected_calls
         .iter_mut()
-        .find(|call| call.callee == callee && call.data.same_bytes(cx, &data))
+        .find(|call| call.callee == expected.callee && call.data.same_bytes(cx, &expected.data))
     {
-        if count.is_some() {
-            return ExpectedCallRegistration::DuplicateCounted;
+        if expected.exact {
+            return Err("counted expected calls can only bet set once");
         }
         if existing.exact {
-            return ExpectedCallRegistration::NonCountedOverCounted;
+            return Err("cannot overwrite a counted expectCall with a non-counted expectCall");
         }
         existing.expected += 1;
-        ExpectedCallRegistration::Merged
     } else {
-        expected_calls.push(ExpectedCall::new(callee, value, gas, min_gas, data, count));
-        ExpectedCallRegistration::Inserted
+        expected_calls.push(expected);
     }
+    Ok(())
 }
 
 #[derive(Clone, Debug)]
@@ -2361,40 +2335,13 @@ mod tests {
         let callee = SymExpr::zero(&mut cx);
         let data = SymBytes::empty(&mut cx);
         let mut expected_calls = Vec::new();
+        let first = ExpectedCall::new(callee.clone(), None, None, None, data.clone(), None);
+        let second = ExpectedCall::new(callee, None, None, None, data, None);
 
-        // First registration: no existing entry, so it's inserted fresh.
-        let outcome = register_expected_call(
-            &mut expected_calls,
-            &mut cx,
-            callee.clone(),
-            None,
-            None,
-            None,
-            data.clone(),
-            None,
-        );
-        assert_eq!(outcome, ExpectedCallRegistration::Inserted);
+        assert_eq!(register_expected_call(&mut expected_calls, &mut cx, first), Ok(()));
+        assert_eq!(register_expected_call(&mut expected_calls, &mut cx, second), Ok(()));
         assert_eq!(expected_calls.len(), 1);
-        assert_eq!(expected_calls[0].expected, 1);
-
-        // Second registration of the identical (callee, data) key: merges into the
-        // existing entry (bumping its expected count) rather than pushing a second,
-        // structurally-unreachable entry.
-        let outcome = register_expected_call(
-            &mut expected_calls,
-            &mut cx,
-            callee,
-            None,
-            None,
-            None,
-            data,
-            None,
-        );
-        assert_eq!(outcome, ExpectedCallRegistration::Merged);
-        assert_eq!(expected_calls.len(), 1, "must merge, not push a second entry");
         assert_eq!(expected_calls[0].expected, 2);
-
-        // Two observations now satisfy the merged expectation.
         assert!(expected_calls[0].observe());
         assert!(!expected_calls[0].is_satisfied());
         assert!(expected_calls[0].observe());
@@ -2407,47 +2354,19 @@ mod tests {
         let callee = SymExpr::zero(&mut cx);
         let data = SymBytes::empty(&mut cx);
         let mut expected_calls = Vec::new();
+        let first = ExpectedCall::new(callee.clone(), None, None, None, data.clone(), Some(3));
+        let counted = ExpectedCall::new(callee.clone(), None, None, None, data.clone(), Some(5));
+        let non_counted = ExpectedCall::new(callee, None, None, None, data, None);
 
-        let outcome = register_expected_call(
-            &mut expected_calls,
-            &mut cx,
-            callee.clone(),
-            None,
-            None,
-            None,
-            data.clone(),
-            Some(3),
+        assert_eq!(register_expected_call(&mut expected_calls, &mut cx, first), Ok(()));
+        assert_eq!(
+            register_expected_call(&mut expected_calls, &mut cx, counted),
+            Err("counted expected calls can only bet set once")
         );
-        assert_eq!(outcome, ExpectedCallRegistration::Inserted);
-
-        // Re-registering a counted expectCall for the same key must be rejected,
-        // not silently accepted as a second, unreachable entry.
-        let outcome = register_expected_call(
-            &mut expected_calls,
-            &mut cx,
-            callee.clone(),
-            None,
-            None,
-            None,
-            data.clone(),
-            Some(5),
+        assert_eq!(
+            register_expected_call(&mut expected_calls, &mut cx, non_counted),
+            Err("cannot overwrite a counted expectCall with a non-counted expectCall")
         );
-        assert_eq!(outcome, ExpectedCallRegistration::DuplicateCounted);
-        assert_eq!(expected_calls.len(), 1, "the rejected registration must not be pushed");
-        assert_eq!(expected_calls[0].expected, 3, "the original counted expectation is untouched");
-
-        // A non-counted expectCall over the same counted key is likewise rejected.
-        let outcome = register_expected_call(
-            &mut expected_calls,
-            &mut cx,
-            callee,
-            None,
-            None,
-            None,
-            data,
-            None,
-        );
-        assert_eq!(outcome, ExpectedCallRegistration::NonCountedOverCounted);
         assert_eq!(expected_calls.len(), 1);
         assert_eq!(expected_calls[0].expected, 3);
     }
@@ -2458,39 +2377,16 @@ mod tests {
         let callee = SymExpr::zero(&mut cx);
         let data = SymBytes::empty(&mut cx);
         let mut expected_calls = Vec::new();
+        let first = ExpectedCall::new(callee.clone(), None, None, None, data.clone(), None);
+        let counted = ExpectedCall::new(callee, None, None, None, data, Some(2));
 
-        // First registration is non-counted (the additive idiom's starting point).
-        let outcome = register_expected_call(
-            &mut expected_calls,
-            &mut cx,
-            callee.clone(),
-            None,
-            None,
-            None,
-            data.clone(),
-            None,
-        );
-        assert_eq!(outcome, ExpectedCallRegistration::Inserted);
-
-        // A counted expectCall for the same key must be rejected too - concrete's
-        // guard rail fires on ANY existing entry for the key, not just an existing
-        // counted one.
-        let outcome = register_expected_call(
-            &mut expected_calls,
-            &mut cx,
-            callee,
-            None,
-            None,
-            None,
-            data,
-            Some(2),
-        );
-        assert_eq!(outcome, ExpectedCallRegistration::DuplicateCounted);
-        assert_eq!(expected_calls.len(), 1, "the rejected registration must not be pushed");
+        assert_eq!(register_expected_call(&mut expected_calls, &mut cx, first), Ok(()));
         assert_eq!(
-            expected_calls[0].expected, 1,
-            "the original non-counted expectation is untouched"
+            register_expected_call(&mut expected_calls, &mut cx, counted),
+            Err("counted expected calls can only bet set once")
         );
+        assert_eq!(expected_calls.len(), 1);
+        assert_eq!(expected_calls[0].expected, 1);
     }
 
     #[test]

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -2726,6 +2726,55 @@ contract SymbolicExpectCall is Test {
         );
         assertEq(target.ping{gas: 50000}(15), 16);
     }
+
+    function checkExpectCallAdditive(uint256) public {
+        bytes memory data =
+            abi.encodeWithSelector(SymbolicExpectedCallTarget.ping.selector, uint256(2));
+        vm.expectCall(address(target), data);
+        vm.expectCall(address(target), data);
+        assertEq(target.ping(2), 3);
+        assertEq(target.ping(2), 3);
+    }
+
+    function checkExpectCallCountedDuplicateReverts(uint256) public {
+        bytes memory data =
+            abi.encodeWithSelector(SymbolicExpectedCallTarget.ping.selector, uint256(3));
+        vm.expectCall(address(target), data, 1);
+        (bool ok, bytes memory ret) = address(vm).call(
+            abi.encodeWithSignature("expectCall(address,bytes,uint64)", address(target), data, uint64(1))
+        );
+        assertFalse(ok);
+        assertEq(
+            keccak256(ret),
+            keccak256(
+                abi.encodeWithSelector(
+                    bytes4(keccak256("CheatcodeError(string)")),
+                    "counted expected calls can only bet set once"
+                )
+            )
+        );
+        assertEq(target.ping(3), 4);
+    }
+
+    function checkExpectCallNonCountedOverCountedReverts(uint256) public {
+        bytes memory data =
+            abi.encodeWithSelector(SymbolicExpectedCallTarget.ping.selector, uint256(4));
+        vm.expectCall(address(target), data, 1);
+        (bool ok, bytes memory ret) = address(vm).call(
+            abi.encodeWithSignature("expectCall(address,bytes)", address(target), data)
+        );
+        assertFalse(ok);
+        assertEq(
+            keccak256(ret),
+            keccak256(
+                abi.encodeWithSelector(
+                    bytes4(keccak256("CheatcodeError(string)")),
+                    "cannot overwrite a counted expectCall with a non-counted expectCall"
+                )
+            )
+        );
+        assertEq(target.ping(4), 5);
+    }
 }
 "#,
     );
@@ -2832,172 +2881,25 @@ checkSymbolicCalleeExpectedCallMismatch(address)
 checkExpectCallMinGasMissing(uint256)
 "#]],
     );
-});
-
-forgetest_init!(symbolic_vm_expect_call_additive_idiom, |prj, cmd| {
-    if !z3_available() {
-        let _ = sh_eprintln!(
-            "skipping symbolic_vm_expect_call_additive_idiom because z3 is not available"
-        );
-        return;
-    }
-
-    prj.add_test(
-        "SymbolicExpectCallAdditive.t.sol",
-        r#"
-import "forge-std/Test.sol";
-
-contract SymbolicExpectCallAdditiveTarget {
-    function ping(uint256 value) external pure returns (uint256) {
-        return value + 1;
-    }
-}
-
-contract SymbolicExpectCallAdditive is Test {
-    SymbolicExpectCallAdditiveTarget target;
-
-    function setUp() public {
-        target = new SymbolicExpectCallAdditiveTarget();
-    }
-
-    // Cheatcode-usage errors are returned as `CheatcodeError(string)`. Compare
-    // whole-buffer hashes against a precomputed expected encoding rather than
-    // slicing `ret` with a length-dependent loop, which the symbolic engine
-    // cannot bound and blows the path depth limit.
-    function _expectedCheatcodeError(string memory message) internal pure returns (bytes memory) {
-        return abi.encodeWithSelector(bytes4(keccak256("CheatcodeError(string)")), message);
-    }
-
-    // Two identical non-counted registrations followed by only one matching
-    // call: an end-to-end smoke check that this shape still reports a clean
-    // "expected call ... unmet" failure rather than crashing or misbehaving
-    // under --symbolic. This does NOT by itself distinguish the fix from the
-    // pre-fix bug (the old unconditional-push behavior also fails here, for
-    // the wrong reason: its unreachable second entry is never observed
-    // either). The real regression coverage for the merge itself - that a
-    // duplicate registration raises the expected count rather than pushing a
-    // structurally-unreachable second entry - lives in the
-    // `duplicate_non_counted_expect_call_merges_additively` Rust unit test in
-    // `crates/evm/symbolic/src/runtime/state.rs`, which exercises
-    // `register_expected_call` and `observe()`/`is_satisfied()` directly. A
-    // pre-existing, unrelated symbolic-replay limitation (any --symbolic test
-    // that registers 2+ `vm.expectCall`s and fully satisfies all of them
-    // produces a false "symbolic counterexample did not replay", reproduced
-    // identically on unmodified master with plain distinct-key registrations)
-    // makes the satisfied-by-two-calls direction unreliable to assert
-    // end-to-end here.
-    function checkExpectCallAdditiveUnmetSecondCall(uint256) public {
-        vm.expectCall(
-            address(target),
-            abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(2))
-        );
-        vm.expectCall(
-            address(target),
-            abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(2))
-        );
-        assertEq(target.ping(2), 3);
-    }
-
-    // Re-registering an already-counted expectCall with the same key must
-    // revert, matching the concrete cheatcode's guard rail.
-    function checkExpectCallCountedDuplicateReverts(uint256) public {
-        vm.expectCall(
-            address(target),
-            abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(3)),
-            1
-        );
-        (bool ok, bytes memory ret) = address(vm).call(
-            abi.encodeWithSignature(
-                "expectCall(address,bytes,uint64)",
-                address(target),
-                abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(3)),
-                uint64(1)
-            )
-        );
-        assertFalse(ok);
-        assertEq(
-            keccak256(ret),
-            keccak256(_expectedCheatcodeError("counted expected calls can only bet set once"))
-        );
-        assertEq(target.ping(3), 4);
-    }
-
-    // Registering a non-counted expectCall over an already-counted one with
-    // the same key must revert, matching the concrete cheatcode's guard rail.
-    function checkExpectCallNonCountedOverCountedReverts(uint256) public {
-        vm.expectCall(
-            address(target),
-            abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(4)),
-            1
-        );
-        (bool ok, bytes memory ret) = address(vm).call(
-            abi.encodeWithSignature(
-                "expectCall(address,bytes)",
-                address(target),
-                abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(4))
-            )
-        );
-        assertFalse(ok);
-        assertEq(
-            keccak256(ret),
-            keccak256(
-                _expectedCheatcodeError(
-                    "cannot overwrite a counted expectCall with a non-counted expectCall"
-                )
-            )
-        );
-        assertEq(target.ping(4), 5);
-    }
-}
-"#,
-    );
-
-    let stdout = cmd
-        .args(["test", "--symbolic", "--match-test", "checkExpectCallAdditiveUnmetSecondCall"])
-        .assert_failure()
-        .get_output()
-        .stdout_lossy();
-
-    assert_relevant_lines(
-        &stdout,
-        foundry_test_utils::str![[r#"
-[FAIL:
-"#]],
-    );
-    assert_relevant_lines(
-        &stdout,
-        foundry_test_utils::str![[r#"
-checkExpectCallAdditiveUnmetSecondCall(uint256)
-"#]],
-    );
 
     let stdout = prj
         .forge_command()
-        .args(["test", "--symbolic", "--match-test", "checkExpectCallCountedDuplicateReverts"])
+        .args(["test", "--symbolic", "--match-test", "checkExpectCallAdditive"])
         .assert_success()
         .get_output()
         .stdout_lossy();
-
     assert_relevant_lines(
         &stdout,
         foundry_test_utils::str![[r#"
-[PASS] checkExpectCallCountedDuplicateReverts(uint256)
+[PASS] checkExpectCallAdditive(uint256)
 "#]],
     );
 
-    let stdout = prj
-        .forge_command()
-        .args(["test", "--symbolic", "--match-test", "checkExpectCallNonCountedOverCountedReverts"])
-        .assert_success()
-        .get_output()
-        .stdout_lossy();
-
-    assert_relevant_lines(
-        &stdout,
-        foundry_test_utils::str![[r#"
-[PASS] checkExpectCallNonCountedOverCountedReverts(uint256)
-"#]],
-    );
+    for test in
+        ["checkExpectCallCountedDuplicateReverts", "checkExpectCallNonCountedOverCountedReverts"]
+    {
+        prj.forge_command().args(["test", "--symbolic", "--match-test", test]).assert_success();
+    }
 });
 
 forgetest_init!(symbolic_vm_mock_call_returns_and_reverts, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -2834,6 +2834,172 @@ checkExpectCallMinGasMissing(uint256)
     );
 });
 
+forgetest_init!(symbolic_vm_expect_call_additive_idiom, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_vm_expect_call_additive_idiom because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicExpectCallAdditive.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicExpectCallAdditiveTarget {
+    function ping(uint256 value) external pure returns (uint256) {
+        return value + 1;
+    }
+}
+
+contract SymbolicExpectCallAdditive is Test {
+    SymbolicExpectCallAdditiveTarget target;
+
+    function setUp() public {
+        target = new SymbolicExpectCallAdditiveTarget();
+    }
+
+    // Cheatcode-usage errors are returned as `CheatcodeError(string)`. Compare
+    // whole-buffer hashes against a precomputed expected encoding rather than
+    // slicing `ret` with a length-dependent loop, which the symbolic engine
+    // cannot bound and blows the path depth limit.
+    function _expectedCheatcodeError(string memory message) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(bytes4(keccak256("CheatcodeError(string)")), message);
+    }
+
+    // Two identical non-counted registrations followed by only one matching
+    // call: an end-to-end smoke check that this shape still reports a clean
+    // "expected call ... unmet" failure rather than crashing or misbehaving
+    // under --symbolic. This does NOT by itself distinguish the fix from the
+    // pre-fix bug (the old unconditional-push behavior also fails here, for
+    // the wrong reason: its unreachable second entry is never observed
+    // either). The real regression coverage for the merge itself - that a
+    // duplicate registration raises the expected count rather than pushing a
+    // structurally-unreachable second entry - lives in the
+    // `duplicate_non_counted_expect_call_merges_additively` Rust unit test in
+    // `crates/evm/symbolic/src/runtime/state.rs`, which exercises
+    // `register_expected_call` and `observe()`/`is_satisfied()` directly. A
+    // pre-existing, unrelated symbolic-replay limitation (any --symbolic test
+    // that registers 2+ `vm.expectCall`s and fully satisfies all of them
+    // produces a false "symbolic counterexample did not replay", reproduced
+    // identically on unmodified master with plain distinct-key registrations)
+    // makes the satisfied-by-two-calls direction unreliable to assert
+    // end-to-end here.
+    function checkExpectCallAdditiveUnmetSecondCall(uint256) public {
+        vm.expectCall(
+            address(target),
+            abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(2))
+        );
+        vm.expectCall(
+            address(target),
+            abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(2))
+        );
+        assertEq(target.ping(2), 3);
+    }
+
+    // Re-registering an already-counted expectCall with the same key must
+    // revert, matching the concrete cheatcode's guard rail.
+    function checkExpectCallCountedDuplicateReverts(uint256) public {
+        vm.expectCall(
+            address(target),
+            abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(3)),
+            1
+        );
+        (bool ok, bytes memory ret) = address(vm).call(
+            abi.encodeWithSignature(
+                "expectCall(address,bytes,uint64)",
+                address(target),
+                abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(3)),
+                uint64(1)
+            )
+        );
+        assertFalse(ok);
+        assertEq(
+            keccak256(ret),
+            keccak256(_expectedCheatcodeError("counted expected calls can only bet set once"))
+        );
+        assertEq(target.ping(3), 4);
+    }
+
+    // Registering a non-counted expectCall over an already-counted one with
+    // the same key must revert, matching the concrete cheatcode's guard rail.
+    function checkExpectCallNonCountedOverCountedReverts(uint256) public {
+        vm.expectCall(
+            address(target),
+            abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(4)),
+            1
+        );
+        (bool ok, bytes memory ret) = address(vm).call(
+            abi.encodeWithSignature(
+                "expectCall(address,bytes)",
+                address(target),
+                abi.encodeWithSelector(SymbolicExpectCallAdditiveTarget.ping.selector, uint256(4))
+            )
+        );
+        assertFalse(ok);
+        assertEq(
+            keccak256(ret),
+            keccak256(
+                _expectedCheatcodeError(
+                    "cannot overwrite a counted expectCall with a non-counted expectCall"
+                )
+            )
+        );
+        assertEq(target.ping(4), 5);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkExpectCallAdditiveUnmetSecondCall"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+checkExpectCallAdditiveUnmetSecondCall(uint256)
+"#]],
+    );
+
+    let stdout = prj
+        .forge_command()
+        .args(["test", "--symbolic", "--match-test", "checkExpectCallCountedDuplicateReverts"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExpectCallCountedDuplicateReverts(uint256)
+"#]],
+    );
+
+    let stdout = prj
+        .forge_command()
+        .args(["test", "--symbolic", "--match-test", "checkExpectCallNonCountedOverCountedReverts"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkExpectCallNonCountedOverCountedReverts(uint256)
+"#]],
+    );
+});
+
 forgetest_init!(symbolic_vm_mock_call_returns_and_reverts, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(


### PR DESCRIPTION
Sibling to #16660 (`add_call_mock` dedupe) - same root cause and file, but `vm.expectCall` has its own independently-pinned semantics so this is its own PR.

## The divergence

Concrete (`crates/cheatcodes/src/test/expect.rs`, `expect_call`, ~lines 837-880) keys duplicate `expectCall` registrations on `(calldata, scheme)` with three behaviors:

- Duplicate **non-counted** registration of the same call -> merges into a higher expected count (the documented "additive" idiom).
- Duplicate **counted** registration of the same call -> hard error: `"counted expected calls can only bet set once"`.
- A **non-counted** registration over an existing **counted** one -> error: `"cannot overwrite a counted expectCall with a non-counted expectCall"`.

Symbolic (`crates/evm/symbolic/src/executor/cheatcodes.rs`, `set_expected_call`) ignored all of this and unconditionally pushed a new `ExpectedCall` entry on every registration - no dedupe, no merge, no error.

## Why this is a real bug, not just redundant bookkeeping

`observe_expected_call` (`crates/evm/symbolic/src/executor/calls.rs`, ~388-399) resolves a matching call to the **first** matching entry only. Two identical registrations produce two separate entries each expecting count=1; every actual matching call resolves to the first entry and returns immediately, so the second entry's `observed` count can never advance. A test using the documented additive idiom - e.g. the repo's own existing, already-passing concrete test `testExpectMultipleCallsWithDataAdditive` (`testdata/default/cheats/ExpectCall.t.sol:87`, plus its `...AdditiveLowerBound` sibling) - would **falsely fail** under `--symbolic`.

This is a false FAILURE (symbolic rejects code the concrete engine accepts), the less dangerous direction than a false pass, but it makes a documented, test-pinned idiom unusable under `--symbolic`.

A second, smaller divergence: symbolic also silently accepted a duplicate **counted** registration with no error at all, where concrete raises an explicit one. Same root cause (unconditional append, no dedupe/error logic), fixed in the same PR.

## Fix

Adds `register_expected_call` (`crates/evm/symbolic/src/runtime/state.rs`), which mirrors concrete's three-way behavior at insert time:

- duplicate non-counted key -> merge (increment `expected`)
- duplicate counted key (existing counted or non-counted) -> `DuplicateCounted` -> revert with concrete's exact message
- non-counted over an existing counted key -> `NonCountedOverCounted` -> revert with concrete's exact message

`set_expected_call` now delegates to this helper instead of inlining `state.expected_calls.push(...)`.

## Verification

- **New Rust unit tests** (`crates/evm/symbolic/src/runtime/state.rs`) exercise `register_expected_call` + `observe()`/`is_satisfied()` directly against the real production code path: `duplicate_non_counted_expect_call_merges_additively` (merge raises the expected count from 1 to 2, and two observations satisfy it), `duplicate_counted_expect_call_is_rejected` (both duplicate-counted and non-counted-over-counted transitions, from a counted starting point), `counted_expect_call_over_existing_non_counted_is_rejected` (the same guard rail from a non-counted starting point). All pass; full symbolic crate suite is 319/319 green (up from 318, no regressions).
- **New E2E test** (`crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs`, `symbolic_vm_expect_call_additive_idiom`) drives real `--symbolic` runs: an unmet-additive-expectation smoke check, and both revert paths verified via a raw low-level call to the VM address, comparing the returned `CheatcodeError(string)` bytes' keccak256 against a precomputed expected encoding (avoids a length-dependent Solidity loop over `ret`, which blows the symbolic engine's path-depth limit).
- Full `symbolic_cheatcodes` suite: 61 passed, 1 pre-existing unrelated failure (`symbolic_mapping_storage_hooks`, a local `fuzz.runs` config error, confirmed via `git stash` to be identical on unmodified master - not a regression).
- clippy (`-D warnings`) and `cargo fmt --check` both clean.

## Known limitations (disclosed, not fixed here)

- **Structural equality only.** Dedup keys on `callee == callee` (`SymExpr` `PartialEq`) and `data.same_bytes(...)` - only syntactically-identical duplicate registrations are recognized, same caveat as the already-shipped #16660. A solver-equivalent-but-syntactically-distinct duplicate (e.g. two calldata expressions that always evaluate equal but aren't built the same way) won't be deduped.
- **No `scheme` dimension.** Concrete's key is `(calldata, scheme)`; the symbolic engine has no notion of `CallScheme` in its expected-call model at all (pre-existing, out of scope for this PR) - the fix's key is just `(callee, calldata)`.
- **A separate, pre-existing, unrelated symbolic-replay bug** (not introduced or touched by this PR, confirmed via `git stash` against unmodified master): any `--symbolic` test that registers 2+ `vm.expectCall` entries - duplicate OR merely distinct keys - and fully satisfies all of them via matching calls produces a false `"symbolic counterexample did not replay"` failure. This is why the E2E test above only exercises the unmet direction end-to-end; the merge-then-satisfy direction is instead covered by the Rust unit test, which sidesteps full symbolic path exploration/SMT solving entirely.

No linked issue - found via manual code audit of `crates/evm/symbolic/src/executor/cheatcodes.rs` after shipping #16660 on the sibling `mockCall` bug.