### PR TITLE
fix(lint): allow public uppercase getter names

### DIFF
--- a/.changelog/public-constant-getter-naming.md
+++ b/.changelog/public-constant-getter-naming.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-lint: patch
+---
+
+Allow uppercase public view getter names in `mixed-case-function`, matching the existing exemption for external getters.

--- a/crates/lint/src/sol/info/mixed_case.rs
+++ b/crates/lint/src/sol/info/mixed_case.rs
@@ -84,10 +84,10 @@ fn check_mixed_case(s: &str, is_fn: bool, allowed_patterns: &[String]) -> Option
     check_mixed_case_pure(s)
 }
 
-/// Heuristic for a getter of a constant: `SCREAMING_SNAKE_CASE` name, `external view`, no
-/// parameters and exactly one elementary or custom-typed return value.
+/// Heuristic for a getter of a constant: `SCREAMING_SNAKE_CASE` name, `public view` or `external
+/// view`, no parameters and exactly one elementary or custom-typed return value.
 fn is_constant_getter(header: &FunctionHeader<'_>) -> bool {
-    matches!(header.visibility(), Some(Visibility::External))
+    matches!(header.visibility(), Some(Visibility::Public | Visibility::External))
         && header.state_mutability().is_view()
         && header.parameters.is_empty()
         && matches!(header.returns(), [ret] if ret.ty.kind.is_elementary() || ret.ty.kind.is_custom())

--- a/crates/lint/testdata/MixedCase.sol
+++ b/crates/lint/testdata/MixedCase.sol
@@ -97,3 +97,15 @@ contract MixedCaseTest {
     function HAS_MORE_THAN_ONE_RETURN() external view returns (uint256, uint256) {} //~NOTE: function names should use mixedCase
     function NOT_ELEMENTARY_RETURN() external view returns (uint256[] memory) {} //~NOTE: function names should use mixedCase
 }
+
+contract PublicConstantGetters {
+    bytes32 private separator;
+
+    // Public getters follow the same naming convention as external getters.
+    function DOMAIN_SEPARATOR() public view returns (bytes32) { return separator; }
+    function PUBLIC_CUSTOM_TYPE() public view returns (IERC20) { return IERC20(address(0)); }
+
+    function PUBLIC_WITH_PARAM(uint256 value) public view returns (uint256) { return value; } //~NOTE: function names should use mixedCase
+    function INTERNAL_GETTER() internal view returns (bytes32) { return separator; } //~NOTE: function names should use mixedCase
+    function PUBLIC_MUTATOR() public returns (bytes32) { separator = bytes32(uint256(1)); return separator; } //~NOTE: function names should use mixedCase
+}

--- a/crates/lint/testdata/MixedCase.stderr
+++ b/crates/lint/testdata/MixedCase.stderr
@@ -150,6 +150,30 @@ LL │     function NOT_ELEMENTARY_RETURN() external view returns (uint256[] mem
    │
    ╰ help: https://getfoundry.sh/forge/linting/mixed-case-function
 
+note[mixed-case-function]: function names should use mixedCase
+   ╭▸ ROOT/testdata/MixedCase.sol:LL:CC
+   │
+LL │     function PUBLIC_WITH_PARAM(uint256 value) public view returns (uint256) { return value; }
+   │              ━━━━━━━━━━━━━━━━━ help: consider using: `publicWithParam`
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/mixed-case-function
+
+note[mixed-case-function]: function names should use mixedCase
+   ╭▸ ROOT/testdata/MixedCase.sol:LL:CC
+   │
+LL │     function INTERNAL_GETTER() internal view returns (bytes32) { return separator; }
+   │              ━━━━━━━━━━━━━━━ help: consider using: `internalGetter`
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/mixed-case-function
+
+note[mixed-case-function]: function names should use mixedCase
+   ╭▸ ROOT/testdata/MixedCase.sol:LL:CC
+   │
+LL │     function PUBLIC_MUTATOR() public returns (bytes32) { separator = bytes32(uint256(1)); return separator; }
+   │              ━━━━━━━━━━━━━━ help: consider using: `publicMutator`
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/mixed-case-function
+
 note[multi-contract-file]: prefer having only one contract, interface or library per file
    ╭▸ ROOT/testdata/MixedCase.sol:LL:CC
    │
@@ -163,6 +187,14 @@ note[multi-contract-file]: prefer having only one contract, interface or library
    │
 LL │ contract MixedCaseTest {
    │          ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/MixedCase.sol:LL:CC
+   │
+LL │ contract PublicConstantGetters {
+   │          ━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
 


### PR DESCRIPTION
`mixed-case-function` exempted uppercase `external view` getters but still warned on equivalent `public view` getters such as `DOMAIN_SEPARATOR()`. Extend the existing exemption to public visibility, preserving its signature restrictions, with regression coverage for accepted getters and functions that should still warn.

AI-assisted
