### PR TITLE
fix(anvil): include simulated block BAL hash

### DIFF
--- a/.changelog/anvil-simulate-block-access-list-hash.md
+++ b/.changelog/anvil-simulate-block-access-list-hash.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Include the computed block access list hash in `eth_simulateV1` block headers after Amsterdam.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -60,7 +60,7 @@ use alloy_eips::{
     eip7685::EMPTY_REQUESTS_HASH,
     eip7840::BlobParams,
     eip7910::SystemContract,
-    eip7928::EMPTY_BLOCK_ACCESS_LIST_HASH,
+    eip7928::{EMPTY_BLOCK_ACCESS_LIST_HASH, compute_block_access_list_hash},
 };
 use alloy_evm::{
     Database, EthEvmFactory, Evm, EvmEnv, EvmFactory, FromTxWithEncoded,
@@ -166,7 +166,10 @@ use revm::{
         result::{ExecutionResult, HaltReason, Output, ResultAndState},
         transaction::TransactionType,
     },
-    database::{AccountState, CacheDB, DbAccount, WrapDatabaseRef},
+    database::{
+        AccountState, CacheDB, DbAccount, WrapDatabaseRef,
+        bal::{BalDatabase, BalState},
+    },
     handler::{
         EthFrame, EvmTr, EvmTrError, FrameResult, FrameTr, Handler as EvmHandler, validation,
     },
@@ -2734,7 +2737,7 @@ impl<N: Network> Backend<N> {
         transitions: EthereumBlockTransitions,
     ) -> Result<(), BlockchainError>
     where
-        DB: StateDB<Error = DatabaseError>,
+        DB: StateDB,
     {
         let inspector = self.build_mining_inspector();
         let mut evm =
@@ -2753,7 +2756,7 @@ impl<N: Network> Backend<N> {
         receipts: &[FoundryReceiptEnvelope],
     ) -> Result<alloy_eips::eip7685::Requests, BlockchainError>
     where
-        DB: StateDB<Error = DatabaseError>,
+        DB: StateDB,
     {
         let inspector = self.build_mining_inspector();
         let mut evm =
@@ -7897,7 +7900,7 @@ impl Backend<FoundryNetwork> {
                 base_timestamp,
                 block_interval,
             )?;
-            let mut cache_db = CacheDB::new(state);
+            let mut cache_db = BalDatabase::new(CacheDB::new(state));
             cache_db.cache.block_hashes.insert(U256::from(base_number), base_hash);
             let mut block_res = Vec::with_capacity(block_state_calls.len());
             let mut parent_hash = base_hash;
@@ -8006,8 +8009,15 @@ impl Backend<FoundryNetwork> {
                         &cache_db.cache.accounts,
                         state_overrides.keys().copied(),
                     );
-                    apply_state_overrides(state_overrides, &mut cache_db)?;
+                    apply_state_overrides(state_overrides, &mut cache_db.db)?;
                     preserve_deleted_storage(&mut cache_db.cache.accounts, previously_deleted);
+                }
+
+                // Overrides define the starting state, so only execution contributes BAL writes.
+                if ethereum_transitions
+                    .is_some_and(|transitions| transitions.hardfork >= EthereumHardfork::Amsterdam)
+                {
+                    cache_db.bal_state = BalState::new().with_bal_builder();
                 }
 
                 if let Some(transitions) = ethereum_transitions {
@@ -8018,6 +8028,8 @@ impl Backend<FoundryNetwork> {
                         transitions,
                     )?;
                 }
+
+                cache_db.bump_bal_index();
 
                 // execute all calls in that block
                 for (req_idx, mut request) in calls.into_iter().enumerate() {
@@ -8092,7 +8104,7 @@ impl Backend<FoundryNetwork> {
                     }
 
                     let caller = request.from.unwrap_or_default();
-                    let caller_nonce = RevmDatabase::basic(&mut cache_db, caller)?
+                    let caller_nonce = RevmDatabase::basic(&mut cache_db.db, caller)?
                         .map(|account| account.nonce)
                         .unwrap_or_default();
                     let tempo_nonce_key =
@@ -8102,7 +8114,7 @@ impl Backend<FoundryNetwork> {
                         });
                     if request.nonce.is_none() {
                         let nonce = tempo_nonce_key.map_or(Ok(caller_nonce), |nonce_key| {
-                            tempo_nonce(&cache_db, caller, nonce_key)
+                            tempo_nonce(&cache_db.db, caller, nonce_key)
                         })?;
                         request.nonce = Some(nonce);
                         if let Some(parsed_request) = &mut parsed_request {
@@ -8131,14 +8143,14 @@ impl Backend<FoundryNetwork> {
                     let PreparedCall { mut evm_env, mut tx_env, simulated_tempo_tx } =
                         if let Some(parsed_request) = parsed_request {
                             self.prepare_typed_call_env(
-                                &cache_db,
+                                &cache_db.db,
                                 parsed_request,
                                 fee_details,
                                 block_env.clone(),
                             )?
                         } else {
                             self.prepare_call_env(
-                                &cache_db,
+                                &cache_db.db,
                                 request.clone(),
                                 fee_details,
                                 block_env.clone(),
@@ -8182,7 +8194,7 @@ impl Backend<FoundryNetwork> {
                                 && tx_env.max_fee_per_blob_gas == 0 =>
                         {
                             self.transact_eth_simulation_with_inspector_ref(
-                                &cache_db,
+                                &cache_db.db,
                                 &evm_env,
                                 &mut inspector,
                                 tx_env,
@@ -8191,14 +8203,14 @@ impl Backend<FoundryNetwork> {
                         }
                         tx_env if precompile_overrides.moves.is_empty() => self
                             .transact_call_with_inspector_ref(
-                                &cache_db,
+                                &cache_db.db,
                                 &evm_env,
                                 &mut inspector,
                                 tx_env,
                                 monad_context.as_mut().map(next_monad_context),
                             ),
                         tx_env => self.transact_eth_with_inspector_ref_and_precompile_overrides(
-                            &cache_db,
+                            &cache_db.db,
                             &evm_env,
                             &mut inspector,
                             tx_env.into_base(),
@@ -8267,7 +8279,7 @@ impl Backend<FoundryNetwork> {
                     #[cfg(feature = "optimism")]
                     if optimism_jovian {
                         let tx_blob_gas = crate::eth::backend::executor::optimism::blob_gas_used(
-                            &mut cache_db,
+                            &mut cache_db.db,
                             tx.as_ref(),
                             true,
                         )
@@ -8285,6 +8297,7 @@ impl Backend<FoundryNetwork> {
                     // Commit after calculating the footprint so the scalar comes from pre-tx
                     // state, matching the upstream OP block executor.
                     cache_db.commit(state);
+                    cache_db.bump_bal_index();
                     preserve_deleted_storage(&mut cache_db.cache.accounts, previously_deleted);
                     #[cfg(feature = "optimism")]
                     let receipt = if tx.as_ref().is_deposit() {
@@ -8399,7 +8412,12 @@ impl Backend<FoundryNetwork> {
                     .maybe_full_db()
                     .map(|accounts| state_root(&accounts))
                     .unwrap_or_default();
+                let block_access_list_hash = cache_db
+                    .bal_state
+                    .take_built_alloy_bal()
+                    .map(|bal| compute_block_access_list_hash(bal.as_slice()));
                 let header = Header {
+                    block_access_list_hash,
                     logs_bloom: receipts.iter().fold(Bloom::ZERO, |mut bloom, receipt| {
                         bloom.accrue_bloom(receipt.logs_bloom());
                         bloom

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -1,14 +1,25 @@
 //! general eth api tests
 
-use alloy_consensus::constants::EMPTY_WITHDRAWALS;
+use alloy_consensus::{Header, constants::EMPTY_WITHDRAWALS};
 
 use alloy_eips::{
+    eip2935::HISTORY_STORAGE_ADDRESS,
+    eip4788::BEACON_ROOTS_ADDRESS,
     eip6110::DEPOSIT_REQUEST_TYPE,
     eip7002::{WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, WITHDRAWAL_REQUEST_TYPE},
     eip7251::{CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS, CONSOLIDATION_REQUEST_TYPE},
     eip7685::{EMPTY_REQUESTS_HASH, Requests},
+    eip7928::{
+        AccountChanges, BlockAccessIndex, NonceChange, SlotChanges, StorageChange,
+        compute_block_access_list_hash,
+    },
 };
-use alloy_evm::precompiles::{DynPrecompile, PrecompileInput, PrecompilesMap};
+use alloy_evm::{
+    block::system_calls::{
+        BUILDER_DEPOSIT_REQUEST_PREDEPLOY_ADDRESS, BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS,
+    },
+    precompiles::{DynPrecompile, PrecompileInput, PrecompilesMap},
+};
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256, Bloom, Bytes, Log, TxKind, U256, address};
 use alloy_provider::Provider;
@@ -60,6 +71,101 @@ fn deposit_event_runtime(event: DepositEvent) -> Bytes {
     code.extend([0x5f, 0xa1, 0x00]);
     code.extend(data);
     code.into()
+}
+
+/// Checks BAL contents and indices for pre-block, transaction, and post-block execution.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_block_access_list_hash_rpc() {
+    let from = Address::with_last_byte(0x41);
+    let contract = Address::with_last_byte(0x42);
+    let beneficiary = Address::with_last_byte(0x43);
+    let system_contracts = [
+        HISTORY_STORAGE_ADDRESS,
+        BEACON_ROOTS_ADDRESS,
+        WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS,
+        CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS,
+        BUILDER_DEPOSIT_REQUEST_PREDEPLOY_ADDRESS,
+        BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS,
+    ];
+    let mut overrides = serde_json::Map::new();
+    for address in system_contracts {
+        overrides.insert(address.to_string(), json!({"code": "0x", "state": {}}));
+    }
+    // Deterministic system writes expose the pre/post-block access indices in the BAL hash.
+    for address in [HISTORY_STORAGE_ADDRESS, WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS] {
+        overrides.insert(address.to_string(), json!({"code": "0x602a5f5500", "state": {}}));
+    }
+    overrides.insert(from.to_string(), json!({"nonce": "0x0"}));
+    overrides.insert(contract.to_string(), json!({"code": "0x5f5450602a60015500", "state": {}}));
+    let block = json!({
+        "stateOverrides": overrides,
+        "blockOverrides": {"feeRecipient": beneficiary},
+        "calls": [{"from": from, "to": contract}]
+    });
+    let mut expected = system_contracts.map(AccountChanges::new).to_vec();
+    for (address, index) in
+        [(HISTORY_STORAGE_ADDRESS, 0), (WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, 2)]
+    {
+        expected.iter_mut().find(|account| account.address == address).unwrap().storage_changes =
+            vec![SlotChanges::new(
+                U256::ZERO,
+                vec![StorageChange::new(BlockAccessIndex::new(index), U256::from(42))],
+            )];
+    }
+    expected.push(AccountChanges {
+        nonce_changes: vec![NonceChange::new(BlockAccessIndex::new(1), 1)],
+        ..AccountChanges::new(from)
+    });
+    expected.push(AccountChanges {
+        storage_reads: vec![U256::ZERO],
+        storage_changes: vec![SlotChanges::new(
+            U256::from(1),
+            vec![StorageChange::new(BlockAccessIndex::new(1), U256::from(42))],
+        )],
+        ..AccountChanges::new(contract)
+    });
+    expected.push(AccountChanges::new(beneficiary));
+    expected.sort_by_key(|account| account.address);
+    let expected_hash = compute_block_access_list_hash(&expected);
+
+    for hardfork in [EthereumHardfork::Osaka, EthereumHardfork::Amsterdam] {
+        let (_api, handle) =
+            spawn(NodeConfig::test().with_hardfork(Some(hardfork.into())).with_base_fee(Some(0)))
+                .await;
+        for trace_transfers in [false, true] {
+            let response = rpc_request(
+                &handle.http_endpoint(),
+                "eth_simulateV1",
+                json!([{
+                    "blockStateCalls": [block.clone(), block.clone(), {}],
+                    "traceTransfers": trace_transfers,
+                    "returnFullTransactions": true
+                }, "latest"]),
+            )
+            .await;
+            assert!(response.get("error").is_none(), "{response}");
+            let blocks = response["result"].as_array().unwrap();
+            assert_eq!(blocks.len(), 3);
+            for block in &blocks[..2] {
+                assert_eq!(block["calls"][0]["status"], "0x1");
+                if hardfork == EthereumHardfork::Amsterdam {
+                    assert_eq!(block["blockAccessListHash"], json!(expected_hash));
+                } else {
+                    assert!(block.get("blockAccessListHash").is_none());
+                }
+                let header = serde_json::from_value::<Header>(block.clone()).unwrap();
+                assert_eq!(block["hash"], json!(header.hash_slow()));
+                assert_eq!(block["transactions"][0]["blockHash"], block["hash"]);
+            }
+            if hardfork == EthereumHardfork::Amsterdam {
+                assert!(blocks[2]["blockAccessListHash"].is_string());
+                assert_ne!(blocks[2]["blockAccessListHash"], json!(expected_hash));
+            }
+            for pair in blocks.windows(2) {
+                assert_eq!(pair[1]["parentHash"], pair[0]["hash"]);
+            }
+        }
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Collect a fresh BAL for each Amsterdam simulation block, including pre/post-block system calls and transaction execution, and set `blockAccessListHash` before hashing the header. Add RPC coverage for exact BAL contents and access indices, per-block reset, empty blocks, transfer tracing, and pre-Amsterdam behavior.

Addresses the missing BAL hash from https://github.com/ethereum/execution-apis/issues/868. Corresponding Reth fix: https://github.com/paradigmxyz/reth/pull/27023.

AI assistance was used for implementation and tests.
