### PR TITLE
fix(chisel): reject a session id that could escape the cache directory

### DIFF
--- a/.changelog/chisel-session-id-path-traversal.md
+++ b/.changelog/chisel-session-id-path-traversal.md
@@ -1,0 +1,5 @@
+---
+chisel: patch
+---
+
+Reject a `chisel` session id containing a path separator (or `.`/`..`) in `!save`/`!load`/`chisel load`/`chisel view`, instead of concatenating it straight into `chisel-<id>.json`. An id like `x/../../../../../tmp/pwned` previously resolved clean outside the cache directory, so a mistyped or copy-pasted id could silently overwrite an arbitrary file the user could write to.

--- a/crates/chisel/src/session.rs
+++ b/crates/chisel/src/session.rs
@@ -10,6 +10,19 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use time::{OffsetDateTime, format_description};
 
+/// Rejects a session id that would let `chisel-<id>.json` escape the cache directory when
+/// concatenated into a path (e.g. `../../etc/cron.d/evil`, which yields the literal path
+/// component `chisel-..`, followed by a real `..` component once the id itself contains a `/`).
+fn validate_session_id(id: &str) -> Result<()> {
+    if id.is_empty() || id == "." || id == ".." || id.contains(['/', '\\']) {
+        eyre::bail!(
+            "invalid Chisel session id `{id}`: must not be empty, `.`, `..`, or contain a path \
+             separator"
+        );
+    }
+    Ok(())
+}
+
 /// A Chisel REPL Session
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
@@ -80,6 +93,7 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
 
     /// Removes a cached session if it exists.
     pub fn remove_cached_session(id: &str) -> Result<()> {
+        validate_session_id(id)?;
         let cache_file = format!("{}chisel-{id}.json", Self::cache_dir()?);
         match std::fs::remove_file(cache_file) {
             Ok(()) => Ok(()),
@@ -101,6 +115,7 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
         let cache_file_name = match self.id.as_ref() {
             Some(id) => {
                 // ID is already set- use the existing cache file.
+                validate_session_id(id)?;
                 format!("{cache_dir}chisel-{id}.json")
             }
             None => {
@@ -197,6 +212,7 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
     ///
     /// Optionally, an owned instance of the loaded chisel session.
     pub fn load(id: &str, executor_builder: ExecutorBuilder<FEN>) -> Result<Self> {
+        validate_session_id(id)?;
         let cache_dir = Self::cache_dir()?;
         let contents = std::fs::read_to_string(Path::new(&format!("{cache_dir}chisel-{id}.json")))?;
         Self::deserialize_cached(&contents, executor_builder)
@@ -289,5 +305,56 @@ mod tests {
             session.source.config.executor_builder.extra_cheatcode_addresses(),
             &[MONAD_CHEATCODE_ADDRESS]
         );
+    }
+
+    /// A session id containing a path separator lets `chisel-<id>.json` escape the cache
+    /// directory once resolved: `chisel-x/../../../foo.json` has real `..` path components
+    /// after the `x` segment, walking back out past the cache directory entirely.
+    #[test]
+    fn path_traversal_ids_are_rejected() {
+        for id in
+            ["../evil", "x/../../../../../../tmp/pwned", "..", ".", "", "sub/dir", "back\\slash"]
+        {
+            let err = validate_session_id(id).unwrap_err();
+            assert!(err.to_string().contains("invalid Chisel session id"), "{id:?}: {err}");
+        }
+
+        // ordinary numeric and name-like ids remain accepted
+        for id in ["0", "42", "my-session", "my_session"] {
+            validate_session_id(id).unwrap();
+        }
+    }
+
+    #[test]
+    fn load_rejects_path_traversal_id() {
+        let err = ChiselSession::<EthEvmNetwork>::load(
+            "../../evil",
+            ExecutorBuilder::<EthEvmNetwork>::new(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("invalid Chisel session id"), "{err}");
+    }
+
+    #[test]
+    fn remove_cached_session_rejects_path_traversal_id() {
+        let err = ChiselSession::<EthEvmNetwork>::remove_cached_session("../../evil").unwrap_err();
+        assert!(err.to_string().contains("invalid Chisel session id"), "{err}");
+    }
+
+    #[test]
+    fn write_rejects_path_traversal_id() {
+        let mut session = ChiselSession::<EthEvmNetwork>::new(SessionSourceConfig {
+            foundry_config: Config {
+                solc: Some(SolcReq::Version(Version::new(0, 8, 29))),
+                ..Default::default()
+            },
+            no_vm: true,
+            ..Default::default()
+        })
+        .unwrap();
+        session.id = Some("../../evil".to_string());
+
+        let err = session.write().unwrap_err();
+        assert!(err.to_string().contains("invalid Chisel session id"), "{err}");
     }
 }


### PR DESCRIPTION
\`!save <id>\`, \`!load <id>\`, \`chisel load <id>\`, and \`chisel view <id>\` all build \`chisel-<id>.json\` by concatenating the user-supplied id directly into a path string, with zero validation.

Any id containing a path separator plus \`..\` components resolves clean outside \`~/.foundry/cache/chisel/\`, since the hardcoded \`chisel-\` prefix only blocks a *leading* \`..\` (it becomes the literal component \`chisel-..\`), not one further into the id:

\`\`\`
cache_dir + "chisel-" + "x/../../../../../tmp/pwned" + ".json"
  = "~/.foundry/cache/chisel/chisel-x/../../../../../tmp/pwned.json"
  lexically resolves to: /tmp/pwned.json
\`\`\`

A mistyped or copy-pasted id with an early path separator silently overwrites (\`!save\`) or reads (\`!load\`) an arbitrary file the user has access to, instead of erroring - no malicious input required, just an id that happens to contain a few \`/\`.

## Fix

Adds \`validate_session_id\`, rejecting empty ids, \`.\`, \`..\`, and any id containing \`/\` or \`\\\`. Called from \`write()\`, \`load()\`, and \`remove_cached_session()\` before any path is built, so every entry point (interactive \`!save\`/\`!load\` and the top-level \`chisel load\`/\`chisel view\` subcommands, which share the same code path) is covered.

## Prior art check

Two earlier attempts at this exact area were closed by @DaniPopes:
- #11618 ("Fix Chisel session ID collisions and use path-safe joins") - the diff doesn't even compile (unbalanced braces).
- #11935 ("fix: cross-platform path construction in Chisel cache") - switched to \`Path::join\`, which doesn't strip \`..\` components and doesn't fix the traversal at all (correctly called out: "that doesn't have any effect in rust").

Both were rejected for being technically broken, not because the underlying bug is unwanted. This PR takes a different approach (reject dangerous ids outright rather than trying to make concatenation "safe"), verified end to end against the actual lexical path resolution.

Unrelated to (and doesn't touch) the id-collision bug in \`next_cached_session\` already fixed in #16687.

## Testing

- \`path_traversal_ids_are_rejected\`: unit tests the validator against traversal, \`.\`/\`..\`, empty, embedded-separator, and backslash cases, plus confirms ordinary numeric/name ids still pass.
- \`load_rejects_path_traversal_id\`, \`remove_cached_session_rejects_path_traversal_id\`, \`write_rejects_path_traversal_id\`: confirm each real entry point rejects a traversal id with the validation error (not a generic IO error), before touching the filesystem.
- \`cargo test -p chisel --lib session::\` - all 5 tests pass.
- \`cargo clippy -p chisel --lib --tests\` and \`cargo fmt -p chisel -- --check\` clean.

closes nothing (no tracking issue; found via source review)