### PR TITLE
fix(symbolic): normalize bounded divisions

### DIFF
--- a/.changelog/symbolic-udiv-comparisons.md
+++ b/.changelog/symbolic-udiv-comparisons.md
@@ -1,0 +1,5 @@
+---
+foundry-evm-symbolic: patch
+---
+
+Improved symbolic completeness for bounded comparisons against unsigned division by constant scales.

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -50,11 +50,11 @@ fn normalize_constraints_for_solver_with(
     // rather than dropping a fact.
     let retained_count = normalized
         .iter()
-        .filter(|constraint| !ConstraintContext::could_contextually_disappear(constraint))
+        .filter(|constraint| !ConstraintContext::requires_independent_context(constraint))
         .count();
     let retained = normalized
         .iter()
-        .filter(|constraint| !ConstraintContext::could_contextually_disappear(constraint));
+        .filter(|constraint| !ConstraintContext::requires_independent_context(constraint));
     let context = ConstraintContext::from_constraints(retained, retained_count);
     let normalized_len = normalized.len();
     normalize_constraint_batch(
@@ -807,25 +807,48 @@ impl ConstraintContext {
         self.lower_bounds.get(expr).copied()
     }
 
-    /// Conservatively identifies every conjunct that path facts may rewrite to `true`.
-    fn could_contextually_disappear(expr: &SymBoolExpr) -> bool {
+    /// Conservatively identifies every conjunct that path facts may rewrite.
+    fn requires_independent_context(expr: &SymBoolExpr) -> bool {
         match expr.kind() {
-            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => {
-                Self::mul_div_identity_operands(left, right).is_some()
-                    || Self::mul_div_identity_operands(right, left).is_some()
-                    || Self::masked_word_side_eq_self_shape(left, right).is_some()
-                    || Self::masked_word_side_eq_self_shape(right, left).is_some()
-            }
-            SymBoolExprKind::Not(value) => value
-                .zero_check_operand()
-                .is_some_and(|word| matches!(word.kind(), SymExprKind::BinOp(SymBinOp::Or, _, _))),
-            SymBoolExprKind::Const(_) | SymBoolExprKind::Cmp(_, _, _) | SymBoolExprKind::And(_) => {
-                false
-            }
+            SymBoolExprKind::Cmp(op, left, right) => match op {
+                SymCmpOp::Eq => {
+                    Self::mul_div_identity_operands(left, right).is_some()
+                        || Self::mul_div_identity_operands(right, left).is_some()
+                        || Self::masked_word_side_eq_self_shape(left, right).is_some()
+                        || Self::masked_word_side_eq_self_shape(right, left).is_some()
+                }
+                SymCmpOp::Ult | SymCmpOp::Ule => {
+                    Self::udiv_comparison_operands(*op, left, right).is_some()
+                }
+                SymCmpOp::Ugt | SymCmpOp::Uge | SymCmpOp::Slt | SymCmpOp::Sgt => false,
+            },
+            SymBoolExprKind::Not(value) => match value.kind() {
+                SymBoolExprKind::Cmp(op, left, right)
+                    if Self::udiv_comparison_operands(*op, left, right).is_some() =>
+                {
+                    true
+                }
+                _ => value.zero_check_operand().is_some_and(|word| {
+                    matches!(word.kind(), SymExprKind::BinOp(SymBinOp::Or, _, _))
+                }),
+            },
+            SymBoolExprKind::Const(_) | SymBoolExprKind::And(_) => false,
         }
     }
 
     fn normalize_bool(&self, cx: &mut SymCx, expr: SymBoolExpr) -> SymBoolExpr {
+        if let SymBoolExprKind::Cmp(op, left, right) = expr.kind()
+            && let Some(normalized) = self.normalize_udiv_comparison(cx, *op, left, right)
+        {
+            return normalized;
+        }
+        if let SymBoolExprKind::Not(value) = expr.kind()
+            && let SymBoolExprKind::Cmp(op, left, right) = value.kind()
+            && let Some(normalized) = self.normalize_udiv_comparison(cx, *op, left, right)
+        {
+            return normalized.not(cx);
+        }
+
         match expr.kind() {
             SymBoolExprKind::Not(value) if self.unsigned_bool_always_true(value) => {
                 SymBoolExpr::constant(cx, false)
@@ -1107,6 +1130,62 @@ impl ConstraintContext {
             return None;
         };
         (other == expected).then_some((denominator, other))
+    }
+
+    fn udiv_comparison_operands<'a>(
+        op: SymCmpOp,
+        left: &'a SymExpr,
+        right: &'a SymExpr,
+    ) -> Option<(&'a SymExpr, &'a SymExpr, &'a SymExpr, bool)> {
+        if !matches!(op, SymCmpOp::Ult | SymCmpOp::Ule) {
+            return None;
+        }
+        if let Some((numerator, denominator)) = left.udiv_operands()
+            && denominator.as_const().is_some_and(|value| !value.is_zero())
+            && !right.contains_udiv()
+        {
+            return Some((numerator, denominator, right, true));
+        }
+        if let Some((numerator, denominator)) = right.udiv_operands()
+            && denominator.as_const().is_some_and(|value| !value.is_zero())
+            && !left.contains_udiv()
+        {
+            return Some((numerator, denominator, left, false));
+        }
+        None
+    }
+
+    fn normalize_udiv_comparison(
+        &self,
+        cx: &mut SymCx,
+        op: SymCmpOp,
+        left: &SymExpr,
+        right: &SymExpr,
+    ) -> Option<SymBoolExpr> {
+        let (numerator, denominator, threshold, quotient_on_left) =
+            Self::udiv_comparison_operands(op, left, right)?;
+        let increment_threshold =
+            matches!((op, quotient_on_left), (SymCmpOp::Ule, true) | (SymCmpOp::Ult, false));
+        let threshold = if increment_threshold {
+            // Prove the successor cannot wrap before constructing the word addition.
+            self.interval(threshold)?.max.checked_add(U256::ONE)?;
+            let one = SymExpr::one(cx);
+            SymExpr::binop(cx, SymBinOp::Add, threshold.clone(), one)
+        } else {
+            threshold.clone()
+        };
+        if !self.mul_cannot_overflow_256(&threshold, denominator) {
+            return None;
+        }
+
+        let scaled_threshold = SymExpr::binop(cx, SymBinOp::Mul, threshold, denominator.clone());
+        Some(if quotient_on_left {
+            // `n / d < k => n < k * d`; `n / d <= k => n < (k + 1) * d`.
+            SymBoolExpr::cmp(cx, SymCmpOp::Ult, numerator.clone(), scaled_threshold)
+        } else {
+            // `k <= n / d => k * d <= n`; `k < n / d => (k + 1) * d <= n`.
+            SymBoolExpr::cmp(cx, SymCmpOp::Ule, scaled_threshold, numerator.clone())
+        })
     }
 
     fn interval(&self, expr: &SymExpr) -> Option<WordInterval> {
@@ -1936,6 +2015,34 @@ mod tests {
         );
         assert_eq!(normalized, vec![identity]);
         assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn cached_normalization_keeps_udiv_rewrites_contextual() {
+        let mut cx = SymCx::new();
+        let numerator = SymExpr::var(&mut cx, "numerator");
+        let threshold = SymExpr::var(&mut cx, "threshold");
+        let scale = SymExpr::constant(&mut cx, U256::from(1_000_000_000_000_000_000u128));
+        let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, scale);
+        let comparison = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, quotient, threshold.clone());
+        let uint128_max = SymExpr::constant(&mut cx, U256::from(u128::MAX));
+        let bounded = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, threshold, uint128_max);
+        let mut cache = HashMap::default();
+
+        let normalized = normalize_constraints_for_solver_cached(
+            &mut cx,
+            &[comparison.clone(), bounded],
+            &mut cache,
+        );
+        assert!(normalized.iter().all(|constraint| !constraint.contains_udiv()));
+        assert_eq!(cache.get(&comparison), Some(&comparison));
+
+        let normalized = normalize_constraints_for_solver_cached(
+            &mut cx,
+            std::slice::from_ref(&comparison),
+            &mut cache,
+        );
+        assert_eq!(normalized, vec![comparison]);
     }
 
     #[test]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3586,6 +3586,191 @@ fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
 }
 
 #[test]
+fn solver_normalizes_bounded_udiv_comparisons_without_bvudiv() {
+    let mut cx = SymCx::new();
+    let numerator = SymExpr::var(&mut cx, "numerator");
+    let threshold_word = SymExpr::var(&mut cx, "threshold");
+    let uint64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
+    let threshold = SymExpr::binop(&mut cx, SymBinOp::And, threshold_word, uint64_max);
+    let divisor = SymExpr::constant(&mut cx, U256::from(3));
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, divisor);
+    let conditions = [
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, quotient.clone(), threshold.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, quotient.clone(), threshold.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, quotient.clone(), threshold.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, quotient.clone(), threshold.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, threshold.clone(), quotient.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, threshold.clone(), quotient.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, threshold.clone(), quotient.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, threshold, quotient),
+    ];
+
+    for condition in conditions {
+        for original in [condition.clone(), condition.not(&mut cx)] {
+            let normalized =
+                normalize_constraints_for_solver(&mut cx, std::slice::from_ref(&original));
+            assert_eq!(normalized.len(), 1);
+            assert!(!normalized[0].smt(&cx).contains("bvudiv"));
+
+            for threshold in [U256::ZERO, U256::ONE, U256::from(u64::MAX)] {
+                let lower = threshold * U256::from(3);
+                let upper = (threshold + U256::ONE) * U256::from(3);
+                let mut numerators = vec![U256::ZERO, lower, upper, U256::MAX];
+                if let Some(value) = lower.checked_sub(U256::ONE) {
+                    numerators.push(value);
+                }
+                if let Some(value) = upper.checked_sub(U256::ONE) {
+                    numerators.push(value);
+                }
+                if let Some(value) = upper.checked_add(U256::ONE) {
+                    numerators.push(value);
+                }
+
+                for numerator in numerators {
+                    let model = symbolic_model(
+                        &mut cx,
+                        [
+                            ("numerator".to_string(), numerator),
+                            ("threshold".to_string(), threshold),
+                        ],
+                    );
+                    assert_eq!(
+                        original.eval_model(&model).unwrap(),
+                        normalized[0].eval_model(&model).unwrap(),
+                        "numerator={numerator} threshold={threshold} condition={original:?}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn solver_normalizes_udiv_comparisons_only_at_safe_product_boundaries() {
+    let mut cx = SymCx::new();
+    let numerator = SymExpr::var(&mut cx, "numerator");
+    let divisor_value = U256::from(3);
+    let divisor = SymExpr::constant(&mut cx, divisor_value);
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, divisor);
+    let threshold = SymExpr::constant(&mut cx, U256::MAX / divisor_value);
+    let safe = [
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, quotient.clone(), threshold.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, threshold.clone(), quotient.clone()),
+    ];
+    let overflowing = [
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, quotient.clone(), threshold.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, threshold, quotient.clone()),
+    ];
+
+    for condition in safe {
+        let normalized =
+            normalize_constraints_for_solver(&mut cx, std::slice::from_ref(&condition));
+        assert_eq!(normalized.len(), 1);
+        assert!(!normalized[0].smt(&cx).contains("bvudiv"));
+    }
+    for condition in overflowing {
+        let normalized =
+            normalize_constraints_for_solver(&mut cx, std::slice::from_ref(&condition));
+        assert_eq!(normalized, vec![condition]);
+    }
+
+    let threshold = SymExpr::constant(&mut cx, U256::MAX / divisor_value - U256::ONE);
+    let comparison = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, quotient.clone(), threshold.clone());
+    let normalized = normalize_constraints_for_solver(&mut cx, std::slice::from_ref(&comparison));
+    assert_eq!(normalized.len(), 1);
+    assert!(!normalized[0].smt(&cx).contains("bvudiv"));
+    for numerator in [U256::MAX - U256::ONE, U256::MAX] {
+        let model = symbolic_model(&mut cx, [("numerator", numerator)]);
+        assert_eq!(
+            comparison.eval_model(&model).unwrap(),
+            normalized[0].eval_model(&model).unwrap(),
+            "numerator={numerator} threshold={threshold:?}"
+        );
+    }
+
+    let symbolic_threshold = SymExpr::var(&mut cx, "symbolic_threshold");
+    let max = SymExpr::constant(&mut cx, U256::MAX);
+    let threshold_is_max = SymBoolExpr::eq(&mut cx, symbolic_threshold.clone(), max);
+    let comparison = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, quotient, symbolic_threshold);
+    let normalized =
+        normalize_constraints_for_solver(&mut cx, &[threshold_is_max, comparison.clone()]);
+    assert!(normalized.contains(&comparison));
+
+    let symbolic_divisor = SymExpr::var(&mut cx, "divisor");
+    let numerator = SymExpr::var(&mut cx, "other_numerator");
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, symbolic_divisor);
+    let threshold = SymExpr::constant(&mut cx, U256::from(10));
+    let comparison = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, quotient, threshold);
+    let normalized = normalize_constraints_for_solver(&mut cx, &[comparison]);
+    assert!(normalized[0].smt(&cx).contains("bvudiv"));
+}
+
+#[test]
+fn solver_normalizes_udiv_comparison_with_independent_bound() {
+    let mut cx = SymCx::new();
+    let numerator = SymExpr::var(&mut cx, "numerator");
+    let threshold = SymExpr::var(&mut cx, "threshold");
+    let divisor = SymExpr::constant(&mut cx, U256::from(1_000_000_000_000_000_000u128));
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, divisor);
+    let uint128_max = SymExpr::constant(&mut cx, U256::from(u128::MAX));
+    let threshold_bounded =
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, threshold.clone(), uint128_max);
+    let comparison = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, quotient, threshold);
+    let constraints = vec![threshold_bounded, comparison];
+
+    let normalized = normalize_constraints_for_solver(&mut cx, &constraints);
+    assert_eq!(normalized.len(), 2);
+    assert!(normalized.iter().all(|constraint| !constraint.smt(&cx).contains("bvudiv")));
+}
+
+#[test]
+fn solver_does_not_use_udiv_comparison_to_bound_itself() {
+    let mut cx = SymCx::new();
+    let numerator = SymExpr::var(&mut cx, "numerator");
+    let threshold = SymExpr::var(&mut cx, "threshold");
+    let divisor_value = U256::from(3);
+    let divisor = SymExpr::constant(&mut cx, divisor_value);
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, divisor);
+    let five = SymExpr::constant(&mut cx, U256::from(5));
+    let quotient_is_five = SymBoolExpr::eq(&mut cx, quotient.clone(), five.clone());
+    let comparison = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, threshold, quotient.clone());
+    let constraints = vec![quotient_is_five, comparison.clone()];
+    let model = symbolic_model(
+        &mut cx,
+        [
+            ("numerator".to_string(), U256::from(15)),
+            ("threshold".to_string(), U256::MAX / divisor_value + U256::ONE),
+            ("quotient_alias".to_string(), U256::from(5)),
+        ],
+    );
+
+    assert!(constraints[0].eval_model(&model).unwrap());
+    assert!(!comparison.eval_model(&model).unwrap());
+    let normalized = normalize_constraints_for_solver(&mut cx, &constraints);
+    assert!(normalized.contains(&comparison));
+    assert!(normalized.iter().any(|constraint| !constraint.eval_model(&model).unwrap()));
+
+    let alias = SymExpr::var(&mut cx, "quotient_alias");
+    let alias_is_quotient = SymBoolExpr::eq(&mut cx, alias.clone(), quotient.clone());
+    let alias_is_five = SymBoolExpr::eq(&mut cx, alias, five);
+    let threshold = SymExpr::var(&mut cx, "threshold");
+    let reversed = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, quotient.clone(), threshold.clone());
+    let less_than = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, quotient, threshold);
+    let negated = less_than.not(&mut cx);
+    for comparison in [reversed, negated] {
+        let conjunction = SymBoolExpr::and(
+            &mut cx,
+            vec![comparison, alias_is_quotient.clone(), alias_is_five.clone()],
+        );
+        let constraints = vec![conjunction];
+        assert!(constraints.iter().any(|constraint| !constraint.eval_model(&model).unwrap()));
+
+        let normalized = normalize_constraints_for_solver(&mut cx, &constraints);
+        assert!(normalized.iter().any(|constraint| !constraint.eval_model(&model).unwrap()));
+    }
+}
+
+#[test]
 fn solver_normalizes_constraint_batches_by_flattening_and_deduping() {
     let mut cx = SymCx::new();
     let x = SymExpr::var(&mut cx, "x");

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -652,6 +652,67 @@ contract SymbolicBoundedCarry {
     assert_eq!(result["symbolic"]["replay"]["status"], "confirmed");
 });
 
+forgetest_init!(symbolic_proves_fixed_point_fee_bounds, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_proves_fixed_point_fee_bounds because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicFixedPointFee.t.sol",
+        r#"
+library FixedPointMathLib {
+    function mulWad(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        assembly {
+            if gt(x, div(not(0), y)) {
+                if y { revert(0, 0) }
+            }
+            z := div(mul(x, y), 1000000000000000000)
+        }
+    }
+}
+
+contract SymbolicFixedPointFee {
+    uint256 constant WAD = 1e18;
+    uint256 constant RATE = 3e15;
+
+    function checkMinimumFee(uint128 amount, uint128 minimum) public pure {
+        uint256 fee = FixedPointMathLib.mulWad(amount, RATE);
+        if (fee >= minimum) {
+            unchecked {
+                assert(uint256(amount) * RATE >= uint256(minimum) * WAD);
+            }
+        }
+    }
+
+    function checkMaximumFee(uint128 amount, uint128 maximum) public pure {
+        uint256 fee = FixedPointMathLib.mulWad(amount, RATE);
+        if (fee <= maximum) {
+            unchecked {
+                assert(uint256(amount) * RATE < (uint256(maximum) + 1) * WAD);
+            }
+        }
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--json", "--match-contract", "SymbolicFixedPointFee"])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+
+    for signature in ["checkMinimumFee(uint128,uint128)", "checkMaximumFee(uint128,uint128)"] {
+        let result = json_test_result(&output, signature);
+        assert_eq!(result["symbolic"]["status"], "pass");
+        assert_eq!(result["symbolic"]["solver"]["stats"]["heuristic_witnesses"], 0);
+    }
+});
+
 forgetest_init!(symbolic_proves_saturating_mul_equivalence, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(


### PR DESCRIPTION
Unsigned division by constant scales is common in fixed-point math, but leaving `UDIV` in an inequality can make an otherwise bounded property incomplete. This rewrites the four unsigned inequality forms into scaled comparisons only when the divisor is a nonzero constant and existing path bounds prove that `k * d` or `(k + 1) * d` cannot overflow 256 bits. The comparison being rewritten is excluded from the bound context, so it cannot justify its own rewrite; zero or symbolic divisors and unsafe boundaries remain unchanged.

On a fixture importing Solady v0.1.26 `FixedPointMathLib.mulWad`, two `uint128` fee-bound properties now complete. The standard symbolic portfolio keeps identical outcomes, paths, and query counts. Its wall-time shifts are included for audit but are not claimed as a speedup.

### Results

| Workload | master | this PR |
| --- | --- | --- |
| Solady `mulWad` minimum fee | incomplete; 8 solver queries; 1 heuristic witness | pass; 7 solver queries; 0 heuristic witnesses |
| Solady `mulWad` maximum fee | incomplete; 8 solver queries; 1 heuristic witness | pass; 8 solver queries; 0 heuristic witnesses |
| Standard Solady suite | 13 pass; 35 paths; 148 solver / 59 SMT queries; 224.2 ms | unchanged counters; 212.9 ms |
| Standard Angstrom suite | 1 incomplete; 9 paths; 12 solver / 1 SMT query; 294.3 ms | unchanged counters; 292.1 ms |
| Standard Farcaster suite | 2 pass; 14 paths; 14 solver / 5 SMT queries; 103.1 ms | unchanged counters; 100.4 ms |

Developed with AI assistance.
