### PR TITLE
test(forge): reuse binding dependency artifacts

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -78,7 +78,7 @@ t_linux_arm = Target(
 t_macos = Target("depot-macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
 t_windows = Target("depot-windows-latest-16", "x86_64-pc-windows-msvc", "windows-amd64")
 if is_pr:
-    targets = [t_linux_x86]
+    targets = [t_linux_x86, t_macos, t_windows]
 else:
     targets = [t_linux_x86, t_linux_arm, t_macos, t_windows]
 

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -78,7 +78,7 @@ t_linux_arm = Target(
 t_macos = Target("depot-macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
 t_windows = Target("depot-windows-latest-16", "x86_64-pc-windows-msvc", "windows-amd64")
 if is_pr:
-    targets = [t_linux_x86, t_macos, t_windows]
+    targets = [t_linux_x86]
 else:
     targets = [t_linux_x86, t_linux_arm, t_macos, t_windows]
 

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -1,12 +1,20 @@
 use foundry_compilers::utils::read_json_file;
 use foundry_config::SolcReq;
-use foundry_test_utils::TestProject;
+use foundry_test_utils::{TestProject, cargo_profile_dir};
 use std::{fs, path::Path, process::Command};
 
+// Keep each generated crate isolated while reusing its dependencies across binding tests.
+// Cargo locks the shared target directory across nextest processes and fingerprints each crate.
+pub(super) fn bindings_cargo(bindings_path: &Path) -> Command {
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(bindings_path)
+        .env("CARGO_TARGET_DIR", cargo_profile_dir().join("bind-test-target"));
+    cmd
+}
+
 fn assert_bindings_compile(bindings_path: &Path) {
-    let out = Command::new("cargo")
+    let out = bindings_cargo(bindings_path)
         .args(["check", "--tests"])
-        .current_dir(bindings_path)
         .output()
         .expect("failed to run cargo check");
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -4718,9 +4718,8 @@ Bindings have been generated to [..]
     let bindings_path = prj.root().join("out/bindings");
 
     assert!(bindings_path.exists(), "Bindings directory should exist");
-    let out = Command::new("cargo")
+    let out = super::bind::bindings_cargo(&bindings_path)
         .arg("build")
-        .current_dir(&bindings_path)
         .output()
         .expect("Failed to run cargo build");
 


### PR DESCRIPTION
Reuse a dedicated Cargo target directory for generated-binding tests so they share dependency artifacts. Every test still generates its own crate and runs its original cargo check --tests or cargo build command; Cargo fingerprints the distinct sources and locks the shared directory. The temporary cross-platform PR matrix used for measurement has been removed. Authored with Codex; this test-only change uses `L-ignore`.

### Results

[Linux control](https://github.com/foundry-rs/foundry/actions/runs/34036415555/job/101495450964), [master cross-platform baseline](https://github.com/foundry-rs/foundry/actions/runs/34025611270), and [candidate](https://github.com/foundry-rs/foundry/actions/runs/34036490684), using the existing CI profiles and runners:

| Measurement | Before | After |
| --- | --- | --- |
| Linux binding checks, each | 58.5–60.3s | 26.1–27.3s |
| macOS binding checks | Two at 132.7–134.6s; four retried | All pass first try, 44.0–48.9s |
| Windows binding checks | Two at 149.8–150.6s; four time out | All pass first try, 49.8–52.2s |
| Linux suite, 5,389 tests | 202.2s | 181.6s |
| Windows suite, 5,265 tests | 444.3s | 271.0s |

Full-suite timings include runner variance: the final PR run passed 5,393 tests in 225.7s, with two flaky retries, so the suite-wide improvement is not consistent across runs. The same two unrelated brutalize/symbolic failures remain on macOS and Windows; all binding tests pass.
