### PR TITLE
chore(deps): bump foundry-core and svm

### DIFF
--- a/.changelog/bump-foundry-core-svm.md
+++ b/.changelog/bump-foundry-core-svm.md
@@ -1,0 +1,8 @@
+---
+forge: patch
+cast: patch
+anvil: patch
+chisel: patch
+---
+
+Update foundry-core and svm to improve reliability when installing and running solc concurrently.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4afd49526c95bc5abc60fcd4767a6212bea03fed#4afd49526c95bc5abc60fcd4767a6212bea03fed"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4afd49526c95bc5abc60fcd4767a6212bea03fed#4afd49526c95bc5abc60fcd4767a6212bea03fed"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4afd49526c95bc5abc60fcd4767a6212bea03fed#4afd49526c95bc5abc60fcd4767a6212bea03fed"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4afd49526c95bc5abc60fcd4767a6212bea03fed#4afd49526c95bc5abc60fcd4767a6212bea03fed"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4afd49526c95bc5abc60fcd4767a6212bea03fed#4afd49526c95bc5abc60fcd4767a6212bea03fed"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4afd49526c95bc5abc60fcd4767a6212bea03fed#4afd49526c95bc5abc60fcd4767a6212bea03fed"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4afd49526c95bc5abc60fcd4767a6212bea03fed#4afd49526c95bc5abc60fcd4767a6212bea03fed"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6ce81d5c491121c22b3912fb91455d4f2875439e#6ce81d5c491121c22b3912fb91455d4f2875439e"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4afd49526c95bc5abc60fcd4767a6212bea03fed#4afd49526c95bc5abc60fcd4767a6212bea03fed"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12411,9 +12411,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs"
-version = "0.5.26"
+version = "0.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719335a19e8e3a37111f6bc98934f23b352c90ba4c212093de468040045cba6c"
+checksum = "4c237a2fa75db3754792aae93571a0e172c0b60f52cfe20fb96632d96fdf37fa"
 dependencies = [
  "const-hex",
  "dirs",
@@ -12430,9 +12430,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.5.26"
+version = "0.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fad35f683c073d486fac669d71433752a8bfff3b19e49f2bc089fd6b0c158dd"
+checksum = "fa9535b2e1700ef60c8036dee0ead4e0dd36f5e6c7120d616ca4171aaa37c506"
 dependencies = [
  "const-hex",
  "semver 1.0.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,7 +343,7 @@ solar = { package = "solar-compiler", version = "=0.2.0", default-features = fal
 solar-cli = { version = "=0.2.0", default-features = false }
 solar-lsp = { version = "=0.2.0", default-features = false }
 solar-lint = { version = "=0.2.0", default-features = false }
-svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
+svm = { package = "svm-rs", version = "0.5.27", default-features = false, features = [
     "rustls",
 ] }
 
@@ -562,10 +562,10 @@ solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd539
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "8d73a1e1fd53980a7f4ae020c821fb92f025616a" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "6ce81d5c491121c22b3912fb91455d4f2875439e" }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "4afd49526c95bc5abc60fcd4767a6212bea03fed" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4afd49526c95bc5abc60fcd4767a6212bea03fed" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4afd49526c95bc5abc60fcd4767a6212bea03fed" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "4afd49526c95bc5abc60fcd4767a6212bea03fed" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -43,3 +43,12 @@ version = "1.7.2"
 [[allow.exact]]
 crate = "wnaf"
 version = "0.14.1"
+
+# Exact-version exceptions for the solc installation race fixes.
+[[allow.exact]]
+crate = "svm-rs"
+version = "0.5.27"
+
+[[allow.exact]]
+crate = "svm-rs-builds"
+version = "0.5.27"


### PR DESCRIPTION
Update all foundry-core Git pins to [4afd4952](https://github.com/foundry-rs/foundry-core/commit/4afd49526c95bc5abc60fcd4767a6212bea03fed) and bump svm-rs and svm-rs-builds to 0.5.27. This picks up [bounded retries for busy solc spawns](https://github.com/foundry-rs/foundry-core/pull/179) and [concurrent installation fixes](https://github.com/alloy-rs/svm-rs/pull/230). Raise the workspace svm requirement to 0.5.27 and refresh the lockfile.

This PR's dependency changes and description were prepared by Centaur AI.

Prompted by: @DaniPopes
