### PR TITLE
chore(ci): cache build-check dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          cache-targets: false
-          prefix-key: v1-rust-doctest-no-target
+          cache-bin: false
+          prefix-key: v2-rust-doctest
       - run: cargo test --workspace --doc --locked
 
   no-default-features:
@@ -76,6 +76,10 @@ jobs:
           toolchain: stable
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-bin: false
+          prefix-key: v1-rust-no-default-features
       - run: cargo build --workspace --no-default-features --locked
 
   touch-id-link:
@@ -205,9 +209,8 @@ jobs:
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          cache-targets: false
           cache-bin: false
-          prefix-key: v1-rust-forge-fmt-no-target
+          prefix-key: v2-rust-forge-fmt
       - name: forge fmt
         shell: bash
         run: ./.github/scripts/format.sh --check


### PR DESCRIPTION
Restore Cargo dependency artifacts for doctests and Solidity formatting, and cache the no-default-features build. These jobs repeatedly rebuilt dependencies despite warm sccache; all commands and checks are unchanged. Dedicated keys keep their artifacts separate. Authored with Codex; this CI-only change uses `L-ignore`.

### Results

Full job durations, including cache restore/save, compared with medians from six recent PR runs. The [first run](https://github.com/foundry-rs/foundry/actions/runs/34036415555/attempts/1) populated the new caches; the [warm rerun](https://github.com/foundry-rs/foundry/actions/runs/34036415555/attempts/2) reused them.

| Job | Recent baseline median | New cache, cold | New cache, warm |
| --- | ---: | ---: | ---: |
| Doctest | 328.5s | 416s | 153s |
| No default features | 321s | 397s | 134s |
| Forge fmt | 288.5s | 359s | 113s |

The warm run saves about nine runner-minutes across these jobs; overall PR latency still depends on the parallel tests/docs jobs. Initial cache creation costs 61–66s to save, and each archive is approximately 2.5GB. Warm restore takes 22–23s.
