### PR TITLE
fix(cheatcodes): don't follow fs_permissions-escaping symlinks in readDir

### DIFF
--- a/.changelog/readdir-fs-permissions-symlink-escape.md
+++ b/.changelog/readdir-fs-permissions-symlink-escape.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Stop `vm.readDir(path, maxDepth, followLinks: true)` from following a symlink out of the `fs_permissions` boundary and listing file/directory names outside it.

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -881,6 +881,59 @@ fn read_dir<FEN: FoundryEvmNetwork>(
         .same_file_system(true)
         .sort_by_file_name()
         .into_iter()
+        // `follow_links(true)` lets the walk descend *through* a symlink whose target lies
+        // outside the permitted `fs_permissions` boundary (the boundary check above only
+        // covers `root` itself). Once that happens, every entry found beyond the symlink is
+        // reachable only because an ancestor path component resolved outside the sandbox, so
+        // check each entry's *parent* against the boundary and prune the walk the moment it
+        // escapes: rejecting a directory entry here means `WalkDir` won't queue or return any
+        // of *its* children, so nothing beneath it - however deep, even if a later symlink
+        // would resolve back inside the sandbox - is ever returned to the caller. `filter_entry`
+        // (not a post-hoc `.filter()`) is required for this: a post-hoc filter still lets the
+        // walk enumerate and yield every descendant before discarding them one by one, which is
+        // exactly how an escape that later resolves back in-bounds would slip through (its
+        // *own* immediate parent looks fine once fully resolved, even though reaching it required
+        // stepping outside). `filter_entry` instead stops queuing an entry's children the moment
+        // the entry itself is rejected, so an escape can't be "laundered" by a later re-entry.
+        //
+        // This intentionally checks the parent, not the entry's own path: canonicalizing the
+        // entry itself would also resolve a symlink that IS the entry (e.g. the `escape` entry
+        // for a symlink directly inside an allowed dir), which would incorrectly hide that
+        // symlink's own name even when it isn't followed (`follow_links: false` must keep
+        // listing it, unchanged from today). The parent check only fires once traversal has
+        // actually stepped through an escaping symlink - mirrors the boundary `read_file`
+        // already enforces for a single path, just applied per-entry along the walk.
+        //
+        // The root entry itself (depth 0) is exempt: it already passed `ensure_path_allowed`
+        // above, and checking *its* parent would often fail even for a fully legitimate root
+        // (a permission can be granted for a directory without separately granting its parent).
+        .filter_entry(|entry| {
+            entry.depth() == 0
+                || entry
+                    .path()
+                    .parent()
+                    .is_none_or(|parent| state.config.is_path_allowed(parent, FsAccessKind::Read))
+        })
+        .filter(|entry| {
+            // `filter_entry`'s predicate only ever sees `Ok` entries; errors pass through it
+            // untouched, so apply the same parent-boundary check here for the `Err` case -
+            // except at the root (depth 0), whose error must be preserved even if its *parent*
+            // isn't separately permitted, matching the exemption above. `WalkDir`'s own root
+            // error always carries a path (so it's covered by the depth check above regardless);
+            // a non-root error can occasionally carry no path at all (e.g. a lower-level I/O
+            // failure enumerating a directory's children, or an internal `same_file_system`
+            // check) - since there is then nothing to check against the boundary, fail closed
+            // and drop it rather than defaulting to keeping something we can't verify.
+            match entry {
+                Ok(_) => true,
+                Err(e) if e.depth() == 0 => true,
+                Err(e) => e.path().is_some_and(|p| {
+                    p.parent().is_none_or(|parent| {
+                        state.config.is_path_allowed(parent, FsAccessKind::Read)
+                    })
+                }),
+            }
+        })
         .map(|entry| match entry {
             Ok(entry) => DirEntry {
                 errorMessage: String::new(),

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -22,6 +22,7 @@ mod fuzz;
 mod invariant;
 mod logs;
 mod mutation;
+mod readdir_fs_permissions;
 mod repros;
 mod showmap;
 mod spec;

--- a/crates/forge/tests/cli/test_cmd/readdir_fs_permissions.rs
+++ b/crates/forge/tests/cli/test_cmd/readdir_fs_permissions.rs
@@ -1,0 +1,392 @@
+// CLI integration tests for `vm.readDir`'s `fs_permissions` boundary.
+//
+// `read_dir` (crates/cheatcodes/src/fs.rs) only checked the root path passed to `readDir`
+// against `fs_permissions`. With `followLinks: true`, `WalkDir` follows a symlink inside a
+// permitted directory out to wherever it points, and every entry beyond it was returned
+// completely unchecked - a permitted directory containing a stray symlink could be used to
+// enumerate file/directory *names* anywhere else on disk that the walk could reach.
+// `vm.readFile` on the identical escaped path was (and still is) correctly rejected; only
+// `readDir` skipped the equivalent check for entries found while walking.
+
+use foundry_config::fs_permissions::PathPermission;
+use foundry_test_utils::forgetest_init;
+use std::fs;
+
+#[cfg(unix)]
+forgetest_init!(readdir_does_not_follow_symlink_out_of_fs_permissions_boundary, |prj, cmd| {
+    // A directory genuinely outside the project entirely, not just outside the permitted
+    // subpath - anything reachable through the escaping symlink should be unreachable via
+    // `readDir` regardless of how deep the walk follows it.
+    let outside = tempfile::tempdir().unwrap();
+    fs::write(outside.path().join("secret.txt"), "leaked").unwrap();
+    let outside_sub = outside.path().join("sub");
+    fs::create_dir(&outside_sub).unwrap();
+    fs::write(outside_sub.join("nested.txt"), "leaked-nested").unwrap();
+
+    let allowed = prj.root().join("allowed");
+    fs::create_dir(&allowed).unwrap();
+    fs::write(allowed.join("normal.txt"), "fine").unwrap();
+    std::os::unix::fs::symlink(outside.path(), allowed.join("escape")).unwrap();
+
+    prj.update_config(|config| {
+        config.fs_permissions.add(PathPermission::read(prj.root().join("allowed")));
+    });
+
+    prj.add_raw_test(
+        "ReadDirSymlinkEscape.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface Vm {
+    struct DirEntry {
+        string errorMessage;
+        string path;
+        uint64 depth;
+        bool isDir;
+        bool isSymlink;
+    }
+
+    function readDir(string calldata path, uint64 maxDepth, bool followLinks)
+        external
+        view
+        returns (DirEntry[] memory entries);
+    function readFile(string calldata path) external view returns (string memory data);
+    function _expectCheatcodeRevert() external;
+}
+
+contract ReadDirSymlinkEscapeTest {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function _hasPathEndingWith(Vm.DirEntry[] memory entries, string memory suffix)
+        internal
+        pure
+        returns (bool)
+    {
+        bytes memory suffixBytes = bytes(suffix);
+        for (uint256 i = 0; i < entries.length; i++) {
+            bytes memory p = bytes(entries[i].path);
+            if (p.length < suffixBytes.length) continue;
+            bool matches = true;
+            for (uint256 j = 0; j < suffixBytes.length; j++) {
+                if (p[p.length - suffixBytes.length + j] != suffixBytes[j]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return true;
+        }
+        return false;
+    }
+
+    // followLinks: true must not surface anything beyond the escaping symlink, at any depth,
+    // while still listing the normal in-bounds entries and the symlink's own (in-bounds) name.
+    function test_followLinksTrue_excludesEscapedEntries() public {
+        Vm.DirEntry[] memory entries = vm.readDir("allowed", 10, true);
+
+        require(!_hasPathEndingWith(entries, "secret.txt"), "leaked top-level escaped file");
+        require(!_hasPathEndingWith(entries, "nested.txt"), "leaked nested escaped file");
+        require(!_hasPathEndingWith(entries, "/sub"), "leaked escaped subdirectory");
+
+        require(_hasPathEndingWith(entries, "normal.txt"), "normal in-bounds entry missing");
+        require(_hasPathEndingWith(entries, "escape"), "symlink's own name should still list");
+        require(entries.length == 2, "expected exactly the two in-bounds entries");
+    }
+
+    // followLinks: false must be completely unaffected: the symlink itself is still listed
+    // (it lives inside the permitted directory), it's just never descended into.
+    function test_followLinksFalse_unchanged() public {
+        Vm.DirEntry[] memory entries = vm.readDir("allowed", 10, false);
+
+        require(!_hasPathEndingWith(entries, "secret.txt"));
+        require(_hasPathEndingWith(entries, "normal.txt"));
+        require(_hasPathEndingWith(entries, "escape"));
+        require(entries.length == 2);
+    }
+
+    // Control: readFile on the exact same escaped path was already correctly rejected before
+    // this fix and must remain so - readDir's leak was in listing names, never in granting
+    // content access.
+    function test_readFile_sameEscapedPath_stillRejected() public {
+        vm._expectCheatcodeRevert();
+        vm.readFile("allowed/escape/secret.txt");
+    }
+}
+"#,
+    );
+
+    cmd.args([
+        "test",
+        "--mt",
+        "test_(followLinksTrue_excludesEscapedEntries|followLinksFalse_unchanged|readFile_sameEscapedPath_stillRejected)",
+    ])
+    .assert_success();
+});
+
+// A symlink that escapes the sandbox and then, further down its own target tree, points back
+// to somewhere legitimately in-bounds must not leak any of the outside path components it took
+// to get there. Canonicalizing only an entry's immediate parent is not enough to catch this:
+// the final destination can resolve as "allowed" even though the walk had to step outside the
+// sandbox to reach it, so the fix must stop descending at the first escaping step rather than
+// judging each entry purely by where it ultimately, fully-resolved, ends up.
+#[cfg(unix)]
+forgetest_init!(readdir_does_not_leak_names_when_escape_reenters_boundary, |prj, cmd| {
+    let allowed = prj.root().join("allowed");
+    fs::create_dir(&allowed).unwrap();
+    let local = allowed.join("local");
+    fs::create_dir(&local).unwrap();
+    fs::write(local.join("visible.txt"), "fine").unwrap();
+
+    let outside = tempfile::tempdir().unwrap();
+    let hidden_dir = outside.path().join("hidden_dir");
+    fs::create_dir(&hidden_dir).unwrap();
+    // Points back inside the sandbox - but reaching it at all requires having already stepped
+    // through `outside/`, which is not permitted.
+    std::os::unix::fs::symlink(&local, hidden_dir.join("reentry")).unwrap();
+
+    std::os::unix::fs::symlink(outside.path(), allowed.join("escape")).unwrap();
+
+    prj.update_config(|config| {
+        config.fs_permissions.add(PathPermission::read(prj.root().join("allowed")));
+    });
+
+    prj.add_raw_test(
+        "ReadDirEscapeReentry.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface Vm {
+    struct DirEntry {
+        string errorMessage;
+        string path;
+        uint64 depth;
+        bool isDir;
+        bool isSymlink;
+    }
+
+    function readDir(string calldata path, uint64 maxDepth, bool followLinks)
+        external
+        view
+        returns (DirEntry[] memory entries);
+}
+
+contract ReadDirEscapeReentryTest {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function _hasPathEndingWith(Vm.DirEntry[] memory entries, string memory suffix)
+        internal
+        pure
+        returns (bool)
+    {
+        bytes memory suffixBytes = bytes(suffix);
+        for (uint256 i = 0; i < entries.length; i++) {
+            bytes memory p = bytes(entries[i].path);
+            if (p.length < suffixBytes.length) continue;
+            bool matches = true;
+            for (uint256 j = 0; j < suffixBytes.length; j++) {
+                if (p[p.length - suffixBytes.length + j] != suffixBytes[j]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return true;
+        }
+        return false;
+    }
+
+    function test_escapeThenReenter_doesNotLeakIntermediateNames() public {
+        Vm.DirEntry[] memory entries = vm.readDir("allowed", 10, true);
+
+        require(!_hasPathEndingWith(entries, "hidden_dir"), "leaked outside directory name");
+        require(!_hasPathEndingWith(entries, "reentry"), "leaked outside symlink name");
+        require(
+            !_hasPathEndingWith(entries, "escape/hidden_dir/reentry/visible.txt"),
+            "leaked file reached only via the escaped chain"
+        );
+        // Reached directly through the in-bounds `allowed/local`, unrelated to the escape - must
+        // still be listed once.
+        require(_hasPathEndingWith(entries, "local/visible.txt"), "direct in-bounds entry missing");
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--mt", "test_escapeThenReenter_doesNotLeakIntermediateNames"])
+        .assert_success();
+});
+
+// A root that's genuinely authorized (granted directly, not merely inheriting from a permitted
+// ancestor) must still surface its own read error - e.g. because it doesn't exist - rather than
+// silently returning an empty list. The root is exempt from the parent-boundary check (it was
+// already validated by `ensure_path_allowed` before the walk starts), and that exemption must
+// extend to the root's *error* entry, not just a successful one.
+#[cfg(unix)]
+forgetest_init!(readdir_root_error_preserved_even_if_parent_unpermitted, |prj, cmd| {
+    // Permission is granted directly on `missing_root` itself; its parent (`prj.root()`) is not
+    // separately permitted, so a naive parent-based check on the root's own error would drop it.
+    let missing_root = prj.root().join("missing_root");
+
+    prj.update_config(|config| {
+        config.fs_permissions.add(PathPermission::read(missing_root.clone()));
+    });
+
+    prj.add_raw_test(
+        "ReadDirMissingRoot.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface Vm {
+    struct DirEntry {
+        string errorMessage;
+        string path;
+        uint64 depth;
+        bool isDir;
+        bool isSymlink;
+    }
+
+    function readDir(string calldata path, uint64 maxDepth, bool followLinks)
+        external
+        view
+        returns (DirEntry[] memory entries);
+}
+
+contract ReadDirMissingRootTest {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function test_missingRoot_stillReportsItsOwnError() public {
+        Vm.DirEntry[] memory entries = vm.readDir("missing_root", 1, true);
+        require(entries.length == 1, "expected the root's own error entry, got an empty list");
+        require(bytes(entries[0].errorMessage).length > 0, "root error message was dropped");
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--mt", "test_missingRoot_stillReportsItsOwnError"]).assert_success();
+});
+
+// A permitted directory containing a symlink to *another* permitted directory must still list
+// everything reached through it with `followLinks: true` - the fix must stop an escaping walk,
+// not a legitimate one.
+#[cfg(unix)]
+forgetest_init!(readdir_still_follows_symlink_to_another_permitted_dir, |prj, cmd| {
+    let allowed = prj.root().join("allowed");
+    fs::create_dir(&allowed).unwrap();
+    let allowed_more = prj.root().join("allowed_more");
+    fs::create_dir(&allowed_more).unwrap();
+    fs::write(allowed_more.join("deep.txt"), "fine").unwrap();
+    std::os::unix::fs::symlink(&allowed_more, allowed.join("link_to_more")).unwrap();
+
+    prj.update_config(|config| {
+        config.fs_permissions.add(PathPermission::read(prj.root().join("allowed")));
+        config.fs_permissions.add(PathPermission::read(prj.root().join("allowed_more")));
+    });
+
+    prj.add_raw_test(
+        "ReadDirLegitimateSymlink.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface Vm {
+    struct DirEntry {
+        string errorMessage;
+        string path;
+        uint64 depth;
+        bool isDir;
+        bool isSymlink;
+    }
+
+    function readDir(string calldata path, uint64 maxDepth, bool followLinks)
+        external
+        view
+        returns (DirEntry[] memory entries);
+}
+
+contract ReadDirLegitimateSymlinkTest {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function _hasPathEndingWith(Vm.DirEntry[] memory entries, string memory suffix)
+        internal
+        pure
+        returns (bool)
+    {
+        bytes memory suffixBytes = bytes(suffix);
+        for (uint256 i = 0; i < entries.length; i++) {
+            bytes memory p = bytes(entries[i].path);
+            if (p.length < suffixBytes.length) continue;
+            bool matches = true;
+            for (uint256 j = 0; j < suffixBytes.length; j++) {
+                if (p[p.length - suffixBytes.length + j] != suffixBytes[j]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return true;
+        }
+        return false;
+    }
+
+    function test_legitimateSymlinkTarget_stillListed() public {
+        Vm.DirEntry[] memory entries = vm.readDir("allowed", 10, true);
+        require(_hasPathEndingWith(entries, "link_to_more"), "symlink's own name missing");
+        require(_hasPathEndingWith(entries, "link_to_more/deep.txt"), "legitimate symlink target not followed");
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--mt", "test_legitimateSymlinkTarget_stillListed"]).assert_success();
+});
+
+// A permitted directory with no escaping symlink at all must list identically to before this
+// fix - the parent-boundary check must never affect an ordinary, fully in-bounds walk.
+#[cfg(unix)]
+forgetest_init!(readdir_unaffected_when_no_symlink_present, |prj, cmd| {
+    let allowed = prj.root().join("allowed_plain");
+    fs::create_dir(&allowed).unwrap();
+    fs::write(allowed.join("a.txt"), "a").unwrap();
+    let nested = allowed.join("nested");
+    fs::create_dir(&nested).unwrap();
+    fs::write(nested.join("b.txt"), "b").unwrap();
+
+    prj.update_config(|config| {
+        config.fs_permissions.add(PathPermission::read(prj.root().join("allowed_plain")));
+    });
+
+    prj.add_raw_test(
+        "ReadDirNoSymlink.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface Vm {
+    struct DirEntry {
+        string errorMessage;
+        string path;
+        uint64 depth;
+        bool isDir;
+        bool isSymlink;
+    }
+
+    function readDir(string calldata path, uint64 maxDepth, bool followLinks)
+        external
+        view
+        returns (DirEntry[] memory entries);
+}
+
+contract ReadDirNoSymlinkTest {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function test_ordinaryWalk_listsEverything() public {
+        Vm.DirEntry[] memory entries = vm.readDir("allowed_plain", 10, true);
+        require(entries.length == 3, "a.txt, nested/, nested/b.txt");
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--mt", "test_ordinaryWalk_listsEverything"]).assert_success();
+});


### PR DESCRIPTION
## Summary

`vm.readDir(path, maxDepth, followLinks: true)` only checks the *root* path against `fs_permissions` before walking (`crates/cheatcodes/src/fs.rs`, `read_dir`). With `followLinks: true`, `WalkDir` follows a symlink inside a permitted directory out to wherever it points, and every entry found beyond it was returned completely unchecked - a permitted directory containing a stray symlink could be used to enumerate file/directory *names* anywhere else on disk the walk could reach. `vm.readFile` on the identical escaped path is (and was) correctly rejected; only `readDir` skipped the equivalent per-entry check.

**Severity, honestly**: this is listing/enumeration disclosure only (file and directory *names*), not content disclosure - reading the content of anything discovered this way still goes through `readFile`'s existing, unaffected check. It also requires a symlink to already exist inside a permitted directory pointing outside it; there's no symlink-creation cheatcode, so this can't be self-planted by a test running under `forge test` - it requires the symlink to already be present from some external source (a compromised/malicious submodule, a build artifact, a pre-existing environment quirk).

## Fix

Prune the walk with `WalkDir::filter_entry` (not a post-hoc `.filter()`) the moment an entry's *parent* resolves outside the `fs_permissions` boundary, so nothing beneath an escaping symlink is ever queued or returned by `WalkDir` - this matters specifically for a symlink chain that escapes and then, further down its own target tree, resolves back to somewhere legitimately in-bounds: a post-hoc filter that only judges each entry by its fully-resolved final location would still let that leak through, since canonicalizing only the immediate parent erases the fact that reaching it required stepping outside the sandbox first. `filter_entry` stops descent at the first escaping step instead.

The check is on each entry's *parent*, not the entry's own path - canonicalizing the entry itself would also resolve a symlink that *is* the entry (e.g. the escaping symlink's own name inside the permitted directory), which would incorrectly hide that name even when it isn't followed (`followLinks: false` must list it unchanged, and does).

The root entry/error (depth 0) is exempt from the parent check: it was already validated by `ensure_path_allowed` before the walk starts, and a permission can be granted for a directory without separately granting its parent - checking the root's own parent would incorrectly reject a fully legitimate root. A non-root `WalkDir` error that carries no path at all (an internal I/O failure with no path context) fails closed (excluded) rather than defaulting to kept, since there's nothing to check its boundary against.

## Review history (disclosed for transparency)

This went through two rounds of adversarial Codex review before the version in this PR:

- **Round 1** caught that an earlier version (checking only via a post-hoc `.filter()`) still leaked names on an escape-then-reenter chain, silently dropped a genuinely-authorized root's own read error, and had tests that didn't meaningfully exercise `followLinks: true` traversal.
- **Round 2**, after switching to `filter_entry`, independently traced all 5 test scenarios by hand and confirmed the fix is correct, but found one smaller residual gap: a non-root `WalkDir` error without a path defaulted to being kept rather than rejected, which could leak an OS error message + depth (not a filename) for something behind an escaped symlink. Fixed by failing closed on that case.

All findings from both rounds are addressed in the diff as it stands.

## Testing

`crates/forge/tests/cli/test_cmd/readdir_fs_permissions.rs`, 5 new tests:
- `readdir_does_not_follow_symlink_out_of_fs_permissions_boundary` - the core bug: `followLinks: true` excludes everything beyond the escaping symlink; `followLinks: false` is unaffected; `readFile` on the same escaped path still correctly reverts.
- `readdir_does_not_leak_names_when_escape_reenters_boundary` - the escape-then-reenter chain from round 1's review.
- `readdir_root_error_preserved_even_if_parent_unpermitted` - round 1's root-error-dropped finding.
- `readdir_still_follows_symlink_to_another_permitted_dir` - positive control: a symlink to a *separately permitted* directory is still followed and listed, proving the fix stops an escaping walk, not a legitimate one.
- `readdir_unaffected_when_no_symlink_present` - an ordinary in-bounds walk lists identically to before the fix.

Verified true red-before/green-after via `git stash` against unmodified `origin/master` for every scenario: the 2 security-relevant tests fail on master, the other 3 pass on master too (confirming they aren't master bugs, just regression coverage for the fix's own correctness). Full `foundry-cheatcodes` unit suite (76 tests) and the full `testdata` integration suite (`Fs.t.sol`'s existing `testReadDir`/`testFsMetadata`, etc.) pass unchanged. `cargo fmt`/`clippy --all-features` clean on the changed files.

closes nothing (no existing issue tracked this - found via manual code review of the `fs_permissions` cheatcode family)