### PR TITLE
fix(anvil): stop pending-block queries from crashing the node

### DIFF
--- a/.changelog/anvil-pending-block-panic-on-invalid-deposit-log.md
+++ b/.changelog/anvil-pending-block-panic-on-invalid-deposit-log.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed a node panic when building the pending block if a Prague+ post-execution deposit-request log couldn't be decoded, instead of returning an RPC error.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1578,7 +1578,7 @@ impl EthApi<FoundryNetwork> {
     ) -> Result<Option<AnyRpcTransaction>> {
         node_info!("eth_getTransactionByBlockNumberAndIndex");
         if block == BlockNumber::Pending {
-            return Ok(self.pending_block_full().await.and_then(|block| {
+            return Ok(self.pending_block_full().await?.and_then(|block| {
                 let WithOtherFields { inner: block, .. } = block.0;
                 block.transactions.into_transactions().nth(idx.into())
             }));
@@ -2581,7 +2581,7 @@ impl EthApi<FoundryNetwork> {
     pub async fn block_by_number(&self, number: BlockNumber) -> Result<Option<AnyRpcBlock>> {
         node_info!("eth_getBlockByNumber");
         if number == BlockNumber::Pending {
-            return Ok(Some(self.pending_block().await));
+            return Ok(Some(self.pending_block().await?));
         }
 
         self.backend.block_by_number(number).await
@@ -2596,7 +2596,7 @@ impl EthApi<FoundryNetwork> {
     ) -> Result<Option<WithOtherFields<AnyRpcHeader>>> {
         node_info!("eth_getHeaderByNumber");
         if number == BlockNumber::Pending {
-            let WithOtherFields { inner: block, other } = self.pending_block().await.0;
+            let WithOtherFields { inner: block, other } = self.pending_block().await?.0;
             return Ok(Some(WithOtherFields { inner: block.header, other }));
         }
 
@@ -2612,7 +2612,7 @@ impl EthApi<FoundryNetwork> {
     pub async fn block_by_number_full(&self, number: BlockNumber) -> Result<Option<AnyRpcBlock>> {
         node_info!("eth_getBlockByNumber");
         if number == BlockNumber::Pending {
-            return Ok(self.pending_block_full().await);
+            return Ok(self.pending_block_full().await?);
         }
         self.backend.block_by_number_full(number).await
     }
@@ -2717,7 +2717,7 @@ impl EthApi<FoundryNetwork> {
         node_info!("eth_getBlockTransactionCountByNumber");
         if block_number == BlockNumber::Pending {
             let txs = self.pool.ready_transactions().collect();
-            let block = self.backend.pending_block(txs).await;
+            let block = self.backend.pending_block(txs).await?;
             return Ok(Some(U256::from(block.block.body.transactions.len())));
         }
 
@@ -3669,7 +3669,7 @@ impl EthApi<FoundryNetwork> {
             if transactions.is_empty() {
                 return Ok(Some(Vec::new()));
             }
-            return Ok(Some(self.backend.pending_block_receipts(transactions).await));
+            return Ok(Some(self.backend.pending_block_receipts(transactions).await?));
         }
 
         self.backend.block_receipts(number).await
@@ -4774,17 +4774,17 @@ impl EthApi<FoundryNetwork> {
     }
 
     /// Returns the pending block with tx hashes
-    async fn pending_block(&self) -> AnyRpcBlock {
+    async fn pending_block(&self) -> Result<AnyRpcBlock> {
         let transactions = self.pool.ready_transactions().collect::<Vec<_>>();
-        let info = self.backend.pending_block(transactions).await;
-        self.backend.convert_block(info.block)
+        let info = self.backend.pending_block(transactions).await?;
+        Ok(self.backend.convert_block(info.block))
     }
 
     /// Returns the full pending block with `Transaction` objects
-    async fn pending_block_full(&self) -> Option<AnyRpcBlock> {
+    async fn pending_block_full(&self) -> Result<Option<AnyRpcBlock>> {
         let transactions = self.pool.ready_transactions().collect::<Vec<_>>();
         let BlockInfo { block, transactions, receipts: _ } =
-            self.backend.pending_block(transactions).await;
+            self.backend.pending_block(transactions).await?;
 
         let mut partial_block = self.backend.convert_block(block.clone());
 
@@ -4792,7 +4792,10 @@ impl EthApi<FoundryNetwork> {
         let base_fee = self.backend.base_fee();
 
         for info in transactions {
-            let tx = block.body.transactions.get(info.transaction_index as usize)?.clone();
+            let Some(tx) = block.body.transactions.get(info.transaction_index as usize).cloned()
+            else {
+                return Ok(None);
+            };
 
             let tx = transaction_build(
                 Some(info.transaction_hash),
@@ -4806,7 +4809,7 @@ impl EthApi<FoundryNetwork> {
 
         partial_block.transactions = BlockTransactions::from(block_transactions);
 
-        Some(partial_block)
+        Ok(Some(partial_block))
     }
 
     /// Prepares transaction request by filling missing fields using Anvil's API, then attempts

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2612,7 +2612,7 @@ impl EthApi<FoundryNetwork> {
     pub async fn block_by_number_full(&self, number: BlockNumber) -> Result<Option<AnyRpcBlock>> {
         node_info!("eth_getBlockByNumber");
         if number == BlockNumber::Pending {
-            return Ok(self.pending_block_full().await?);
+            return self.pending_block_full().await;
         }
         self.backend.block_by_number_full(number).await
     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5674,7 +5674,7 @@ where
     pub async fn pending_block(
         &self,
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
-    ) -> BlockInfo<N> {
+    ) -> Result<BlockInfo<N>, BlockchainError> {
         self.with_pending_block(pool_transactions, |_, block| block).await
     }
 
@@ -5685,7 +5685,7 @@ where
         &self,
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
         f: F,
-    ) -> T
+    ) -> Result<T, BlockchainError>
     where
         F: FnOnce(Box<dyn MaybeFullDatabase + '_>, BlockInfo<N>) -> T,
     {
@@ -5701,27 +5701,21 @@ where
         let inspector_tx_config = self.inspector_tx_config();
         let gas_config = self.pool_tx_gas_config(&evm_env);
 
-        let (pool_result, block_result) = self
-            .execute_with_block_executor(
-                &mut cache_db,
-                &evm_env,
-                parent_hash,
-                spec_id,
-                self.hardfork(),
-                Some(B256::ZERO),
-                BlockExecutionKind::Complete,
-                &pool_transactions,
-                &gas_config,
-                &inspector_tx_config,
-                &|pool_tx, account| {
-                    self.validate_pool_transaction_for(
-                        &pool_tx.pending_transaction,
-                        account,
-                        &evm_env,
-                    )
-                },
-            )
-            .expect("pending block execution failed");
+        let (pool_result, block_result) = self.execute_with_block_executor(
+            &mut cache_db,
+            &evm_env,
+            parent_hash,
+            spec_id,
+            self.hardfork(),
+            Some(B256::ZERO),
+            BlockExecutionKind::Complete,
+            &pool_transactions,
+            &gas_config,
+            &inspector_tx_config,
+            &|pool_tx, account| {
+                self.validate_pool_transaction_for(&pool_tx.pending_transaction, account, &evm_env)
+            },
+        )?;
 
         // Extract inner CacheDB (which implements MaybeFullDatabase)
         let cache_db = cache_db.0;
@@ -5739,7 +5733,7 @@ where
             Some(B256::ZERO),
         );
 
-        f(Box::new(cache_db), block_info)
+        Ok(f(Box::new(cache_db), block_info))
     }
 
     /// Returns the ERC20/TIP20 token balance for an account.
@@ -6200,7 +6194,7 @@ where
                         let block = block.block;
                         f(state, block_env_from_header(&block.header))
                     })
-                    .await;
+                    .await?;
                 return Ok(result);
             }
             Some(BlockRequest::Number(bn)) => Some(BlockNumber::Number(bn)),
@@ -6264,7 +6258,7 @@ where
                         let block_env = block_env_from_header(&block_info.block.header);
                         f(state, block_env, context)
                     })
-                    .await;
+                    .await?;
             }
             Some(BlockRequest::Number(number)) => Some(BlockNumber::Number(number)),
             None => None,
@@ -7289,9 +7283,9 @@ where
     pub async fn pending_block_receipts(
         &self,
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
-    ) -> Vec<FoundryTxReceipt> {
+    ) -> Result<Vec<FoundryTxReceipt>, BlockchainError> {
         let BlockInfo { block, transactions, receipts } =
-            self.pending_block(pool_transactions).await;
+            self.pending_block(pool_transactions).await?;
         let block_hash = block.header.hash_slow();
         let mut pending_receipts = Vec::with_capacity(receipts.len());
         let mut next_log_index = 0;
@@ -7309,7 +7303,7 @@ where
             next_log_index += log_count;
         }
 
-        pending_receipts
+        Ok(pending_receipts)
     }
 
     /// Returns the blocks receipts for the given number
@@ -8550,7 +8544,7 @@ impl Backend<FoundryNetwork> {
                         optimism_jovian,
                     )
                 })
-                .await
+                .await?
             }
             block_request => {
                 let base_block_number = match block_request.as_ref() {

--- a/crates/anvil/tests/it/eip6110.rs
+++ b/crates/anvil/tests/it/eip6110.rs
@@ -1,0 +1,39 @@
+use alloy_eips::{BlockNumberOrTag, eip6110::MAINNET_DEPOSIT_CONTRACT_ADDRESS};
+use alloy_network::TransactionBuilder;
+use alloy_primitives::bytes;
+use alloy_provider::Provider;
+use alloy_rpc_types::TransactionRequest;
+use alloy_serde::WithOtherFields;
+use anvil::{NodeConfig, spawn};
+use foundry_evm::hardfork::EthereumHardfork;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn eip6110_pending_block_returns_malformed_deposit_error() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()));
+    let (api, handle) = spawn(node_config).await;
+    let provider = handle.http_provider();
+
+    // PUSH32 DepositEvent topic, PUSH1 size=0, PUSH1 offset=0, LOG1, STOP.
+    api.anvil_set_code(
+        MAINNET_DEPOSIT_CONTRACT_ADDRESS,
+        bytes!("7f649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c560006000a100"),
+    )
+    .await
+    .unwrap();
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let from = handle.dev_wallets().next().unwrap().address();
+    let _pending = provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .from(from)
+                .to(MAINNET_DEPOSIT_CONTRACT_ADDRESS)
+                .with_gas_limit(100_000),
+        ))
+        .await
+        .unwrap();
+
+    let error = provider.get_block_by_number(BlockNumberOrTag::Pending).await.unwrap_err();
+    let response = error.as_error_resp().expect("should return a JSON-RPC error");
+    assert_eq!(response.code, -32603);
+    assert_eq!(provider.get_block_number().await.unwrap(), 0);
+}

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -6,6 +6,7 @@ mod beacon_api;
 mod block_index;
 mod eip2935;
 mod eip4844;
+mod eip6110;
 mod eip7702;
 mod eip7928;
 mod filter;


### PR DESCRIPTION
Does what it says on the box - `with_pending_block` called the exact same `execute_with_block_executor` that `do_mine_block` already handles cleanly via `?`, but did `.expect("pending block execution failed")` on it instead. Any `Err` there panics the whole process, and since `[profile.release]` sets `panic = "abort"`, that's not a caught task panic - it takes the entire anvil process down for every connected client.

## Reachability

`with_pending_block`/`pending_block` back several completely ordinary RPC methods: `eth_getBlockByNumber("pending", ...)`, `eth_getHeaderByNumber("pending")`, `eth_getBlockTransactionCountByNumber("pending")`, `eth_getBlockReceipts`, `eth_getTransactionByBlockNumberAndIndex`, and the pending-block path of `eth_simulateV1`.

Concretely: at Prague+ hardfork, post-execution processing parses EIP-6110 deposit-request logs from every pool transaction's receipts. If a contract sitting at the deposit-contract address emits a log with the `DepositEvent` topic0 but data that doesn't decode as the expected 5-`bytes` tuple (e.g. empty data), decoding fails and the error propagates up through `execute_with_block_executor`. Placing arbitrary bytecode at an arbitrary address via the documented `anvil_setCode` cheat is completely ordinary anvil usage - nothing exotic is needed to hit this.

Reproduced with a minimal `LOG1`-then-`STOP` contract deployed at the deposit-contract address (emits the correct topic0 with empty data) plus one pending, unmined transaction, then a plain `eth_getBlockByNumber("pending", ...)` call - confirmed panic pre-fix, clean RPC error post-fix.

## Fix

`with_pending_block`/`Backend::pending_block` now return `Result<_, BlockchainError>` instead of unwrapping internally, propagating the error exactly like `do_mine_block` already does for the identical call. Threaded the `Result` through every caller up to the JSON-RPC boundary in `crates/anvil/src/eth/api.rs`, plus the two other backend call sites (`with_database_at`/`with_database_at_and_context`'s `BlockRequest::Pending` branches, `pending_block_receipts`, `simulate_raw`'s pending path).

## receipts

no runtime changes to a UI surface - this is a backend RPC-handler fix, verified via `cargo test`:

```
$ cargo test -p anvil --test it eip6110 -- --nocapture
# pre-fix (stashed the fix, kept the test):
thread 'tokio-rt-worker' panicked at crates/anvil/src/eth/backend/mem/mod.rs:5724:14:
pending block execution failed: Internal("failed to decode deposit requests from receipts: ABI decoding failed: buffer overrun while deserializing")
test eip6110::eip6110_pending_block_returns_malformed_deposit_error ... FAILED

# post-fix:
test eip6110::eip6110_pending_block_returns_malformed_deposit_error ... ok
test result: ok. 1 passed; 0 failed
```

Also re-ran `eip2935` (11 passed), `simulate` (78 passed), `anvil_api` (63 passed), `txpool` (7 passed), `block_index` (6 passed, incl. the pending-tx-by-index test), `gas` (70 passed, incl. `estimates_gas_on_pending_by_default`), plus `cargo check -p anvil -p cast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh6V2uPTUqauqq45BM7m5k
