### PR TITLE
test(chisel): restore disabled REPL coverage

### DIFF
--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -288,14 +288,16 @@ repl_test!(last_result_resets_with_session, |repl| {
 });
 
 // Issue #4393: Test edit command with traces.
-// TODO: test `!edit`
-// repl_test!(edit_with_traces, |repl| {
-//     repl.sendln("!traces");
-//     repl.sendln("uint x = 42");
-//     repl.sendln("!edit");
-//     // Should open editor without errors.
-//     repl.expect("Running");
-// });
+repl_test!(edit_with_traces, |repl| {
+    repl.sendln("!traces");
+    repl.expect("Enabled traces!");
+    repl.sendln("uint x = 42");
+    repl.sendln("!edit");
+    repl.expect("Traces:");
+    repl.expect("Successfully edited `run()` function's body!");
+    repl.sendln("x");
+    repl.expect("Decimal: 42");
+});
 
 // Test tuple support.
 repl_test!(tuples, |repl| {
@@ -310,15 +312,10 @@ repl_test!(tuples, |repl| {
 repl_test!(import, "", init = true, |repl| {
     repl.sendln("import {Counter} from \"src/Counter.sol\"");
     repl.sendln("Counter c = new Counter()");
-    // TODO: pre-existing inspection failure.
-    // repl.sendln("c.number()");
-    repl.sendln("uint x = c.number();");
-    repl.sendln("x");
+    repl.sendln("c.number()");
     repl.expect("Decimal: 0");
     repl.sendln("c.increment();");
-    // repl.sendln("c.number()");
-    repl.sendln("x = c.number();");
-    repl.sendln("x");
+    repl.sendln("c.number()");
     repl.expect("Decimal: 1");
 });
 

--- a/crates/chisel/tests/it/repl/session.rs
+++ b/crates/chisel/tests/it/repl/session.rs
@@ -34,10 +34,11 @@ impl ChiselSession {
         let bin = env!("CARGO_BIN_EXE_chisel");
         let mut command = std::process::Command::new(bin);
 
-        // TODO: TTY works but logs become unreadable.
+        // Keep terminal output readable and use a non-interactive editor for `!edit`.
         command.current_dir(project.root());
         command.env("NO_COLOR", "1");
         command.env("TERM", "dumb");
+        command.env("EDITOR", "true");
 
         command.env("ETHERSCAN_API_KEY", foundry_test_utils::rpc::next_etherscan_api_key());
 


### PR DESCRIPTION
Stacked on [#16690](https://github.com/foundry-rs/foundry/pull/16690). Restore the `!edit` test with tracing enabled, using a non-interactive no-op editor and checking successful execution and preserved session state. Re-enable direct `Counter.number()` inspection before and after incrementing, remove the temporary-variable workarounds, and clean up the stale test TODOs.

This test-only change uses the `L-ignore` changelog exemption.

Centaur AI authored the code and PR description.

Prompted by: @DaniPopes
