### PR TITLE
fix(symbolic): only validate JUMPI destination when the branch is taken

### DIFF
--- a/.changelog/symbolic-jumpi-ordering.md
+++ b/.changelog/symbolic-jumpi-ordering.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fix symbolic execution rejecting or erroring on a `JUMPI` whose destination is garbage but whose condition is falsy, by only validating the jump destination when the branch is actually taken (matching the concrete EVM's behavior).

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -1100,15 +1100,19 @@ impl SymbolicExecutor {
             }
             opcode::JUMPI => {
                 let dest = state.stack.pop()?;
-                let dest = state.expect_constrained_usize(
-                    &mut self.cx,
-                    dest,
-                    "symbolic JUMPI destination",
-                )?;
-                ensure_jumpdest(dest, jumpdests)?;
                 let cond = state.stack.pop()?;
                 match cond.truth() {
+                    // EVM only validates/uses the destination when the jump is actually taken
+                    // (see revm's `jumpi`, which calls `jump_inner` only inside
+                    // `if !cond.is_zero()`). A falsy condition must fall through regardless of
+                    // what garbage sits in the destination slot.
                     Some(true) => {
+                        let dest = state.expect_constrained_usize(
+                            &mut self.cx,
+                            dest,
+                            "symbolic JUMPI destination",
+                        )?;
+                        ensure_jumpdest(dest, jumpdests)?;
                         if !self.take_loop_jump(state, state.pc, dest) {
                             return Ok(StepOutcome::AssumeRejected);
                         }
@@ -1116,6 +1120,12 @@ impl SymbolicExecutor {
                     }
                     Some(false) => {}
                     None => {
+                        let dest = state.expect_constrained_usize(
+                            &mut self.cx,
+                            dest,
+                            "symbolic JUMPI destination",
+                        )?;
+                        ensure_jumpdest(dest, jumpdests)?;
                         let op_pc = state.pc.saturating_sub(1);
                         let _branch_span = trace_span!("jumpi_branch", pc = op_pc, dest).entered();
                         let true_cond = cond.nonzero_bool(&mut self.cx);

--- a/crates/forge/tests/cli/test_cmd/symbolic_opcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_opcodes.rs
@@ -590,3 +590,225 @@ incomplete symbolic execution (Error): solver error: solver model does not satis
         "expected Keccak-heuristic taint or warning in output, got:\n{stdout}"
     );
 });
+
+// EVM only validates/uses a JUMPI destination when the jump is actually
+// taken (revm's `jumpi` calls `jump_inner` only inside `if !cond.is_zero()`).
+// A falsy condition must fall through regardless of what garbage sits in the
+// destination slot on the stack. Solidity's strict-assembly mode forbids raw
+// `jump`/`jumpi`, so this needs hand-assembled bytecode via `vm.etch`.
+forgetest_init!(symbolic_jumpi_falsy_condition_skips_dest_validation, |prj, cmd| {
+    skip_unless_z3!("symbolic_jumpi_falsy_condition_skips_dest_validation");
+
+    prj.add_test(
+        "SymbolicJumpiOrdering.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicJumpiFalsyCondition is Test {
+    function checkFalsyConditionSkipsDestValidation() public {
+        address target = address(0xBEEF);
+        // PUSH1 0x00 (cond, falsy)  PUSH1 0x01 (dest, NOT a JUMPDEST)  JUMPI  STOP
+        // dest sits on top of the stack (popped first), cond below it (popped
+        // second) - see runtime/evm.rs `ensure_jumpdest` / opcodes.rs JUMPI.
+        vm.etch(target, hex"600060015700");
+        (bool ok, ) = target.call("");
+        assertTrue(ok);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkFalsyConditionSkipsDestValidation"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkFalsyConditionSkipsDestValidation()
+"#]],
+    );
+    assert!(!stdout.contains("invalid jump destination"), "{stdout}");
+});
+
+// Companion to the falsy-condition case above: a JUMPI with an invalid
+// destination and a TRUTHY condition must still be rejected. This guards
+// against a fix that accidentally stops validating the destination
+// altogether instead of only skipping it on the not-taken path.
+forgetest_init!(symbolic_jumpi_truthy_condition_still_validates_dest, |prj, cmd| {
+    skip_unless_z3!("symbolic_jumpi_truthy_condition_still_validates_dest");
+
+    prj.add_test(
+        "SymbolicJumpiOrderingTruthy.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicJumpiTruthyCondition is Test {
+    function checkTruthyConditionStillValidatesDest() public {
+        address target = address(0xBEEF);
+        // PUSH1 0x01 (cond, truthy)  PUSH1 0x01 (dest, NOT a JUMPDEST)  JUMPI  STOP
+        vm.etch(target, hex"600160015700");
+        (bool ok, ) = target.call("");
+        assertFalse(ok);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkTruthyConditionStillValidatesDest"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Error): invalid jump destination 1
+"#]],
+    );
+});
+
+// Stronger version of the falsy-condition case: the destination here is
+// genuinely symbolic (derived from calldata), not just a concrete invalid
+// value. Before the fix this hit `expect_constrained_usize`'s "symbolic
+// JUMPI destination" Unsupported error unconditionally; with the falsy
+// condition never touching the destination, resolution must be skipped
+// entirely, symbolic or not.
+forgetest_init!(symbolic_jumpi_falsy_condition_skips_symbolic_dest_resolution, |prj, cmd| {
+    skip_unless_z3!("symbolic_jumpi_falsy_condition_skips_symbolic_dest_resolution");
+
+    prj.add_test(
+        "SymbolicJumpiOrderingSymbolicDest.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicJumpiSymbolicDest is Test {
+    function checkFalsyConditionSkipsSymbolicDestResolution(uint256 dest) public {
+        address target = address(0xBEEF);
+        // PUSH1 0x00 (cond, falsy)  PUSH1 0x00  CALLDATALOAD (dest, symbolic)  JUMPI  STOP
+        vm.etch(target, hex"60006000355700");
+        (bool ok, ) = target.call(abi.encode(dest));
+        assertTrue(ok);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--match-test",
+            "checkFalsyConditionSkipsSymbolicDestResolution",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkFalsyConditionSkipsSymbolicDestResolution(uint256)
+"#]],
+    );
+    assert!(!stdout.contains("symbolic JUMPI destination"), "{stdout}");
+    assert!(!stdout.contains("invalid jump destination"), "{stdout}");
+});
+
+// The `None` (symbolic condition) branch resolves and validates the
+// destination unconditionally, since both the true and false forks are
+// explored and the true fork needs a concrete valid destination. That is
+// unchanged by this fix (only the concrete-condition arms were reordered) -
+// pin it so a future refactor can't silently start skipping validation here.
+forgetest_init!(symbolic_jumpi_symbolic_condition_still_validates_dest, |prj, cmd| {
+    skip_unless_z3!("symbolic_jumpi_symbolic_condition_still_validates_dest");
+
+    prj.add_test(
+        "SymbolicJumpiOrderingSymbolicCond.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicJumpiSymbolicCondition is Test {
+    function checkSymbolicConditionStillValidatesDest(uint256 cond) public {
+        address target = address(0xBEEF);
+        // PUSH1 0x00  CALLDATALOAD (cond, symbolic)  PUSH1 0x01 (dest, NOT a JUMPDEST)  JUMPI  STOP
+        vm.etch(target, hex"60003560015700");
+        (bool ok, ) = target.call(abi.encode(cond));
+        assertFalse(ok);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkSymbolicConditionStillValidatesDest"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Error): invalid jump destination 1
+"#]],
+    );
+});
+
+// Sanity check that unconditional JUMP (a sibling opcode, textually adjacent
+// in the same match statement) was not accidentally touched by this fix:
+// an invalid destination must still always be rejected, and a valid one
+// must still always succeed.
+forgetest_init!(symbolic_jump_unconditional_dest_validation_unaffected, |prj, cmd| {
+    skip_unless_z3!("symbolic_jump_unconditional_dest_validation_unaffected");
+
+    prj.add_test(
+        "SymbolicJumpUnaffected.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicJumpUnaffected is Test {
+    function checkInvalidJumpStillRejected() public {
+        address invalidTarget = address(0xBEEF);
+        // PUSH1 0x01 (dest, NOT a JUMPDEST)  JUMP  STOP
+        vm.etch(invalidTarget, hex"60015600");
+        (bool ok, ) = invalidTarget.call("");
+        assertFalse(ok);
+    }
+
+    function checkValidJumpStillSucceeds() public {
+        address validTarget = address(0xC0FE);
+        // PUSH1 0x03 (dest)  JUMP  JUMPDEST  STOP
+        vm.etch(validTarget, hex"6003565b00");
+        (bool ok, ) = validTarget.call("");
+        assertTrue(ok);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--match-test",
+            "checkInvalidJumpStillRejected|checkValidJumpStillSucceeds",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkValidJumpStillSucceeds()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+incomplete symbolic execution (Error): invalid jump destination 1
+"#]],
+    );
+});


### PR DESCRIPTION
## Summary

The symbolic engine resolved and validated `JUMPI`'s jump destination unconditionally, before even inspecting the condition. Real EVM only validates/uses the destination when the jump is actually taken — verified directly against revm source (`revm-interpreter-42.0.0/src/instructions/control.rs:24`):

```rust
pub fn jumpi(...) {
    popn!([target, cond], context.interpreter);
    if !cond.is_zero() {
        jump_inner(context.interpreter, target)?;   // validity checked ONLY here, only when taken
    }
    Ok(())
}
```

`JUMPI(invalid_dest, 0)` is completely legal EVM bytecode — a no-op fallthrough, since the destination is never touched when the branch isn't taken. Foundry's symbolic engine (`crates/evm/symbolic/src/executor/opcodes.rs`) instead resolved+validated the destination before looking at the condition at all, so a falsy condition with garbage in the destination slot failed two ways it shouldn't:

- concrete invalid destination → `Err(SymbolicError::InvalidJump(dest))`
- genuinely symbolic destination → `Err(Unsupported("symbolic JUMPI destination"))`

## Fix

Pop both `dest` and `cond` first, then only resolve+validate `dest` inside the arms that actually need it:
- `Some(true)` (condition concretely true): validate before jumping, same as before, just reordered.
- `Some(false)` (condition concretely false): do nothing — `dest` is never touched, concrete or symbolic.
- `None` (condition symbolic): unchanged — both true/false paths are forked, and the true fork still needs a concrete valid destination, so this arm still resolves+validates eagerly. Fixing that (so an unresolvable destination only kills the true fork instead of erroring the whole step) is a larger modeling change, out of scope here.

## Scope / severity, stated honestly

solc always emits constant, valid `JUMPI` destinations, so ordinary Solidity-compiled contracts essentially never hit this. Reaching it needs hand-written bytecode (`vm.etch`), or unusual/adversarial/obfuscated code (e.g. analyzing another contract's raw bytecode). This is a genuine, clean, runnable spec-conformance divergence, but not a mainstream-impact bug.

## Related, explicitly out of scope

The symbolic engine models *any* invalid jump (when actually taken) as `SymbolicStopReason::Error`/`Stuck` — an engine-level analysis abort — whereas real EVM treats an invalid jump as an exceptional halt that reverts only the current call frame (the caller just sees `success == false`). That's a materially larger modeling change and is tracked separately in #16670.

## Tests

Added to `crates/forge/tests/cli/test_cmd/symbolic_opcodes.rs` (Solidity's strict-assembly mode forbids raw `jump`/`jumpi`, so these use `vm.etch` with hand-assembled bytecode — stack order double-checked against revm's own `popn!([target, cond], ...)` pop order, not just assumed from a comment):

- `symbolic_jumpi_falsy_condition_skips_dest_validation` — concrete invalid dest, falsy cond → must pass (was red pre-fix with `invalid jump destination 1`, confirmed via `git stash` of just the source fix).
- `symbolic_jumpi_falsy_condition_skips_symbolic_dest_resolution` — same but the destination is derived from calldata (genuinely symbolic), guarding the `Unsupported("symbolic JUMPI destination")` half of the bug, not just the concrete-invalid-dest half.
- `symbolic_jumpi_truthy_condition_still_validates_dest` — invalid dest, truthy cond → must still fail with `invalid jump destination 1`. Guards against a fix that disables validation entirely instead of only skipping it on the not-taken path.
- `symbolic_jumpi_symbolic_condition_still_validates_dest` — invalid dest, symbolic cond → must still fail the same way, pinning that the `None` arm's validation is untouched by this refactor.
- `symbolic_jump_unconditional_dest_validation_unaffected` — sanity check that unconditional `JUMP` (textually adjacent, not touched by this diff) still rejects an invalid destination and still succeeds on a valid one.

All 5 pass with the fix; the first one reproduces red on unmodified master (verified via `git stash` of just the opcodes.rs change).

Ran the full symbolic suite (`cargo test -p forge --test cli symbolic`) both with and without the fix: 33 pre-existing failures identical on both runs (unrelated snapshot/env issue, confirmed via `git stash` back to clean master — same 33 test names fail either way), zero regressions, +5 new passing tests.

`cargo clippy -p foundry-evm-symbolic --all-targets -- -D warnings` and `cargo fmt --check` clean. Synchronous Codex adversarial review (gpt-6-astra, xhigh) run; addressed all 3 findings (added the symbolic-destination, symbolic-condition, and JUMP-sanity test coverage it flagged as missing) before opening.

## receipts

no runtime UI changes — this is a symbolic-execution-engine-internal fix; the CLI test output above (both the red repro and the green fixed run) is the runtime evidence for this PR.
