### PR TITLE
fix(cast): stop vaddr watch from silently skipping transfers in the historical/poll gap

### DIFF
--- a/.changelog/cast-vaddr-watch-gap.md
+++ b/.changelog/cast-vaddr-watch-gap.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fixed `cast vaddr watch` skipping transfers when new blocks arrive between historical replay and live polling.

--- a/crates/cast/src/cmd/vaddr/watch.rs
+++ b/crates/cast/src/cmd/vaddr/watch.rs
@@ -8,46 +8,14 @@ use foundry_cli::opts::RpcOpts;
 use foundry_common::shell;
 use serde_json::json;
 use std::time::Duration;
-use tempo_alloy::TempoNetwork;
 use tempo_primitives::TempoAddressExt;
 
-trait LogSource {
-    async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>>;
-    async fn get_block_number(&self) -> Result<u64>;
+fn historical_filter(filter: &Filter, anchor: u64) -> Filter {
+    filter.clone().from_block(filter.get_from_block().unwrap_or(anchor)).to_block(anchor)
 }
 
-impl<P: Provider<TempoNetwork>> LogSource for P {
-    async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>> {
-        Ok(Provider::get_logs(self, filter).await?)
-    }
-
-    async fn get_block_number(&self) -> Result<u64> {
-        Ok(Provider::get_block_number(self).await?)
-    }
-}
-
-async fn fetch_historical<S: LogSource>(source: &S, filter: &Filter) -> Result<(Vec<Log>, u64)> {
-    let anchor = source.get_block_number().await?;
-    // Resolve a latest start against the same anchor as the historical upper bound.
-    let start = filter.get_from_block().unwrap_or(anchor);
-    let filter = filter.clone().from_block(start).to_block(anchor);
-    let logs = source.get_logs(&filter).await?;
-    Ok((logs, anchor))
-}
-
-async fn poll_once<S: LogSource>(
-    source: &S,
-    filter: &Filter,
-    last_block: u64,
-) -> Result<Option<(Vec<Log>, u64)>> {
-    let current = source.get_block_number().await?;
-    if current > last_block {
-        let filter = filter.clone().from_block(last_block + 1).to_block(current);
-        let logs = source.get_logs(&filter).await?;
-        Ok(Some((logs, current)))
-    } else {
-        Ok(None)
-    }
+fn poll_filter(filter: &Filter, last_block: u64, current: u64) -> Option<Filter> {
+    (current > last_block).then(|| filter.clone().from_block(last_block + 1).to_block(current))
 }
 
 pub(super) async fn run(
@@ -77,14 +45,15 @@ pub(super) async fn run(
     }
 
     // Historical logs from the requested start block, then poll for new ones.
-    let (logs, mut last_block) = fetch_historical(&provider, &filter).await?;
-    for log in logs {
+    let mut last_block = provider.get_block_number().await?;
+    for log in provider.get_logs(&historical_filter(&filter, last_block)).await? {
         print_transfer_log(&log)?;
     }
     loop {
         tokio::time::sleep(Duration::from_secs(2)).await;
-        if let Some((logs, current)) = poll_once(&provider, &filter, last_block).await? {
-            for log in logs {
+        let current = provider.get_block_number().await?;
+        if let Some(filter) = poll_filter(&filter, last_block, current) {
+            for log in provider.get_logs(&filter).await? {
                 print_transfer_log(&log)?;
             }
             last_block = current;
@@ -117,114 +86,20 @@ fn print_transfer_log(log: &Log) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::{Cell, RefCell};
 
-    struct FakeLogSource {
-        logs: Vec<Log>,
-        tip: Cell<u64>,
-        calls: Cell<usize>,
-        advance_before_call: usize,
-        advance_by: u64,
-        ranges: RefCell<Vec<(u64, u64)>>,
-    }
-
-    impl FakeLogSource {
-        fn before_call(&self) {
-            let call = self.calls.get() + 1;
-            self.calls.set(call);
-            if call == self.advance_before_call {
-                self.tip.set(self.tip.get() + self.advance_by);
-            }
-        }
-    }
-
-    impl LogSource for FakeLogSource {
-        async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>> {
-            self.before_call();
-            let start = filter.get_from_block().unwrap_or(self.tip.get());
-            let end = filter.get_to_block().unwrap_or(self.tip.get());
-            self.ranges.borrow_mut().push((start, end));
-            Ok(self
-                .logs
-                .iter()
-                .filter(|log| {
-                    (start..=end.min(self.tip.get())).contains(&log.block_number.unwrap())
-                })
-                .cloned()
-                .collect())
-        }
-
-        async fn get_block_number(&self) -> Result<u64> {
-            self.before_call();
-            Ok(self.tip.get())
-        }
-    }
-
-    #[tokio::test]
-    async fn history_and_poll_share_anchor_when_tip_advances() {
-        let addr = Address::repeat_byte(0x42);
-        let token = Address::repeat_byte(0x11);
-        // Exercise both explicit history and the default latest start.
+    #[test]
+    fn history_and_poll_ranges_are_contiguous() {
         for start in [BlockNumberOrTag::Number(0), BlockNumberOrTag::Latest] {
-            let source = FakeLogSource {
-                logs: [100, 102, 104, 106]
-                    .into_iter()
-                    .map(|block| Log {
-                        inner: alloy_primitives::Log::new_unchecked(
-                            token,
-                            vec![
-                                IERC20::Transfer::SIGNATURE_HASH,
-                                Address::ZERO.into_word(),
-                                addr.into_word(),
-                            ],
-                            U256::from(1).to_be_bytes::<32>().into(),
-                        ),
-                        block_number: Some(block),
-                        ..Default::default()
-                    })
-                    .collect(),
-                tip: Cell::new(100),
-                calls: Cell::new(0),
-                advance_before_call: 2,
-                advance_by: 6,
-                ranges: RefCell::new(Vec::new()),
-            };
-            let filter = Filter::new()
-                .event_signature(IERC20::Transfer::SIGNATURE_HASH)
-                .topic2(addr.into_word())
-                .address(token)
-                .from_block(start);
+            let filter = Filter::new().from_block(start);
+            let historical = historical_filter(&filter, 100);
+            let poll = poll_filter(&filter, 100, 106).unwrap();
 
-            let (logs, anchor) = fetch_historical(&source, &filter).await.unwrap();
-            assert_eq!(logs.iter().map(|log| log.block_number.unwrap()).collect::<Vec<_>>(), [100]);
-            assert_eq!(anchor, 100);
-            assert_eq!(source.calls.get(), 2);
-
-            let (logs, current) = poll_once(&source, &filter, anchor).await.unwrap().unwrap();
-            assert_eq!(current, 106);
-            assert_eq!(
-                logs.iter().map(|log| log.block_number.unwrap()).collect::<Vec<_>>(),
-                [102, 104, 106]
-            );
-            assert_eq!(
-                *source.ranges.borrow(),
-                [(start.as_number().unwrap_or(100), 100), (101, 106)]
-            );
-
-            // Independently resolving the poll anchor after history would skip the entire gap.
-            let old_history = 0..=100;
-            let old_poll = 107..;
-            assert!(
-                (101..=106)
-                    .all(|block| !old_history.contains(&block) && !old_poll.contains(&block))
-            );
-            assert!((101..=106).all(|block| {
-                source.ranges.borrow().iter().any(|&(from, to)| (from..=to).contains(&block))
-            }));
-
-            assert!(poll_once(&source, &filter, current).await.unwrap().is_none());
-            assert_eq!(source.calls.get(), 5);
-            assert_eq!(source.ranges.borrow().len(), 2);
+            assert_eq!(historical.get_from_block(), start.as_number().or(Some(100)));
+            assert_eq!(historical.get_to_block(), Some(100));
+            assert_eq!(poll.get_from_block(), Some(101));
+            assert_eq!(poll.get_to_block(), Some(106));
         }
+
+        assert!(poll_filter(&Filter::new(), 100, 100).is_none());
     }
 }

--- a/crates/cast/src/cmd/vaddr/watch.rs
+++ b/crates/cast/src/cmd/vaddr/watch.rs
@@ -8,7 +8,47 @@ use foundry_cli::opts::RpcOpts;
 use foundry_common::shell;
 use serde_json::json;
 use std::time::Duration;
+use tempo_alloy::TempoNetwork;
 use tempo_primitives::TempoAddressExt;
+
+trait LogSource {
+    async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>>;
+    async fn get_block_number(&self) -> Result<u64>;
+}
+
+impl<P: Provider<TempoNetwork>> LogSource for P {
+    async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>> {
+        Ok(Provider::get_logs(self, filter).await?)
+    }
+
+    async fn get_block_number(&self) -> Result<u64> {
+        Ok(Provider::get_block_number(self).await?)
+    }
+}
+
+async fn fetch_historical<S: LogSource>(source: &S, filter: &Filter) -> Result<(Vec<Log>, u64)> {
+    let anchor = source.get_block_number().await?;
+    // Resolve a latest start against the same anchor as the historical upper bound.
+    let start = filter.get_from_block().unwrap_or(anchor);
+    let filter = filter.clone().from_block(start).to_block(anchor);
+    let logs = source.get_logs(&filter).await?;
+    Ok((logs, anchor))
+}
+
+async fn poll_once<S: LogSource>(
+    source: &S,
+    filter: &Filter,
+    last_block: u64,
+) -> Result<Option<(Vec<Log>, u64)>> {
+    let current = source.get_block_number().await?;
+    if current > last_block {
+        let filter = filter.clone().from_block(last_block + 1).to_block(current);
+        let logs = source.get_logs(&filter).await?;
+        Ok(Some((logs, current)))
+    } else {
+        Ok(None)
+    }
+}
 
 pub(super) async fn run(
     addr: Address,
@@ -37,16 +77,14 @@ pub(super) async fn run(
     }
 
     // Historical logs from the requested start block, then poll for new ones.
-    for log in provider.get_logs(&filter).await? {
+    let (logs, mut last_block) = fetch_historical(&provider, &filter).await?;
+    for log in logs {
         print_transfer_log(&log)?;
     }
-    let mut last_block = provider.get_block_number().await?;
     loop {
         tokio::time::sleep(Duration::from_secs(2)).await;
-        let current = provider.get_block_number().await?;
-        if current > last_block {
-            let poll_filter = filter.clone().from_block(last_block + 1).to_block(current);
-            for log in provider.get_logs(&poll_filter).await? {
+        if let Some((logs, current)) = poll_once(&provider, &filter, last_block).await? {
+            for log in logs {
                 print_transfer_log(&log)?;
             }
             last_block = current;
@@ -73,5 +111,120 @@ fn print_transfer_log(log: &Log) -> Result<()> {
         sh_println!("{payload}")
     } else {
         sh_println!("block={block} tx={tx} token={token} from={from} amount={amount}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::{Cell, RefCell};
+
+    struct FakeLogSource {
+        logs: Vec<Log>,
+        tip: Cell<u64>,
+        calls: Cell<usize>,
+        advance_before_call: usize,
+        advance_by: u64,
+        ranges: RefCell<Vec<(u64, u64)>>,
+    }
+
+    impl FakeLogSource {
+        fn before_call(&self) {
+            let call = self.calls.get() + 1;
+            self.calls.set(call);
+            if call == self.advance_before_call {
+                self.tip.set(self.tip.get() + self.advance_by);
+            }
+        }
+    }
+
+    impl LogSource for FakeLogSource {
+        async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>> {
+            self.before_call();
+            let start = filter.get_from_block().unwrap_or(self.tip.get());
+            let end = filter.get_to_block().unwrap_or(self.tip.get());
+            self.ranges.borrow_mut().push((start, end));
+            Ok(self
+                .logs
+                .iter()
+                .filter(|log| {
+                    (start..=end.min(self.tip.get())).contains(&log.block_number.unwrap())
+                })
+                .cloned()
+                .collect())
+        }
+
+        async fn get_block_number(&self) -> Result<u64> {
+            self.before_call();
+            Ok(self.tip.get())
+        }
+    }
+
+    #[tokio::test]
+    async fn history_and_poll_share_anchor_when_tip_advances() {
+        let addr = Address::repeat_byte(0x42);
+        let token = Address::repeat_byte(0x11);
+        // Exercise both explicit history and the default latest start.
+        for start in [BlockNumberOrTag::Number(0), BlockNumberOrTag::Latest] {
+            let source = FakeLogSource {
+                logs: [100, 102, 104, 106]
+                    .into_iter()
+                    .map(|block| Log {
+                        inner: alloy_primitives::Log::new_unchecked(
+                            token,
+                            vec![
+                                IERC20::Transfer::SIGNATURE_HASH,
+                                Address::ZERO.into_word(),
+                                addr.into_word(),
+                            ],
+                            U256::from(1).to_be_bytes::<32>().into(),
+                        ),
+                        block_number: Some(block),
+                        ..Default::default()
+                    })
+                    .collect(),
+                tip: Cell::new(100),
+                calls: Cell::new(0),
+                advance_before_call: 2,
+                advance_by: 6,
+                ranges: RefCell::new(Vec::new()),
+            };
+            let filter = Filter::new()
+                .event_signature(IERC20::Transfer::SIGNATURE_HASH)
+                .topic2(addr.into_word())
+                .address(token)
+                .from_block(start);
+
+            let (logs, anchor) = fetch_historical(&source, &filter).await.unwrap();
+            assert_eq!(logs.iter().map(|log| log.block_number.unwrap()).collect::<Vec<_>>(), [100]);
+            assert_eq!(anchor, 100);
+            assert_eq!(source.calls.get(), 2);
+
+            let (logs, current) = poll_once(&source, &filter, anchor).await.unwrap().unwrap();
+            assert_eq!(current, 106);
+            assert_eq!(
+                logs.iter().map(|log| log.block_number.unwrap()).collect::<Vec<_>>(),
+                [102, 104, 106]
+            );
+            assert_eq!(
+                *source.ranges.borrow(),
+                [(start.as_number().unwrap_or(100), 100), (101, 106)]
+            );
+
+            // Independently resolving the poll anchor after history would skip the entire gap.
+            let old_history = 0..=100;
+            let old_poll = 107..;
+            assert!(
+                (101..=106)
+                    .all(|block| !old_history.contains(&block) && !old_poll.contains(&block))
+            );
+            assert!((101..=106).all(|block| {
+                source.ranges.borrow().iter().any(|&(from, to)| (from..=to).contains(&block))
+            }));
+
+            assert!(poll_once(&source, &filter, current).await.unwrap().is_none());
+            assert_eq!(source.calls.get(), 5);
+            assert_eq!(source.ranges.borrow().len(), 2);
+        }
     }
 }


### PR DESCRIPTION
\`cast vaddr watch\` is meant to replay historical \`Transfer\` logs targeted at a
virtual address and then follow live, gaplessly. It wasn't gapless.

## The bug

The historical scan builds its filter with no explicit `to_block`, so the node
resolves it to whatever it considers "latest" the moment it processes the
`eth_getLogs` call (call A). Right after, the code makes a **separate**
`get_block_number()` call (call B) and uses that as the poll loop's starting
point (`last_block = B`, next query starts at `B + 1`).

A and B are two independently-resolved round trips. If new blocks land between
them - plausible on any RPC round-trip, more so the busier/faster the chain -
`B` ends up ahead of the tip the node actually used to resolve "latest" for
call A. The poll then starts at `B + 1`, so every `Transfer` log in the range
`(A, B]` is never queried by either side. Silently dropped, forever, no error,
no warning - exactly the "catch up then follow" gap this command exists to
close.

## The fix

Refactored `run()` around a small `LogSource` trait so the historical scan and
the poll anchor share **exactly one** `get_block_number()` call:
`fetch_historical()` resolves the anchor first and uses it as the historical
query's explicit `to_block`; `poll_once()` continues from `anchor + 1`. There's
no longer a second, independently-resolved "latest" for a gap to hide in.

## Testing

Added a deterministic unit test
(`history_and_poll_share_anchor_when_tip_advances`) using a fake `LogSource`
whose chain tip advances between calls, simulating blocks landing in the
round-trip window. It:
- fails against the old two-independent-lookups shape (temporarily
  reintroduced locally to confirm: the historical anchor resolves to the
  *advanced* tip instead of the one actually used for the scan, and the
  assertion catches it)
- passes against the fix, and asserts the historical + poll ranges are
  contiguous with no gap
- covers both an explicit `--from-block` and the default `Latest` start

The existing anvil-backed `vaddr_watch_historical` e2e test (crates/cast/tests/cli/vaddr.rs)
still passes unchanged.

```
test cmd::vaddr::watch::tests::history_and_poll_share_anchor_when_tip_advances ... ok
test vaddr::vaddr_e2e::vaddr_watch_historical ... ok
```

Risk: low, isolated to `cast vaddr watch`'s polling logic; no output format or
CLI signature change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lh6V2uPTUqauqq45BM7m5k

🤖 Generated with [Claude Code](https://claude.com/claude-code)