### PR TITLE
fix(chisel): stop autosave from reusing a session id after a deletion or rename

### DIFF
--- a/.changelog/chisel-session-id-collision.md
+++ b/.changelog/chisel-session-id-collision.md
@@ -1,0 +1,5 @@
+---
+chisel: patch
+---
+
+Fixed `chisel`'s autosave picking a session id from the cache directory's entry count instead of the highest existing numeric id, which could silently overwrite an existing saved session once any session had been deleted or renamed.

--- a/crates/chisel/src/session.rs
+++ b/crates/chisel/src/session.rs
@@ -134,8 +134,11 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
     /// lowest unused numeric id, and reusing it as a fresh autosave id silently overwrites
     /// whichever existing session already happens to occupy that number.
     pub fn next_cached_session() -> Result<(String, String)> {
-        let cache_dir = Self::cache_dir()?;
-        let next_id = std::fs::read_dir(&cache_dir)?
+        Self::next_cached_session_in(&Self::cache_dir()?)
+    }
+
+    fn next_cached_session_in(cache_dir: &str) -> Result<(String, String)> {
+        let next_id = std::fs::read_dir(cache_dir)?
             .filter_map(|entry| entry.ok())
             .filter_map(|entry| {
                 entry
@@ -147,7 +150,8 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
                     .ok()
             })
             .max()
-            .map_or(0, |max| max + 1);
+            .map_or(Some(0), |max| max.checked_add(1))
+            .ok_or_else(|| eyre::eyre!("no unused chisel session id available"))?;
 
         Ok((format!("{next_id}"), format!("{cache_dir}chisel-{next_id}.json")))
     }
@@ -270,22 +274,40 @@ mod tests {
     /// machine running the test.
     #[test]
     fn next_cached_session_skips_gaps_left_by_deleted_sessions() {
-        let cache_dir = ChiselSession::<EthEvmNetwork>::cache_dir().unwrap();
-        std::fs::create_dir_all(&cache_dir).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let cache_dir = format!("{}/", dir.path().to_str().unwrap());
 
-        let low = "999990";
-        let high = "999992"; // gap at 999991, simulating a deleted/renamed middle session
-        for id in [low, high] {
-            std::fs::write(format!("{cache_dir}chisel-{id}.json"), "{}").unwrap();
-        }
+        // Sessions 0 and 2 exist; session 1 was deleted or renamed away, leaving a gap.
+        std::fs::write(format!("{cache_dir}chisel-0.json"), "{\"id\":\"0\"}").unwrap();
+        std::fs::write(format!("{cache_dir}chisel-2.json"), "{\"id\":\"2\"}").unwrap();
 
-        let result = ChiselSession::<EthEvmNetwork>::next_cached_session();
+        let (next_id, next_file) =
+            ChiselSession::<EthEvmNetwork>::next_cached_session_in(&cache_dir).unwrap();
 
-        std::fs::remove_file(format!("{cache_dir}chisel-{low}.json")).unwrap();
-        std::fs::remove_file(format!("{cache_dir}chisel-{high}.json")).unwrap();
+        // The buggy count-based implementation returns "2" here (2 entries in the directory),
+        // which collides with the still-live chisel-2.json and would silently overwrite it.
+        assert_eq!(next_id, "3", "must skip past the gap instead of reusing the occupied id 2");
+        assert_eq!(next_file, format!("{cache_dir}chisel-3.json"));
 
-        let (next_id, _) = result.unwrap();
-        assert_eq!(next_id, "999993", "next id must exceed every existing numeric session");
+        // The existing sessions must be untouched by merely computing the next id.
+        assert_eq!(
+            std::fs::read_to_string(format!("{cache_dir}chisel-0.json")).unwrap(),
+            "{\"id\":\"0\"}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(format!("{cache_dir}chisel-2.json")).unwrap(),
+            "{\"id\":\"2\"}"
+        );
+    }
+
+    #[test]
+    fn next_cached_session_does_not_overflow_on_a_usize_max_named_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_dir = format!("{}/", dir.path().to_str().unwrap());
+        std::fs::write(format!("{cache_dir}chisel-{}.json", usize::MAX), "{}").unwrap();
+
+        let result = ChiselSession::<EthEvmNetwork>::next_cached_session_in(&cache_dir);
+        assert!(result.is_err(), "must error instead of panicking or wrapping to a reused id");
     }
 
     #[test]

--- a/crates/chisel/src/session.rs
+++ b/crates/chisel/src/session.rs
@@ -127,12 +127,29 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
     /// ### Returns
     ///
     /// Optionally, returns a tuple containing the next cached session's id and file name.
+    ///
+    /// The next id is one past the highest existing `chisel-<n>.json` id, not the directory's
+    /// entry count: once a session has been deleted or renamed (both already possible via
+    /// `!save <new-id>` and `remove_cached_session`), the entry count no longer matches the
+    /// lowest unused numeric id, and reusing it as a fresh autosave id silently overwrites
+    /// whichever existing session already happens to occupy that number.
     pub fn next_cached_session() -> Result<(String, String)> {
         let cache_dir = Self::cache_dir()?;
-        let entries = std::fs::read_dir(&cache_dir)?;
-        let session_num = entries.filter(Result::is_ok).count();
+        let next_id = std::fs::read_dir(&cache_dir)?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                entry
+                    .file_name()
+                    .to_str()?
+                    .strip_prefix("chisel-")?
+                    .strip_suffix(".json")?
+                    .parse::<usize>()
+                    .ok()
+            })
+            .max()
+            .map_or(0, |max| max + 1);
 
-        Ok((format!("{session_num}"), format!("{cache_dir}chisel-{session_num}.json")))
+        Ok((format!("{next_id}"), format!("{cache_dir}chisel-{next_id}.json")))
     }
 
     /// The Chisel Cache Directory
@@ -244,6 +261,32 @@ mod tests {
     #[cfg(feature = "monad")]
     use foundry_evm::core::{constants::MONAD_CHEATCODE_ADDRESS, evm::MonadEvmNetwork};
     use semver::Version;
+
+    /// A deleted or renamed session leaves a gap in the numeric id sequence; the directory's
+    /// entry count no longer matches the lowest unused id. The next autosave must still land
+    /// past every existing numeric session, never reusing one of their filenames.
+    ///
+    /// Uses a block of very high ids so this can't collide with a real session already on the
+    /// machine running the test.
+    #[test]
+    fn next_cached_session_skips_gaps_left_by_deleted_sessions() {
+        let cache_dir = ChiselSession::<EthEvmNetwork>::cache_dir().unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        let low = "999990";
+        let high = "999992"; // gap at 999991, simulating a deleted/renamed middle session
+        for id in [low, high] {
+            std::fs::write(format!("{cache_dir}chisel-{id}.json"), "{}").unwrap();
+        }
+
+        let result = ChiselSession::<EthEvmNetwork>::next_cached_session();
+
+        std::fs::remove_file(format!("{cache_dir}chisel-{low}.json")).unwrap();
+        std::fs::remove_file(format!("{cache_dir}chisel-{high}.json")).unwrap();
+
+        let (next_id, _) = result.unwrap();
+        assert_eq!(next_id, "999993", "next id must exceed every existing numeric session");
+    }
 
     #[test]
     fn deserialized_sessions_do_not_restore_force() {

--- a/crates/chisel/src/session.rs
+++ b/crates/chisel/src/session.rs
@@ -143,11 +143,7 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
     ///
     /// Optionally, returns a tuple containing the next cached session's id and file name.
     ///
-    /// The next id is one past the highest existing `chisel-<n>.json` id, not the directory's
-    /// entry count: once a session has been deleted or renamed (both already possible via
-    /// `!save <new-id>` and `remove_cached_session`), the entry count no longer matches the
-    /// lowest unused numeric id, and reusing it as a fresh autosave id silently overwrites
-    /// whichever existing session already happens to occupy that number.
+    /// Uses one past the highest numeric ID to avoid collisions after deletion.
     pub fn next_cached_session() -> Result<(String, String)> {
         Self::next_cached_session_in(&Self::cache_dir()?)
     }
@@ -282,12 +278,7 @@ mod tests {
     use foundry_evm::core::{constants::MONAD_CHEATCODE_ADDRESS, evm::MonadEvmNetwork};
     use semver::Version;
 
-    /// A deleted or renamed session leaves a gap in the numeric id sequence; the directory's
-    /// entry count no longer matches the lowest unused id. The next autosave must still land
-    /// past every existing numeric session, never reusing one of their filenames.
-    ///
-    /// Uses a block of very high ids so this can't collide with a real session already on the
-    /// machine running the test.
+    /// Deleted sessions must not cause the next ID to collide with an existing file.
     #[test]
     fn next_cached_session_skips_gaps_left_by_deleted_sessions() {
         let dir = tempfile::tempdir().unwrap();
@@ -300,12 +291,10 @@ mod tests {
         let (next_id, next_file) =
             ChiselSession::<EthEvmNetwork>::next_cached_session_in(&cache_dir).unwrap();
 
-        // The buggy count-based implementation returns "2" here (2 entries in the directory),
-        // which collides with the still-live chisel-2.json and would silently overwrite it.
+        // Counting entries would select the occupied ID 2.
         assert_eq!(next_id, "3", "must skip past the gap instead of reusing the occupied id 2");
         assert_eq!(next_file, format!("{cache_dir}chisel-3.json"));
 
-        // The existing sessions must be untouched by merely computing the next id.
         assert_eq!(
             std::fs::read_to_string(format!("{cache_dir}chisel-0.json")).unwrap(),
             "{\"id\":\"0\"}"


### PR DESCRIPTION
\`next_cached_session()\` picked the next autosave id from the cache directory's entry count, not the highest existing \`chisel-<n>.json\` id. Once any session had been deleted (\`remove_cached_session\`, e.g. via a rename) or renamed (\`!save <new-id>\`, which already removes the old cache file per #15796), the entry count no longer matches the lowest unused numeric id.

Repro: sessions 0, 1, 2 exist (3 files). Delete/rename session 1 away, leaving chisel-0.json and chisel-2.json (2 files). The next unnamed autosave computes id = entry count = 2, and silently overwrites the still-live chisel-2.json with unrelated session content - no warning, no prompt, the old session is just gone.

Fix: scan for the highest existing numeric id and use `max + 1` (via a directory-taking `next_cached_session_in` helper, tested against a `tempfile::tempdir()` rather than the real home cache dir). Also guards the increment with `checked_add` so a `chisel-<usize::MAX>.json` entry (reachable via an explicit `!save`) errors instead of panicking or wrapping to 0 and overwriting `chisel-0.json`.

## Testing
- `next_cached_session_skips_gaps_left_by_deleted_sessions`: proves the old count-based implementation returns the *occupied* id `"2"` in this exact 0/2-gap scenario (verified this fails against the pre-fix code), while the fix returns `"3"`.
- `next_cached_session_does_not_overflow_on_a_usize_max_named_session`: the overflow guard.
- Full `chisel` crate unit suite (24 tests) green after the change.
- `cargo fmt` / `cargo clippy -p chisel --lib -- -D warnings` clean.

closes nothing (no tracking issue found for this specific case; searched for prior reports first, only found the related-but-distinct #15796 rename-cleanup issue).

AI assistance: Codex performed a follow-up review and shortened comments.
