### PR TITLE
test(forge): expect canonical mutation paths

### DIFF
--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -809,26 +809,27 @@ mod tests {
         config.mutation.timeout = Some(5);
 
         let temp_config = temp_config_for_mutation(&config, temp.path());
+        let expected_root = dunce::canonicalize(temp.path()).unwrap();
 
-        assert_eq!(temp_config.root, temp.path());
-        assert_eq!(temp_config.src, temp.path().join("contracts"));
-        assert_eq!(temp_config.test, temp.path().join("checks"));
-        assert_eq!(temp_config.script, temp.path().join("deploy"));
-        assert_eq!(temp_config.out, temp.path().join("custom-out"));
-        assert_eq!(temp_config.cache_path, temp.path().join("custom-cache"));
-        assert_eq!(temp_config.snapshots, temp.path().join("custom-snapshots"));
-        assert_eq!(temp_config.broadcast, temp.path().join("custom-broadcast"));
-        assert_eq!(temp_config.mutation_dir, temp.path().join("custom-cache/mutation"));
-        assert_eq!(temp_config.libs, vec![temp.path().join("vendor")]);
-        assert_eq!(temp_config.include_paths, vec![temp.path().join("shared")]);
-        assert_eq!(temp_config.allow_paths, vec![temp.path().join("fixtures")]);
+        assert_eq!(temp_config.root, expected_root);
+        assert_eq!(temp_config.src, expected_root.join("contracts"));
+        assert_eq!(temp_config.test, expected_root.join("checks"));
+        assert_eq!(temp_config.script, expected_root.join("deploy"));
+        assert_eq!(temp_config.out, expected_root.join("custom-out"));
+        assert_eq!(temp_config.cache_path, expected_root.join("custom-cache"));
+        assert_eq!(temp_config.snapshots, expected_root.join("custom-snapshots"));
+        assert_eq!(temp_config.broadcast, expected_root.join("custom-broadcast"));
+        assert_eq!(temp_config.mutation_dir, expected_root.join("custom-cache/mutation"));
+        assert_eq!(temp_config.libs, vec![expected_root.join("vendor")]);
+        assert_eq!(temp_config.include_paths, vec![expected_root.join("shared")]);
+        assert_eq!(temp_config.allow_paths, vec![expected_root.join("fixtures")]);
         assert_eq!(
             temp_config.fuzz.failure_persist_dir,
-            Some(temp.path().join("custom-cache/fuzz"))
+            Some(expected_root.join("custom-cache/fuzz"))
         );
         assert_eq!(
             temp_config.invariant.failure_persist_dir,
-            Some(temp.path().join("custom-cache/invariant"))
+            Some(expected_root.join("custom-cache/invariant"))
         );
         assert!(temp_config.dynamic_test_linking);
         assert!(temp_config.cache);


### PR DESCRIPTION
The mutation configuration test still compares rebased paths with the raw temporary-directory spelling. Workspace-root canonicalization expands `ADMINI~1` to `Administrator` on Windows and the assertion fails. Derive the expected root with `dunce::canonicalize` and use it for all rebased-path assertions. An aliased temporary directory reproduces the mismatch on Linux before this correction; all 34 mutation-runner and workspace tests pass with that alias afterward.

This is a test-only follow-up to [#16725](https://github.com/foundry-rs/foundry/pull/16725) for the [Windows CI failure](https://github.com/foundry-rs/foundry/actions/runs/34191709248/job/101951274944). A maintainer should apply `L-ignore` to exempt it from the changelog requirement.

AI assistance: Centaur (Codex) authored the test correction and investigated the failure.

Prompted by: @grandizzy
