### PR TITLE
perf(forge): share validated ABI reuse

### DIFF
--- a/.changelog/forge-test-discovery-cache.md
+++ b/.changelog/forge-test-discovery-cache.md
@@ -1,5 +1,9 @@
 ---
 forge: patch
+foundry-common: patch
+cast: patch
+forge-verify: patch
+foundry-bench: minor
 ---
 
-Cache ABI discovery for repeated filtered test runs.
+Reuse validated ABI results without replacing normal build artifacts, and add a local benchmark for filtered tests with partial compilation caches.

--- a/.changelog/forge-test-discovery-cache.md
+++ b/.changelog/forge-test-discovery-cache.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Cache ABI discovery for repeated filtered test runs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=51f82b642d1a43e323fa2869e3f734957a8e091c#51f82b642d1a43e323fa2869e3f734957a8e091c"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=51f82b642d1a43e323fa2869e3f734957a8e091c#51f82b642d1a43e323fa2869e3f734957a8e091c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=51f82b642d1a43e323fa2869e3f734957a8e091c#51f82b642d1a43e323fa2869e3f734957a8e091c"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=51f82b642d1a43e323fa2869e3f734957a8e091c#51f82b642d1a43e323fa2869e3f734957a8e091c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=51f82b642d1a43e323fa2869e3f734957a8e091c#51f82b642d1a43e323fa2869e3f734957a8e091c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=51f82b642d1a43e323fa2869e3f734957a8e091c#51f82b642d1a43e323fa2869e3f734957a8e091c"
 dependencies = [
  "alloy-primitives",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b2559662424e4060c198b463185d547a0a288737#b2559662424e4060c198b463185d547a0a288737"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b2559662424e4060c198b463185d547a0a288737#b2559662424e4060c198b463185d547a0a288737"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b2559662424e4060c198b463185d547a0a288737#b2559662424e4060c198b463185d547a0a288737"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b2559662424e4060c198b463185d547a0a288737#b2559662424e4060c198b463185d547a0a288737"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b2559662424e4060c198b463185d547a0a288737#b2559662424e4060c198b463185d547a0a288737"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b2559662424e4060c198b463185d547a0a288737#b2559662424e4060c198b463185d547a0a288737"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b2559662424e4060c198b463185d547a0a288737#b2559662424e4060c198b463185d547a0a288737"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b2559662424e4060c198b463185d547a0a288737#b2559662424e4060c198b463185d547a0a288737"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b77890977943a0618b0da300288249381fb92e71#b77890977943a0618b0da300288249381fb92e71"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=51f82b642d1a43e323fa2869e3f734957a8e091c#51f82b642d1a43e323fa2869e3f734957a8e091c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=51f82b642d1a43e323fa2869e3f734957a8e091c#51f82b642d1a43e323fa2869e3f734957a8e091c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d#4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -562,10 +562,10 @@ solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd539
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd53980a7f4ae020c821fb92f025616a" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "51f82b642d1a43e323fa2869e3f734957a8e091c" }
 foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "51f82b642d1a43e323fa2869e3f734957a8e091c" }
 foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "51f82b642d1a43e323fa2869e3f734957a8e091c" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "51f82b642d1a43e323fa2869e3f734957a8e091c" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -562,10 +562,10 @@ solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd539
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd53980a7f4ae020c821fb92f025616a" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d" }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -563,8 +563,8 @@ solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd53
 
 ## foundry-core
 foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "51f82b642d1a43e323fa2869e3f734957a8e091c" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "51f82b642d1a43e323fa2869e3f734957a8e091c" }
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
 
 ## alloy-core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -562,10 +562,10 @@ solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd539
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd53980a7f4ae020c821fb92f025616a" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "b2559662424e4060c198b463185d547a0a288737" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b2559662424e4060c198b463185d547a0a288737" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b2559662424e4060c198b463185d547a0a288737" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "b2559662424e4060c198b463185d547a0a288737" }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "b77890977943a0618b0da300288249381fb92e71" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b77890977943a0618b0da300288249381fb92e71" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b77890977943a0618b0da300288249381fb92e71" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "b77890977943a0618b0da300288249381fb92e71" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -562,10 +562,10 @@ solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd539
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd53980a7f4ae020c821fb92f025616a" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "b77890977943a0618b0da300288249381fb92e71" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b77890977943a0618b0da300288249381fb92e71" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b77890977943a0618b0da300288249381fb92e71" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "b77890977943a0618b0da300288249381fb92e71" }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "4dd499a8ccc60fb6284fbc28c7f3f58b6aadce0d" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/benches/README.md
+++ b/benches/README.md
@@ -131,6 +131,17 @@ and uses the generic symbolic command for other repositories.
 Use `--symbolic-sidecar-output <FILE>` with exactly one `--versions` value to capture the
 versioned per-run results. Like `--json-output`, the sidecar path is relative to `--output-dir`.
 
+For filtered test discovery, use `--benchmarks forge_test_filtered` with test filters
+in the repository's extra arguments. This keeps the project's dynamic-linking
+configuration and warms only the selected tests twice: once to populate normal
+artifacts and once to populate ABI discovery for that cache. It does not run an
+unfiltered build, which would hide partial-cache discovery costs. For example:
+
+```bash
+foundry-bench --versions local --benchmarks forge_test_filtered \
+  --repos "aave/aave-v4:1e8de8630dfeb26ad309d986eaec44c1ceb48a6d --match-contract EngineFlagsTest --match-test test_toBool_zero_returnsFalse --threads 1"
+```
+
 ## Branch vs master PR-body workflow
 
 Use this workflow when preparing performance numbers for a PR body. It keeps the

--- a/benches/README.md
+++ b/benches/README.md
@@ -133,9 +133,10 @@ versioned per-run results. Like `--json-output`, the sidecar path is relative to
 
 For filtered test discovery, use `--benchmarks forge_test_filtered` with test filters
 in the repository's extra arguments or `foundry.toml`. This keeps the project's
-dynamic-linking configuration, cleans inherited artifacts once before each benchmark
-series, and warms the selected tests twice: once to populate normal artifacts and
-once to populate ABI discovery for that cache. Timed runs retain that warm cache.
+dynamic-linking configuration and warms the selected tests twice. The first warmup
+forces cleanup using the same root and configuration as the tests, then populates
+normal artifacts. The second populates ABI discovery for that cache. Timed runs
+retain that warm cache.
 The result is labeled `Forge Test (Warm Cache)` because without effective filters
 it measures ordinary unfiltered tests; it does not guarantee ABI-discovery coverage.
 No unfiltered build runs during setup. For example:

--- a/benches/README.md
+++ b/benches/README.md
@@ -132,10 +132,13 @@ Use `--symbolic-sidecar-output <FILE>` with exactly one `--versions` value to ca
 versioned per-run results. Like `--json-output`, the sidecar path is relative to `--output-dir`.
 
 For filtered test discovery, use `--benchmarks forge_test_filtered` with test filters
-in the repository's extra arguments. This keeps the project's dynamic-linking
-configuration and warms only the selected tests twice: once to populate normal
-artifacts and once to populate ABI discovery for that cache. It does not run an
-unfiltered build, which would hide partial-cache discovery costs. For example:
+in the repository's extra arguments or `foundry.toml`. This keeps the project's
+dynamic-linking configuration, cleans inherited artifacts once before each benchmark
+series, and warms the selected tests twice: once to populate normal artifacts and
+once to populate ABI discovery for that cache. Timed runs retain that warm cache.
+The result is labeled `Forge Test (Warm Cache)` because without effective filters
+it measures ordinary unfiltered tests; it does not guarantee ABI-discovery coverage.
+No unfiltered build runs during setup. For example:
 
 ```bash
 foundry-bench --versions local --benchmarks forge_test_filtered \

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -341,6 +341,31 @@ impl BenchmarkProject {
         )
     }
 
+    /// Benchmarks filtered tests after warming only the selected tests.
+    ///
+    /// Keeps the project's dynamic linking configuration and partial compilation cache.
+    pub fn bench_forge_test_filtered(
+        &self,
+        version: &str,
+        runs: u32,
+        verbose: bool,
+    ) -> Result<HyperfineResult> {
+        let command = self.cmd("forge test");
+        // The first invocation populates normal artifacts; the second warms discovery for
+        // that normal cache. Neither invocation builds unselected tests.
+        let setup = format!("{command} && {command}");
+        self.hyperfine(
+            "forge_test_filtered",
+            version,
+            &command,
+            runs,
+            Some(&setup),
+            None,
+            None,
+            verbose,
+        )
+    }
+
     /// Benchmark forge build with cache
     pub fn bench_forge_build_with_cache(
         &self,
@@ -569,6 +594,7 @@ impl BenchmarkProject {
     ) -> Result<HyperfineResult> {
         match benchmark {
             "forge_test" => self.bench_forge_test(version, runs, verbose),
+            "forge_test_filtered" => self.bench_forge_test_filtered(version, runs, verbose),
             "forge_build_no_cache" => self.bench_forge_build_no_cache(version, runs, verbose),
             "forge_build_with_cache" => self.bench_forge_build_with_cache(version, runs, verbose),
             "forge_fuzz_test" => self.bench_forge_fuzz_test(version, runs, verbose),

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -352,9 +352,9 @@ impl BenchmarkProject {
         verbose: bool,
     ) -> Result<HyperfineResult> {
         let command = self.cmd("forge test");
-        // Clean inherited artifacts once so earlier benchmarks cannot hide discovery misses.
-        // The first test invocation populates normal artifacts; the second warms discovery.
-        let setup = format!("forge clean && {command} && {command}");
+        // Force cleanup in the first warmup using the same root/configuration as the tests.
+        // The second invocation warms discovery against the resulting normal artifacts.
+        let setup = format!("FOUNDRY_FORCE=true {command} && {command}");
         self.hyperfine(
             "forge_test_filtered",
             version,

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -341,9 +341,10 @@ impl BenchmarkProject {
         )
     }
 
-    /// Benchmarks filtered tests after warming only the selected tests.
+    /// Benchmarks tests after cleaning once and warming the selected workload.
     ///
-    /// Keeps the project's dynamic linking configuration and partial compilation cache.
+    /// Keeps the project's dynamic linking configuration. Effective CLI or configuration
+    /// filters are needed to exercise partial-cache discovery.
     pub fn bench_forge_test_filtered(
         &self,
         version: &str,
@@ -351,9 +352,9 @@ impl BenchmarkProject {
         verbose: bool,
     ) -> Result<HyperfineResult> {
         let command = self.cmd("forge test");
-        // The first invocation populates normal artifacts; the second warms discovery for
-        // that normal cache. Neither invocation builds unselected tests.
-        let setup = format!("{command} && {command}");
+        // Clean inherited artifacts once so earlier benchmarks cannot hide discovery misses.
+        // The first test invocation populates normal artifacts; the second warms discovery.
+        let setup = format!("forge clean && {command} && {command}");
         self.hyperfine(
             "forge_test_filtered",
             version,

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -16,8 +16,9 @@ use std::{
     sync::Mutex,
 };
 
-const ALL_BENCHMARKS: [&str; 7] = [
+const ALL_BENCHMARKS: [&str; 8] = [
     "forge_test",
+    "forge_test_filtered",
     "forge_build_no_cache",
     "forge_build_with_cache",
     "forge_fuzz_test",
@@ -75,8 +76,8 @@ struct Cli {
     symbolic_sidecar_output: Option<PathBuf>,
 
     /// Run only specific benchmarks (comma-separated:
-    /// forge_test,forge_build_no_cache,forge_build_with_cache,forge_fuzz_test,forge_coverage,
-    /// forge_symbolic_test)
+    /// forge_test,forge_test_filtered,forge_build_no_cache,forge_build_with_cache,forge_fuzz_test,
+    /// forge_coverage, forge_symbolic_test)
     #[clap(long, value_delimiter = ',')]
     benchmarks: Option<Vec<String>>,
 

--- a/benches/src/results.rs
+++ b/benches/src/results.rs
@@ -481,7 +481,7 @@ pub fn versioned_summary_filename(json_output: &Path, version: &str) -> String {
 pub fn format_benchmark_name(name: &str) -> String {
     match name {
         "forge_test" => "Forge Test",
-        "forge_test_filtered" => "Forge Test (Filtered Cache)",
+        "forge_test_filtered" => "Forge Test (Warm Cache)",
         "forge_build_no_cache" => "Forge Build (No Cache)",
         "forge_build_with_cache" => "Forge Build (With Cache)",
         "forge_fuzz_test" => "Forge Fuzz Test",

--- a/benches/src/results.rs
+++ b/benches/src/results.rs
@@ -481,6 +481,7 @@ pub fn versioned_summary_filename(json_output: &Path, version: &str) -> String {
 pub fn format_benchmark_name(name: &str) -> String {
     match name {
         "forge_test" => "Forge Test",
+        "forge_test_filtered" => "Forge Test (Filtered Cache)",
         "forge_build_no_cache" => "Forge Build (No Cache)",
         "forge_build_with_cache" => "Forge Build (With Cache)",
         "forge_fuzz_test" => "Forge Fuzz Test",

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -80,6 +80,9 @@ pub struct ProjectCompiler {
 
     /// Whether to compile with dynamic linking tests and scripts.
     dynamic_test_linking: bool,
+
+    /// Whether ABI acquisition may consult the compiler-owned ABI cache.
+    abi_cache: bool,
 }
 
 impl Default for ProjectCompiler {
@@ -104,6 +107,7 @@ impl ProjectCompiler {
             size_limits: ContractSizeLimits::default(),
             files: Vec::new(),
             dynamic_test_linking: false,
+            abi_cache: false,
         }
     }
 
@@ -196,6 +200,7 @@ impl ProjectCompiler {
         // Taking is fine since we don't need these in `compile_with`.
         let files = std::mem::take(&mut self.files);
         let preprocess = self.dynamic_test_linking;
+        let abi_cache = self.abi_cache;
         self.compile_with(|| {
             let sources = if files.is_empty() {
                 project.paths.read_input_files()?
@@ -208,7 +213,11 @@ impl ProjectCompiler {
             if preprocess {
                 compiler = compiler.with_preprocessor(DynamicTestLinkingPreprocessor);
             }
-            compiler.compile().map_err(Into::into)
+            if abi_cache {
+                compiler.compile_abi_cached().map_err(Into::into)
+            } else {
+                compiler.compile().map_err(Into::into)
+            }
         })
     }
 
@@ -697,7 +706,7 @@ where
 /// Compiles the project requesting only ABI output.
 pub fn compile_abi_project<C: Compiler<CompilerContract = Contract>>(
     project: &mut Project<C>,
-    compiler: ProjectCompiler,
+    mut compiler: ProjectCompiler,
 ) -> Result<ProjectCompileOutput<C>>
 where
     DynamicTestLinkingPreprocessor: Preprocessor<C>,
@@ -706,7 +715,30 @@ where
         // Request ABI so compilers populate `contracts` without producing bytecode outputs.
         *selection = OutputSelection::common_output_selection(["abi".to_string()]);
     });
+    compiler.abi_cache |= project.no_artifacts;
     compiler.compile(project)
+}
+
+/// Acquires ABI output with compiler-owned persistence separate from normal artifacts.
+///
+/// Requests for additional files or full build info retain their existing output behavior.
+pub fn compile_abi_project_cached<C: Compiler<CompilerContract = Contract>>(
+    project: &mut Project<C>,
+    mut compiler: ProjectCompiler,
+) -> Result<ProjectCompileOutput<C>>
+where
+    DynamicTestLinkingPreprocessor: Preprocessor<C>,
+{
+    if !project.cached
+        || project.build_info
+        || project.artifacts.additional_files != Default::default()
+    {
+        return compile_abi_project(project, compiler);
+    }
+    let mut cached_project = project.clone();
+    cached_project.no_artifacts = false;
+    compiler.abi_cache = true;
+    compile_abi_project(&mut cached_project, compiler)
 }
 
 /// Compiles the target contract requesting only ABI output and returns its ABI.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1485,6 +1485,12 @@ impl TestArgs {
         }
 
         let mut project = config.create_project(true, true)?;
+        // Keep discovery artifacts separate from deployable bytecode artifacts.
+        let discovery_cache = config.cache_path.join("test-discovery");
+        project.paths.cache = discovery_cache.join("solidity-files-cache.json");
+        project.paths.artifacts = discovery_cache.join("out");
+        project.paths.build_infos = discovery_cache.join("build-info");
+        project.no_artifacts = false;
         let sources = src_files()
             .chain(
                 // Preserve path-filter behavior for conventional test files while still

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -39,7 +39,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     ContractsByArtifact, EmptyTestFilter, TestFilter, TestFunctionExt, TestFunctionKind,
-    compile::{ProjectCompiler, compile_abi_project},
+    compile::{ProjectCompiler, compile_abi_project, compile_abi_project_cached},
     fs, sh_status, sh_warn, shell,
 };
 use foundry_compilers::{
@@ -1484,13 +1484,7 @@ impl TestArgs {
             return Ok((src_files().chain(test_files()).collect(), None));
         }
 
-        let mut project = config.create_project(true, true)?;
-        // Keep discovery artifacts separate from deployable bytecode artifacts.
-        let discovery_cache = config.cache_path.join("test-discovery");
-        project.paths.cache = discovery_cache.join("solidity-files-cache.json");
-        project.paths.artifacts = discovery_cache.join("out");
-        project.paths.build_infos = discovery_cache.join("build-info");
-        project.no_artifacts = false;
+        let mut project = config.create_project(config.cache, true)?;
         let sources = src_files()
             .chain(
                 // Preserve path-filter behavior for conventional test files while still
@@ -1498,7 +1492,7 @@ impl TestArgs {
                 test_files().filter(|path| !path.is_sol_test() || test_filter.matches_path(path)),
             )
             .collect::<BTreeSet<_>>();
-        let output = compile_abi_project(
+        let output = compile_abi_project_cached(
             &mut project,
             ProjectCompiler::new()
                 .files(sources.iter().cloned())

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -1,6 +1,8 @@
 //! Tests for commands using the preprocessed cache.
 
 use foundry_compilers::artifacts::{EvmVersion, remappings::Remapping};
+#[cfg(unix)]
+use foundry_compilers::artifacts::{SolcInput, output_selection::OutputSelection};
 use foundry_config::{CompilationRestrictions, SettingsOverrides};
 
 // <https://github.com/foundry-rs/foundry/issues/16682>
@@ -401,7 +403,7 @@ if [ "$1" = "--version" ]; then
     echo "Version: 0.8.35+commit.69074fbd"
     exit 0
 fi
-touch "$0.invoked"
+cat > "$0.invoked"
 exit 1
 "#,
     )
@@ -446,6 +448,16 @@ exit 1
     prj.update_config(|config| config.cache = false);
     cmd.forge_fuse().args(["test", "--match-contract", "CounterTest"]).assert_failure();
     assert!(invoked.exists(), "cache=false reused cached discovery");
+    let input = serde_json::from_slice::<SolcInput>(&fs::read(&invoked).unwrap()).unwrap();
+    // A bytecode compile could also fail here; prove that discovery itself invoked Solc.
+    let expected = OutputSelection::common_output_selection(["abi".to_string()]);
+    assert!(!input.settings.output_selection.0.is_empty());
+    for selection in input.settings.output_selection.0.values() {
+        assert_eq!(
+            selection, &expected.0["*"],
+            "cache=false must recompile ABI discovery before attempting bytecode compilation",
+        );
+    }
     cmd.forge_fuse().arg("clean").assert_success();
     assert!(!abi_cache.exists());
 });

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -410,7 +410,7 @@ exit 1
     permissions.set_mode(0o755);
     fs::set_permissions(&solc, permissions).unwrap();
     prj.update_config(|config| {
-        config.solc = Some(foundry_config::SolcReq::Local(solc));
+        config.solc = Some(foundry_config::SolcReq::Local(solc.clone()));
     });
 
     let output =
@@ -424,6 +424,30 @@ exit 1
 
     cmd.forge_fuse().args(["selectors", "list"]).assert_success();
     assert!(!invoked.exists(), "selector compilation did not reuse the preprocessed cache");
+
+    // A new, unselected test is available only through discovery's secondary cache.
+    prj.update_config(|config| {
+        config.solc = Some(foundry_config::SolcReq::Version(
+            foundry_test_utils::util::SOLC_VERSION.parse().unwrap(),
+        ));
+    });
+    prj.add_test("Other.t.sol", "contract OtherTest { function test_other() public {} }");
+    cmd.forge_fuse().args(["test", "--match-contract", "CounterTest"]).assert_success();
+    let abi_cache = prj.cache().with_file_name("solidity-files-cache.json.abi");
+    assert!(abi_cache.is_dir());
+    assert!(!prj.artifacts().join("Other.t.sol").exists());
+    prj.update_config(|config| {
+        config.solc = Some(foundry_config::SolcReq::Local(solc));
+    });
+    cmd.forge_fuse().args(["test", "--match-contract", "CounterTest"]).assert_success();
+    assert!(!invoked.exists(), "partial-cache discovery invoked solc");
+
+    // Disabling caching must bypass both stores, even after warming them.
+    prj.update_config(|config| config.cache = false);
+    cmd.forge_fuse().args(["test", "--match-contract", "CounterTest"]).assert_failure();
+    assert!(invoked.exists(), "cache=false reused cached discovery");
+    cmd.forge_fuse().arg("clean").assert_success();
+    assert!(!abi_cache.exists());
 });
 
 // <https://github.com/foundry-rs/foundry/issues/8842>


### PR DESCRIPTION
Filtered Forge tests repeatedly compile ABI-only sources absent from the normal artifact cache. Use the compiler-owned layer in https://github.com/foundry-rs/foundry-core/pull/180 to reuse validated normal artifacts first and publish separate ABI cache generations atomically. Preserve compiler paths, build provenance, cache=false and cleanup behavior; existing read-only ABI consumers share acquisition while filtered discovery enables persistence. Pin every Foundry-core crate to the same revision. The filtered-test benchmark forces cleanup in its first warmup using the same root/configuration, and labels results as warm-cache timings without assuming effective filters. Measurements use profiling builds against Foundry master at `34ba6dec`, the local `foundry-bench` runner, and ten samples per binary in counterbalanced batches. These are warm-cache results; initial compilation, refresh copying, and contention are excluded. The full-cache control was repeated with explicit test warmups after a noisy first batch; its wall time is neutral and user CPU is 1.6% higher. Code and PR text were generated with Codex, with iterative Omp/Astra xhigh review.

### Results

| Workload | Master wall | PR wall | Wall change | User CPU, master → PR | Result on both |
| --- | ---: | ---: | --- | ---: | --- |
| Aave v4 `1e8de863`, `EngineFlagsTest::test_toBool_zero_returnsFalse`, partial cache | 4.706 s | 0.396 s | 11.89× faster | 4.498 → 0.507 s | 1 pass; gas 8,493 |
| Solady `acd959aa`, `SafeCastLibTest::testSafeCastUint256ToInt256Bench`, full cache | 138.04 ms | 137.92 ms | Neutral (within noise) | 210.81 → 214.11 ms | 1 pass; gas 29,446 |
