### PR TITLE
fix(lint): allow single-bit mask shifts

### DIFF
--- a/.changelog/lint-single-bit-mask.md
+++ b/.changelog/lint-single-bit-mask.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-lint: patch
+---
+
+Avoid `incorrect-shift` warnings for Yul `shl(index, 1)` expressions that construct single-bit masks.

--- a/crates/lint/src/sol/high/incorrect_shift.rs
+++ b/crates/lint/src/sol/high/incorrect_shift.rs
@@ -3,8 +3,9 @@ use crate::{
     linter::{EarlyLintPass, LintContext},
     sol::{Severity, SolLint},
 };
+use alloy_primitives::U256;
 use solar::{
-    ast::{Stmt, StmtKind, visit::Visit, yul},
+    ast::{LitKind, Stmt, StmtKind, visit::Visit, yul},
     data_structures::Never,
     interface::kw,
 };
@@ -33,13 +34,15 @@ impl<'ast> Visit<'ast> for ShiftChecker<'_, '_> {
     type BreakValue = Never;
 
     fn visit_yul_expr(&mut self, expr: &'ast yul::Expr<'ast>) -> ControlFlow<Self::BreakValue> {
-        // `shl(x, 2)`: the shift amount comes first in Yul, so a literal in the value position
-        // and a computed amount betray swapped arguments.
+        // A computed shift of a literal suggests swapped arguments, except `shl(n, 1)`,
+        // which constructs a single-bit mask.
         if let yul::ExprKind::Call(call) = &expr.kind
             && matches!(call.name.name, kw::Shl | kw::Shr | kw::Sar)
             && let [left, right] = call.arguments.as_ref()
             && !matches!(left.kind, yul::ExprKind::Lit(_))
-            && matches!(right.kind, yul::ExprKind::Lit(_))
+            && let yul::ExprKind::Lit(lit) = &right.kind
+            && !(call.name.name == kw::Shl
+                && matches!(lit.kind, LitKind::Number(value) if value == U256::ONE))
         {
             self.ctx.emit(&INCORRECT_SHIFT, expr.span);
         }

--- a/crates/lint/testdata/IncorrectShiftBitMask.sol
+++ b/crates/lint/testdata/IncorrectShiftBitMask.sol
@@ -1,0 +1,22 @@
+//@compile-flags: --only-lint incorrect-shift
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract IncorrectShiftBitMask {
+    function singleBit(uint256 index, uint256 mask) external pure returns (uint256 result) {
+        assembly ("memory-safe") {
+            result := shl(index, 1)
+            result := or(result, shl(add(index, 1), 0x01))
+            result := and(result, and(shl(index, 1), mask))
+        }
+    }
+
+    function suspiciousShifts(uint256 index) external pure returns (uint256 result) {
+        assembly ("memory-safe") {
+            result := shl(index, 8) //~WARN: the order of args in a shift operation is incorrect
+            result := shr(index, 1) //~WARN: the order of args in a shift operation is incorrect
+            result := sar(index, 1) //~WARN: the order of args in a shift operation is incorrect
+            result := shl(shr(index, 8), 1) //~WARN: the order of args in a shift operation is incorrect
+        }
+    }
+}

--- a/crates/lint/testdata/IncorrectShiftBitMask.stderr
+++ b/crates/lint/testdata/IncorrectShiftBitMask.stderr
@@ -1,0 +1,32 @@
+warning[incorrect-shift]: the order of args in a shift operation is incorrect
+   ╭▸ ROOT/testdata/IncorrectShiftBitMask.sol:LL:CC
+   │
+LL │             result := shl(index, 8)
+   │                       ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-shift
+
+warning[incorrect-shift]: the order of args in a shift operation is incorrect
+   ╭▸ ROOT/testdata/IncorrectShiftBitMask.sol:LL:CC
+   │
+LL │             result := shr(index, 1)
+   │                       ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-shift
+
+warning[incorrect-shift]: the order of args in a shift operation is incorrect
+   ╭▸ ROOT/testdata/IncorrectShiftBitMask.sol:LL:CC
+   │
+LL │             result := sar(index, 1)
+   │                       ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-shift
+
+warning[incorrect-shift]: the order of args in a shift operation is incorrect
+   ╭▸ ROOT/testdata/IncorrectShiftBitMask.sol:LL:CC
+   │
+LL │             result := shl(shr(index, 8), 1)
+   │                           ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-shift
+


### PR DESCRIPTION
`incorrect-shift` warned on `shl(index, 1)`, a conventional way to construct a single-bit mask used in [OpenZeppelin Base64](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/Base64.sol). Exempt this pattern while preserving warnings for other literal values, right shifts, and suspicious expressions nested inside the shift, with regression coverage for each case.

AI-assisted
