### PR TITLE
fix(tempo): bump dependencies for T13

### DIFF
--- a/.changelog/tempo-t13-detection.md
+++ b/.changelog/tempo-t13-detection.md
@@ -1,0 +1,9 @@
+---
+cast: patch
+forge: patch
+anvil: patch
+chisel: patch
+foundry-evm-hardforks: patch
+---
+
+Updated Tempo support through T13. Cast now reports unknown RPC hardforks instead of selecting the legacy keychain authorization ABI.

--- a/.changelog/tempo-t13-detection.md
+++ b/.changelog/tempo-t13-detection.md
@@ -6,4 +6,4 @@ chisel: patch
 foundry-evm-hardforks: patch
 ---
 
-Updated Tempo support through T13. Cast now reports unknown RPC hardforks instead of selecting the legacy keychain authorization ABI.
+Updated Tempo support through T13 so Cast correctly detects the active hardfork and uses the current keychain authorization ABI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9531,7 +9531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -10144,7 +10144,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10196,7 +10196,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10210,7 +10210,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10223,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10264,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10280,7 +10280,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10293,7 +10293,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10307,7 +10307,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10351,7 +10351,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10364,7 +10364,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10428,7 +10428,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10444,7 +10444,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10472,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10486,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10500,7 +10500,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10542,7 +10542,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10552,7 +10552,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=420513c#420513cfa78fc60d63274652eae23fc76cf449ef"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12017,7 +12017,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -12029,7 +12029,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -12062,7 +12062,7 @@ dependencies = [
  "solar-interface",
  "solar-parse",
  "solar-sema",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "toml_edit",
@@ -12088,7 +12088,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint 0.5.1",
  "num-rational",
@@ -12558,16 +12558,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12607,7 +12607,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12630,7 +12630,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12642,7 +12642,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12654,7 +12654,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12685,7 +12685,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12697,7 +12697,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12724,7 +12724,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12735,7 +12735,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12763,7 +12763,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=4e77205d0006f040c0b20a639cc7c1878be39b30#4e77205d0006f040c0b20a639cc7c1878be39b30"
+source = "git+https://github.com/tempoxyz/tempo?rev=3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0#3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -519,20 +519,20 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "965692a8a5457896b2269
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0" }
 
 # Monad
 alloy-monad-evm = { version = "0.7.0", default-features = false, features = [
@@ -624,9 +624,9 @@ op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "56
 alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "566d19ee21aef0b1235c028bd1a4a98eacb95753" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "4e77205d0006f040c0b20a639cc7c1878be39b30" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -26,6 +26,7 @@ use serde_json::Value;
 use std::str::FromStr;
 use tempo_alloy::{
     TempoNetwork,
+    provider::TempoProviderExt,
     transport::{RelayConnector, SponsorshipMode},
 };
 
@@ -184,25 +185,12 @@ struct AnvilNodeInfo {
     network: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-struct TempoForkSchedule {
-    active: String,
-}
-
 pub(crate) async fn is_tempo_hardfork_active<P: Provider<TempoNetwork>>(
     provider: &P,
     hardfork: TempoHardfork,
 ) -> Result<bool> {
-    match provider.raw_request::<_, TempoForkSchedule>("tempo_forkSchedule".into(), ()).await {
-        Ok(schedule) => {
-            let active = schedule.active.parse::<TempoHardfork>().map_err(|_| {
-                eyre::eyre!(
-                    "RPC reported unknown Tempo hardfork '{}'; upgrade Foundry before using this chain",
-                    schedule.active
-                )
-            })?;
-            Ok(active >= hardfork)
-        }
+    match provider.is_hardfork_active(hardfork).await {
+        Ok(active) => Ok(active),
         Err(err) if is_rpc_method_not_found(&err) => {
             match anvil_tempo_hardfork_active(provider, hardfork).await {
                 Ok(Some(active)) => Ok(active),
@@ -353,41 +341,9 @@ mod tests {
     use alloy_rpc_client::RpcClient;
 
     #[tokio::test]
-    async fn tempo_fork_schedule_detects_t13_and_earlier_forks() {
-        for (active, required, expected) in [
-            ("T2", TempoHardfork::T3, false),
-            ("T3", TempoHardfork::T3, true),
-            ("T11", TempoHardfork::T3, true),
-            ("T12", TempoHardfork::T13, false),
-            ("T13", TempoHardfork::T3, true),
-            ("T13", TempoHardfork::T13, true),
-        ] {
-            let asserter = Asserter::new();
-            asserter.push_success(&serde_json::json!({ "active": active }));
-            let provider = AlloyProviderBuilder::new()
-                .network::<TempoNetwork>()
-                .connect_mocked_client(asserter);
-            assert_eq!(is_tempo_hardfork_active(&provider, required).await.unwrap(), expected);
-        }
-    }
-
-    #[tokio::test]
-    async fn tempo_fork_schedule_rejects_unknown_forks() {
+    async fn tempo_fork_schedule_detects_t13_as_t3_active() {
         let asserter = Asserter::new();
-        asserter.push_success(&serde_json::json!({ "active": "T999" }));
-        let provider =
-            AlloyProviderBuilder::new().network::<TempoNetwork>().connect_mocked_client(asserter);
-        assert_eq!(
-            is_tempo_hardfork_active(&provider, TempoHardfork::T3).await.unwrap_err().to_string(),
-            "RPC reported unknown Tempo hardfork 'T999'; upgrade Foundry before using this chain"
-        );
-    }
-
-    #[tokio::test]
-    async fn tempo_fork_schedule_falls_back_to_anvil_t13() {
-        let asserter = Asserter::new();
-        asserter.push_failure(alloy_json_rpc::ErrorPayload::method_not_found());
-        asserter.push_success(&serde_json::json!({ "network": "tempo", "hardFork": "T13" }));
+        asserter.push_success(&serde_json::json!({ "active": "T13" }));
         let provider =
             AlloyProviderBuilder::new().network::<TempoNetwork>().connect_mocked_client(asserter);
         assert!(is_tempo_hardfork_active(&provider, TempoHardfork::T3).await.unwrap());
@@ -405,14 +361,6 @@ mod tests {
         assert_eq!(active_from_anvil_node_info(&tempo_t3, TempoHardfork::T4), Some(false));
         assert_eq!(
             active_from_anvil_node_info(&info("tempo", "T11"), TempoHardfork::T11),
-            Some(true)
-        );
-        assert_eq!(
-            active_from_anvil_node_info(&info("tempo", "T13"), TempoHardfork::T3),
-            Some(true)
-        );
-        assert_eq!(
-            active_from_anvil_node_info(&info("tempo", "T13"), TempoHardfork::T13),
             Some(true)
         );
         assert_eq!(active_from_anvil_node_info(&info("ethereum", "T3"), TempoHardfork::T3), None);

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -26,7 +26,6 @@ use serde_json::Value;
 use std::str::FromStr;
 use tempo_alloy::{
     TempoNetwork,
-    provider::TempoProviderExt,
     transport::{RelayConnector, SponsorshipMode},
 };
 
@@ -185,12 +184,25 @@ struct AnvilNodeInfo {
     network: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct TempoForkSchedule {
+    active: String,
+}
+
 pub(crate) async fn is_tempo_hardfork_active<P: Provider<TempoNetwork>>(
     provider: &P,
     hardfork: TempoHardfork,
 ) -> Result<bool> {
-    match provider.is_hardfork_active(hardfork).await {
-        Ok(active) => Ok(active),
+    match provider.raw_request::<_, TempoForkSchedule>("tempo_forkSchedule".into(), ()).await {
+        Ok(schedule) => {
+            let active = schedule.active.parse::<TempoHardfork>().map_err(|_| {
+                eyre::eyre!(
+                    "RPC reported unknown Tempo hardfork '{}'; upgrade Foundry before using this chain",
+                    schedule.active
+                )
+            })?;
+            Ok(active >= hardfork)
+        }
         Err(err) if is_rpc_method_not_found(&err) => {
             match anvil_tempo_hardfork_active(provider, hardfork).await {
                 Ok(Some(active)) => Ok(active),
@@ -340,6 +352,47 @@ mod tests {
     use alloy_provider::{ProviderBuilder as AlloyProviderBuilder, mock::Asserter};
     use alloy_rpc_client::RpcClient;
 
+    #[tokio::test]
+    async fn tempo_fork_schedule_detects_t13_and_earlier_forks() {
+        for (active, required, expected) in [
+            ("T2", TempoHardfork::T3, false),
+            ("T3", TempoHardfork::T3, true),
+            ("T11", TempoHardfork::T3, true),
+            ("T12", TempoHardfork::T13, false),
+            ("T13", TempoHardfork::T3, true),
+            ("T13", TempoHardfork::T13, true),
+        ] {
+            let asserter = Asserter::new();
+            asserter.push_success(&serde_json::json!({ "active": active }));
+            let provider = AlloyProviderBuilder::new()
+                .network::<TempoNetwork>()
+                .connect_mocked_client(asserter);
+            assert_eq!(is_tempo_hardfork_active(&provider, required).await.unwrap(), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn tempo_fork_schedule_rejects_unknown_forks() {
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!({ "active": "T999" }));
+        let provider =
+            AlloyProviderBuilder::new().network::<TempoNetwork>().connect_mocked_client(asserter);
+        assert_eq!(
+            is_tempo_hardfork_active(&provider, TempoHardfork::T3).await.unwrap_err().to_string(),
+            "RPC reported unknown Tempo hardfork 'T999'; upgrade Foundry before using this chain"
+        );
+    }
+
+    #[tokio::test]
+    async fn tempo_fork_schedule_falls_back_to_anvil_t13() {
+        let asserter = Asserter::new();
+        asserter.push_failure(alloy_json_rpc::ErrorPayload::method_not_found());
+        asserter.push_success(&serde_json::json!({ "network": "tempo", "hardFork": "T13" }));
+        let provider =
+            AlloyProviderBuilder::new().network::<TempoNetwork>().connect_mocked_client(asserter);
+        assert!(is_tempo_hardfork_active(&provider, TempoHardfork::T3).await.unwrap());
+    }
+
     #[test]
     fn active_from_anvil_node_info_requires_tempo_network() {
         let info = |network: &str, hard_fork: &str| AnvilNodeInfo {
@@ -352,6 +405,14 @@ mod tests {
         assert_eq!(active_from_anvil_node_info(&tempo_t3, TempoHardfork::T4), Some(false));
         assert_eq!(
             active_from_anvil_node_info(&info("tempo", "T11"), TempoHardfork::T11),
+            Some(true)
+        );
+        assert_eq!(
+            active_from_anvil_node_info(&info("tempo", "T13"), TempoHardfork::T3),
+            Some(true)
+        );
+        assert_eq!(
+            active_from_anvil_node_info(&info("tempo", "T13"), TempoHardfork::T13),
             Some(true)
         );
         assert_eq!(active_from_anvil_node_info(&info("ethereum", "T3"), TempoHardfork::T3), None);

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -659,9 +659,10 @@ casttest!(send_with_authorized_access_key_succeeds, async |_prj, cmd| {
     assert_eq!(receipt["status"], "0x1", "unexpected receipt: {output}");
 });
 
-// On-chain: `keychain set-scope` keeps the tuple ABI across T11.
-casttest!(keychain_set_scope_succeeds_across_t11, async |_prj, cmd| {
-    for hardfork in [TempoHardfork::T10, TempoHardfork::T11] {
+// On-chain: key authorization and `keychain set-scope` keep the tuple ABI through T13.
+casttest!(keychain_set_scope_succeeds_through_t13, async |_prj, cmd| {
+    for hardfork in [TempoHardfork::T10, TempoHardfork::T11, TempoHardfork::T12, TempoHardfork::T13]
+    {
         let (_, handle) =
             anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(hardfork.into()))).await;
         let rpc = handle.http_endpoint();

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -742,6 +742,8 @@ mod tests {
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("tempo:T2"), Some(TempoHardfork::T2));
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("tempo:T7"), Some(TempoHardfork::T7));
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("tempo:T8"), Some(TempoHardfork::T8));
+        assert_eq!(evm_spec_id_from_str::<TempoHardfork>("tempo:T13"), Some(TempoHardfork::T13));
+        assert_eq!(evm_spec_id_from_str::<TempoHardfork>("T13"), Some(TempoHardfork::T13));
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("ethereum:prague"), None);
 
         #[cfg(feature = "monad")]


### PR DESCRIPTION
Bump the Tempo dependencies to [3f1b3f2](https://github.com/tempoxyz/tempo/commit/3f1b3f2b122f7cb8e14fe9863b87e4609c76e7d0) so Foundry recognizes T13. Previously, a T13 node's fork schedule was treated as “T3 inactive,” causing `cast keychain auth` to send the legacy selector and revert with `LegacyAuthorizeKeySelectorChanged`.

The dependency bump adds T13 to the existing hardfork parser. Add focused T13 parsing and RPC detection coverage, and extend the keychain authorization/scope integration test through T13.

Prompted by: @grandizzy

This PR's code, tests, and description were generated by Centaur (OpenAI Codex).
