### PR TITLE
chore(ci): avoid duplicate documentation runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,6 @@ name: docs
 permissions: {}
 
 on:
-  push:
-    branches:
-      - master
   workflow_call:
 
 concurrency:


### PR DESCRIPTION
Run the docs workflow only through CI. Each master push currently invokes it twice: directly through its push trigger and through ci.yml. Both invocations build, upload, and deploy the same documentation; the CI caller already runs on master pushes and supplies the deployment permissions.

On master commit aaf9c1192, the [redundant standalone run](https://github.com/foundry-rs/foundry/actions/runs/34025611180) used 9m 11s of job time across dependency cooldown, documentation, and deployment. Removing that trigger preserves the [CI invocation](https://github.com/foundry-rs/foundry/actions/runs/34025611270) and PR documentation checks.

This CI-only change uses `L-ignore`. Investigation and change authored with Codex.
