### PR TITLE
fix(anvil): apply a consistent fork-boundary policy to both blocks and transactions

### DIFF
--- a/.changelog/anvil-loadstate-fork-block-corruption.md
+++ b/.changelog/anvil-loadstate-fork-block-corruption.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed loading state when the fork head is selected: dumped blocks and transactions at or below that head are no longer inserted into local storage, either by hash or by number. Block-by-hash, block-by-number, transaction-by-hash, and transaction-by-block-and-index queries consistently use the fork's live chain for that range.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -7408,6 +7408,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
     pub async fn load_state(&self, mut state: SerializableState) -> Result<bool, BlockchainError> {
         let _mining_guard = self.mining.lock().await;
         let mut block_env = state.block.take();
+        let mut fork_block_boundary = None;
         let mut selected_head = None;
         let mut selected_header = None;
         let mut checkpoint = None;
@@ -7431,6 +7432,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
                 } else {
                     // If loading state file on a fork, set best number to the fork block number.
                     // Ref: https://github.com/foundry-rs/foundry/pull/9215#issue-2618681838
+                    fork_block_boundary = Some(number);
                     (number, Some(hash))
                 }
             } else {
@@ -7506,8 +7508,8 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         let blocks = std::mem::take(&mut state.blocks);
         let transactions = std::mem::take(&mut state.transactions);
         let mut storage = self.blockchain.storage.read().clone();
-        storage.load_blocks(blocks);
-        storage.load_transactions(transactions);
+        storage.load_blocks(blocks, fork_block_boundary);
+        storage.load_transactions(transactions, fork_block_boundary);
         if let Some(checkpoint) = checkpoint {
             storage.insert_block(checkpoint);
         }

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -469,10 +469,17 @@ impl<N: Network> BlockchainStorage<N> {
         block_hash
     }
 
-    /// Deserialize and add all blocks data to the backend storage
-    pub fn load_blocks(&mut self, serializable_blocks: Vec<SerializableBlock>) {
+    /// Deserialize and add blocks above the fork boundary to the backend storage.
+    pub fn load_blocks(
+        &mut self,
+        serializable_blocks: Vec<SerializableBlock>,
+        fork_boundary: Option<u64>,
+    ) {
         for serializable_block in serializable_blocks {
             let block: Block = serializable_block.into();
+            if fork_boundary.is_some_and(|boundary| block.header.number() <= boundary) {
+                continue;
+            }
             self.insert_block(block);
         }
     }
@@ -515,9 +522,18 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> BlockchainStorage<N> 
         transactions
     }
 
-    /// Deserialize and add all transactions data to the backend storage
-    pub fn load_transactions(&mut self, serializable_transactions: Vec<SerializableTransaction>) {
+    /// Deserialize and add transactions above the fork boundary to the backend storage.
+    pub fn load_transactions(
+        &mut self,
+        serializable_transactions: Vec<SerializableTransaction>,
+        fork_boundary: Option<u64>,
+    ) {
         for serializable_transaction in serializable_transactions {
+            if fork_boundary
+                .is_some_and(|boundary| serializable_transaction.block_number <= boundary)
+            {
+                continue;
+            }
             let transaction: MinedTransaction<N> = serializable_transaction.into();
             self.transactions.insert(transaction.info.transaction_hash, transaction);
         }
@@ -880,8 +896,8 @@ mod tests {
 
         let mut load_storage = BlockchainStorage::<FoundryNetwork>::empty();
 
-        load_storage.load_blocks(serialized_blocks);
-        load_storage.load_transactions(serialized_transactions);
+        load_storage.load_blocks(serialized_blocks, None);
+        load_storage.load_transactions(serialized_transactions, None);
 
         let loaded_block = load_storage.blocks.get(&block_hash).unwrap();
         assert_eq!(loaded_block.header.gas_limit(), header.gas_limit());
@@ -911,7 +927,7 @@ mod tests {
         assert!(canonical_hash < stale_hash);
 
         let mut loaded = BlockchainStorage::<FoundryNetwork>::empty();
-        loaded.load_blocks(storage.serialized_blocks());
+        loaded.load_blocks(storage.serialized_blocks(), None);
         assert_eq!(loaded.hashes.get(&1), Some(&canonical_hash));
     }
 
@@ -992,7 +1008,7 @@ mod tests {
         let serialized = serde_json::to_string(&dump_storage.serialized_blocks()).unwrap();
         let blocks: Vec<SerializableBlock> = serde_json::from_str(&serialized).unwrap();
         let mut load_storage = BlockchainStorage::<FoundryNetwork>::empty();
-        load_storage.load_blocks(blocks);
+        load_storage.load_blocks(blocks, None);
 
         let loaded_block = load_storage.blocks.get(&block_hash).unwrap();
         assert_eq!(loaded_block.header, expected_header);
@@ -1025,7 +1041,7 @@ mod tests {
         let dummy_genesis_hash = B256::repeat_byte(0xab);
         load_storage.genesis_hash = dummy_genesis_hash;
 
-        load_storage.load_blocks(serialized_blocks);
+        load_storage.load_blocks(serialized_blocks, None);
 
         assert_eq!(load_storage.genesis_hash, block_hash);
         assert_ne!(load_storage.genesis_hash, dummy_genesis_hash);
@@ -1042,7 +1058,7 @@ mod tests {
             header_only_73.into(),
             Vec::<MaybeImpersonatedTransaction<FoundryTxEnvelope>>::new(),
         );
-        sanity_storage.load_blocks(vec![block_73.into()]);
+        sanity_storage.load_blocks(vec![block_73.into()], None);
         assert_eq!(sanity_storage.genesis_hash, dummy_genesis_hash);
     }
 }

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -786,6 +786,128 @@ async fn test_fork_load_state() {
     assert_eq!(balance_alice + value, latest_balance_alice);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_load_state_preserves_fork_blocks_below_head() {
+    let (_origin_api, origin) =
+        spawn(NodeConfig::test().with_genesis_timestamp(Some(1_700_000_000u64))).await;
+    let (dump_source_api, dump_source) =
+        spawn(NodeConfig::test().with_genesis_timestamp(Some(1_700_000_001u64))).await;
+    let origin_provider = origin.http_provider();
+    let dump_provider = dump_source.http_provider();
+    let sender = origin.dev_wallets().next().unwrap().address();
+    let recipient = Address::repeat_byte(0x11);
+    let fork_boundary = 3;
+    let mut origin_transactions = Vec::new();
+    let mut dump_transactions = Vec::new();
+
+    for _ in 0..fork_boundary {
+        for (provider, value, transactions) in [
+            (&origin_provider, 1, &mut origin_transactions),
+            (&dump_provider, 2, &mut dump_transactions),
+        ] {
+            let receipt = provider
+                .send_transaction(WithOtherFields::new(
+                    TransactionRequest::default()
+                        .with_from(sender)
+                        .with_to(recipient)
+                        .with_value(U256::from(value)),
+                ))
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+            assert!(receipt.status());
+            transactions.push(receipt.transaction_hash);
+        }
+    }
+
+    let mut origin_blocks = Vec::new();
+    let mut dump_blocks = Vec::new();
+    for number in 0..=fork_boundary {
+        let origin_block =
+            origin_provider.get_block_by_number(number.into()).await.unwrap().unwrap();
+        let dump_block = dump_provider.get_block_by_number(number.into()).await.unwrap().unwrap();
+        assert_ne!(origin_block.header.hash, dump_block.header.hash);
+        origin_blocks.push(origin_block);
+        dump_blocks.push(dump_block);
+    }
+    let state = dump_source_api.serialized_state(false).await.unwrap();
+    let (_forked_api, forked) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin.http_endpoint()))
+            .with_fork_block_number(Some(fork_boundary))
+            .with_init_state(Some(state)),
+    )
+    .await;
+    let forked_provider = forked.http_provider();
+    assert_eq!(forked_provider.get_block_number().await.unwrap(), fork_boundary);
+
+    for (number, (origin_block, dump_block)) in origin_blocks.iter().zip(&dump_blocks).enumerate() {
+        let block =
+            forked_provider.get_block_by_number((number as u64).into()).await.unwrap().unwrap();
+        assert_eq!(block.header.hash, origin_block.header.hash);
+        assert_eq!(block.header.parent_hash, origin_block.header.parent_hash);
+        if number > 0 {
+            assert_eq!(block.header.parent_hash, origin_blocks[number - 1].header.hash);
+        }
+        assert!(forked_provider.get_block_by_hash(dump_block.header.hash).await.unwrap().is_none());
+        assert!(
+            forked_provider
+                .get_block_by_hash(dump_block.header.hash)
+                .full()
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            forked_provider
+                .get_transaction_by_block_hash_and_index(dump_block.header.hash, 0)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        if number > 0 {
+            let origin_tx = origin_provider
+                .get_transaction_by_hash(origin_transactions[number - 1])
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                forked_provider
+                    .get_transaction_by_hash(origin_transactions[number - 1])
+                    .await
+                    .unwrap(),
+                Some(origin_tx.clone())
+            );
+            assert!(
+                forked_provider
+                    .get_transaction_by_hash(dump_transactions[number - 1])
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+            assert_eq!(
+                forked_provider
+                    .get_transaction_by_block_hash_and_index(origin_block.header.hash, 0)
+                    .await
+                    .unwrap(),
+                Some(origin_tx.clone())
+            );
+            // Number-and-index forwarding currently excludes the fork head.
+            if (number as u64) < fork_boundary {
+                assert_eq!(
+                    forked_provider
+                        .get_transaction_by_block_number_and_index((number as u64).into(), 0)
+                        .await
+                        .unwrap(),
+                    Some(origin_tx)
+                );
+            }
+        }
+    }
+}
+
 // <https://github.com/foundry-rs/foundry/issues/10501>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_load_state_keeps_number_opcode_in_sync() {


### PR DESCRIPTION
This is a rework of #16642 (closed, not merged) per mablr's explicit review request. His review, verbatim:

> Thanks for investigating this. The current approach retains imported blocks by hash but discards their transaction metadata, so hash-only block lookup succeeds while full-transaction lookup returns null. I'd prefer to close this version and revisit the fix with a consistent policy for imported blocks and transactions, covered by both query forms.

The underlying diagnosis from #16642 is unchanged and was accepted as correct: `anvil_loadState` on a forked node (`--fork-url` + `--load-state`) let dumped blocks silently corrupt the fork's own canonical chain below the fork's head, because `BlockchainStorage::load_blocks` wrote both `blocks[hash]` and `hashes[number]` for every dumped block, and only one entry in `hashes` (the head) ever got corrected. Only the *fix's shape* was rejected.

## What was inconsistent in #16642

The previous fix added an `Option<u64>` `fork_boundary` to `load_blocks`/`load_transactions`. `load_transactions` correctly dropped a transaction entirely when its `blockNumber <= boundary`. But `load_blocks` only stopped writing the canonical `hashes[number]` entry - it still called a separate `insert_block_data_only` helper that unconditionally wrote `blocks[hash]`. So a dumped (foreign) block at/below the boundary was still retrievable by `eth_getBlockByHash`, while its transactions were correctly gone from `eth_getTransactionByHash`. Two query forms, two different answers for the same foreign data.

## The consistent policy in this PR

`load_blocks` now skips a dumped block **entirely** - neither `blocks[hash]` nor `hashes[number]` gets populated - when its number is at or below the fork boundary, exactly mirroring what `load_transactions` already did. There's no more `insert_block_data_only` path. The fork's own live chain is the sole source of truth for anything at or below its head, full stop - across block-by-hash, block-by-number, transaction-by-hash, and transaction-by-block-and-index alike.

The non-fork load path is untouched: `fork_boundary` is `None` there, so every existing non-fork test (`test_storage_dump_reload_cycle`, `serialized_blocks_puts_canonical_block_last`, `test_tempo_storage_dump_reload_cycle`, `test_load_blocks_sets_genesis_hash_with_non_zero_genesis_number`) passes `None` and is byte-for-bit unchanged.

## Regression test

`test_fork_load_state_preserves_fork_blocks_below_head` (`crates/anvil/tests/it/state.rs`) forks a node from an `origin` node, loads an unrelated dump from a separate `dump_source` node at matching height, then for every block at/below the fork boundary asserts **all of the following move together**:

- `get_block_by_number` returns the fork's own block, with a correctly chained `parentHash`
- `get_block_by_hash` (both default and `.full()`) for the **foreign dump's** block hash returns `None`
- `get_transaction_by_block_hash_and_index` for the foreign block returns `None`
- `get_transaction_by_hash` for the fork's own transaction succeeds; for the foreign dump's transaction returns `None`
- `get_transaction_by_block_hash_and_index` for the fork's own block returns the fork's transaction
- `get_transaction_by_block_number_and_index` returns the fork's transaction below the head (see note below on one pre-existing, unrelated limitation at the exact head)

This directly proves the fix mablr asked for: block-lookup and transaction-lookup for the same foreign data now consistently return null together, rather than disagreeing.

## Known pre-existing limitation (not introduced or fixed here, disclosed)

While extending test coverage, an unrelated pre-existing limitation surfaced: `Backend::transaction_by_block_number_and_index` uses `fork.predates_fork(number)`, whose predicate is strictly `< fork.block_number()`. At the exact fork head, that means transaction-by-number-and-index can return `None` even though the same transaction is available via transaction-by-hash and transaction-by-block-hash-and-index. This is orthogonal to the block/transaction consistency this PR addresses and is left untouched; the new test's number-and-index assertion is scoped to heights strictly below the head to avoid asserting on that separate limitation.

## Verification

All run on `crates/anvil`:

- `cargo check -p anvil` - pass
- `cargo fmt --check -p anvil` and `cargo +nightly fmt --check -p anvil` - pass, no diff
- `cargo test -p anvil --test it -- state:: --test-threads=4` - **30 passed, 0 failed**, including `test_fork_load_state_preserves_fork_blocks_below_head` and the original `test_fork_load_state`
- `cargo clippy -p anvil --all-targets -- -D warnings` - fails only on two pre-existing, unrelated `missing_const_for_fn` lints on `active_monad_context_for_mined_block` / `active_monad_context_before_mined_transaction` (neither touched by this diff; confirmed pre-existing on clean master in a prior round). `cargo clippy -p anvil --all-targets -- -D warnings -A clippy::missing_const_for_fn` passes clean otherwise.

## Changelog

`.changelog/anvil-loadstate-fork-block-corruption.md` added (`anvil: patch`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lh6V2uPTUqauqq45BM7m5k

🤖 Generated with [Claude Code](https://claude.com/claude-code)
