### PR TITLE
fix(doc): preserve NatSpec characters in fenced code blocks

### DIFF
--- a/.changelog/forge-doc-natspec-fenced-characters.md
+++ b/.changelog/forge-doc-natspec-fenced-characters.md
@@ -2,4 +2,4 @@
 forge-doc: patch
 ---
 
-Preserve `<` and `{` inside unambiguous fenced code blocks (` ``` ` / `~~~`) in NatSpec when rendering `forge doc` pages, so Solidity examples like `if (a < b) { revert Err(); }` reach the documentation verbatim instead of being escaped to entities. Prose, inline code spans, and table cells keep the existing MDX-hazard escaping.
+Preserve `<` and `{` inside complete, standalone fenced code blocks (` ``` ` / `~~~`) in NatSpec notice and developer descriptions when rendering `forge doc` pages. Other text keeps the existing MDX-hazard escaping.

--- a/.changelog/forge-doc-natspec-fenced-characters.md
+++ b/.changelog/forge-doc-natspec-fenced-characters.md
@@ -1,0 +1,5 @@
+---
+forge-doc: patch
+---
+
+Preserve `<` and `{` inside unambiguous fenced code blocks (` ``` ` / `~~~`) in NatSpec when rendering `forge doc` pages, so Solidity examples like `if (a < b) { revert Err(); }` reach the documentation verbatim instead of being escaped to entities. Prose, inline code spans, and table cells keep the existing MDX-hazard escaping.

--- a/crates/doc/src/hir_ext.rs
+++ b/crates/doc/src/hir_ext.rs
@@ -6,7 +6,6 @@
 //! * `natspec_doc`: resolves effective NatSpec for a callable item.
 //! * `replace_inline_links`: rewrites `{Ident}` to markdown links.
 
-use crate::render::{logical_lines, region_contains};
 use path_slash::PathBufExt;
 use solar::{
     ast::{
@@ -21,7 +20,6 @@ use solar::{
 };
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
-    ops::Range,
     path::{Path, PathBuf},
 };
 use tracing::warn;
@@ -463,7 +461,7 @@ fn normalized_natspec_content(gcx: Gcx<'_>, item: &NatSpecItem) -> String {
         .to_string()
 }
 
-/// Returns the original tagged parent of a synthetic line-comment notice. The outer `Option`
+/// Returns the original tagged parent of a synthetic comment notice. The outer `Option`
 /// distinguishes a continuation from a standalone untagged notice; the inner value is `None` when
 /// Solar's resolved view omitted the parent because a local section replaced it.
 fn continuation_parent(
@@ -471,14 +469,37 @@ fn continuation_parent(
     all_items: &[NatSpecItem],
     item: &NatSpecItem,
 ) -> Option<Option<Span>> {
-    if !matches!(item.kind, NatSpecKind::Notice)
-        || !gcx.sess.source_map().span_to_snippet(item.span).ok()?.starts_with("///")
-    {
+    if !matches!(item.kind, NatSpecKind::Notice) {
         return None;
     }
 
     let source_map = gcx.sess.source_map();
+    let snippet = source_map.span_to_snippet(item.span).ok()?;
     let location = source_map.lookup_char_pos(item.span.lo());
+    if snippet.starts_with("/**") {
+        let index = all_items.iter().position(|candidate| candidate.span == item.span)?;
+        let previous = all_items.get(index.checked_sub(1)?)?;
+        if !matches!(
+            previous.kind,
+            NatSpecKind::Notice
+                | NatSpecKind::Dev
+                | NatSpecKind::Param { .. }
+                | NatSpecKind::Return { .. }
+        ) {
+            return None;
+        }
+        let previous_location = source_map.lookup_char_pos(previous.span.lo());
+        if location.line != previous_location.line + 1
+            || !std::sync::Arc::ptr_eq(&location.file, &previous_location.file)
+        {
+            return None;
+        }
+        return Some(continuation_parent(gcx, all_items, previous).unwrap_or(Some(previous.span)));
+    }
+    if !snippet.starts_with("///") {
+        return None;
+    }
+
     let mut previous_line = location.line.checked_sub(2)?;
     loop {
         let line = location.file.get_line(previous_line)?.trim_start();
@@ -930,71 +951,6 @@ fn escape_link_label(s: &str) -> String {
     s.replace('{', "&#123;").replace('<', "&lt;").replace('[', "\\[").replace(']', "\\]")
 }
 
-/// Sequential fenced-code-block state across a stream of logical lines.
-///
-/// `collect_comments` sanitizes NatSpec items one line at a time (solar emits one item per
-/// `///` line, before continuations are stitched back together), so a fenced example's
-/// boundaries span successive calls. This tracker applies the same CommonMark rules as
-/// `fenced_code_regions` to each line in order; `feed` reports whether the line belongs to a
-/// fenced code block (an opening or closing marker line, or content inside one) and must be
-/// emitted verbatim.
-#[derive(Default)]
-pub(crate) struct FenceTracker {
-    /// Open fence state: (marker, marker length).
-    open: Option<(char, usize)>,
-}
-
-impl FenceTracker {
-    pub(crate) fn feed(&mut self, line: &str) -> bool {
-        let indent = line.len() - line.trim_start_matches(' ').len();
-        if indent <= 3 {
-            let trimmed = &line[indent..];
-            if let Some(marker @ ('`' | '~')) = trimmed.chars().next() {
-                let len = trimmed.chars().take_while(|&ch| ch == marker).count();
-                if let Some((open_marker, open_len)) = self.open {
-                    if marker == open_marker && len >= open_len && trimmed[len..].trim().is_empty()
-                    {
-                        self.open = None;
-                        return true;
-                    }
-                } else if len >= 3 && !(marker == '`' && trimmed[len..].contains('`')) {
-                    self.open = Some((marker, len));
-                    return true;
-                }
-            }
-        }
-        self.open.is_some()
-    }
-}
-
-/// Byte ranges of unambiguous fenced code blocks (` ``` ` or `~~~`) in `text`.
-///
-/// NatSpec descriptions reach `replace_inline_links` with their continuation lines already
-/// stitched back together (see `positional_description`), so a fenced example's opening and
-/// closing lines are visible in the same string. Detection follows the CommonMark
-/// fenced-code-block rules MDX inherits; see `FenceTracker` for the per-line rules.
-/// Everything else - prose, inline code spans, tables, ambiguous constructs - stays outside
-/// these ranges and keeps its existing escaping.
-pub(crate) fn fenced_code_regions(text: &str) -> Vec<Range<usize>> {
-    let mut regions = Vec::new();
-    let mut tracker = FenceTracker::default();
-    let mut open_start: Option<usize> = None;
-    let mut last_end = 0;
-    for (start, line) in logical_lines(text) {
-        if tracker.feed(line) {
-            open_start.get_or_insert(start);
-            last_end = start + line.len();
-        } else if let Some(region_start) = open_start.take() {
-            regions.push(region_start..last_end);
-        }
-    }
-    if let Some(region_start) = open_start {
-        // An unclosed fence runs to the end of the text (CommonMark).
-        regions.push(region_start..text.len());
-    }
-    regions
-}
-
 /// Replace `{Ident}` and `{xref-Ident}` with markdown links using `name_to_page`.
 ///
 /// Matches the legacy pattern: `{[xref-]Ident[-part]}[label]` where `label` defaults
@@ -1004,34 +960,17 @@ pub(crate) fn fenced_code_regions(text: &str) -> Vec<Range<usize>> {
 /// contract (`{member}`, or `{Contract-member}` where `Contract` is the current
 /// contract) becomes an anchor-only link within the page; everything else goes
 /// through the global `name_to_page` index.
-///
-/// Text inside unambiguous fenced code blocks (` ``` ` or `~~~`) is emitted verbatim:
-/// a fenced example is code, so its `<` and `{` are literal content, not MDX hazards
-/// or link references. Prose, inline code spans, and table cells keep the existing
-/// escaping behavior unchanged.
 pub fn replace_inline_links(
     text: &str,
     name_to_page: &NameToPage,
     current_page: &Path,
     local: Option<&LocalMembers>,
 ) -> String {
-    let fences = fenced_code_regions(text);
-    let mut fence_cursor = 0;
-
     let mut out = String::with_capacity(text.len());
     let bytes = text.as_bytes();
     let mut i = 0;
 
     while i < bytes.len() {
-        if region_contains(&fences, &mut fence_cursor, i) {
-            // Inside a fenced code example: emit verbatim, so `<` and `{` are neither escaped
-            // nor rewritten into links. `fence_cursor` now points at the covering region.
-            let end = fences[fence_cursor].end;
-            out.push_str(&text[i..end]);
-            i = end;
-            continue;
-        }
-
         if bytes[i] == b'{' {
             // Try to parse {[xref-]Ident[-part]}[optional label].
             if let Some((end, ident, part, label)) = parse_inline_link(&text[i..]) {
@@ -1347,136 +1286,5 @@ mod tests {
             None,
         );
         assert_eq!(out, "Calls [transfer](/src/other/contract.transfer).");
-    }
-
-    #[test]
-    fn fenced_example_preserves_mdx_hazards_verbatim() {
-        let mut name_to_page = NameToPage::new();
-        name_to_page
-            .by_name
-            .insert("ERC721".to_string(), vec![PathBuf::from("src/contract.ERC721.mdx")]);
-
-        let text = "Prose with {ERC721} and <0xABC>.\n\
-                    ```solidity\n\
-                    if (a < b) { revert TooSmall(a, b); }\n\
-                    ```\n\
-                    Trailing {ERC721} and <b> prose.";
-        let out =
-            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
-
-        assert_eq!(
-            out,
-            "Prose with [ERC721](/src/contract.ERC721) and &lt;0xABC>.\n\
-             ```solidity\n\
-             if (a < b) { revert TooSmall(a, b); }\n\
-             ```\n\
-             Trailing [ERC721](/src/contract.ERC721) and &lt;b> prose."
-        );
-    }
-
-    #[test]
-    fn fenced_tilde_and_longer_backtick_fences() {
-        let name_to_page = NameToPage::new();
-
-        // A ~~~ fence, and a 4-backtick fence wrapping a 3-backtick block, stay verbatim.
-        let text = "~~~\n{a} <b>\n~~~\n\
-                    ````markdown\n```solidity\ncontract C {}\n```\n````\n\
-                    Outside <b> {brace.";
-        let out =
-            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
-
-        assert!(out.contains("~~~\n{a} <b>\n~~~"));
-        assert!(out.contains("````markdown\n```solidity\ncontract C {}\n```\n````"));
-        assert!(out.ends_with("Outside &lt;b> &#123;brace."));
-    }
-
-    #[test]
-    fn ambiguous_backtick_fence_info_keeps_escaping() {
-        // A backtick fence whose info string contains a backtick opens nothing (CommonMark),
-        // so the following lines are prose and keep the existing escaping.
-        let text = "```bad`\n<still> {unclosed\n";
-        let out =
-            replace_inline_links(text, &NameToPage::new(), Path::new("src/contract.Foo.mdx"), None);
-
-        assert_eq!(out, "```bad`\n&lt;still> &#123;unclosed\n");
-    }
-
-    #[test]
-    fn unclosed_fence_runs_to_end_of_text() {
-        // CommonMark: an unclosed fence swallows the rest of the text as code.
-        let text = "```solidity\nif (a < b) { revert(); }\nand <more> {prose";
-        let out =
-            replace_inline_links(text, &NameToPage::new(), Path::new("src/contract.Foo.mdx"), None);
-
-        assert_eq!(out, text);
-    }
-
-    #[test]
-    fn fence_indentation_follows_commonmark() {
-        let name_to_page = NameToPage::new();
-
-        // Up to three spaces of indentation still opens a fence.
-        let text = "   ```solidity\nif (a < b) { revert(); }\n   ```\nafter <b> {c\n";
-        let out =
-            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
-
-        assert!(out.contains("   ```solidity\nif (a < b) { revert(); }\n   ```"));
-        assert!(out.ends_with("after &lt;b> &#123;c\n"));
-
-        // Four spaces is an indented code block, not a fence, so prose escaping applies.
-        let text = "    ```solidity\n<inside> {it\n";
-        let out =
-            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
-
-        assert_eq!(out, "    ```solidity\n&lt;inside> &#123;it\n");
-    }
-
-    #[test]
-    fn closing_fence_requires_same_marker_and_count() {
-        let name_to_page = NameToPage::new();
-
-        // A ~~~ line cannot close a ``` fence; the ``` after it does, and prose between the
-        // two fences is escaped normally.
-        let text = "```solidity\n{a} <b>\n~~~\n```\nstill <inside>\n```\nafter <c> {d\n";
-        let out =
-            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
-
-        assert!(out.contains("```solidity\n{a} <b>\n~~~\n```"));
-        assert!(out.contains("still &lt;inside>"));
-        assert!(out.ends_with("after <c> {d\n"));
-    }
-
-    #[test]
-    fn prose_and_inline_code_escaping_unchanged() {
-        // Outside fences the existing behavior is retained byte-for-byte: `<` in prose and
-        // inline code is escaped, and an unresolved `{Ident}` is emitted as inline code.
-        let out = replace_inline_links(
-            "Use `forge create <Contract>` then {OWNER} and <plain>.",
-            &NameToPage::new(),
-            Path::new("src/contract.Foo.mdx"),
-            None,
-        );
-
-        assert_eq!(out, "Use `forge create &lt;Contract>` then `OWNER` and &lt;plain>.");
-    }
-
-    #[test]
-    fn fence_tracker_tracks_state_across_lines() {
-        let mut fences = FenceTracker::default();
-
-        // Prose before the fence.
-        assert!(!fences.feed("Some prose."));
-        // Opening marker, content, and closing marker are all fence lines.
-        assert!(fences.feed("```solidity"));
-        assert!(fences.feed("if (a < b) { revert Err(); }"));
-        assert!(fences.feed("```"));
-        // Back inside prose.
-        assert!(!fences.feed("More <prose>."));
-
-        // A fence whose closing line is indented up to three spaces still closes.
-        assert!(fences.feed("~~~"));
-        assert!(fences.feed("text"));
-        assert!(fences.feed("   ~~~"));
-        assert!(!fences.feed("text"));
     }
 }

--- a/crates/doc/src/hir_ext.rs
+++ b/crates/doc/src/hir_ext.rs
@@ -6,6 +6,7 @@
 //! * `natspec_doc`: resolves effective NatSpec for a callable item.
 //! * `replace_inline_links`: rewrites `{Ident}` to markdown links.
 
+use crate::render::{logical_lines, region_contains};
 use path_slash::PathBufExt;
 use solar::{
     ast::{
@@ -20,6 +21,7 @@ use solar::{
 };
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
+    ops::Range,
     path::{Path, PathBuf},
 };
 use tracing::warn;
@@ -928,6 +930,71 @@ fn escape_link_label(s: &str) -> String {
     s.replace('{', "&#123;").replace('<', "&lt;").replace('[', "\\[").replace(']', "\\]")
 }
 
+/// Sequential fenced-code-block state across a stream of logical lines.
+///
+/// `collect_comments` sanitizes NatSpec items one line at a time (solar emits one item per
+/// `///` line, before continuations are stitched back together), so a fenced example's
+/// boundaries span successive calls. This tracker applies the same CommonMark rules as
+/// `fenced_code_regions` to each line in order; `feed` reports whether the line belongs to a
+/// fenced code block (an opening or closing marker line, or content inside one) and must be
+/// emitted verbatim.
+#[derive(Default)]
+pub(crate) struct FenceTracker {
+    /// Open fence state: (marker, marker length).
+    open: Option<(char, usize)>,
+}
+
+impl FenceTracker {
+    pub(crate) fn feed(&mut self, line: &str) -> bool {
+        let indent = line.len() - line.trim_start_matches(' ').len();
+        if indent <= 3 {
+            let trimmed = &line[indent..];
+            if let Some(marker @ ('`' | '~')) = trimmed.chars().next() {
+                let len = trimmed.chars().take_while(|&ch| ch == marker).count();
+                if let Some((open_marker, open_len)) = self.open {
+                    if marker == open_marker && len >= open_len && trimmed[len..].trim().is_empty()
+                    {
+                        self.open = None;
+                        return true;
+                    }
+                } else if len >= 3 && !(marker == '`' && trimmed[len..].contains('`')) {
+                    self.open = Some((marker, len));
+                    return true;
+                }
+            }
+        }
+        self.open.is_some()
+    }
+}
+
+/// Byte ranges of unambiguous fenced code blocks (` ``` ` or `~~~`) in `text`.
+///
+/// NatSpec descriptions reach `replace_inline_links` with their continuation lines already
+/// stitched back together (see `positional_description`), so a fenced example's opening and
+/// closing lines are visible in the same string. Detection follows the CommonMark
+/// fenced-code-block rules MDX inherits; see `FenceTracker` for the per-line rules.
+/// Everything else - prose, inline code spans, tables, ambiguous constructs - stays outside
+/// these ranges and keeps its existing escaping.
+pub(crate) fn fenced_code_regions(text: &str) -> Vec<Range<usize>> {
+    let mut regions = Vec::new();
+    let mut tracker = FenceTracker::default();
+    let mut open_start: Option<usize> = None;
+    let mut last_end = 0;
+    for (start, line) in logical_lines(text) {
+        if tracker.feed(line) {
+            open_start.get_or_insert(start);
+            last_end = start + line.len();
+        } else if let Some(region_start) = open_start.take() {
+            regions.push(region_start..last_end);
+        }
+    }
+    if let Some(region_start) = open_start {
+        // An unclosed fence runs to the end of the text (CommonMark).
+        regions.push(region_start..text.len());
+    }
+    regions
+}
+
 /// Replace `{Ident}` and `{xref-Ident}` with markdown links using `name_to_page`.
 ///
 /// Matches the legacy pattern: `{[xref-]Ident[-part]}[label]` where `label` defaults
@@ -937,17 +1004,34 @@ fn escape_link_label(s: &str) -> String {
 /// contract (`{member}`, or `{Contract-member}` where `Contract` is the current
 /// contract) becomes an anchor-only link within the page; everything else goes
 /// through the global `name_to_page` index.
+///
+/// Text inside unambiguous fenced code blocks (` ``` ` or `~~~`) is emitted verbatim:
+/// a fenced example is code, so its `<` and `{` are literal content, not MDX hazards
+/// or link references. Prose, inline code spans, and table cells keep the existing
+/// escaping behavior unchanged.
 pub fn replace_inline_links(
     text: &str,
     name_to_page: &NameToPage,
     current_page: &Path,
     local: Option<&LocalMembers>,
 ) -> String {
+    let fences = fenced_code_regions(text);
+    let mut fence_cursor = 0;
+
     let mut out = String::with_capacity(text.len());
     let bytes = text.as_bytes();
     let mut i = 0;
 
     while i < bytes.len() {
+        if region_contains(&fences, &mut fence_cursor, i) {
+            // Inside a fenced code example: emit verbatim, so `<` and `{` are neither escaped
+            // nor rewritten into links. `fence_cursor` now points at the covering region.
+            let end = fences[fence_cursor].end;
+            out.push_str(&text[i..end]);
+            i = end;
+            continue;
+        }
+
         if bytes[i] == b'{' {
             // Try to parse {[xref-]Ident[-part]}[optional label].
             if let Some((end, ident, part, label)) = parse_inline_link(&text[i..]) {
@@ -1263,5 +1347,136 @@ mod tests {
             None,
         );
         assert_eq!(out, "Calls [transfer](/src/other/contract.transfer).");
+    }
+
+    #[test]
+    fn fenced_example_preserves_mdx_hazards_verbatim() {
+        let mut name_to_page = NameToPage::new();
+        name_to_page
+            .by_name
+            .insert("ERC721".to_string(), vec![PathBuf::from("src/contract.ERC721.mdx")]);
+
+        let text = "Prose with {ERC721} and <0xABC>.\n\
+                    ```solidity\n\
+                    if (a < b) { revert TooSmall(a, b); }\n\
+                    ```\n\
+                    Trailing {ERC721} and <b> prose.";
+        let out =
+            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
+
+        assert_eq!(
+            out,
+            "Prose with [ERC721](/src/contract.ERC721) and &lt;0xABC>.\n\
+             ```solidity\n\
+             if (a < b) { revert TooSmall(a, b); }\n\
+             ```\n\
+             Trailing [ERC721](/src/contract.ERC721) and &lt;b> prose."
+        );
+    }
+
+    #[test]
+    fn fenced_tilde_and_longer_backtick_fences() {
+        let name_to_page = NameToPage::new();
+
+        // A ~~~ fence, and a 4-backtick fence wrapping a 3-backtick block, stay verbatim.
+        let text = "~~~\n{a} <b>\n~~~\n\
+                    ````markdown\n```solidity\ncontract C {}\n```\n````\n\
+                    Outside <b> {brace.";
+        let out =
+            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
+
+        assert!(out.contains("~~~\n{a} <b>\n~~~"));
+        assert!(out.contains("````markdown\n```solidity\ncontract C {}\n```\n````"));
+        assert!(out.ends_with("Outside &lt;b> &#123;brace."));
+    }
+
+    #[test]
+    fn ambiguous_backtick_fence_info_keeps_escaping() {
+        // A backtick fence whose info string contains a backtick opens nothing (CommonMark),
+        // so the following lines are prose and keep the existing escaping.
+        let text = "```bad`\n<still> {unclosed\n";
+        let out =
+            replace_inline_links(text, &NameToPage::new(), Path::new("src/contract.Foo.mdx"), None);
+
+        assert_eq!(out, "```bad`\n&lt;still> &#123;unclosed\n");
+    }
+
+    #[test]
+    fn unclosed_fence_runs_to_end_of_text() {
+        // CommonMark: an unclosed fence swallows the rest of the text as code.
+        let text = "```solidity\nif (a < b) { revert(); }\nand <more> {prose";
+        let out =
+            replace_inline_links(text, &NameToPage::new(), Path::new("src/contract.Foo.mdx"), None);
+
+        assert_eq!(out, text);
+    }
+
+    #[test]
+    fn fence_indentation_follows_commonmark() {
+        let name_to_page = NameToPage::new();
+
+        // Up to three spaces of indentation still opens a fence.
+        let text = "   ```solidity\nif (a < b) { revert(); }\n   ```\nafter <b> {c\n";
+        let out =
+            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
+
+        assert!(out.contains("   ```solidity\nif (a < b) { revert(); }\n   ```"));
+        assert!(out.ends_with("after &lt;b> &#123;c\n"));
+
+        // Four spaces is an indented code block, not a fence, so prose escaping applies.
+        let text = "    ```solidity\n<inside> {it\n";
+        let out =
+            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
+
+        assert_eq!(out, "    ```solidity\n&lt;inside> &#123;it\n");
+    }
+
+    #[test]
+    fn closing_fence_requires_same_marker_and_count() {
+        let name_to_page = NameToPage::new();
+
+        // A ~~~ line cannot close a ``` fence; the ``` after it does, and prose between the
+        // two fences is escaped normally.
+        let text = "```solidity\n{a} <b>\n~~~\n```\nstill <inside>\n```\nafter <c> {d\n";
+        let out =
+            replace_inline_links(text, &name_to_page, Path::new("src/contract.Foo.mdx"), None);
+
+        assert!(out.contains("```solidity\n{a} <b>\n~~~\n```"));
+        assert!(out.contains("still &lt;inside>"));
+        assert!(out.ends_with("after <c> {d\n"));
+    }
+
+    #[test]
+    fn prose_and_inline_code_escaping_unchanged() {
+        // Outside fences the existing behavior is retained byte-for-byte: `<` in prose and
+        // inline code is escaped, and an unresolved `{Ident}` is emitted as inline code.
+        let out = replace_inline_links(
+            "Use `forge create <Contract>` then {OWNER} and <plain>.",
+            &NameToPage::new(),
+            Path::new("src/contract.Foo.mdx"),
+            None,
+        );
+
+        assert_eq!(out, "Use `forge create &lt;Contract>` then `OWNER` and &lt;plain>.");
+    }
+
+    #[test]
+    fn fence_tracker_tracks_state_across_lines() {
+        let mut fences = FenceTracker::default();
+
+        // Prose before the fence.
+        assert!(!fences.feed("Some prose."));
+        // Opening marker, content, and closing marker are all fence lines.
+        assert!(fences.feed("```solidity"));
+        assert!(fences.feed("if (a < b) { revert Err(); }"));
+        assert!(fences.feed("```"));
+        // Back inside prose.
+        assert!(!fences.feed("More <prose>."));
+
+        // A fence whose closing line is indented up to three spaces still closes.
+        assert!(fences.feed("~~~"));
+        assert!(fences.feed("text"));
+        assert!(fences.feed("   ~~~"));
+        assert!(!fences.feed("text"));
     }
 }

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -161,8 +161,10 @@ fn render_contract<'ast, 'gcx>(
                 });
                 let sanitize =
                     |s: &str| hir_ext::replace_inline_links(s, name_to_page, page_path, local);
+                let sanitize_description =
+                    |s: &str| replace_description_links(s, name_to_page, page_path, local);
                 if let Some(base_doc) = &inherited {
-                    c.inherit_descriptions(base_doc, &sanitize);
+                    c.inherit_descriptions(base_doc, &sanitize_description);
                 }
                 write_comment_block(out, &c);
                 write_code_block(out, &ctx.dedented_snippet(*span));
@@ -480,7 +482,9 @@ fn render_function_section(
     // Merge inherited natspec for missing tags.
     if let Some(inherited) = inherited {
         let sanitize = |s: &str| hir_ext::replace_inline_links(s, name_to_page, page_path, local);
-        c.inherit_descriptions(inherited, &sanitize);
+        let sanitize_description =
+            |s: &str| replace_description_links(s, name_to_page, page_path, local);
+        c.inherit_descriptions(inherited, &sanitize_description);
         if c.params.is_empty() {
             let params = inherited.params.iter().map(|desc| sanitize(desc)).collect::<Vec<_>>();
             for (index, desc) in params.iter().enumerate() {
@@ -610,9 +614,8 @@ impl CommentData {
 /// Collect natspec from doc comments, applying inline link replacement.
 ///
 /// Solar emits each `///` line as a separate `DocComment`. Lines without a `@` tag become
-/// synthetic `@notice` items with leading whitespace in their raw content. We detect these
-/// continuation lines and join them to the previous description paragraph so that multi-line
-/// natspec tags appear as a single coherent block in the right source order.
+/// synthetic `@notice` items. We join adjacent synthetic items to the previous rendered section
+/// so multi-line natspec tags form a single coherent block in source order.
 fn collect_comments(
     docs: &DocComments<'_>,
     name_to_page: &NameToPage,
@@ -646,12 +649,6 @@ fn collect_comments(
         Return,
     }
     let mut last_section: Option<LastSection> = None;
-    // Fenced-code-block state across the comment stream (same CommonMark rules as
-    // `hir_ext::fenced_code_regions`). Solar emits one item per `///` line, before
-    // continuations are stitched back together, so a fenced example's boundaries span
-    // successive items and must be tracked as the lines stream past.
-    let mut fences = hir_ext::FenceTracker::default();
-
     for doc in docs.iter() {
         if doc.natspec.is_empty() {
             prev_doc_was_blank = true;
@@ -665,11 +662,10 @@ fn collect_comments(
             let raw: &str =
                 if doc.kind == CommentKind::Block { &clean_block_doc_content(raw) } else { raw };
 
-            // Detect a solar "synthetic" @notice: a continuation line with no `@` tag.
-            // Solar produces these when a `///` line has no tag; the raw content starts
-            // with whitespace (the indentation after `///`).
-            let is_continuation = matches!(item.kind, NatSpecKind::Notice)
-                && raw.starts_with(|c: char| c.is_whitespace());
+            // Solar represents an untagged doc comment as a synthetic notice whose span is the
+            // whole comment. Treat it as a continuation when it follows a rendered section;
+            // this also joins adjacent line and block doc comments before fence detection.
+            let is_continuation = matches!(item.kind, NatSpecKind::Notice) && item.span == doc.span;
 
             let trimmed = raw.trim();
             if trimmed.is_empty() {
@@ -677,20 +673,9 @@ fn collect_comments(
                 continue;
             }
 
-            // Apply inline {Ident} -> markdown link replacement. Lines belonging to a fenced
-            // code block are code examples: their `<` and `{` are literal content, not MDX
-            // hazards or link references, so they bypass the replacement and reach the page
-            // verbatim. Every line feeds the tracker in order, even when the item as a whole
-            // is not emitted verbatim, so the state stays in sync with the comment stream.
-            let mut is_fenced = !trimmed.is_empty();
-            for line in trimmed.lines() {
-                is_fenced &= fences.feed(line);
-            }
-            let content = if is_fenced {
-                trimmed.to_string()
-            } else {
-                hir_ext::replace_inline_links(trimmed, name_to_page, page_path, local)
-            };
+            // Keep descriptions raw until continuation lines have been joined. Only complete,
+            // standalone descriptions can safely identify fenced code blocks.
+            let content = trimmed.to_string();
 
             if is_continuation && !prev_doc_was_blank {
                 let appended = match last_section {
@@ -740,6 +725,8 @@ fn collect_comments(
                         // Silently ignored.
                     } else if tag == "name" {
                         // `@custom:name <name>` -> unnamed param name (legacy parity).
+                        let content =
+                            hir_ext::replace_inline_links(&content, name_to_page, page_path, local);
                         if let Some(first) = content.split_whitespace().next() {
                             data.unnamed_param_names.push(first.to_string());
                         }
@@ -754,6 +741,27 @@ fn collect_comments(
                 NatSpecKind::Internal { .. } => {}
             }
         }
+    }
+
+    let sanitize = |s: &str| hir_ext::replace_inline_links(s, name_to_page, page_path, local);
+    for content in &mut data.titles {
+        *content = sanitize_description_prose(content, name_to_page, page_path, local);
+    }
+    for content in &mut data.authors {
+        *content = sanitize_description_prose(content, name_to_page, page_path, local);
+    }
+    for (_, content) in &mut data.params {
+        *content = sanitize(content);
+    }
+    for (_, content) in &mut data.returns {
+        *content = sanitize(content);
+    }
+    for (_, content) in &mut data.customs {
+        *content = sanitize_description_prose(content, name_to_page, page_path, local);
+    }
+    for description in &mut data.descriptions {
+        description.content =
+            replace_description_links(&description.content, name_to_page, page_path, local);
     }
 
     data
@@ -894,10 +902,124 @@ fn collect_code_regions(node: &Node, regions: &mut Vec<Range<usize>>) {
     }
 }
 
+/// Replace inline links in a standalone notice or dev description while preserving complete,
+/// top-level fenced code blocks. Other NatSpec fields use `replace_inline_links` directly because
+/// their rendering context (notably table cells) cannot contain block-level Markdown.
+fn replace_description_links(
+    text: &str,
+    name_to_page: &NameToPage,
+    current_page: &Path,
+    local: Option<&hir_ext::LocalMembers>,
+) -> String {
+    let regions = fenced_description_regions(text);
+    let mut out = String::with_capacity(text.len());
+    let mut rendered_regions = Vec::with_capacity(regions.len());
+    let mut copied = 0;
+    for region in regions {
+        out.push_str(&sanitize_description_prose(
+            &text[copied..region.start],
+            name_to_page,
+            current_page,
+            local,
+        ));
+        let start = out.len();
+        out.push_str(&text[region.clone()]);
+        rendered_regions.push(start..out.len());
+        copied = region.end;
+    }
+    out.push_str(&sanitize_description_prose(&text[copied..], name_to_page, current_page, local));
+    let mdx_regions = code_regions(&out, &ParseOptions::mdx());
+    if rendered_regions.iter().all(|region| mdx_regions.contains(region)) {
+        out
+    } else {
+        sanitize_description_prose(text, name_to_page, current_page, local)
+    }
+}
+
+fn sanitize_description_prose(
+    text: &str,
+    name_to_page: &NameToPage,
+    current_page: &Path,
+    local: Option<&hir_ext::LocalMembers>,
+) -> String {
+    let text = hir_ext::replace_inline_links(text, name_to_page, current_page, local);
+    neutralize_fence_markers(&text)
+}
+
+/// Keep rejected or incomplete fence markers from changing the Markdown context of subsequent
+/// descriptions. Entities render as the original marker characters without acting as syntax.
+fn neutralize_fence_markers(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if let marker @ (b'`' | b'~') = bytes[i] {
+            let length = bytes[i..].iter().take_while(|&&byte| byte == marker).count();
+            if length >= 3 {
+                out.push_str(if marker == b'`' { "&#96;" } else { "&#126;" });
+                out.push_str(&text[i + 1..i + length]);
+                i += length;
+                continue;
+            }
+        }
+        let ch = text[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+/// Complete fenced code blocks that are direct children of the description document. Restricting
+/// preservation to root-level blocks keeps list, quote, table, and unclosed-fence behavior on the
+/// conservative escaping path.
+fn fenced_description_regions(text: &str) -> Vec<Range<usize>> {
+    let Ok(Node::Root(root)) = to_mdast(text, &ParseOptions::gfm()) else {
+        return Vec::new();
+    };
+    root.children
+        .iter()
+        .filter_map(|node| {
+            let Node::Code(_) = node else { return None };
+            let position = node.position()?;
+            let range = position.start.offset..position.end.offset;
+            is_complete_fence(&text[range.clone()]).then_some(range)
+        })
+        .collect()
+}
+
+fn is_complete_fence(text: &str) -> bool {
+    let mut lines = logical_lines(text);
+    let Some((_, first)) = lines.next() else { return false };
+    let Some((marker, length)) = fence_marker(first) else { return false };
+    let mut last = None;
+    for (_, line) in lines {
+        last = Some(line);
+    }
+    let Some(last) = last else { return false };
+    let indent = last.len() - last.trim_start_matches(' ').len();
+    if indent > 3 {
+        return false;
+    }
+    let last = &last[indent..];
+    let closing_length = last.chars().take_while(|&ch| ch == marker).count();
+    closing_length >= length && last[closing_length..].trim().is_empty()
+}
+
+fn fence_marker(line: &str) -> Option<(char, usize)> {
+    let indent = line.len() - line.trim_start_matches(' ').len();
+    if indent > 3 {
+        return None;
+    }
+    let line = &line[indent..];
+    let marker @ ('`' | '~') = line.chars().next()? else { return None };
+    let length = line.chars().take_while(|&ch| ch == marker).count();
+    (length >= 3).then_some((marker, length))
+}
+
 /// Logical lines and their byte offsets in the original text. CRLF is one separator; lone CR and
 /// LF are separators too. The separator bytes are excluded from the returned slices and preserved
 /// in the source string.
-pub(crate) fn logical_lines(text: &str) -> impl Iterator<Item = (usize, &str)> {
+fn logical_lines(text: &str) -> impl Iterator<Item = (usize, &str)> {
     let bytes = text.as_bytes();
     let mut offset = 0;
     std::iter::from_fn(move || {
@@ -1360,8 +1482,10 @@ pub fn source<'ast, 'gcx>(
 
 #[cfg(test)]
 mod tests {
-    use super::neutralize_esm;
+    use super::{neutralize_esm, replace_description_links, sanitize_description_prose};
+    use crate::hir_ext::NameToPage;
     use markdown::{MdxSignal, ParseOptions, mdast::Node, to_mdast};
+    use std::path::Path;
 
     fn parse_mdx(text: &str) -> Node {
         let mut options = ParseOptions::mdx();
@@ -1372,6 +1496,71 @@ mod tests {
     fn contains_mdx_esm(node: &Node) -> bool {
         matches!(node, Node::MdxjsEsm(_))
             || node.children().is_some_and(|children| children.iter().any(contains_mdx_esm))
+    }
+
+    fn contains_mdx_expression(node: &Node) -> bool {
+        matches!(node, Node::MdxFlowExpression(_) | Node::MdxTextExpression(_))
+            || node.children().is_some_and(|children| children.iter().any(contains_mdx_expression))
+    }
+
+    #[test]
+    fn preserves_complete_top_level_description_fences() {
+        let input = "Before < and {\n~~~solidity\nif (a < b) { revert(); }\n~~~\nAfter < and {";
+        let output = replace_description_links(
+            input,
+            &NameToPage::new(),
+            Path::new("src/contract.Foo.mdx"),
+            None,
+        );
+
+        assert_eq!(
+            output,
+            "Before &lt; and &#123;\n~~~solidity\nif (a < b) { revert(); }\n~~~\nAfter &lt; and &#123;"
+        );
+    }
+
+    #[test]
+    fn conservatively_escapes_non_standalone_fences() {
+        for (input, expected) in [
+            (
+                "- ~~~\n  example <\n  ~~~\nOutside < and {",
+                "- &#126;~~\n  example &lt;\n  &#126;~~\nOutside &lt; and &#123;",
+            ),
+            ("~~~\nexample < and {", "&#126;~~\nexample &lt; and &#123;"),
+        ] {
+            assert_eq!(
+                replace_description_links(
+                    input,
+                    &NameToPage::new(),
+                    Path::new("src/contract.Foo.mdx"),
+                    None,
+                ),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn rejected_fences_cannot_change_later_mdx_context() {
+        let name_to_page = NameToPage::new();
+        let path = Path::new("src/contract.Foo.mdx");
+        let first = replace_description_links("~~~", &name_to_page, path, None);
+        let second = replace_description_links("~~~\n{1+1}\n~~~", &name_to_page, path, None);
+        let output = format!("{first}\n\n{second}");
+        assert_eq!(output, "&#126;~~\n\n~~~\n{1+1}\n~~~");
+        assert!(!contains_mdx_expression(&parse_mdx(&output)));
+
+        let output =
+            replace_description_links("~~~\n    ~~~\n{1+1}\n~~~", &name_to_page, path, None);
+        assert_eq!(output, "&#126;~~\n    &#126;~~\n`1+1`\n&#126;~~");
+        assert!(!contains_mdx_expression(&parse_mdx(&output)));
+
+        let notice = replace_description_links("~~~\n{1+1}\n~~~", &name_to_page, path, None);
+        for prefix in ["**Title:**", "**Author:**", "- **note:**"] {
+            let metadata = sanitize_description_prose("metadata\n~~~", &name_to_page, path, None);
+            let output = format!("{prefix} {metadata}\n\n{notice}");
+            assert!(!contains_mdx_expression(&parse_mdx(&output)), "{output}");
+        }
     }
 
     #[test]

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -646,6 +646,11 @@ fn collect_comments(
         Return,
     }
     let mut last_section: Option<LastSection> = None;
+    // Fenced-code-block state across the comment stream (same CommonMark rules as
+    // `hir_ext::fenced_code_regions`). Solar emits one item per `///` line, before
+    // continuations are stitched back together, so a fenced example's boundaries span
+    // successive items and must be tracked as the lines stream past.
+    let mut fences = hir_ext::FenceTracker::default();
 
     for doc in docs.iter() {
         if doc.natspec.is_empty() {
@@ -672,8 +677,20 @@ fn collect_comments(
                 continue;
             }
 
-            // Apply inline {Ident} -> markdown link replacement.
-            let content = hir_ext::replace_inline_links(trimmed, name_to_page, page_path, local);
+            // Apply inline {Ident} -> markdown link replacement. Lines belonging to a fenced
+            // code block are code examples: their `<` and `{` are literal content, not MDX
+            // hazards or link references, so they bypass the replacement and reach the page
+            // verbatim. Every line feeds the tracker in order, even when the item as a whole
+            // is not emitted verbatim, so the state stays in sync with the comment stream.
+            let mut is_fenced = !trimmed.is_empty();
+            for line in trimmed.lines() {
+                is_fenced &= fences.feed(line);
+            }
+            let content = if is_fenced {
+                trimmed.to_string()
+            } else {
+                hir_ext::replace_inline_links(trimmed, name_to_page, page_path, local)
+            };
 
             if is_continuation && !prev_doc_was_blank {
                 let appended = match last_section {
@@ -880,7 +897,7 @@ fn collect_code_regions(node: &Node, regions: &mut Vec<Range<usize>>) {
 /// Logical lines and their byte offsets in the original text. CRLF is one separator; lone CR and
 /// LF are separators too. The separator bytes are excluded from the returned slices and preserved
 /// in the source string.
-fn logical_lines(text: &str) -> impl Iterator<Item = (usize, &str)> {
+pub(crate) fn logical_lines(text: &str) -> impl Iterator<Item = (usize, &str)> {
     let bytes = text.as_bytes();
     let mut offset = 0;
     std::iter::from_fn(move || {

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -748,6 +748,60 @@ function act(uint256 v) external override;
     );
 });
 
+// Fenced code examples in NatSpec are code: their MDX-sensitive characters must reach the
+// page verbatim, while prose outside fences keeps the escaping that stops MDX from parsing
+// `<` as a JSX tag and a bare `{` as an expression.
+forgetest_init!(natspec_preserves_fenced_code_characters, |prj, cmd| {
+    prj.add_source(
+        "Fenced.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Fenced {
+    /// @notice Compares two values.
+    ///
+    /// @dev Example:
+    /// ```solidity
+    /// if (a < b) { revert TooSmall(a, b); }
+    /// ```
+    ///
+    /// A bare < in prose like a < b stays escaped, and {Fenced} still links.
+    function cmp(uint256 a, uint256 b) external pure returns (bool) {
+        return a < b;
+    }
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Fenced.mdx"), None),
+        str![[r#"
+...
+### cmp
+
+Compares two values.
+
+<i>
+
+Example:
+```solidity
+if (a < b) { revert TooSmall(a, b); }
+```
+
+</i>
+
+A bare &lt; in prose like a &lt; b stays escaped, and [Fenced](/src/contract.Fenced) still links.
+
+```solidity
+function cmp(uint256 a, uint256 b) external pure returns (bool);
+```
+...
+"#]],
+    );
+});
+
 forgetest_init!(multiline_notice_populates_frontmatter_description, |prj, cmd| {
     prj.add_source(
         "Vault.sol",

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -748,55 +748,107 @@ function act(uint256 v) external override;
     );
 });
 
-// Fenced code examples in NatSpec are code: their MDX-sensitive characters must reach the
-// page verbatim, while prose outside fences keeps the escaping that stops MDX from parsing
-// `<` as a JSX tag and a bare `{` as an expression.
-forgetest_init!(natspec_preserves_fenced_code_characters, |prj, cmd| {
+forgetest_init!(natspec_fences_are_limited_to_standalone_descriptions, |prj, cmd| {
     prj.add_source(
-        "Fenced.sol",
+        "FenceScope.sol",
         r#"
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract Fenced {
-    /// @notice Compares two values.
-    ///
+interface IFenced {
     /// @dev Example:
     /// ```solidity
-    /// if (a < b) { revert TooSmall(a, b); }
-    /// ```
-    ///
-    /// A bare < in prose like a < b stays escaped, and {Fenced} still links.
-    function cmp(uint256 a, uint256 b) external pure returns (bool) {
-        return a < b;
-    }
+    /**
+     * if (value < 1) {
+     * ```
+     * Outside < and {
+     */
+    /// @param value Parameter example:
+    /// ~~~solidity
+    /// if (value < 1) {
+    /// ~~~
+    function inspect(uint256 value) external;
+}
+
+contract Child is IFenced {
+    /// @inheritdoc IFenced
+    function inspect(uint256 value) external override {}
+}
+
+/**
+ * @title Metadata
+ * ~~~
+ * @author Author
+ * ```
+ * @custom:note Note
+ * ~~~~
+ * @notice ~~~
+ * {1+1}
+ * ~~~
+ */
+contract Metadata {
+    /// @custom:name {1+1}
+    /// @custom:name <name>
+    function inspect(uint256, uint256) external {}
 }
 "#,
     );
 
     cmd.args(["doc"]).assert_success();
-    assert_data_eq!(
-        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Fenced.mdx"), None),
-        str![[r#"
+    for page in ["interface.IFenced.mdx", "contract.Child.mdx"] {
+        assert_data_eq!(
+            Data::read_from(&prj.root().join("docs/src/pages/src").join(page), None),
+            str![[r#"
 ...
-### cmp
-
-Compares two values.
+### inspect
 
 <i>
 
 Example:
 ```solidity
-if (a < b) { revert TooSmall(a, b); }
+if (value < 1) {
 ```
+Outside &lt; and &#123;
 
 </i>
 
-A bare &lt; in prose like a &lt; b stays escaped, and [Fenced](/src/contract.Fenced) still links.
+...
+**Parameters**
 
-```solidity
-function cmp(uint256 a, uint256 b) external pure returns (bool);
-```
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| value | `uint256` | Parameter example:<br/>~~~solidity<br/>if (value &lt; 1) &#123;<br/>~~~ |
+...
+"#]],
+        );
+    }
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Metadata.mdx"), None),
+        str![[r#"
+...
+# Metadata
+
+**Title:** Metadata
+&#126;~~
+
+**Author:** Author
+&#96;``
+
+~~~
+{1+1}
+~~~
+
+**Note:**
+
+- **note:** Note
+&#126;~~~
+
+...
+### inspect
+
+...
+| `1+1` | `uint256` |  |
+| &lt;name> | `uint256` |  |
 ...
 "#]],
     );


### PR DESCRIPTION
Closes #16684

## Problem

`forge doc` sanitizes NatSpec Markdown for MDX (Vocs) by escaping MDX-hazardous characters — `{` and `<` — but the sanitizer is not aware of fenced code blocks. A fenced Solidity example in a NatSpec comment reaches the generated `.mdx` page with `<` rewritten to `&lt;` and `{` to `&#123;` **inside** the fence, so the rendered docs show HTML entities instead of the literal characters the example needs:

````markdown
/// @dev Example:
/// ```solidity
/// if (a < b) { revert TooSmall(a, b); }
/// ```
````

## Approach

Fenced code blocks are unambiguous under the CommonMark fenced-code-block rules MDX inherits (backtick or tilde markers, the info-string backtick rule, <=3-space indentation, same-marker closing, unclosed fence runs to end of text). The fix tracks exactly those rules and emits fence lines verbatim, at the two places where sanitizing runs:

- **`collect_comments` (`render.rs`)** — solar emits one item per `///` line, before continuations are stitched back together, so a fenced example's boundaries span successive items. `FenceTracker` carries the fence state across the item stream; every line feeds it in order, even when the item as a whole is not emitted verbatim.
- **`replace_inline_links` (`hir_ext.rs`)** — descriptions arrive here with continuation lines already stitched back together (see `positional_description`), so opening and closing fence lines are visible in the same string. `fenced_code_regions` computes the fence ranges for the whole string, and the scan emits those ranges untouched.

The scope stays exactly what the issue asks for: characters **outside** fences (prose, inline code spans, table cells) keep the existing escaping byte-for-byte, and nothing beyond the CommonMark fence rules is reimplemented — no attempt to reproduce the downstream MDX/GFM pipeline.

## Tests

- 8 focused unit tests in `hir_ext.rs` covering: MDX hazards preserved verbatim inside fences while `{Ident}` links and prose escaping keep working outside; `~~~` and longer-backtick fences; the CommonMark info-string backtick rule (an ambiguous fence opens nothing and keeps escaping); unclosed fences running to end of text; <=3-space indentation opening a fence vs. 4-space indented code blocks staying prose; closing fences requiring the same marker and length; and `FenceTracker` state across sequential lines.
- CLI documentation-generation test `natspec_preserves_fenced_code_characters` in `crates/forge/tests/cli/doc.rs`: end-to-end `forge doc` run asserting the fenced example reaches the generated page verbatim, while a bare `<` in prose stays escaped and `{Fenced}` still resolves to a link.
- `.changelog/forge-doc-natspec-fenced-characters.md` added per the changelog convention.
