### PR TITLE
fix(lint): track stale-balance relations

### DIFF
--- a/.changelog/lint-balance-relations.md
+++ b/.changelog/lint-balance-relations.md
@@ -2,4 +2,4 @@
 forge-lint: patch
 ---
 
-Recognize stale-balance differences through arithmetic offsets, locals, and internal helper returns in `reentrancy-balance`, and avoid warnings based only on the presence of unrelated balance terms.
+Recognize stale-balance differences through arithmetic offsets, locals, and internal helper returns in `reentrancy-balance`, preserve direct comparisons with transformed balances and conditional operands, and avoid treating unsupported same-side arithmetic as a balance difference.

--- a/.changelog/lint-balance-relations.md
+++ b/.changelog/lint-balance-relations.md
@@ -1,0 +1,5 @@
+---
+forge-lint: patch
+---
+
+Recognize stale-balance differences through arithmetic offsets, locals, and internal helper returns in `reentrancy-balance`, and avoid warnings based only on the presence of unrelated balance terms.

--- a/.changelog/lint-balance-relations.md
+++ b/.changelog/lint-balance-relations.md
@@ -2,4 +2,4 @@
 forge-lint: patch
 ---
 
-Recognize stale-balance differences through arithmetic offsets, locals, and internal helper returns in `reentrancy-balance`, preserve direct comparisons with transformed balances and conditional operands, and avoid treating unsupported same-side arithmetic as a balance difference.
+Recognize stale-balance differences through arithmetic offsets, locals, and internal helper returns in `reentrancy-balance`. Preserve direct comparisons with conditional operands and transformed balances, including through assignments and helper returns, without treating unsupported same-side arithmetic as a balance difference.

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -1022,16 +1022,35 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                         | BinOpKind::Ne
                 );
                 (is_comparison && {
+                    let lhs_dependencies = self.balance_operand_dependencies(lhs, state);
+                    let rhs_dependencies = self.balance_operand_dependencies(rhs, state);
+                    let direct = lhs_dependencies.iter().any(|lhs| {
+                        rhs_dependencies.iter().any(|rhs| {
+                            paths_compatible(&lhs.path, &rhs.path)
+                                && call.iter().any(|path| {
+                                    paths_compatible(path, &lhs.path)
+                                        && paths_compatible(path, &rhs.path)
+                                })
+                                && lhs.terms.iter().any(|a| {
+                                    rhs.terms.iter().any(|b| {
+                                        a.stale_calls.contains(&span)
+                                            != b.stale_calls.contains(&span)
+                                    })
+                                })
+                        })
+                    });
                     let lhs = self.balance_forms(lhs, state);
                     let rhs = self.balance_forms(rhs, state);
-                    lhs.iter().any(|lhs| {
-                        rhs.iter().filter_map(|rhs| lhs.combine(rhs, true)).any(|form| {
-                            let [a, b] = form.terms.as_slice() else { return false };
-                            a.negative != b.negative
-                                && a.stale_calls.contains(&span) != b.stale_calls.contains(&span)
-                                && call.iter().any(|path| paths_compatible(path, &form.path))
+                    direct
+                        || lhs.iter().any(|lhs| {
+                            rhs.iter().filter_map(|rhs| lhs.combine(rhs, true)).any(|form| {
+                                let [a, b] = form.terms.as_slice() else { return false };
+                                a.negative != b.negative
+                                    && a.stale_calls.contains(&span)
+                                        != b.stale_calls.contains(&span)
+                                    && call.iter().any(|path| paths_compatible(path, &form.path))
+                            })
                         })
-                    })
                 }) || recurse(lhs, state)
                     || recurse(rhs, state)
             }
@@ -1231,6 +1250,35 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         }
     }
 
+    /// Retains balance occurrences across comparison operands without assuming arithmetic
+    /// identities.
+    fn balance_operand_dependencies(
+        &self,
+        expr: &'gcx Expr<'gcx>,
+        state: &FlowState,
+    ) -> BTreeSet<BalanceForm> {
+        let recurse = |expr| self.balance_operand_dependencies(expr, state);
+        match &expr.peel_parens().kind {
+            ExprKind::Binary(lhs, _, rhs) => [*lhs, *rhs].into_iter().flat_map(recurse).collect(),
+            ExprKind::Unary(_, inner) | ExprKind::Payable(inner) => recurse(inner),
+            ExprKind::Ternary(cond, true_expr, false_expr) => {
+                let mut then_state = state.clone();
+                let mut else_state = state.clone();
+                let (then_reachable, else_reachable) =
+                    self.split_on(cond, &mut then_state, &mut else_state);
+                [(true_expr, then_state, then_reachable), (false_expr, else_state, else_reachable)]
+                    .into_iter()
+                    .filter(|(_, _, reachable)| *reachable)
+                    .flat_map(|(expr, state, _)| self.balance_operand_dependencies(expr, &state))
+                    .collect()
+            }
+            ExprKind::Call(..) if let Some(args) = cast_args(expr) => {
+                args.exprs().flat_map(recurse).collect()
+            }
+            _ => self.balance_forms(expr, state),
+        }
+    }
+
     /// Preserves balance terms through addition/subtraction and value-preserving integer casts.
     /// Other operators may form independent offsets, but cannot transform balance terms.
     /// Unsupported expressions return no forms, rather than an independent offset.
@@ -1265,6 +1313,17 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                         .collect(),
                     None => independent(),
                 }
+            }
+            ExprKind::Ternary(cond, true_expr, false_expr) => {
+                let mut then_state = state.clone();
+                let mut else_state = state.clone();
+                let (then_reachable, else_reachable) =
+                    self.split_on(cond, &mut then_state, &mut else_state);
+                [(true_expr, then_state, then_reachable), (false_expr, else_state, else_reachable)]
+                    .into_iter()
+                    .filter(|(_, _, reachable)| *reachable)
+                    .flat_map(|(expr, state, _)| self.balance_forms(expr, &state))
+                    .collect()
             }
             ExprKind::Binary(lhs, op, rhs) => {
                 let lhs = self.balance_forms(lhs, state);

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -5,9 +5,9 @@ use crate::{
         Severity, SolLint,
         analysis::{
             DEFAULT_HELPER_ANALYSIS_CACHE_LIMIT, HelperAnalysisCache, arg_for_param,
-            branch_always_exits, count_placeholders, for_each_child, for_each_lhs_var,
-            function_ids, is_address_cast, is_address_like, is_builtin, is_inc_dec,
-            is_require_or_assert, lhs_local_var, loop_update, state_lhs_vars,
+            branch_always_exits, cast_type, count_placeholders, expr_ty, for_each_child,
+            for_each_lhs_var, function_ids, is_address_cast, is_address_like, is_builtin,
+            is_inc_dec, is_require_or_assert, lhs_local_var, loop_update, state_lhs_vars,
             stmts_before_placeholder, tuple_elems, unique,
         },
     },
@@ -19,8 +19,8 @@ use solar::{
     sema::{
         Gcx,
         hir::{
-            self, CallArgs, CallOptions, Expr, ExprKind, FunctionId, ItemId, LoopSource, Res, Stmt,
-            StmtKind, VariableId, Visit,
+            self, CallArgs, CallOptions, ElementaryType, Expr, ExprKind, FunctionId, ItemId,
+            LoopSource, Res, Stmt, StmtKind, VariableId, Visit,
         },
         ty::{TyFnKind, TyKind},
     },
@@ -100,21 +100,16 @@ struct FlowState {
     self_address_local_paths: BTreeMap<VariableId, PathAlternatives>,
     /// Locals derived from `address(this).balance`, with the predicates under which they are.
     balance_local_paths: BTreeMap<VariableId, PathAlternatives>,
+    /// Supported arithmetic forms of local values; an empty set means unknown.
+    balance_local_forms: BTreeMap<VariableId, BTreeSet<BalanceForm>>,
     /// Locals holding a comparison against a balance made stale by the given calls.
     balance_comparison_locals: BTreeMap<VariableId, BTreeSet<Span>>,
     /// External calls after which cached balance locals are stale.
-    pending_balance_calls: BTreeMap<Span, PendingBalanceCall>,
+    pending_balance_calls: BTreeMap<Span, PathAlternatives>,
     /// Reentrancy-guard locks written or bypassed while active.
     invalidated_balance_guards: BTreeSet<VariableId>,
     /// Boolean facts known to hold on this path.
     path_predicates: PathPredicates,
-}
-
-/// Balance locals made stale by an external call, and the predicates under which it was made.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-struct PendingBalanceCall {
-    stale_locals: BTreeSet<VariableId>,
-    paths: PathAlternatives,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -148,30 +143,71 @@ enum ReentrantCallKind {
     NoEth,
 }
 
+/// One signed balance read, retaining the calls across which it was cached.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct BalanceTerm {
+    negative: bool,
+    stale_calls: BTreeSet<Span>,
+}
+
+/// A supported additive source pattern on one path. An empty term list is balance-independent.
+/// At most two balance terms are retained: a stale/current comparison needs one of each. More
+/// terms are rejected rather than cancelled, since Solidity arithmetic may wrap or revert.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct BalanceForm {
+    terms: Vec<BalanceTerm>,
+    path: PathPredicates,
+}
+
+impl BalanceForm {
+    fn combine(&self, rhs: &Self, subtract: bool) -> Option<Self> {
+        if self.terms.len() + rhs.terms.len() > 2 || !paths_compatible(&self.path, &rhs.path) {
+            return None;
+        }
+        let mut terms = self.terms.clone();
+        terms.extend(rhs.terms.iter().cloned().map(|mut term| {
+            term.negative ^= subtract;
+            term
+        }));
+        Some(Self {
+            terms,
+            path: self.path.iter().chain(&rhs.path).map(|(p, v)| (*p, *v)).collect(),
+        })
+    }
+
+    fn constrained(&self, active: &PathPredicates) -> Option<Self> {
+        paths_compatible(&self.path, active).then(|| Self {
+            terms: self.terms.clone(),
+            path: self.path.iter().chain(active).map(|(p, v)| (*p, *v)).collect(),
+        })
+    }
+}
+
 /// Balance-related facts about a value flowing into a local, parameter or return slot.
 #[derive(Clone, Debug, Default)]
 struct BalanceValue {
+    /// Supported arithmetic forms, separate from occurrence-based dependencies.
+    forms: BTreeSet<BalanceForm>,
     /// Predicates under which the value derives from `address(this).balance`.
     balance_paths: PathAlternatives,
     /// Predicates under which the value is `address(this)`.
     self_address_paths: PathAlternatives,
-    /// Calls after which the balance the value derives from went stale.
-    stale_calls: BTreeSet<Span>,
     /// Calls whose stale balance the value compares against.
     stale_comparisons: BTreeSet<Span>,
 }
 
 impl BalanceValue {
     fn merge(&mut self, other: Self) {
+        self.forms.extend(other.forms);
         self.balance_paths.extend(other.balance_paths);
         self.self_address_paths.extend(other.self_address_paths);
-        self.stale_calls.extend(other.stale_calls);
         self.stale_comparisons.extend(other.stale_comparisons);
     }
 
     /// The same value seen from a path on which `predicates` hold.
     fn constrained(&self, predicates: &PathPredicates) -> Self {
         Self {
+            forms: self.forms.iter().filter_map(|form| form.constrained(predicates)).collect(),
             balance_paths: constrain_paths(&self.balance_paths, predicates),
             self_address_paths: constrain_paths(&self.self_address_paths, predicates),
             ..self.clone()
@@ -187,18 +223,28 @@ impl FlowState {
     }
 
     fn push_balance_call(&mut self, span: Span) {
-        let stale_locals = self
+        if self
             .balance_local_paths
-            .iter()
-            .filter(|(_, paths)| {
-                paths.iter().any(|path| paths_compatible(path, &self.path_predicates))
-            })
-            .map(|(var_id, _)| *var_id)
-            .collect::<BTreeSet<_>>();
-        if !stale_locals.is_empty() {
-            let call = self.pending_balance_calls.entry(span).or_default();
-            call.stale_locals.extend(stale_locals);
-            call.paths.insert(self.path_predicates.clone());
+            .values()
+            .any(|paths| paths.iter().any(|path| paths_compatible(path, &self.path_predicates)))
+        {
+            self.pending_balance_calls
+                .entry(span)
+                .or_default()
+                .insert(self.path_predicates.clone());
+            for forms in self.balance_local_forms.values_mut() {
+                *forms = std::mem::take(forms)
+                    .into_iter()
+                    .map(|mut form| {
+                        if paths_compatible(&form.path, &self.path_predicates) {
+                            for term in &mut form.terms {
+                                term.stale_calls.insert(span);
+                            }
+                        }
+                        form
+                    })
+                    .collect();
+            }
         }
     }
 
@@ -212,13 +258,10 @@ impl FlowState {
         merge_maps(&mut self.internal_function_targets, &other.internal_function_targets);
         merge_maps(&mut self.self_address_local_paths, &other.self_address_local_paths);
         merge_maps(&mut self.balance_local_paths, &other.balance_local_paths);
+        merge_maps(&mut self.balance_local_forms, &other.balance_local_forms);
         merge_maps(&mut self.balance_comparison_locals, &other.balance_comparison_locals);
         self.invalidated_balance_guards.extend(&other.invalidated_balance_guards);
-        for (span, other_call) in &other.pending_balance_calls {
-            let call = self.pending_balance_calls.entry(*span).or_default();
-            call.stale_locals.extend(&other_call.stale_locals);
-            call.paths.extend(other_call.paths.iter().cloned());
-        }
+        merge_maps(&mut self.pending_balance_calls, &other.pending_balance_calls);
     }
 
     fn balance_only(&self) -> Self {
@@ -426,7 +469,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                     self.analyze_expr(init, state);
                     self.update_internal_function_target(state, var_id, init);
                     if self.reentrancy_balance_enabled {
-                        self.bind_locals(state, &[Some(var_id)], init, false);
+                        self.bind_locals(state, &[Some(var_id)], init, None);
                     }
                 } else if self.reentrancy_balance_enabled {
                     self.set_self_address_paths(state, var_id, PathAlternatives::new());
@@ -436,7 +479,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             StmtKind::DeclMulti(vars, expr) => {
                 self.analyze_expr(expr, state);
                 if self.reentrancy_balance_enabled {
-                    self.bind_locals(state, vars, expr, false);
+                    self.bind_locals(state, vars, expr, None);
                 }
                 true
             }
@@ -582,7 +625,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                             .collect(),
                         None => vec![lhs_local_var(&self.gcx.hir, lhs)],
                     };
-                    self.bind_locals(state, &targets, rhs, op.is_some());
+                    self.bind_locals(state, &targets, rhs, op.map(|op| op.kind));
                 }
             }
             ExprKind::Delete(inner) => {
@@ -950,7 +993,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         &self,
         expr: &'gcx Expr<'gcx>,
         span: Span,
-        call: &PendingBalanceCall,
+        call: &PathAlternatives,
         state: &FlowState,
     ) -> bool {
         let expr = expr.peel_parens();
@@ -978,12 +1021,18 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                         | BinOpKind::Eq
                         | BinOpKind::Ne
                 );
-                let depends = |e, stale| self.expr_depends_on_balance(e, span, call, stale, state);
-                (is_comparison
-                    && [(lhs, rhs), (rhs, lhs)]
-                        .into_iter()
-                        .any(|(current, stale)| depends(current, false) && depends(stale, true)))
-                    || recurse(lhs, state)
+                (is_comparison && {
+                    let lhs = self.balance_forms(lhs, state);
+                    let rhs = self.balance_forms(rhs, state);
+                    lhs.iter().any(|lhs| {
+                        rhs.iter().filter_map(|rhs| lhs.combine(rhs, true)).any(|form| {
+                            let [a, b] = form.terms.as_slice() else { return false };
+                            a.negative != b.negative
+                                && a.stale_calls.contains(&span) != b.stale_calls.contains(&span)
+                                && call.iter().any(|path| paths_compatible(path, &form.path))
+                        })
+                    })
+                }) || recurse(lhs, state)
                     || recurse(rhs, state)
             }
             ExprKind::Unary(_, inner) | ExprKind::Payable(inner) => recurse(inner, state),
@@ -1012,7 +1061,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         state: &mut FlowState,
         targets: &[Option<VariableId>],
         rhs: &'gcx Expr<'gcx>,
-        reads_old_value: bool,
+        op: Option<BinOpKind>,
     ) {
         if targets.iter().all(Option::is_none) {
             return;
@@ -1020,9 +1069,9 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         let values = self.balance_values(rhs, state);
         for (var_id, value) in targets.iter().zip(values) {
             let Some(var_id) = *var_id else { continue };
-            self.set_balance_local(state, var_id, &value, reads_old_value);
+            self.set_balance_local(state, var_id, &value, op);
             let paths =
-                if reads_old_value { PathAlternatives::new() } else { value.self_address_paths };
+                if op.is_some() { PathAlternatives::new() } else { value.self_address_paths };
             self.set_self_address_paths(state, var_id, paths);
         }
     }
@@ -1045,24 +1094,29 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         state: &mut FlowState,
         var_id: VariableId,
         value: &BalanceValue,
-        reads_old_value: bool,
+        op: Option<BinOpKind>,
     ) {
+        let forms = match op {
+            None => value.forms.clone(),
+            Some(op @ (BinOpKind::Add | BinOpKind::Sub)) => state
+                .balance_local_forms
+                .get(&var_id)
+                .into_iter()
+                .flatten()
+                .flat_map(|lhs| {
+                    value.forms.iter().filter_map(move |rhs| lhs.combine(rhs, op == BinOpKind::Sub))
+                })
+                .collect(),
+            Some(_) => BTreeSet::new(),
+        };
+        state.balance_local_forms.insert(var_id, forms);
         let mut balance_paths = value.balance_paths.clone();
         let mut stale_comparisons = value.stale_comparisons.clone();
-        if reads_old_value {
+        if op.is_some() {
             balance_paths
                 .extend(state.balance_local_paths.get(&var_id).into_iter().flatten().cloned());
             stale_comparisons
                 .extend(state.balance_comparison_locals.get(&var_id).into_iter().flatten());
-        }
-        for (span, call) in &mut state.pending_balance_calls {
-            if value.stale_calls.contains(span)
-                || (reads_old_value && call.stale_locals.contains(&var_id))
-            {
-                call.stale_locals.insert(var_id);
-            } else {
-                call.stale_locals.remove(&var_id);
-            }
         }
         state.balance_local_paths.remove(&var_id);
         state.balance_comparison_locals.remove(&var_id);
@@ -1093,15 +1147,9 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
     fn balance_dependency(&self, expr: &'gcx Expr<'gcx>, state: &FlowState) -> BalanceValue {
         let pending = &state.pending_balance_calls;
         BalanceValue {
+            forms: self.balance_forms(expr, state),
             balance_paths: self.expr_balance_paths(expr, state),
             self_address_paths: self.self_address_path(expr, state),
-            stale_calls: pending
-                .iter()
-                .filter(|(span, call)| {
-                    self.expr_depends_on_balance(expr, **span, call, true, state)
-                })
-                .map(|(span, _)| *span)
-                .collect(),
             stale_comparisons: pending
                 .iter()
                 .filter(|(span, call)| {
@@ -1183,49 +1231,89 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         }
     }
 
-    /// True if `expr` reads the contract balance as it was before the pending `call` (`stale`)
-    /// or as it is after it, directly or through a local.
-    fn expr_depends_on_balance(
-        &self,
-        expr: &'gcx Expr<'gcx>,
-        span: Span,
-        call: &PendingBalanceCall,
-        stale: bool,
-        state: &FlowState,
-    ) -> bool {
+    /// Preserves balance terms through addition/subtraction and value-preserving integer casts.
+    /// Other operators may form independent offsets, but cannot transform balance terms.
+    /// Unsupported expressions return no forms, rather than an independent offset.
+    fn balance_forms(&self, expr: &'gcx Expr<'gcx>, state: &FlowState) -> BTreeSet<BalanceForm> {
         let expr = expr.peel_parens();
-        let self_balance = self.self_balance_paths(expr, state);
-        if !self_balance.is_empty() {
-            return !stale
-                && self_balance
-                    .iter()
-                    .any(|lhs| call.paths.iter().any(|rhs| paths_compatible(lhs, rhs)));
+        let paths = self.self_balance_paths(expr, state);
+        if !paths.is_empty() {
+            return paths
+                .into_iter()
+                .map(|path| BalanceForm {
+                    terms: vec![BalanceTerm { negative: false, stale_calls: BTreeSet::new() }],
+                    path,
+                })
+                .collect();
         }
-        let recurse = |e| self.expr_depends_on_balance(e, span, call, stale, state);
+        let independent = || {
+            BTreeSet::from([BalanceForm {
+                path: state.path_predicates.clone(),
+                ..BalanceForm::default()
+            }])
+        };
         match &expr.kind {
-            ExprKind::Ident(reses) => reses.iter().filter_map(Res::as_variable).any(|v| {
-                let is_stale = call.stale_locals.contains(&v);
-                if stale {
-                    is_stale
-                } else {
-                    !is_stale && state.balance_local_paths.contains_key(&v)
+            ExprKind::Lit(_) => independent(),
+            ExprKind::Ident(reses) => {
+                let Some(var) = unique(reses.iter().filter_map(Res::as_variable)) else {
+                    return BTreeSet::new();
+                };
+                match state.balance_local_forms.get(&var) {
+                    Some(forms) => forms
+                        .iter()
+                        .filter_map(|form| form.constrained(&state.path_predicates))
+                        .collect(),
+                    None => independent(),
                 }
-            }),
-            ExprKind::Unary(_, inner) | ExprKind::Payable(inner) => recurse(inner),
-            ExprKind::Binary(lhs, _, rhs) => recurse(lhs) || recurse(rhs),
-            ExprKind::Ternary(cond, true_expr, false_expr) => {
-                [*cond, *true_expr, *false_expr].into_iter().any(recurse)
             }
-            ExprKind::Call(..) => match cast_args(expr) {
-                Some(args) => args.exprs().any(recurse),
-                None => self.call_balance_values.get(&expr.span).is_some_and(|values| {
-                    values.iter().any(|value| {
-                        let is_stale = value.stale_calls.contains(&span);
-                        if stale { is_stale } else { !is_stale && !value.balance_paths.is_empty() }
+            ExprKind::Binary(lhs, op, rhs) => {
+                let lhs = self.balance_forms(lhs, state);
+                let rhs = self.balance_forms(rhs, state);
+                lhs.iter()
+                    .flat_map(|lhs| {
+                        rhs.iter().filter_map(|rhs| {
+                            if matches!(op.kind, BinOpKind::Add | BinOpKind::Sub)
+                                || (lhs.terms.is_empty() && rhs.terms.is_empty())
+                            {
+                                lhs.combine(rhs, op.kind == BinOpKind::Sub)
+                            } else {
+                                None
+                            }
+                        })
                     })
-                }),
-            },
-            _ => false,
+                    .collect()
+            }
+            ExprKind::Call(callee, args, _) if cast_type(callee).is_some() && args.len() == 1 => {
+                let inner = args.exprs().next().expect("one argument");
+                let preserving = match (expr_ty(self.gcx, inner), expr_ty(self.gcx, expr)) {
+                    (Some(from), Some(to)) => match (from.kind, to.kind) {
+                        (
+                            TyKind::Elementary(ElementaryType::UInt(from)),
+                            TyKind::Elementary(ElementaryType::UInt(to)),
+                        )
+                        | (
+                            TyKind::Elementary(ElementaryType::Int(from)),
+                            TyKind::Elementary(ElementaryType::Int(to)),
+                        ) => from.bits() <= to.bits(),
+                        _ => false,
+                    },
+                    _ => false,
+                };
+                self.balance_forms(inner, state)
+                    .into_iter()
+                    .filter(|form| preserving || form.terms.is_empty())
+                    .collect()
+            }
+            ExprKind::Call(..) => self
+                .call_balance_values
+                .get(&expr.span)
+                .into_iter()
+                .flatten()
+                .flat_map(|value| {
+                    value.forms.iter().filter_map(|form| form.constrained(&state.path_predicates))
+                })
+                .collect(),
+            _ => BTreeSet::new(),
         }
     }
 
@@ -1241,14 +1329,14 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         }
         for &param in func.parameters {
             match arg_for_param(&self.gcx.hir, func, param, args) {
-                Some(arg) => self.bind_locals(state, &[Some(param)], arg, false),
+                Some(arg) => self.bind_locals(state, &[Some(param)], arg, None),
                 None => self.clear_local(state, param),
             }
         }
     }
 
     fn clear_local(&self, state: &mut FlowState, var_id: VariableId) {
-        self.set_balance_local(state, var_id, &BalanceValue::default(), false);
+        self.set_balance_local(state, var_id, &BalanceValue::default(), None);
         self.set_self_address_paths(state, var_id, PathAlternatives::new());
     }
 
@@ -1276,18 +1364,13 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
     /// The balance facts currently recorded for the local `var_id`.
     fn local_value(&self, var_id: VariableId, state: &FlowState) -> BalanceValue {
         BalanceValue {
+            forms: state.balance_local_forms.get(&var_id).cloned().unwrap_or_default(),
             balance_paths: state.balance_local_paths.get(&var_id).cloned().unwrap_or_default(),
             self_address_paths: state
                 .self_address_local_paths
                 .get(&var_id)
                 .cloned()
                 .unwrap_or_default(),
-            stale_calls: state
-                .pending_balance_calls
-                .iter()
-                .filter(|(_, call)| call.stale_locals.contains(&var_id))
-                .map(|(span, _)| *span)
-                .collect(),
             stale_comparisons: state
                 .balance_comparison_locals
                 .get(&var_id)
@@ -1302,11 +1385,9 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         state.internal_function_targets.retain(|v, _| !owned(*v));
         state.self_address_local_paths.retain(|v, _| !owned(*v));
         state.balance_local_paths.retain(|v, _| !owned(*v));
+        state.balance_local_forms.retain(|v, _| !owned(*v));
         state.balance_comparison_locals.retain(|v, _| !owned(*v));
         state.path_predicates.retain(|predicate, _| !predicate.mentions(&owned));
-        for call in state.pending_balance_calls.values_mut() {
-            call.stale_locals.retain(|v| !owned(*v));
-        }
     }
 
     fn reentrant_call_kind(
@@ -1466,31 +1547,31 @@ fn remap_return_paths(
     values: &mut [BalanceValue],
 ) {
     let owned = owned_by(hir, func_id);
-    let remap = |paths: &PathAlternatives| -> PathAlternatives {
-        paths
-            .iter()
-            .filter_map(|path| {
-                let mut path = path.clone();
-                for (&parameter, &argument) in parameters.iter().zip(parameter_predicates) {
-                    let Some(parameter_value) = path.remove(&PathPredicate::Boolean(parameter))
-                    else {
-                        continue;
-                    };
-                    let Some((predicate, argument_value)) = argument else { continue };
-                    let mapped = parameter_value == argument_value;
-                    if path.get(&predicate).is_some_and(|existing| *existing != mapped) {
-                        return None;
-                    }
-                    path.insert(predicate, mapped);
+    let remap = |mut path: PathPredicates| {
+        for (&parameter, &argument) in parameters.iter().zip(parameter_predicates) {
+            let Some(parameter_value) = path.remove(&PathPredicate::Boolean(parameter)) else {
+                continue;
+            };
+            if let Some((predicate, argument_value)) = argument {
+                let mapped = parameter_value == argument_value;
+                if path.get(&predicate).is_some_and(|existing| *existing != mapped) {
+                    return None;
                 }
-                path.retain(|predicate, _| !predicate.mentions(&owned));
-                Some(path)
-            })
-            .collect()
+                path.insert(predicate, mapped);
+            }
+        }
+        path.retain(|predicate, _| !predicate.mentions(&owned));
+        Some(path)
     };
     for value in values {
-        value.balance_paths = remap(&value.balance_paths);
-        value.self_address_paths = remap(&value.self_address_paths);
+        value.balance_paths =
+            std::mem::take(&mut value.balance_paths).into_iter().filter_map(remap).collect();
+        value.self_address_paths =
+            std::mem::take(&mut value.self_address_paths).into_iter().filter_map(remap).collect();
+        value.forms = std::mem::take(&mut value.forms)
+            .into_iter()
+            .filter_map(|form| Some(BalanceForm { path: remap(form.path)?, ..form }))
+            .collect();
     }
 }
 
@@ -1504,9 +1585,18 @@ fn forget_path_predicates(state: &mut FlowState, var_id: VariableId) {
             .map(|path| path.iter().filter(|(p, _)| !mentions(p)).map(|(p, v)| (*p, *v)).collect())
             .collect();
     };
+    for forms in state.balance_local_forms.values_mut() {
+        *forms = std::mem::take(forms)
+            .into_iter()
+            .map(|mut form| {
+                form.path.retain(|p, _| !mentions(p));
+                form
+            })
+            .collect();
+    }
     state.balance_local_paths.values_mut().for_each(strip);
     state.self_address_local_paths.values_mut().for_each(strip);
-    state.pending_balance_calls.values_mut().for_each(|call| strip(&mut call.paths));
+    state.pending_balance_calls.values_mut().for_each(strip);
 }
 
 /// Arguments of a plain type conversion such as `uint256(x)` or `address(x)`.

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -102,6 +102,8 @@ struct FlowState {
     balance_local_paths: BTreeMap<VariableId, PathAlternatives>,
     /// Supported arithmetic forms of local values; an empty set means unknown.
     balance_local_forms: BTreeMap<VariableId, BTreeSet<BalanceForm>>,
+    /// Balance occurrences retained through arbitrary arithmetic on local values.
+    balance_local_dependencies: BTreeMap<VariableId, BTreeSet<BalanceForm>>,
     /// Locals holding a comparison against a balance made stale by the given calls.
     balance_comparison_locals: BTreeMap<VariableId, BTreeSet<Span>>,
     /// External calls after which cached balance locals are stale.
@@ -188,6 +190,8 @@ impl BalanceForm {
 struct BalanceValue {
     /// Supported arithmetic forms, separate from occurrence-based dependencies.
     forms: BTreeSet<BalanceForm>,
+    /// Individual balance occurrences, without arithmetic signs or identities.
+    dependencies: BTreeSet<BalanceForm>,
     /// Predicates under which the value derives from `address(this).balance`.
     balance_paths: PathAlternatives,
     /// Predicates under which the value is `address(this)`.
@@ -199,6 +203,7 @@ struct BalanceValue {
 impl BalanceValue {
     fn merge(&mut self, other: Self) {
         self.forms.extend(other.forms);
+        self.dependencies.extend(other.dependencies);
         self.balance_paths.extend(other.balance_paths);
         self.self_address_paths.extend(other.self_address_paths);
         self.stale_comparisons.extend(other.stale_comparisons);
@@ -208,6 +213,11 @@ impl BalanceValue {
     fn constrained(&self, predicates: &PathPredicates) -> Self {
         Self {
             forms: self.forms.iter().filter_map(|form| form.constrained(predicates)).collect(),
+            dependencies: self
+                .dependencies
+                .iter()
+                .filter_map(|form| form.constrained(predicates))
+                .collect(),
             balance_paths: constrain_paths(&self.balance_paths, predicates),
             self_address_paths: constrain_paths(&self.self_address_paths, predicates),
             ..self.clone()
@@ -232,7 +242,11 @@ impl FlowState {
                 .entry(span)
                 .or_default()
                 .insert(self.path_predicates.clone());
-            for forms in self.balance_local_forms.values_mut() {
+            for forms in self
+                .balance_local_forms
+                .values_mut()
+                .chain(self.balance_local_dependencies.values_mut())
+            {
                 *forms = std::mem::take(forms)
                     .into_iter()
                     .map(|mut form| {
@@ -259,6 +273,7 @@ impl FlowState {
         merge_maps(&mut self.self_address_local_paths, &other.self_address_local_paths);
         merge_maps(&mut self.balance_local_paths, &other.balance_local_paths);
         merge_maps(&mut self.balance_local_forms, &other.balance_local_forms);
+        merge_maps(&mut self.balance_local_dependencies, &other.balance_local_dependencies);
         merge_maps(&mut self.balance_comparison_locals, &other.balance_comparison_locals);
         self.invalidated_balance_guards.extend(&other.invalidated_balance_guards);
         merge_maps(&mut self.pending_balance_calls, &other.pending_balance_calls);
@@ -831,6 +846,8 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             let slots = vec![BalanceValue::default(); func.returns.len()];
             self.return_collectors.push((func_id, slots));
         }
+        // Call-site results belong to this invocation; only its evaluation alternatives merge.
+        let caller_balance_values = std::mem::take(&mut self.call_balance_values);
         self.call_stack.push(func_id);
         let mut after = state.clone();
         let falls_through = self.analyze_callable(func, body, &mut after);
@@ -850,6 +867,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                 &mut returns,
             );
         }
+        self.call_balance_values = caller_balance_values;
         self.clear_function_locals(func_id, &mut after);
         if self.balance_only_analysis {
             after = after.balance_only();
@@ -1129,14 +1147,24 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             Some(_) => BTreeSet::new(),
         };
         state.balance_local_forms.insert(var_id, forms);
+        let mut dependencies = value.dependencies.clone();
         let mut balance_paths = value.balance_paths.clone();
         let mut stale_comparisons = value.stale_comparisons.clone();
         if op.is_some() {
+            dependencies.extend(
+                state
+                    .balance_local_dependencies
+                    .get(&var_id)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|form| form.constrained(&state.path_predicates)),
+            );
             balance_paths
                 .extend(state.balance_local_paths.get(&var_id).into_iter().flatten().cloned());
             stale_comparisons
                 .extend(state.balance_comparison_locals.get(&var_id).into_iter().flatten());
         }
+        state.balance_local_dependencies.insert(var_id, dependencies);
         state.balance_local_paths.remove(&var_id);
         state.balance_comparison_locals.remove(&var_id);
         if !balance_paths.is_empty() {
@@ -1167,6 +1195,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         let pending = &state.pending_balance_calls;
         BalanceValue {
             forms: self.balance_forms(expr, state),
+            dependencies: self.balance_operand_dependencies(expr, state),
             balance_paths: self.expr_balance_paths(expr, state),
             self_address_paths: self.self_address_path(expr, state),
             stale_comparisons: pending
@@ -1275,6 +1304,21 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             ExprKind::Call(..) if let Some(args) = cast_args(expr) => {
                 args.exprs().flat_map(recurse).collect()
             }
+            ExprKind::Ident(reses) => reses
+                .iter()
+                .filter_map(Res::as_variable)
+                .filter_map(|var| state.balance_local_dependencies.get(&var))
+                .flatten()
+                .filter_map(|form| form.constrained(&state.path_predicates))
+                .collect(),
+            ExprKind::Call(..) => self
+                .call_balance_values
+                .get(&expr.peel_parens().span)
+                .into_iter()
+                .flatten()
+                .flat_map(|value| &value.dependencies)
+                .filter_map(|form| form.constrained(&state.path_predicates))
+                .collect(),
             _ => self.balance_forms(expr, state),
         }
     }
@@ -1424,6 +1468,11 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
     fn local_value(&self, var_id: VariableId, state: &FlowState) -> BalanceValue {
         BalanceValue {
             forms: state.balance_local_forms.get(&var_id).cloned().unwrap_or_default(),
+            dependencies: state
+                .balance_local_dependencies
+                .get(&var_id)
+                .cloned()
+                .unwrap_or_default(),
             balance_paths: state.balance_local_paths.get(&var_id).cloned().unwrap_or_default(),
             self_address_paths: state
                 .self_address_local_paths
@@ -1445,6 +1494,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         state.self_address_local_paths.retain(|v, _| !owned(*v));
         state.balance_local_paths.retain(|v, _| !owned(*v));
         state.balance_local_forms.retain(|v, _| !owned(*v));
+        state.balance_local_dependencies.retain(|v, _| !owned(*v));
         state.balance_comparison_locals.retain(|v, _| !owned(*v));
         state.path_predicates.retain(|predicate, _| !predicate.mentions(&owned));
     }
@@ -1627,10 +1677,12 @@ fn remap_return_paths(
             std::mem::take(&mut value.balance_paths).into_iter().filter_map(remap).collect();
         value.self_address_paths =
             std::mem::take(&mut value.self_address_paths).into_iter().filter_map(remap).collect();
-        value.forms = std::mem::take(&mut value.forms)
-            .into_iter()
-            .filter_map(|form| Some(BalanceForm { path: remap(form.path)?, ..form }))
-            .collect();
+        for forms in [&mut value.forms, &mut value.dependencies] {
+            *forms = std::mem::take(forms)
+                .into_iter()
+                .filter_map(|form| Some(BalanceForm { path: remap(form.path)?, ..form }))
+                .collect();
+        }
     }
 }
 
@@ -1644,7 +1696,9 @@ fn forget_path_predicates(state: &mut FlowState, var_id: VariableId) {
             .map(|path| path.iter().filter(|(p, _)| !mentions(p)).map(|(p, v)| (*p, *v)).collect())
             .collect();
     };
-    for forms in state.balance_local_forms.values_mut() {
+    for forms in
+        state.balance_local_forms.values_mut().chain(state.balance_local_dependencies.values_mut())
+    {
         *forms = std::mem::take(forms)
             .into_iter()
             .map(|mut form| {

--- a/crates/lint/testdata/ReentrancyBalance.sol
+++ b/crates/lint/testdata/ReentrancyBalance.sol
@@ -47,13 +47,6 @@ contract ReentrancyBalance {
         );
     }
 
-    function assertAfterLowLevelCall(address target, uint256 amount) external {
-        uint256 balanceBefore = address(this).balance;
-        (bool ok,) = target.call(""); //~WARN: external call can be reentered before a stale contract balance is checked
-        require(ok, "call failed");
-        assert(address(this).balance - balanceBefore >= amount);
-    }
-
     function revertingBranchAfterCall(IReentrancyBalanceCallback callback, uint256 amount) external {
         uint256 balanceBefore = address(this).balance;
         callback.pay(); //~WARN: external call can be reentered before a stale contract balance is checked

--- a/crates/lint/testdata/ReentrancyBalance.sol
+++ b/crates/lint/testdata/ReentrancyBalance.sol
@@ -49,7 +49,7 @@ contract ReentrancyBalance {
 
     function assertAfterLowLevelCall(address target, uint256 amount) external {
         uint256 balanceBefore = address(this).balance;
-        (bool ok,) = target.call("");
+        (bool ok,) = target.call(""); //~WARN: external call can be reentered before a stale contract balance is checked
         require(ok, "call failed");
         assert(address(this).balance - balanceBefore >= amount);
     }

--- a/crates/lint/testdata/ReentrancyBalance.stderr
+++ b/crates/lint/testdata/ReentrancyBalance.stderr
@@ -9,14 +9,6 @@ LL │         callback.pay();
 warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
    ╭▸ ROOT/testdata/ReentrancyBalance.sol:LL:CC
    │
-LL │         (bool ok,) = target.call("");
-   │                      ━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
-
-warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
-   ╭▸ ROOT/testdata/ReentrancyBalance.sol:LL:CC
-   │
 LL │         callback.pay();
    │         ━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ReentrancyBalance.stderr
+++ b/crates/lint/testdata/ReentrancyBalance.stderr
@@ -9,6 +9,14 @@ LL │         callback.pay();
 warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
    ╭▸ ROOT/testdata/ReentrancyBalance.sol:LL:CC
    │
+LL │         (bool ok,) = target.call("");
+   │                      ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalance.sol:LL:CC
+   │
 LL │         callback.pay();
    │         ━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ReentrancyBalanceRelations.sol
+++ b/crates/lint/testdata/ReentrancyBalanceRelations.sol
@@ -1,0 +1,151 @@
+//@compile-flags: --only-lint reentrancy-balance
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface IBalanceObservation {
+    function observe() external;
+}
+
+contract ReentrancyBalanceRelations {
+    function inlineDelta(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(address(this).balance - beforeBalance >= amount);
+    }
+
+    function reversedDelta(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(amount <= address(this).balance - beforeBalance);
+    }
+
+    function nestedOffsets(IBalanceObservation target, uint256 amount, uint256 fee) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require((address(this).balance - beforeBalance) - fee >= amount * uint256(2));
+    }
+
+    function preservedCast(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(uint256(address(this).balance - beforeBalance) >= amount);
+    }
+
+    function localDelta(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        uint256 delta = address(this).balance - beforeBalance;
+        require(delta >= amount);
+    }
+
+    function tupleDelta(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        (uint256 delta, uint256 required) = (address(this).balance - beforeBalance, amount);
+        require(delta >= required);
+    }
+
+    function helperDelta(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(difference(address(this).balance, beforeBalance) >= amount);
+    }
+
+    function difference(uint256 current, uint256 previous) internal pure returns (uint256 delta) {
+        delta = current - previous;
+    }
+
+    function compoundDelta(IBalanceObservation target, uint256 amount, uint256 fee) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        uint256 delta = address(this).balance;
+        delta -= beforeBalance;
+        delta -= fee;
+        require(delta >= amount);
+    }
+
+    function reversedContributions(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(beforeBalance - address(this).balance <= amount);
+    }
+
+    // Recognize the source pattern without claiming equivalence to checked arithmetic.
+    function uncheckedDelta(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        unchecked {
+            require(address(this).balance - beforeBalance >= amount);
+        }
+    }
+
+    // No later valid guard may mask an incorrect diagnostic from these negative cases.
+    function unrelatedSubtraction(IBalanceObservation target, uint256 a, uint256 b) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        require(a - b > 0);
+    }
+
+    function additiveComparison(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        require(address(this).balance >= amount - beforeBalance);
+    }
+
+    function repeatedTerms(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        require((address(this).balance + beforeBalance) - beforeBalance >= amount);
+    }
+
+    function multipliedBalance(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        require(address(this).balance * 2 - beforeBalance >= amount);
+    }
+
+    function narrowingCast(IBalanceObservation target, uint128 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        require(uint128(address(this).balance - beforeBalance) >= amount);
+    }
+
+    function signChangingCast(IBalanceObservation target, int256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        require(int256(address(this).balance - beforeBalance) >= amount);
+    }
+
+    function overwrittenDelta(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        uint256 delta = address(this).balance - beforeBalance;
+        delta = amount;
+        require(delta >= amount);
+    }
+
+    function unsupportedCompound(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        uint256 delta = address(this).balance - beforeBalance;
+        delta *= 2;
+        require(delta >= amount);
+    }
+
+    function exclusivePaths(IBalanceObservation target, uint256 amount, bool check) external {
+        uint256 beforeBalance = address(this).balance;
+        if (check) target.observe();
+        if (!check) {
+            uint256 delta = address(this).balance - beforeBalance;
+            require(delta >= amount);
+        }
+    }
+
+    function bothStale(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        uint256 delta = address(this).balance - beforeBalance;
+        target.observe();
+        require(delta >= amount);
+    }
+}

--- a/crates/lint/testdata/ReentrancyBalanceRelations.sol
+++ b/crates/lint/testdata/ReentrancyBalanceRelations.sol
@@ -8,47 +8,35 @@ interface IBalanceObservation {
 }
 
 contract ReentrancyBalanceRelations {
-    function inlineDelta(IBalanceObservation target, uint256 amount) external {
-        uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
-        require(address(this).balance - beforeBalance >= amount);
+    function assertAfterLowLevelCall(address target, uint256 amount) external {
+        uint256 balanceBefore = address(this).balance;
+        (bool ok,) = target.call("");
+        require(ok, "call failed");
+        assert(address(this).balance - balanceBefore >= amount);
     }
 
     function reversedDelta(IBalanceObservation target, uint256 amount) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
-        require(amount <= address(this).balance - beforeBalance);
+        target.observe();
+        require(amount >= beforeBalance - address(this).balance);
     }
 
     function nestedOffsets(IBalanceObservation target, uint256 amount, uint256 fee) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        target.observe();
         require((address(this).balance - beforeBalance) - fee >= amount * uint256(2));
-    }
-
-    function preservedCast(IBalanceObservation target, uint256 amount) external {
-        uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
-        require(uint256(address(this).balance - beforeBalance) >= amount);
-    }
-
-    function localDelta(IBalanceObservation target, uint256 amount) external {
-        uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
-        uint256 delta = address(this).balance - beforeBalance;
-        require(delta >= amount);
     }
 
     function tupleDelta(IBalanceObservation target, uint256 amount) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
-        (uint256 delta, uint256 required) = (address(this).balance - beforeBalance, amount);
+        target.observe();
+        (uint256 delta, uint256 required) = (uint256(address(this).balance - beforeBalance), amount);
         require(delta >= required);
     }
 
     function helperDelta(IBalanceObservation target, uint256 amount) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        target.observe();
         require(difference(address(this).balance, beforeBalance) >= amount);
     }
 
@@ -58,29 +46,13 @@ contract ReentrancyBalanceRelations {
 
     function compoundDelta(IBalanceObservation target, uint256 amount, uint256 fee) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        target.observe();
         uint256 delta = address(this).balance;
         delta -= beforeBalance;
         delta -= fee;
         require(delta >= amount);
     }
 
-    function reversedContributions(IBalanceObservation target, uint256 amount) external {
-        uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
-        require(beforeBalance - address(this).balance <= amount);
-    }
-
-    // Recognize the source pattern without claiming equivalence to checked arithmetic.
-    function uncheckedDelta(IBalanceObservation target, uint256 amount) external {
-        uint256 beforeBalance = address(this).balance;
-        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
-        unchecked {
-            require(address(this).balance - beforeBalance >= amount);
-        }
-    }
-
-    // No later valid guard may mask an incorrect diagnostic from these negative cases.
     function unrelatedSubtraction(IBalanceObservation target, uint256 a, uint256 b) external {
         uint256 beforeBalance = address(this).balance;
         target.observe();
@@ -115,14 +87,6 @@ contract ReentrancyBalanceRelations {
         uint256 beforeBalance = address(this).balance;
         target.observe();
         require(int256(address(this).balance - beforeBalance) >= amount);
-    }
-
-    function overwrittenDelta(IBalanceObservation target, uint256 amount) external {
-        uint256 beforeBalance = address(this).balance;
-        target.observe();
-        uint256 delta = address(this).balance - beforeBalance;
-        delta = amount;
-        require(delta >= amount);
     }
 
     function unsupportedCompound(IBalanceObservation target, uint256 amount) external {

--- a/crates/lint/testdata/ReentrancyBalanceRelations.sol
+++ b/crates/lint/testdata/ReentrancyBalanceRelations.sol
@@ -10,33 +10,33 @@ interface IBalanceObservation {
 contract ReentrancyBalanceRelations {
     function assertAfterLowLevelCall(address target, uint256 amount) external {
         uint256 balanceBefore = address(this).balance;
-        (bool ok,) = target.call("");
+        (bool ok,) = target.call(""); //~WARN: external call can be reentered before a stale contract balance is checked
         require(ok, "call failed");
         assert(address(this).balance - balanceBefore >= amount);
     }
 
     function reversedDelta(IBalanceObservation target, uint256 amount) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe();
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
         require(amount >= beforeBalance - address(this).balance);
     }
 
     function nestedOffsets(IBalanceObservation target, uint256 amount, uint256 fee) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe();
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
         require((address(this).balance - beforeBalance) - fee >= amount * uint256(2));
     }
 
     function tupleDelta(IBalanceObservation target, uint256 amount) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe();
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
         (uint256 delta, uint256 required) = (uint256(address(this).balance - beforeBalance), amount);
         require(delta >= required);
     }
 
     function helperDelta(IBalanceObservation target, uint256 amount) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe();
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
         require(difference(address(this).balance, beforeBalance) >= amount);
     }
 
@@ -46,7 +46,7 @@ contract ReentrancyBalanceRelations {
 
     function compoundDelta(IBalanceObservation target, uint256 amount, uint256 fee) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe();
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
         uint256 delta = address(this).balance;
         delta -= beforeBalance;
         delta -= fee;
@@ -61,7 +61,7 @@ contract ReentrancyBalanceRelations {
 
     function additiveComparison(IBalanceObservation target, uint256 amount) external {
         uint256 beforeBalance = address(this).balance;
-        target.observe();
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
         require(address(this).balance >= amount - beforeBalance);
     }
 
@@ -111,5 +111,41 @@ contract ReentrancyBalanceRelations {
         uint256 delta = address(this).balance - beforeBalance;
         target.observe();
         require(delta >= amount);
+    }
+
+    function ternaryFresh(IBalanceObservation target, uint256 amount, bool enabled) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require((enabled ? address(this).balance : 0) >= beforeBalance + amount);
+    }
+
+    function ternaryDelta(IBalanceObservation target, uint256 amount, bool enabled) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require((enabled ? 0 : address(this).balance) - beforeBalance >= amount);
+    }
+
+    function ternaryExclusive(IBalanceObservation target, uint256 amount, bool enabled) external {
+        uint256 beforeBalance = address(this).balance;
+        if (enabled) target.observe();
+        require((enabled ? 0 : address(this).balance) >= beforeBalance + amount);
+    }
+
+    function multipliedSaved(IBalanceObservation target) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(address(this).balance >= beforeBalance * 2);
+    }
+
+    function multipliedFreshReversed(IBalanceObservation target) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(beforeBalance <= address(this).balance * 2);
+    }
+
+    function exclusiveOperands(IBalanceObservation target, bool enabled) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        require((enabled ? address(this).balance : 0) >= (enabled ? 0 : beforeBalance * 2));
     }
 }

--- a/crates/lint/testdata/ReentrancyBalanceRelations.sol
+++ b/crates/lint/testdata/ReentrancyBalanceRelations.sol
@@ -148,4 +148,92 @@ contract ReentrancyBalanceRelations {
         target.observe();
         require((enabled ? address(this).balance : 0) >= (enabled ? 0 : beforeBalance * 2));
     }
+
+    function multipliedLocal(IBalanceObservation target) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        beforeBalance *= 2;
+        require(address(this).balance >= beforeBalance);
+    }
+
+    function transformedBeforeCall(IBalanceObservation target) external {
+        uint256 beforeBalance = address(this).balance * 2;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(address(this).balance >= beforeBalance);
+    }
+
+    function transformedTuple(IBalanceObservation target) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        (uint256 current, uint256 previous) = (address(this).balance * 2, beforeBalance / 2);
+        require(previous <= current);
+    }
+
+    function transformedHelper(IBalanceObservation target) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        require(scale(address(this).balance) >= scaleNamed(beforeBalance));
+    }
+
+    function scale(uint256 value) internal pure returns (uint256) {
+        return value * 2;
+    }
+
+    function scaleNamed(uint256 value) internal pure returns (uint256 result) {
+        result = value;
+        result *= 2;
+    }
+
+    function transformedOverwrite(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        beforeBalance *= 2;
+        beforeBalance = amount;
+        require(address(this).balance >= beforeBalance);
+    }
+
+    function transformedBothStale(IBalanceObservation target) external {
+        uint256 beforeBalance = address(this).balance * 2;
+        uint256 otherBalance = scale(address(this).balance);
+        target.observe();
+        require(otherBalance >= beforeBalance);
+    }
+
+    function transformedHelperExclusive(IBalanceObservation target, bool enabled) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        uint256 current = conditionalScale(address(this).balance, enabled);
+        uint256 previous = conditionalScale(beforeBalance, !enabled);
+        require(current >= previous);
+    }
+
+    function conditionalScale(uint256 value, bool enabled) internal pure returns (uint256) {
+        return enabled ? value * 2 : 0;
+    }
+
+    function transformedSameSide(IBalanceObservation target, uint256 amount) external {
+        uint256 beforeBalance = address(this).balance;
+        target.observe();
+        uint256 current = scale(address(this).balance);
+        uint256 previous = scaleNamed(beforeBalance);
+        require(current - previous >= amount);
+    }
+
+    function nestedHelperBothStale(IBalanceObservation target) external {
+        uint256 saved = wrap(address(this).balance);
+        target.observe();
+        uint256 transformed = wrap(saved);
+        require(transformed >= saved);
+    }
+
+    function nestedHelperFresh(IBalanceObservation target) external {
+        uint256 saved = wrap(address(this).balance);
+        target.observe(); //~WARN: external call can be reentered before a stale contract balance is checked
+        uint256 transformed = wrap(address(this).balance);
+        require(transformed >= saved);
+    }
+
+    function wrap(uint256 value) internal pure returns (uint256) {
+        return scale(value);
+    }
 }

--- a/crates/lint/testdata/ReentrancyBalanceRelations.stderr
+++ b/crates/lint/testdata/ReentrancyBalanceRelations.stderr
@@ -46,3 +46,43 @@ LL │         target.observe();
    │
    ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
 
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+

--- a/crates/lint/testdata/ReentrancyBalanceRelations.stderr
+++ b/crates/lint/testdata/ReentrancyBalanceRelations.stderr
@@ -1,40 +1,8 @@
 warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
    ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
    │
-LL │         target.observe();
-   │         ━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
-
-warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
-   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
-   │
-LL │         target.observe();
-   │         ━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
-
-warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
-   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
-   │
-LL │         target.observe();
-   │         ━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
-
-warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
-   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
-   │
-LL │         target.observe();
-   │         ━━━━━━━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
-
-warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
-   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
-   │
-LL │         target.observe();
-   │         ━━━━━━━━━━━━━━━━
+LL │         (bool ok,) = target.call("");
+   │                      ━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
 

--- a/crates/lint/testdata/ReentrancyBalanceRelations.stderr
+++ b/crates/lint/testdata/ReentrancyBalanceRelations.stderr
@@ -1,0 +1,80 @@
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+

--- a/crates/lint/testdata/ReentrancyBalanceRelations.stderr
+++ b/crates/lint/testdata/ReentrancyBalanceRelations.stderr
@@ -86,3 +86,43 @@ LL │         target.observe();
    │
    ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
 
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+
+warning[reentrancy-balance]: external call can be reentered before a stale contract balance is checked
+   ╭▸ ROOT/testdata/ReentrancyBalanceRelations.sol:LL:CC
+   │
+LL │         target.observe();
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-balance
+


### PR DESCRIPTION
Supersedes #16661 and builds on its delta-form case. `reentrancy-balance` now recognizes direct and delta comparisons through signed balance terms carried by the existing local, parameter, tuple, and helper-return analysis. This replaces the presence-only matcher and stale-local bookkeeping, so introducing a local no longer loses the balance relationship. It reuses the existing path, type, and map helpers; repeated terms and unsupported balance operations remain unknown instead of being treated as arithmetic identities.

The fixtures cover offsets, casts, compound assignments, and isolated negative cases, including the previously missed low-level-call assertion. Narrowing and sign-changing casts are not assumed to preserve a balance relation, and checked and unchecked source patterns are not claimed to be algebraically equivalent.

Implementation, fixtures, and PR text were written with Codex assistance; Omp/Astra was consulted for the initial analysis and design.
