### PR TITLE
chore(ci): add nightly Solar dependency bumps

### DIFF
--- a/.github/scripts/bump-solar.sh
+++ b/.github/scripts/bump-solar.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -euo pipefail
+
+# Bump all dependencies from the paradigmxyz/solar repository to the latest commit on main.
+# All solar dependencies share the same commit revision.
+#
+# Usage:
+#   ./bump-solar.sh [--dry-run]
+#
+# Requirements:
+#   - gh (GitHub CLI) must be installed and authenticated
+#
+# Outputs (for GitHub Actions):
+#   Sets outputs in $GITHUB_OUTPUT if it exists:
+#     - current_rev: The current solar revision
+#     - latest_rev: The latest solar revision on main
+#     - latest_rev_short: The short latest solar revision
+#     - updated: "true" if dependencies were updated, "false" otherwise
+#     - changelog: Path to changelog file (if updated)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CARGO_TOML="$REPO_ROOT/Cargo.toml"
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+  echo "Running in dry-run mode (no changes will be made)"
+fi
+
+# Get the current solar revision from any dependency using paradigmxyz/solar
+# They all share the same rev, so we just grab the first one
+get_current_rev() {
+  grep -m 1 'git = "https://github.com/paradigmxyz/solar"' "$CARGO_TOML" | sed 's/.*rev = "\([^"]*\)".*/\1/'
+}
+
+# Get the latest commit SHA from paradigmxyz/solar main branch
+get_latest_rev() {
+  gh api repos/paradigmxyz/solar/commits/main --jq '.sha'
+}
+
+# Generate changelog between two revisions
+generate_changelog() {
+  local old_rev="$1"
+  local new_rev="$2"
+  local output_file="$3"
+
+  echo "Fetching commits from ${old_rev:0:7} to ${new_rev:0:7}..."
+
+  local commits
+  # shellcheck disable=SC2016 # Single quotes intentional for jq expression
+  commits=$(gh api "repos/paradigmxyz/solar/compare/${old_rev}...${new_rev}" \
+    --jq '.commits[] | "- [`\(.sha[0:7])`](https://github.com/paradigmxyz/solar/commit/\(.sha)) \(.commit.message | split("\n")[0] | gsub("#(?<number>[0-9]+)"; "[#\(.number)](https://github.com/paradigmxyz/solar/issues/\(.number))"))"')
+
+  {
+    echo "## Solar Dependency Updates"
+    echo ""
+    echo "Bumped all \`solar*\` dependencies from [\`${old_rev:0:7}\`](https://github.com/paradigmxyz/solar/commit/${old_rev}) to [\`${new_rev:0:7}\`](https://github.com/paradigmxyz/solar/commit/${new_rev})."
+    echo ""
+    echo "### Commits"
+    echo ""
+    echo "$commits"
+  } > "$output_file"
+
+  echo "Changelog written to $output_file"
+}
+
+# Update Cargo.toml with new revision
+update_cargo_toml() {
+  local old_rev="$1"
+  local new_rev="$2"
+
+  sed -i "s|git = \"https://github.com/paradigmxyz/solar\", rev = \"$old_rev\"|git = \"https://github.com/paradigmxyz/solar\", rev = \"$new_rev\"|g" "$CARGO_TOML"
+  echo "Updated Cargo.toml: $old_rev -> $new_rev"
+}
+
+# Regenerate Cargo.lock (may fail if dependencies don't build)
+regenerate_lockfile() {
+  echo ""
+  echo "Regenerating Cargo.lock..."
+  if cargo generate-lockfile 2>&1; then
+    echo "Cargo.lock regenerated successfully"
+    set_output "lockfile_updated" "true"
+  else
+    echo "WARNING: Failed to regenerate Cargo.lock (dependencies may not build)"
+    set_output "lockfile_updated" "false"
+  fi
+}
+
+# Set GitHub Actions output if running in CI
+set_output() {
+  local name="$1"
+  local value="$2"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "$name=$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+main() {
+  echo "=== Bump Solar Dependencies ==="
+  echo ""
+
+  CURRENT_REV=$(get_current_rev)
+  echo "Current revision: $CURRENT_REV"
+  set_output "current_rev" "$CURRENT_REV"
+
+  LATEST_REV=$(get_latest_rev)
+  echo "Latest revision:  $LATEST_REV"
+  set_output "latest_rev" "$LATEST_REV"
+  set_output "latest_rev_short" "${LATEST_REV:0:7}"
+
+  if [[ "$CURRENT_REV" == "$LATEST_REV" ]]; then
+    echo ""
+    echo "Already up to date. No changes needed."
+    set_output "updated" "false"
+    exit 0
+  fi
+
+  echo ""
+  echo "Update available: ${CURRENT_REV:0:7} -> ${LATEST_REV:0:7}"
+
+  CHANGELOG_FILE="$REPO_ROOT/solar-changelog.md"
+
+  echo ""
+  generate_changelog "$CURRENT_REV" "$LATEST_REV" "$CHANGELOG_FILE"
+  set_output "changelog" "$CHANGELOG_FILE"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo ""
+    echo "[DRY RUN] Would update Cargo.toml"
+    echo "[DRY RUN] Would regenerate Cargo.lock"
+    echo ""
+    echo "=== Changelog Preview ==="
+    cat "$CHANGELOG_FILE"
+  else
+    update_cargo_toml "$CURRENT_REV" "$LATEST_REV"
+    regenerate_lockfile
+  fi
+
+  set_output "updated" "true"
+
+  echo ""
+  echo "=== Done ==="
+}
+
+main "$@"

--- a/.github/workflows/bump-solar.yml
+++ b/.github/workflows/bump-solar.yml
@@ -1,0 +1,41 @@
+name: Bump Solar Dependencies
+
+permissions: {}
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  bump-solar:
+    if: github.repository == 'foundry-rs/foundry'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bump solar dependencies
+        id: bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.github/scripts/bump-solar.sh
+
+      - name: Create or update Pull Request
+        if: steps.bump.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          add-paths: |
+            Cargo.toml
+            Cargo.lock
+          commit-message: "chore(deps): bump solar dependencies to ${{ steps.bump.outputs.latest_rev_short }}"
+          title: "chore(deps): bump solar dependencies to ${{ steps.bump.outputs.latest_rev_short }}"
+          labels: L-ignore
+          body-path: ${{ steps.bump.outputs.changelog }}
+          branch: deps/bump-solar


### PR DESCRIPTION
Add a daily Solar dependency bump at 00:00 UTC, matching the existing Tempo workflow. It updates all Solar git pins to the latest commit on `paradigmxyz/solar` main, regenerates the lockfile, and creates or updates `deps/bump-solar` with the upstream commit changelog. The script also supports a manual dry run.

This is a CI-only change; a maintainer must apply `L-ignore` in place of a release changelog entry.

The workflow, script, and PR description were authored by Centaur with AI assistance.

Prompted by: @DaniPopes
