### PR TITLE
test(chisel): synchronize REPL command completion

### DIFF
--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -54,6 +54,29 @@ repl_test!(repl_help, |repl| {
     repl.expect_prompt();
 });
 
+repl_test!(command_output_after_raw_input, |repl| {
+    repl.sendln_raw("!help");
+    repl.expect("Chisel help");
+    repl.expect_prompt();
+
+    // A synchronous command must retain its output even after an explicit prompt wait.
+    repl.sendln("uint256(7)");
+    repl.expect("Hex: 0x7");
+    repl.expect("Decimal: 7");
+    repl.sendln("uint256(8)");
+    repl.expect("Decimal: 8");
+});
+
+repl_test!(sendln_waits_for_save, |repl| {
+    let id = unique_cache_id("wait-for-save");
+    let _cleanup = CacheCleanup(vec![id.clone()]);
+
+    // The first command must finish before the caller observes its filesystem effects.
+    repl.sendln(&format!("!save {id}"));
+    assert!(cache_file(&id).is_file());
+    repl.expect(&format!("Saved session to cache with ID = {id}"));
+});
+
 repl_test!(save_renamed_session_removes_stale_cache, |repl| {
     let old_id = unique_cache_id("rename-old");
     let new_id = unique_cache_id("rename-new");
@@ -105,9 +128,7 @@ repl_test!(failed_save_restores_previous_session_id, |repl| {
     let second_id = unique_cache_id("failed-save-second");
     let _cleanup = CacheCleanup(vec![first_id.clone(), second_id.clone()]);
 
-    repl.sendln_raw(&format!("!save {first_id}"));
-    repl.expect(&format!("Saved session to cache with ID = {first_id}"));
-    repl.expect_prompt();
+    repl.sendln(&format!("!save {first_id}"));
     // A directory at the destination makes a valid ID fail when writing the cache file.
     let blocked_cache = tempfile::Builder::new()
         .prefix("chisel-failed-save-")
@@ -208,7 +229,9 @@ repl_test!(cheatcodes_available, "", init = true, |repl| {
 
 // Test empty inputs.
 repl_test!(empty_input, |repl| {
-    repl.sendln("   \n \n\n    \t \t \n \n\t\t\t\t \n \n");
+    for line in "   \n \n\n    \t \t \n \n\t\t\t\t \n \n".split('\n') {
+        repl.sendln(line);
+    }
 });
 
 // Issue #4130: Test type(intN).min correctness.
@@ -289,11 +312,13 @@ repl_test!(import, "", init = true, |repl| {
     repl.sendln("Counter c = new Counter()");
     // TODO: pre-existing inspection failure.
     // repl.sendln("c.number()");
-    repl.sendln("uint x = c.number();\nx");
+    repl.sendln("uint x = c.number();");
+    repl.sendln("x");
     repl.expect("Decimal: 0");
     repl.sendln("c.increment();");
     // repl.sendln("c.number()");
-    repl.sendln("x = c.number();\nx");
+    repl.sendln("x = c.number();");
+    repl.sendln("x");
     repl.expect("Decimal: 1");
 });
 
@@ -417,7 +442,8 @@ repl_test!(assembly_no_return_intermediate, |repl| {
 
 // Issue #5051, #8978: Test EVM version normalization.
 repl_test!(flaky_evm_version_normalization, "--use 0.7.6 --evm-version london", |repl| {
-    repl.sendln("uint x;\nx");
+    repl.sendln("uint x;");
+    repl.sendln("x");
     repl.expect("Decimal: 0");
 });
 
@@ -449,7 +475,8 @@ repl_test!(fetch_interface_with_structs, |repl| {
         "Added 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789's interface to source as `IEntryPoint`",
     );
     repl.expect_prompt();
-    repl.sendln("uint256 x = 1;\nx");
+    repl.sendln("uint256 x = 1;");
+    repl.sendln("x");
     repl.expect("Decimal: 1");
 });
 

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -104,12 +104,20 @@ repl_test!(failed_save_restores_previous_session_id, |repl| {
     let first_id = unique_cache_id("failed-save-first");
     let second_id = unique_cache_id("failed-save-second");
     let _cleanup = CacheCleanup(vec![first_id.clone(), second_id.clone()]);
-    let invalid_id = format!("{}/id", unique_cache_id("failed-save-invalid"));
 
-    repl.sendln(&format!("!save {first_id}"));
-    // The nested path makes the write fail without touching the existing cache file.
-    repl.sendln_raw(&format!("!save {invalid_id}"));
-    repl.expect("No such file or directory");
+    repl.sendln_raw(&format!("!save {first_id}"));
+    repl.expect(&format!("Saved session to cache with ID = {first_id}"));
+    repl.expect_prompt();
+    // A directory at the destination makes a valid ID fail when writing the cache file.
+    let blocked_cache = tempfile::Builder::new()
+        .prefix("chisel-failed-save-")
+        .suffix(".json")
+        .tempdir_in(CachedChiselSession::<EthEvmNetwork>::cache_dir().unwrap())
+        .unwrap();
+    let blocked_name = blocked_cache.path().file_name().unwrap().to_str().unwrap();
+    let blocked_id = blocked_name.strip_prefix("chisel-").unwrap().strip_suffix(".json").unwrap();
+    repl.sendln_raw(&format!("!save {blocked_id}"));
+    repl.expect("Is a directory");
     repl.expect_prompt();
 
     // A failed rename must not lose the ID of the last successfully saved file.

--- a/crates/chisel/tests/it/repl/session.rs
+++ b/crates/chisel/tests/it/repl/session.rs
@@ -11,6 +11,8 @@ pub struct ChiselSession {
     session: Box<PtySession>,
     project: Box<TestProject>,
     is_repl: bool,
+    /// Unread output from the last completed synchronous command.
+    output: Option<String>,
 }
 
 static SUBCOMMANDS: &[&str] = &["list", "load", "view", "clear-cache", "eval", "help"];
@@ -55,11 +57,13 @@ impl ChiselSession {
         .unwrap();
 
         let is_repl = is_repl(&args);
-        let mut session = Self { session: Box::new(session), project: Box::new(project), is_repl };
+        let mut session =
+            Self { session: Box::new(session), project: Box::new(project), is_repl, output: None };
 
         // Expect initial prompt only if we're in the REPL.
         if session.is_repl() {
             session.expect("Welcome to Chisel!");
+            session.expect_prompt();
         }
 
         session
@@ -73,12 +77,15 @@ impl ChiselSession {
         self.is_repl
     }
 
-    /// Send a line to the REPL and expects the prompt to appear.
+    /// Send one complete REPL input and wait for its next prompt.
+    ///
+    /// Retain the command's output for subsequent `expect` calls. Send multiple independent
+    /// inputs separately, or use `sendln_raw` and explicitly consume their prompts.
     #[track_caller]
     pub fn sendln(&mut self, line: &str) {
         self.sendln_raw(line);
         if self.is_repl() {
-            self.expect_prompt();
+            self.output = Some(self.read_until_prompt());
         }
     }
 
@@ -87,6 +94,7 @@ impl ChiselSession {
     /// You might want to call `expect_prompt` after this.
     #[track_caller]
     pub fn sendln_raw(&mut self, line: &str) {
+        self.output = None;
         match self.session.send_line(line) {
             Ok(_) => (),
             Err(e) => {
@@ -98,6 +106,13 @@ impl ChiselSession {
     /// Expect the needle to appear.
     #[track_caller]
     pub fn expect(&mut self, needle: &str) {
+        if let Some(output) = &mut self.output {
+            let Some(pos) = output.find(needle) else {
+                panic!("expected {needle:?} in completed command output: {output:?}");
+            };
+            output.drain(..pos + needle.len());
+            return;
+        }
         match self.session.exp_string(needle) {
             Ok(_) => (),
             Err(e) => {
@@ -109,7 +124,12 @@ impl ChiselSession {
     /// Expect the prompt to appear.
     #[track_caller]
     pub fn expect_prompt(&mut self) {
-        self.expect(PROMPT);
+        self.read_until_prompt();
+    }
+
+    #[track_caller]
+    fn read_until_prompt(&mut self) -> String {
+        self.session.exp_string(PROMPT).unwrap_or_else(|e| panic!("failed to expect prompt: {e}"))
     }
 
     /// Expect the prompt to appear `n` times.


### PR DESCRIPTION
The Chisel test client leaves the startup prompt unread, so a command can appear complete before it executes. Once prompt consumption catches up, waiting for completion discards output that subsequent assertions need. Synchronize startup and retain each synchronous command's output for ordered assertions, clearing it before the next command. Keep raw input waits explicit and send independent inputs separately.

The failed-save fixture also uses a temporary directory at a valid cache destination to exercise an actual write failure after the session ID validation in [#16689](https://github.com/foundry-rs/foundry/pull/16689). Chisel's production loop already awaits dispatch before printing the next prompt; the changes address the shared test client's handling of that protocol.

This test-only change uses the `L-ignore` changelog exemption.

Centaur AI investigated the failure and authored the code and PR description.

Prompted by: @DaniPopes
