### PR TITLE
fix(script): guard broadcast sender reads

### DIFF
--- a/.changelog/guard-script-broadcast-sender.md
+++ b/.changelog/guard-script-broadcast-sender.md
@@ -1,0 +1,7 @@
+---
+forge: minor
+foundry-cheatcodes: minor
+foundry-evm: minor
+---
+
+Reject `msg.sender` reads in the main script's broadcasting frame when the caller differs from the broadcast sender. This guard follows `script_execution_protection` and can be disabled with that setting.

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -881,6 +881,8 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
 
     /// Deprecated cheatcodes mapped to the reason. Used to report warnings on test results.
     pub deprecated: HashMap<&'static str, Option<&'static str>>,
+    /// Main script contract, when script execution protection is enabled.
+    pub script_address: Option<Address>,
     /// Unlocked wallets used in scripts and testing of scripts.
     pub wallets: Option<Wallets>,
     /// Parsed secp256k1 private-key signers for repeated `vm.addr` / `vm.sign` calls.
@@ -1005,6 +1007,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             pending_storage_hook: Default::default(),
             active_storage_hook: Default::default(),
             deprecated: Default::default(),
+            script_address: Default::default(),
             wallets: Default::default(),
             private_key_signers: Default::default(),
             signatures_identifier: Default::default(),
@@ -2181,6 +2184,32 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
 
         if self.broadcast.is_some() {
             self.set_gas_limit_type(interpreter);
+        }
+
+        // Broadcasting changes outgoing calls, not the caller of the script's current frame.
+        // Only protect the broadcasting frame; callbacks into the script have their own caller.
+        if interpreter.bytecode.opcode() == op::CALLER
+            && let Some(broadcast) = &self.broadcast
+            && let Some(script_address) = self.script_address
+            && ecx.journal().depth() == broadcast.depth
+            && interpreter.input.target_address == script_address
+            && interpreter.input.bytecode_address == Some(script_address)
+            && interpreter.input.caller_address != broadcast.new_origin
+        {
+            interpreter.bytecode.set_action(InterpreterAction::new_return(
+                InstructionResult::Revert,
+                Bytes::from(
+                    format!(
+                        "Usage of `msg.sender` inside a `broadcast` in script contract detected. \
+                         `msg.sender` is `{:#x}`, not the broadcast sender `{:#x}`. \
+                         Use the `--sender` flag or pass the deployer address directly instead.",
+                        interpreter.input.caller_address, broadcast.new_origin,
+                    )
+                    .into_bytes(),
+                ),
+                interpreter.gas,
+            ));
+            return;
         }
 
         // `pauseGasMetering`: pause / resume interpreter gas.

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -818,6 +818,9 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
     pub fn script(&mut self, script_address: Address) {
         self.script_execution_inspector.get_or_insert_with(Default::default).script_address =
             script_address;
+        if let Some(cheatcodes) = &mut self.cheatcodes {
+            cheatcodes.script_address = Some(script_address);
+        }
         self.refresh_static_step_dispatch();
     }
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3593,6 +3593,165 @@ Script ran successfully.
 "#]]);
 });
 
+// Protect both broadcast overloads and durations, including calldata/constructor arguments.
+forgetest_init!(script_broadcast_sender_mismatch, |prj, cmd| {
+    for broadcast in [
+        "vm.startBroadcast(address(0x1337))",
+        "vm.broadcast(address(0x1337))",
+        "vm.startBroadcast(uint256(1))",
+        "vm.broadcast(uint256(1))",
+    ] {
+        prj.add_script(
+            "SenderMismatch.s.sol",
+            &format!(
+                r#"
+import {{Script}} from "forge-std/Script.sol";
+
+contract Recipient {{
+    address public owner;
+    constructor(address owner_) {{ owner = owner_; }}
+}}
+
+contract SenderMismatch is Script {{
+    function run() public {{
+        {broadcast};
+        new Recipient(msg.sender);
+    }}
+}}
+"#
+            ),
+        );
+        prj.update_config(|config| config.script_execution_protection = true);
+        cmd.forge_fuse().args(["script", "SenderMismatch"]).assert_failure().stderr_eq(str![[r#"
+Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`, not the broadcast sender `[..]`. Use the `--sender` flag or pass the deployer address directly instead.
+
+"#]]);
+
+        prj.update_config(|config| config.script_execution_protection = false);
+        cmd.forge_fuse().args(["script", "SenderMismatch"]).assert_success();
+    }
+});
+
+// Explicit and inferred senders, and the default no-argument broadcast, must remain usable.
+forgetest_init!(script_broadcast_sender_matching, |prj, cmd| {
+    prj.add_script(
+        "SenderMatching.s.sol",
+        r#"
+import {Script, console} from "forge-std/Script.sol";
+
+contract SenderMatching is Script {
+    function run() public {
+        vm.startBroadcast();
+        console.log(msg.sender);
+        vm.stopBroadcast();
+    }
+
+    function explicitSender() public {
+        vm.startBroadcast(address(0x1337));
+        console.log(msg.sender);
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+    cmd.forge_fuse().args(["script", "SenderMatching"]).assert_success();
+    cmd.forge_fuse()
+        .args([
+            "script",
+            "SenderMatching",
+            "--private-key",
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        ])
+        .assert_success();
+    cmd.forge_fuse()
+        .args([
+            "script",
+            "SenderMatching",
+            "--sig",
+            "explicitSender()",
+            "--sender",
+            "0x0000000000000000000000000000000000001337",
+        ])
+        .assert_success();
+});
+
+// Outgoing calls and callbacks have their own msg.sender; only the broadcasting frame is guarded.
+forgetest_init!(script_broadcast_sender_scope, |prj, cmd| {
+    prj.add_script(
+        "SenderScope.s.sol",
+        r#"
+import {Script} from "forge-std/Script.sol";
+
+contract Callback {
+    address public creator;
+    constructor() { creator = msg.sender; }
+
+    function check(SenderScope script) external {
+        require(msg.sender == address(0x1337));
+        require(script.callback() == address(this));
+    }
+}
+
+contract SenderScope is Script {
+    // The address guard is installed after the script constructor runs.
+    SenderScope private self = SenderScope(address(this));
+
+    function callback() external view returns (address) {
+        return msg.sender;
+    }
+
+    function run() public {
+        address caller = msg.sender;
+        vm.startBroadcast(address(0x1337));
+        require(tx.origin == caller);
+        Callback target = new Callback();
+        require(target.creator() == address(0x1337));
+        target.check(self);
+        vm.stopBroadcast();
+        require(msg.sender == caller);
+    }
+}
+"#,
+    );
+    cmd.args(["script", "SenderScope"]).assert_success();
+});
+
+// An external script helper's caller can differ from tx.origin in either direction.
+forgetest_init!(script_broadcast_sender_uses_frame_caller, |prj, cmd| {
+    prj.add_script(
+        "FrameCaller.s.sol",
+        r#"
+import {Script, console} from "forge-std/Script.sol";
+
+contract FrameCaller is Script {
+    FrameCaller private self = FrameCaller(address(this));
+
+    function run() public {
+        self.helper(address(self));
+    }
+
+    function mismatch() public {
+        self.helper(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38);
+    }
+
+    function helper(address sender) external {
+        vm.startBroadcast(sender);
+        console.log(msg.sender);
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+    cmd.forge_fuse().args(["script", "FrameCaller"]).assert_success();
+    cmd.forge_fuse()
+        .args(["script", "FrameCaller", "--sig", "mismatch()"])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: script failed: Usage of `msg.sender` inside a `broadcast` in script contract detected. `msg.sender` is `[..]`, not the broadcast sender `0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38`. Use the `--sender` flag or pass the deployer address directly instead.
+
+"#]]);
+});
+
 // Tests that script warns if no tx to broadcast.
 // <https://github.com/foundry-rs/foundry/issues/10015>
 forgetest_async!(warns_if_no_transactions_to_broadcast, |prj, cmd| {

--- a/docs/dev/scripting.md
+++ b/docs/dev/scripting.md
@@ -84,6 +84,14 @@ end
 Executor::call-. BroadcastableTransactions .->ScriptArgs::handle_broadcastable_transactions;
 ```
 
+Script execution protection is installed after deploying the script contract. Alongside the
+`ADDRESS` check, the cheatcode inspector rejects `CALLER` in the main script's broadcasting frame
+when its actual caller differs from the broadcast sender. Called contracts and deeper callbacks
+retain their own caller semantics. Setting `script_execution_protection = false` disables both
+checks. This is an opcode guard: it does not track sender values cached before broadcasting or
+reads moved outside the broadcast by the compiler. Scripts should pass an explicit deployer
+address when constructing transaction arguments.
+
 ## Nonce Management
 
 During the first execution stage on `forge script`, foundry has to adjust the nonce from the sender to make sure the execution and state are as close as possible to its on-chain representation.

--- a/testdata/default/cheats/Broadcast.t.sol
+++ b/testdata/default/cheats/Broadcast.t.sol
@@ -499,19 +499,15 @@ contract CheckOverrides is ForgeTest {
 
         vm.stopBroadcast();
 
-        // startBroadcast(msg.sender)
+        // Use the saved script caller when the broadcast sender differs.
         vm.startBroadcast(address(0x1337));
         require(tx.origin == script_caller);
-        require(msg.sender == script_caller);
-        require(msg.sender != address(0x1337));
 
         ContractB b = new ContractB(script_caller);
         require(tx.origin == script_caller);
-        require(msg.sender == script_caller);
 
         b.method(script_caller);
         require(tx.origin == script_caller);
-        require(msg.sender == script_caller);
 
         vm.stopBroadcast();
     }


### PR DESCRIPTION
`vm.startBroadcast` changes outgoing transaction senders but leaves the script frame's `msg.sender` unchanged, so arguments such as `mint(msg.sender, amount)` can contain an unintended recipient. Reject mismatched `CALLER` reads in the main script's broadcasting frame under `script_execution_protection`, comparing the actual frame caller and allowing deeper callbacks. Existing wallet sender detection is preserved.

Reworks the remaining guard from Georgios Konstantopoulos's [#13349](https://github.com/foundry-rs/foundry/pull/13349), with regression coverage for both broadcast forms, matching senders, disabled protection, external helpers, and callbacks. This opcode guard cannot detect values cached before broadcasting or reads moved outside the broadcast by the compiler.

Implementation, tests, documentation, and this PR description were authored with Centaur (Codex).

Prompted by: @DaniPopes
