### PR TITLE
refactor(evm): narrow Monad replay ownership

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -193,7 +193,8 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
         #[cfg(feature = "monad")]
         let mut reserve_balance = None;
         with_cloned_context(ecx, |db, evm_env, journaled_state| {
-            let mut evm = factory.create_foundry_nested_evm(db, evm_env, chain_context, cheats);
+            let mut evm = factory.create_foundry_nested_evm(db, evm_env, cheats);
+            *evm.chain_mut() = chain_context;
             *evm.journal_inner_mut() = journaled_state;
             #[cfg(feature = "monad")]
             {
@@ -230,12 +231,8 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for TransparentCheatcodesEx
         chain_context: ChainFor<FEN>,
         f: NestedEvmClosureFor<'_, FEN>,
     ) -> Result<EvmEnv<SpecFor<FEN>, BlockEnvFor<FEN>>, EVMError<DatabaseError>> {
-        let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
-            db,
-            evm_env,
-            chain_context,
-            cheats,
-        );
+        let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(db, evm_env, cheats);
+        *evm.chain_mut() = chain_context;
         f(&mut *evm)?;
         Ok(evm.to_evm_env())
     }

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -1,6 +1,8 @@
 //! A wrapper around `Backend` that is clone-on-write used for fuzzing.
 
 use super::BackendError;
+#[cfg(feature = "monad")]
+use crate::evm::MonadEvmNetwork;
 use crate::{
     FoundryInspectorExt,
     backend::{
@@ -105,12 +107,8 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind()));
 
         let factory = FEN::EvmFactory::default();
-        let mut evm = factory.create_foundry_evm_with_inspector(
-            self,
-            evm_env.clone(),
-            chain_context,
-            inspector,
-        );
+        let mut evm = factory.create_foundry_evm_with_inspector(self, evm_env.clone(), inspector);
+        *evm.chain_mut() = chain_context;
 
         let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
 
@@ -118,39 +116,6 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
         *evm_env = evm.finish().1;
 
         Ok(res)
-    }
-
-    /// Tries to execute a canonical system transaction with explicit network-specific context.
-    #[cfg(feature = "monad")]
-    #[instrument(name = "inspect_system_replay", level = "debug", skip_all)]
-    pub fn try_inspect_system_replay_with_context<
-        I: for<'db> FoundryInspectorExt<FoundryContextFor<'db, FEN>>,
-    >(
-        &mut self,
-        evm_env: &mut EvmEnvFor<FEN>,
-        tx_env: &mut TxEnvFor<FEN>,
-        chain_context: ChainFor<FEN>,
-        inspector: &mut I,
-    ) -> eyre::Result<Option<ResultAndState<revm::context_interface::result::HaltReason>>> {
-        if !self.backend.networks().is_monad()
-            || crate::evm::protocol_system_call(tx_env)?.is_none()
-        {
-            return Ok(None);
-        }
-
-        self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind()));
-
-        let factory = FEN::EvmFactory::default();
-        let mut evm =
-            factory.create_foundry_nested_evm(self, evm_env.clone(), chain_context, inspector);
-        let result = evm.transact_raw(tx_env.clone())?;
-
-        // A successful specialized replay replaces the EVM transaction with its synthetic system
-        // call. Keep the canonical envelope in `tx_env`; ordinary execution uses
-        // `inspect_with_context` above and copies inspector mutations back normally.
-        *evm_env = evm.to_evm_env();
-
-        Ok(Some(result))
     }
 
     /// Returns whether there was a state snapshot failure in the backend.
@@ -178,6 +143,39 @@ impl<'a, FEN: FoundryEvmNetwork> CowBackend<'a, FEN> {
             return Some(self.backend.to_mut());
         }
         None
+    }
+}
+
+#[cfg(feature = "monad")]
+impl CowBackend<'_, MonadEvmNetwork> {
+    /// Tries to execute a canonical system transaction with explicit network-specific context.
+    #[instrument(name = "inspect_system_replay", level = "debug", skip_all)]
+    pub fn try_inspect_system_replay_with_context<
+        I: for<'db> FoundryInspectorExt<FoundryContextFor<'db, MonadEvmNetwork>>,
+    >(
+        &mut self,
+        evm_env: &mut EvmEnvFor<MonadEvmNetwork>,
+        tx_env: &mut TxEnvFor<MonadEvmNetwork>,
+        chain_context: ChainFor<MonadEvmNetwork>,
+        inspector: &mut I,
+    ) -> eyre::Result<Option<ResultAndState<revm::context_interface::result::HaltReason>>> {
+        if crate::evm::protocol_system_call(tx_env)?.is_none() {
+            return Ok(None);
+        }
+
+        self.pending_init = Some((evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind()));
+
+        let factory = <MonadEvmNetwork as FoundryEvmNetwork>::EvmFactory::default();
+        let mut evm = factory.create_foundry_nested_evm(self, evm_env.clone(), inspector);
+        *evm.chain_mut() = chain_context;
+        let result = evm.transact_raw(tx_env.clone())?;
+
+        // A successful specialized replay replaces the EVM transaction with its synthetic system
+        // call. Keep the canonical envelope in `tx_env`; ordinary execution uses
+        // `inspect_with_context` above and copies inspector mutations back normally.
+        *evm_env = evm.to_evm_env();
+
+        Ok(Some(result))
     }
 }
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1022,12 +1022,9 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
     ) -> eyre::Result<ResultAndState<HaltReasonFor<FEN>>> {
         self.initialize(evm_env.cfg_env.spec, tx_env.caller(), tx_env.kind());
         let factory = FEN::EvmFactory::default();
-        let mut evm = factory.create_foundry_evm_with_inspector(
-            self,
-            evm_env.to_owned(),
-            chain_context,
-            inspector,
-        );
+        let mut evm =
+            factory.create_foundry_evm_with_inspector(self, evm_env.to_owned(), inspector);
+        *evm.chain_mut() = chain_context;
         let res = evm.transact(tx_env.clone()).wrap_err("EVM error")?;
 
         *tx_env = evm.tx().clone();
@@ -2263,8 +2260,8 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
             let depth = journaled_state.depth + 1;
             let factory = FEN::EvmFactory::default();
             let chain_context = self.chain_context_for_synthetic_transaction(&tx_env)?;
-            let mut evm =
-                factory.create_foundry_nested_evm(&mut db, evm_env, chain_context, inspector);
+            let mut evm = factory.create_foundry_nested_evm(&mut db, evm_env, inspector);
+            *evm.chain_mut() = chain_context;
             evm.journal_inner_mut().depth = depth;
             evm.transact_raw(tx_env)?
         };
@@ -3192,12 +3189,9 @@ fn commit_transaction<FEN: FoundryEvmNetwork>(
             Backend::new_with_fork(fork_id, fork, journaled_state, networks)?;
         db.fork_block_number_override = Some(rpc_block_number);
 
-        let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
-            &mut db,
-            evm_env,
-            chain_context,
-            inspector,
-        );
+        let mut evm =
+            FEN::EvmFactory::default().create_foundry_nested_evm(&mut db, evm_env, inspector);
+        *evm.chain_mut() = chain_context;
         evm.journal_inner_mut().depth = depth + 1;
         evm.transact_raw(tx_env).wrap_err("backend: failed committing transaction")?
     };

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -50,7 +50,6 @@ impl FoundryEvmFactory for EthEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv,
-        _chain_context: Self::Chain,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I> {
         let chain_id = evm_env.cfg_env.chain_id;
@@ -67,13 +66,9 @@ impl FoundryEvmFactory for EthEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv,
-        chain_context: Self::Chain,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> NestedEvmFor<'db, Self> {
-        Box::new(
-            self.create_foundry_evm_with_inspector(db, evm_env, chain_context, inspector)
-                .into_inner(),
-        )
+        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_inner())
     }
 }
 

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, ops::Deref};
+use std::{fmt::Debug, ops::DerefMut};
 
 use crate::{
     FoundryBlock, FoundryChain, FoundryContextExt, FoundryInspectorExt, FoundryJournal,
@@ -156,16 +156,18 @@ pub trait FoundryEvmFactory:
             BlockEnv = Self::BlockEnv,
             Spec = Self::Spec,
             HaltReason = Self::HaltReason,
-        > + Deref<Target = Self::FoundryContext<'db>>
+        > + DerefMut<Target = Self::FoundryContext<'db>>
     where
         Self: 'db;
 
     /// Creates a Foundry-wrapped EVM with the given inspector.
+    ///
+    /// Callers carrying execution context must install it through the returned context's
+    /// `chain_mut` before executing. This also preserves OP's block-derived L1 fee information.
     fn create_foundry_evm_with_inspector<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>>(
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        chain_context: Self::Chain,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I>;
 
@@ -201,11 +203,12 @@ pub trait FoundryEvmFactory:
     /// the generic `I: FoundryInspectorExt<Self::FoundryContext<'db>>` bound when the context
     /// type is only known through an associated type.  Each concrete factory implements this
     /// directly, side-stepping the higher-kinded lifetime issue.
+    /// Install inherited chain state with [`NestedEvm::chain_mut`] before executing or restoring
+    /// journal-derived state.
     fn create_foundry_nested_evm<'db>(
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        chain_context: Self::Chain,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> NestedEvmFor<'db, Self>;
 }

--- a/crates/evm/core/src/evm/monad.rs
+++ b/crates/evm/core/src/evm/monad.rs
@@ -382,11 +382,9 @@ impl FoundryEvmFactory for MonadEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        chain_context: Self::Chain,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I> {
         let mut monad_evm = self.create_evm_with_inspector(db, evm_env, inspector);
-        monad_evm.ctx_mut().chain = chain_context;
         monad_evm.cfg.tx_chain_id_check = true;
         monad_evm
     }
@@ -407,7 +405,6 @@ impl FoundryEvmFactory for MonadEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        chain_context: Self::Chain,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> NestedEvmFor<'db, Self> {
         let spec = evm_env.cfg_env.spec;
@@ -418,7 +415,6 @@ impl FoundryEvmFactory for MonadEvmFactory {
             .build_monad_with_inspector(inspector)
             .with_precompiles(MonadPrecompilesMap::new_with_spec(spec));
 
-        evm.0.ctx.chain = chain_context;
         evm.0.ctx.cfg.tx_chain_id_check = true;
         Box::new(evm)
     }
@@ -498,7 +494,11 @@ impl<'db, I: FoundryInspectorExt<MonadContext<&'db mut dyn DatabaseExt<MonadEvmF
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::evm::{BlockContext, MonadEvmNetwork};
+    use crate::{
+        backend::Backend,
+        evm::{BlockContext, EthEvmNetwork, MonadEvmNetwork},
+    };
+    use alloy_evm::EthEvmFactory;
     use alloy_sol_types::SolEvent;
     use monad_revm::{
         reserve_balance::tracker::ReserveBalanceInit,
@@ -524,6 +524,22 @@ mod tests {
         primitives::{B256, TxKind, address},
         state::{Account, AccountInfo, EvmState},
     };
+
+    #[test]
+    fn ethereum_system_replay_hook_and_nested_execution_are_not_equivalent() {
+        let tx = system_transaction(syscallSnapshotCall {}.abi_encode(), U256::ZERO);
+        let factory = EthEvmFactory::default();
+        let evm_env = EvmEnv::default();
+        let mut regular = factory.create_evm(InMemoryDB::default(), evm_env.clone());
+        assert!(factory.try_transact_system_replay(&mut regular, &tx).unwrap().is_none());
+
+        let mut db = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        db.set_networks(foundry_evm_networks::NetworkConfigs::with_monad());
+        let mut inspector = revm::inspector::NoOpInspector;
+        let mut nested = factory.create_foundry_nested_evm(&mut db, evm_env, &mut inspector);
+        let error = nested.transact_raw(tx).unwrap_err();
+        assert!(format!("{error:?}").contains("gas"), "{error:?}");
+    }
 
     #[derive(Default)]
     struct ProtocolPrestateInspector {

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -74,11 +74,9 @@ impl FoundryEvmFactory for OpEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        chain_context: Self::Chain,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I> {
         let mut op_evm = Self::default().create_evm_with_inspector(db, evm_env, inspector);
-        op_evm.ctx_mut().chain = chain_context;
         op_evm.cfg.tx_chain_id_check = true;
         op_evm
     }
@@ -87,13 +85,9 @@ impl FoundryEvmFactory for OpEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        chain_context: Self::Chain,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> NestedEvmFor<'db, Self> {
-        Box::new(
-            self.create_foundry_evm_with_inspector(db, evm_env, chain_context, inspector)
-                .into_inner(),
-        )
+        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_inner())
     }
 }
 
@@ -153,5 +147,87 @@ impl<'db, I: FoundryInspectorExt<OpEvmContext<&'db mut dyn DatabaseExt<OpEvmFact
 
     fn to_evm_env(&self) -> EvmEnv<Self::Spec, Self::Block> {
         self.ctx_ref().evm_clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{backend::Backend, evm::EvmEnvFor};
+    use alloy_primitives::{Address, TxKind, U256};
+    use op_revm::constants::L1_FEE_RECIPIENT;
+    use revm::{
+        context::{ContextTr, TxEnv},
+        inspector::NoOpInspector,
+        state::AccountInfo,
+    };
+
+    #[test]
+    fn constructors_allow_restoring_l1_block_context() {
+        let factory = OpEvmFactory::default();
+        let mut db = Backend::<OpEvmNetwork>::spawn(None).unwrap();
+        let chain = L1BlockInfo {
+            l2_block: Some(U256::from(42)),
+            l1_base_fee: U256::from(123),
+            tx_l1_cost: Some(U256::from(456)),
+            ..Default::default()
+        };
+        {
+            let mut evm = factory.create_foundry_evm_with_inspector(
+                &mut db,
+                EvmEnvFor::<OpEvmNetwork>::default(),
+                NoOpInspector,
+            );
+            *evm.chain_mut() = chain.clone();
+            assert_eq!(evm.chain().l2_block, chain.l2_block);
+            assert_eq!(evm.chain().l1_base_fee, chain.l1_base_fee);
+            assert_eq!(evm.chain().tx_l1_cost, chain.tx_l1_cost);
+        }
+        let mut inspector = NoOpInspector;
+        let mut evm = factory.create_foundry_nested_evm(
+            &mut db,
+            EvmEnvFor::<OpEvmNetwork>::default(),
+            &mut inspector,
+        );
+        *evm.chain_mut() = chain.clone();
+        assert_eq!(evm.chain_mut().l2_block, chain.l2_block);
+        assert_eq!(evm.chain_mut().l1_base_fee, chain.l1_base_fee);
+        assert_eq!(evm.chain_mut().tx_l1_cost, chain.tx_l1_cost);
+    }
+
+    #[test]
+    fn nested_execution_uses_restored_l1_block_context() {
+        let caller = Address::with_last_byte(0x42);
+        let recipient = Address::with_last_byte(0x43);
+        let l1_cost = U256::from(456);
+        let mut db = Backend::<OpEvmNetwork>::spawn(None).unwrap();
+        db.insert_account_info(caller, AccountInfo { balance: U256::MAX, ..Default::default() });
+
+        let mut evm_env = EvmEnvFor::<OpEvmNetwork>::default();
+        evm_env.cfg_env.spec = OpSpecId::REGOLITH;
+        evm_env.cfg_env.disable_fee_charge = false;
+        let mut inspector = NoOpInspector;
+        let mut evm =
+            OpEvmFactory::default().create_foundry_nested_evm(&mut db, evm_env, &mut inspector);
+        *evm.chain_mut() = L1BlockInfo {
+            l2_block: Some(U256::ZERO),
+            tx_l1_cost: Some(l1_cost),
+            ..Default::default()
+        };
+        let tx = OpTx(op_revm::OpTransaction {
+            base: TxEnv {
+                caller,
+                gas_limit: 21_000,
+                kind: TxKind::Call(recipient),
+                ..Default::default()
+            },
+            enveloped_tx: Some(Default::default()),
+            deposit: Default::default(),
+        });
+
+        let result = evm.transact_raw(tx).unwrap();
+
+        assert!(result.result.is_success());
+        assert_eq!(result.state[&L1_FEE_RECIPIENT].info.balance, l1_cost);
     }
 }

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -53,7 +53,6 @@ impl FoundryEvmFactory for TempoEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        _chain_context: Self::Chain,
         inspector: I,
     ) -> Self::FoundryEvm<'db, I> {
         let is_forked = db.is_forked_mode();
@@ -83,13 +82,9 @@ impl FoundryEvmFactory for TempoEvmFactory {
         &self,
         db: &'db mut dyn DatabaseExt<Self>,
         evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
-        chain_context: Self::Chain,
         inspector: &'db mut dyn FoundryInspectorExt<Self::FoundryContext<'db>>,
     ) -> NestedEvmFor<'db, Self> {
-        Box::new(
-            self.create_foundry_evm_with_inspector(db, evm_env, chain_context, inspector)
-                .into_inner(),
-        )
+        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector).into_inner())
     }
 }
 

--- a/crates/evm/core/tests/tempo.rs
+++ b/crates/evm/core/tests/tempo.rs
@@ -176,7 +176,6 @@ async fn foundry_factory_keychain_limit_refund_does_not_leak_storage_credit() {
     let mut evm = TempoEvmFactory::default().create_foundry_evm_with_inspector(
         &mut db,
         evm_env,
-        (),
         NoOpInspector,
     );
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -147,6 +147,42 @@ pub struct Executor<FEN: FoundryEvmNetwork> {
 
 #[cfg(feature = "monad")]
 impl Executor<MonadEvmNetwork> {
+    /// Tries to execute and commit a canonical system transaction during replay.
+    #[instrument(name = "transact_system_replay", level = "debug", skip_all)]
+    pub fn try_transact_system_replay_with_env_and_context(
+        &mut self,
+        mut evm_env: EvmEnvFor<MonadEvmNetwork>,
+        mut tx_env: TxEnvFor<MonadEvmNetwork>,
+        chain_context: ChainFor<MonadEvmNetwork>,
+    ) -> eyre::Result<Option<RawCallResult<MonadEvmNetwork>>> {
+        let mut stack = self.inspector().clone();
+        let mut backend = CowBackend::new_borrowed(self.backend());
+        let Some(result) = backend.try_inspect_system_replay_with_context(
+            &mut evm_env,
+            &mut tx_env,
+            chain_context,
+            &mut stack,
+        )?
+        else {
+            return Ok(None);
+        };
+        let has_state_snapshot_failure = backend.has_state_snapshot_failure();
+        let fork_block_number = backend.active_fork_block_number();
+        let mut result = convert_executed_result(
+            evm_env,
+            tx_env,
+            stack,
+            result,
+            &backend,
+            has_state_snapshot_failure,
+            fork_block_number,
+        )?;
+        let committed_tx = result.tx_env.clone();
+        self.commit(&mut result);
+        self.record_block_transaction(committed_tx);
+        Ok(Some(result))
+    }
+
     /// Replays Monad transactions and executes the target against one EVM instance.
     #[instrument(name = "transact_monad_block_replay", level = "debug", skip_all)]
     pub fn transact_with_monad_block_replay(
@@ -173,12 +209,8 @@ impl Executor<MonadEvmNetwork> {
             };
             backend.set_test_contract(target_contract);
             let mut evm = <MonadEvmNetwork as FoundryEvmNetwork>::EvmFactory::default()
-                .create_foundry_evm_with_inspector(
-                    backend,
-                    evm_env,
-                    target_chain_context.clone(),
-                    &mut stack,
-                );
+                .create_foundry_evm_with_inspector(backend, evm_env, &mut stack);
+            *evm.chain_mut() = target_chain_context.clone();
             evm.disable_inspector();
             for (tx_hash, tx_env, chain_context) in replay {
                 evm.ctx_mut().chain = chain_context;
@@ -844,9 +876,9 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             let mut evm = FEN::EvmFactory::default().create_foundry_evm_with_inspector(
                 &mut backend,
                 evm_env.clone(),
-                ChainFor::<FEN>::for_transaction(&TxEnvFor::<FEN>::default()),
                 inspector,
             );
+            *evm.chain_mut() = ChainFor::<FEN>::for_transaction(&TxEnvFor::<FEN>::default());
             let result =
                 evm.transact_system_call(SYSTEM_ADDRESS, BEACON_ROOTS_ADDRESS, calldata)?;
             evm_env = evm.finish().1;
@@ -990,13 +1022,9 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
             if !replay.is_empty() {
                 evm_env.cfg_env.disable_balance_check = true;
             }
-            let evm = FEN::EvmFactory::default().create_foundry_evm_with_inspector(
-                backend,
-                evm_env,
-                target_chain_context,
-                &mut stack,
-            );
-            let mut evm = evm;
+            let mut evm = FEN::EvmFactory::default()
+                .create_foundry_evm_with_inspector(backend, evm_env, &mut stack);
+            *evm.chain_mut() = target_chain_context;
             evm.disable_inspector();
             for (tx_hash, tx_env) in replay {
                 let created = match tx_env.kind() {
@@ -1041,43 +1069,6 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         }
         self.commit(&mut result);
         Ok(result)
-    }
-
-    /// Tries to execute and commit a canonical system transaction during replay.
-    #[cfg(feature = "monad")]
-    #[instrument(name = "transact_system_replay", level = "debug", skip_all)]
-    pub fn try_transact_system_replay_with_env_and_context(
-        &mut self,
-        mut evm_env: EvmEnvFor<FEN>,
-        mut tx_env: TxEnvFor<FEN>,
-        chain_context: ChainFor<FEN>,
-    ) -> eyre::Result<Option<RawCallResult<FEN>>> {
-        let mut stack = self.inspector().clone();
-        let mut backend = CowBackend::new_borrowed(self.backend());
-        let Some(result) = backend.try_inspect_system_replay_with_context(
-            &mut evm_env,
-            &mut tx_env,
-            chain_context,
-            &mut stack,
-        )?
-        else {
-            return Ok(None);
-        };
-        let has_state_snapshot_failure = backend.has_state_snapshot_failure();
-        let fork_block_number = backend.active_fork_block_number();
-        let mut result = convert_executed_result(
-            evm_env,
-            tx_env,
-            stack,
-            result,
-            &backend,
-            has_state_snapshot_failure,
-            fork_block_number,
-        )?;
-        let committed_tx = result.tx_env.clone();
-        self.commit(&mut result);
-        self.record_block_transaction(committed_tx);
-        Ok(Some(result))
     }
 
     /// Commit the changeset to the database and adjust `self.inspector_config` values according to
@@ -2741,5 +2732,64 @@ mod tests {
             executor.inspector().cheatcodes.as_ref().unwrap().env_overrides.is_empty(),
             "inactive env overrides must be removed after restoring their metadata",
         );
+    }
+    #[cfg(feature = "monad")]
+    #[test]
+    fn concrete_system_replay_preserves_envelope_and_rejects_without_commit() {
+        let mut executor = ExecutorBuilder::<MonadEvmNetwork>::new().gas_limit(1 << 20).build(
+            EvmEnvFor::<MonadEvmNetwork>::default(),
+            TxEnvFor::<MonadEvmNetwork>::default(),
+            Backend::spawn(None).unwrap(),
+            NetworkConfigs::with_monad(),
+        );
+        let caller = alloy_primitives::address!("6f49a8f621353f12378d0046e7d7e4b9b249dc9e");
+        let selector = keccak256("syscallSnapshot()");
+        let system = TxEnv {
+            caller,
+            gas_limit: 0,
+            kind: TxKind::Call(alloy_primitives::address!(
+                "0000000000000000000000000000000000001000"
+            )),
+            data: Bytes::copy_from_slice(&selector[..4]),
+            chain_id: None,
+            ..Default::default()
+        };
+        let result = executor
+            .try_transact_system_replay_with_env_and_context(
+                EvmEnvFor::<MonadEvmNetwork>::default(),
+                system.clone(),
+                ChainFor::<MonadEvmNetwork>::for_transaction(&system),
+            )
+            .unwrap()
+            .unwrap();
+        assert!(!result.reverted);
+        assert_eq!(result.tx_env, system);
+        assert_eq!(executor.get_nonce(caller).unwrap(), 1);
+
+        // Replaying the same canonical nonce must fail without committing another increment.
+        assert!(
+            executor
+                .try_transact_system_replay_with_env_and_context(
+                    EvmEnvFor::<MonadEvmNetwork>::default(),
+                    system.clone(),
+                    ChainFor::<MonadEvmNetwork>::for_transaction(&system),
+                )
+                .is_err()
+        );
+        assert_eq!(executor.get_nonce(caller).unwrap(), 1);
+
+        let ordinary = TxEnv { caller: CALLER, ..Default::default() };
+        let nonce = executor.get_nonce(CALLER).unwrap();
+        assert!(
+            executor
+                .try_transact_system_replay_with_env_and_context(
+                    EvmEnvFor::<MonadEvmNetwork>::default(),
+                    ordinary.clone(),
+                    ChainFor::<MonadEvmNetwork>::for_transaction(&ordinary),
+                )
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(executor.get_nonce(CALLER).unwrap(), nonce);
     }
 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -513,8 +513,8 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
         #[cfg(feature = "monad")]
         let mut reserve_balance = None;
         with_cloned_context(ecx, |db, evm_env, journaled_state| {
-            let mut evm =
-                factory.create_foundry_nested_evm(db, evm_env, chain_context, &mut inspector);
+            let mut evm = factory.create_foundry_nested_evm(db, evm_env, &mut inspector);
+            *evm.chain_mut() = chain_context;
             *evm.journal_inner_mut() = journaled_state;
             #[cfg(feature = "monad")]
             {
@@ -552,12 +552,9 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
         f: NestedEvmClosureFor<'_, FEN>,
     ) -> Result<EvmEnvFor<FEN>, EVMError<DatabaseError>> {
         let mut inspector = InspectorStackRefMut { cheatcodes: Some(cheats), inner: self };
-        let mut evm = FEN::EvmFactory::default().create_foundry_nested_evm(
-            db,
-            evm_env,
-            chain_context,
-            &mut inspector,
-        );
+        let mut evm =
+            FEN::EvmFactory::default().create_foundry_nested_evm(db, evm_env, &mut inspector);
+        *evm.chain_mut() = chain_context;
         f(&mut *evm)?;
         Ok(evm.to_evm_env())
     }
@@ -1108,8 +1105,8 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         let res = self.with_inspector(|mut inspector| {
             let (res, nested_env) = {
                 let (db, _) = ecx.db_journal_inner_mut();
-                let mut evm =
-                    factory.create_foundry_nested_evm(db, evm_env, chain_context, &mut inspector);
+                let mut evm = factory.create_foundry_nested_evm(db, evm_env, &mut inspector);
+                *evm.chain_mut() = chain_context;
                 evm.journal_inner_mut().state = isolated_state;
                 #[cfg(feature = "monad")]
                 {


### PR DESCRIPTION
Moves inspected system replay onto concrete Monad executors and clone-on-write backends, removing the runtime Monad check from the generic execution path. The selected execution type now owns this behavior, so an Ethereum executor cannot acquire Monad system semantics from its runtime profile.

Removes chain-context arguments from Foundry EVM constructors. Callers restore inherited state through native mutable context access before execution, preserving state such as OP’s L1 fee information without making construction responsible for transporting it. Regression coverage checks OP fee charging, canonical envelope preservation, and rejection without committing protocol prestate. The raw factory replay hook remains for the later stack change because ordinary nested execution does not preserve unsupported-envelope skip behavior.
