### PR TITLE
fix(forge): normalize temporary workspace paths

### DIFF
--- a/.changelog/fix-dynamic-linking-temp-paths.md
+++ b/.changelog/fix-dynamic-linking-temp-paths.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-cheatcodes: patch
+---
+
+Fixed dynamic linking in brutalized temporary workspaces on macOS and Windows, and parsing of Windows absolute artifact paths in `vm.deployCode` and `vm.getCode`.

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -52,7 +52,16 @@ struct ParsedArtifactPath<'a> {
 /// - `ContractName:0.8.23`
 /// - `ContractName:profile`
 fn parse_artifact_path(path: &str) -> std::result::Result<ParsedArtifactPath<'_>, String> {
-    let mut parts = path.split(':');
+    // A Windows drive separator belongs to the file, not the artifact's suffix fields.
+    // Recognize it on every host so parsing does not depend on the current platform.
+    let unprefixed = path.strip_prefix(r"\\?\").unwrap_or(path);
+    let drive_prefix_len = match unprefixed.as_bytes() {
+        [drive, b':', b'/' | b'\\', ..] if drive.is_ascii_alphabetic() => {
+            path.len() - unprefixed.len() + 2
+        }
+        _ => 0,
+    };
+    let mut parts = path[drive_prefix_len..].split(':');
 
     let mut file = None;
     let mut contract_name = None;
@@ -60,6 +69,7 @@ fn parse_artifact_path(path: &str) -> std::result::Result<ParsedArtifactPath<'_>
     let mut profile = None;
 
     let path_or_name = parts.next().unwrap();
+    let path_or_name = &path[..drive_prefix_len + path_or_name.len()];
     if path_or_name.contains('.') {
         file = Some(PathBuf::from(path_or_name));
         if let Some(name_or_version_or_profile) = parts.next() {
@@ -1251,6 +1261,40 @@ mod tests {
         assert_eq!(parsed.contract_name, None);
         assert_eq!(parsed.version, None);
         assert_eq!(parsed.profile, None);
+    }
+
+    #[test]
+    fn test_parse_artifact_path_windows_drive() {
+        for file in [
+            "C:/project/src/Contract.sol",
+            r"C:\project\src\Contract.sol",
+            r"\\?\C:\project\src\Contract.sol",
+            r"\\server\share\Contract.sol",
+        ] {
+            for (suffix, contract_name, version, profile) in [
+                ("", None, None, None),
+                (":MyContract", Some("MyContract"), None, None),
+                (":0.8.23", None, Some(Version::new(0, 8, 23)), None),
+                (":MyContract:0.8.23", Some("MyContract"), Some(Version::new(0, 8, 23)), None),
+                (":MyContract:optimized", Some("MyContract"), None, Some("optimized")),
+            ] {
+                let input = format!("{file}{suffix}");
+                assert_eq!(
+                    parse_artifact_path(&input).unwrap(),
+                    ParsedArtifactPath {
+                        file: Some(PathBuf::from(file)),
+                        contract_name,
+                        version,
+                        profile,
+                    },
+                    "{input}"
+                );
+            }
+        }
+
+        // A one-letter contract name must still allow version and profile suffixes.
+        assert_eq!(parse_artifact_path("C:0.8.23").unwrap().version, Some(Version::new(0, 8, 23)));
+        assert_eq!(parse_artifact_path("C:optimized").unwrap().profile, Some("optimized"));
     }
 
     #[test]

--- a/crates/forge/src/workspace.rs
+++ b/crates/forge/src/workspace.rs
@@ -64,6 +64,10 @@ fn normalize_path(path: &Path) -> PathBuf {
 /// This preserves CLI/env overrides and runtime normalization while rebasing
 /// project-local paths from the original root to `temp_path`.
 pub fn rebase_config_paths(config: &Config, temp_path: &Path) -> Config {
+    // Use the same root spelling as the compiler before materializing remappings. Temp paths
+    // can contain symlinks on macOS or short directory names on Windows.
+    let temp_root = normalize_existing_ancestor(temp_path);
+    let temp_path = temp_root.as_path();
     let mut temp_config = config.clone();
     temp_config.root = temp_path.to_path_buf();
     temp_config.src = rebase_project_path(&config.root, temp_path, &config.src);
@@ -776,11 +780,39 @@ mod tests {
         assert!(remapping.context.unwrap().ends_with(MAIN_SEPARATOR));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_rebase_config_paths_canonicalizes_workspace_alias() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("project");
+        let workspace = temp.path().join("workspace");
+        let alias = temp.path().join("alias");
+        create_test_dir_structure(&root, &["src/Target.sol", "test/Target.t.sol"]);
+        fs::create_dir(&workspace).unwrap();
+        symlink_dir(&workspace, &alias).unwrap();
+
+        let config = Config {
+            root: root.clone(),
+            src: root.join("src"),
+            test: root.join("test"),
+            remappings: vec![Remapping::from_str("@src/=src/").unwrap().into()],
+            ..Default::default()
+        };
+        copy_project(&config, &alias).unwrap();
+        let config = rebase_config_paths(&config, &alias).sanitized();
+        let canonical_root = dunce::canonicalize(&workspace).unwrap();
+        assert_eq!(config.root, canonical_root);
+        assert_eq!(config.src, canonical_root.join("src"));
+        assert_eq!(config.test, canonical_root.join("test"));
+        let remapping = Remapping::from(config.remappings[0].clone());
+        assert_eq!(Path::new(&remapping.path), canonical_root.join("src"));
+    }
+
     #[test]
     fn test_rebase_config_paths_rebases_materialized_project_paths() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         let external = temp.path().join("external");
 
         let mut contracts = BTreeMap::new();
@@ -936,7 +968,7 @@ mod tests {
     fn test_copy_project_preserves_external_read_only_paths() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         let external = temp.path().join("shared-solidity");
         create_test_dir_structure(&root, &["src/Target.sol", "test/Target.t.sol"]);
         create_test_dir_structure(&external, &["Shared.sol"]);
@@ -968,7 +1000,7 @@ mod tests {
     fn test_copy_project_copies_project_local_corpus_and_frontier_paths() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         create_test_dir_structure(
             &root,
             &[
@@ -1027,7 +1059,7 @@ mod tests {
     fn test_copy_project_isolates_external_corpus_and_frontier_paths() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         let corpus = temp.path().join("shared-corpus");
         let frontier = temp.path().join("shared-frontier");
         create_test_dir_structure(&root, &["src/Target.sol", "test/Target.t.sol"]);
@@ -1064,7 +1096,7 @@ mod tests {
     fn test_copy_project_merges_overlapping_mutable_paths() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         create_test_dir_structure(
             &root,
             &[
@@ -1100,7 +1132,7 @@ mod tests {
     fn test_copy_project_isolates_external_failure_persist_dirs() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         let fuzz_failures = temp.path().join("shared-fuzz-failures");
         let invariant_failures = temp.path().join("shared-invariant-failures");
         create_test_dir_structure(&root, &["src/Target.sol", "test/Target.t.sol"]);
@@ -1146,7 +1178,7 @@ mod tests {
     fn test_copy_project_isolates_corpus_under_symlinked_lib_root() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         create_test_dir_structure(
             &root,
             &[
@@ -1187,7 +1219,7 @@ mod tests {
     fn test_rebase_config_paths_preserves_symlink_parent_semantics() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         let external = temp.path().join("external");
         create_test_dir_structure(&root, &["src/Target.sol", "test/Target.t.sol"]);
         create_test_dir_structure(
@@ -1236,7 +1268,7 @@ mod tests {
     fn test_copy_project_copies_project_local_remapping_targets() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         create_test_dir_structure(
             &root,
             &["src/Target.sol", "test/Target.t.sol", "packages/shared/src/Shared.sol"],
@@ -1266,7 +1298,7 @@ mod tests {
     fn test_copy_project_preserves_external_libs() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         let external = temp.path().join("shared-lib");
         create_test_dir_structure(&root, &["src/Target.sol", "test/Target.t.sol", "lib/Local.sol"]);
         create_test_dir_structure(&external, &["External.sol"]);
@@ -1292,7 +1324,7 @@ mod tests {
     fn test_rebase_config_paths_rebases_relative_fs_permissions() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
-        let workspace = temp.path().join("workspace");
+        let workspace = normalize_existing_ancestor(&temp.path().join("workspace"));
         fs::create_dir_all(root.join("writes")).unwrap();
         fs::create_dir_all(workspace.join("writes")).unwrap();
         fs::create_dir_all(workspace.join("logs/sub")).unwrap();

--- a/crates/forge/tests/cli/test_cmd/brutalize.rs
+++ b/crates/forge/tests/cli/test_cmd/brutalize.rs
@@ -952,7 +952,8 @@ contract RemappedTargetTest {
         let alias = temp.path().join("alias");
         fs::create_dir(&real).unwrap();
         symlink(&real, &alias).unwrap();
-        cmd.env("TMPDIR", &alias).assert_success();
+        cmd.env("TMPDIR", &alias);
+        cmd.assert_success();
     }
 });
 

--- a/crates/forge/tests/cli/test_cmd/brutalize.rs
+++ b/crates/forge/tests/cli/test_cmd/brutalize.rs
@@ -1,5 +1,7 @@
 // CLI integration tests for `forge test --brutalize`
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
 use std::{fs, str::FromStr};
 
 use foundry_compilers::artifacts::remappings::Remapping;
@@ -899,6 +901,7 @@ contract JUnitTargetTest is Test {
 // Project-local remappings must resolve to the copied/brutalized temp workspace, not the original.
 forgetest_init!(brutalize_rebases_project_local_remappings, |prj, cmd| {
     prj.update_config(|config| {
+        config.dynamic_test_linking = true;
         config.auto_detect_remappings = false;
         config.remappings = vec![Remapping::from_str("@src/=src/").unwrap().into()];
     });
@@ -939,6 +942,18 @@ contract RemappedTargetTest {
 
     cmd.args(["test", "--brutalize", "--mt", "test_remappedImportUsesBrutalizedTempSource"]);
     cmd.assert_success();
+
+    // Exercise macOS-style temporary directory aliases on every Unix host. Only the child
+    // process sees TMPDIR, so concurrent tests retain their own temporary directory settings.
+    #[cfg(unix)]
+    {
+        let temp = tempfile::tempdir().unwrap();
+        let real = temp.path().join("real");
+        let alias = temp.path().join("alias");
+        fs::create_dir(&real).unwrap();
+        symlink(&real, &alias).unwrap();
+        cmd.env("TMPDIR", &alias).assert_success();
+    }
 });
 
 // Nested casts should not produce overlapping replacements.


### PR DESCRIPTION
`forge test --brutalize` fails with project-local remappings when temporary directory aliases differ from the compiler's canonical root. Canonicalize the copied workspace root before rebasing its paths and remappings so generated artifact references stay relative to the same root. Also preserve Windows drive prefixes when parsing `vm.deployCode` and `vm.getCode` artifact references, including version and profile suffixes.

The existing remapping integration test now also runs with a symlinked temporary directory on Unix. Added workspace-alias and Windows artifact-parser regressions, while retaining the existing source-unit identity and native-linking fallback rules. This addresses the [Windows](https://github.com/foundry-rs/foundry/actions/runs/34165622466/job/101876243657) and [macOS](https://github.com/foundry-rs/foundry/actions/runs/34165622466/job/101876243510) CI failures related to [#16686](https://github.com/foundry-rs/foundry/pull/16686).

All 32 workspace unit tests, 12 artifact-parser unit tests, and seven focused CLI tests pass locally. Removing the workspace normalization reproduces the original `vm.deployCode` read-permission failure with a symlinked temporary directory. Native Windows/macOS execution remains unverified: the current pull-request test matrix targets Linux only.

AI assistance: Centaur (Codex) investigated the failure and authored this change and its tests.

Prompted by: @grandizzy
