### PR TITLE
chore(ci): migrate deny to shared Rust lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,9 +217,16 @@ jobs:
 
   deny:
     needs: cargo-cooldown
-    uses: tempoxyz/ci/.github/workflows/deny.yml@268b3ce142717ff86c58fbbcc3abc3f109f0fb8d # main
+    uses: tempoxyz/gh-actions/.github/workflows/rust-lint.yml@9b0664503f535261c1d4af0aadf0098bb7cbf26f # main
     permissions:
       contents: read
+    secrets:
+      STEP_SECURITY_API_KEY: ${{ secrets.STEP_SECURITY_API_KEY }}
+    with:
+      run-clippy: false
+      run-fmt: false
+      run-typos: false
+      deny-rust-toolchain: nightly
 
   codeql:
     name: analyze (${{ matrix.language }})

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -6,5 +6,5 @@ rules:
   - ignore: true
     conditions:
       - expr: |
-          ActionRepoFullName in ["tempoxyz/ci", "tempoxyz/gh-actions"]
+          ActionRepoFullName == "tempoxyz/gh-actions"
       - expr: ActionVersion matches "^[0-9a-f]{40}$"


### PR DESCRIPTION
Migrate from `tempoxyz/ci` to `tempoxyz/gh-actions`.

Prompted by: @grandizzy
