### PR TITLE
test(symbolic): skip returndata test without solver

### DIFF
--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -1595,6 +1595,12 @@ mod tests {
     #[test]
     fn returndata_copy_range_preserves_valid_and_invalid_paths() {
         let mut executor = SymbolicExecutor::new(SymbolicConfig::default());
+        if let Err(err) = executor.solver.check_available() {
+            let _ = foundry_common::sh_eprintln!(
+                "skipping returndata_copy_range_preserves_valid_and_invalid_paths: {err}"
+            );
+            return;
+        }
         let mut state = empty_state(&mut executor);
         state.return_data = SymReturnData::from_concrete_bytes(&mut executor.cx, vec![0; 64]);
         let offset = state.fresh_word(&mut executor.cx, "offset");


### PR DESCRIPTION
The RETURNDATACOPY regression test added in [#16669](https://github.com/foundry-rs/foundry/pull/16669) fails on macOS and Windows because CI installs Z3 only on Linux. Check the executor's configured solver availability before running the test and print the reason when skipping, matching the existing symbolic CLI test convention. All assertions still run when Z3 is available. This addresses the symbolic failure in [the master CI run](https://github.com/foundry-rs/foundry/actions/runs/34154029563); the separate brutalize failure is outside this change.

This test-only change uses the `L-ignore` changelog exemption.

Prompted by: @grandizzy

This PR was written by Centaur with AI assistance for investigation and code changes.
