### PR TITLE
fix(anvil): stop trace_blockOpcodeGas from drifting to the upstream tip on a fork

### DIFF
--- a/.changelog/fix-trace-block-opcode-gas-tag-drift.md
+++ b/.changelog/fix-trace-block-opcode-gas-tag-drift.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed `trace_blockOpcodeGas` on a forked node forwarding an unresolved block tag (`latest`/`pending`/`safe`/`finalized`) straight to the upstream RPC when the request falls at or before the fork point. The upstream node resolved the tag against its own current chain tip instead of the fork's snapshot, so a forked node whose local chain hadn't advanced past the fork point could silently return opcode-gas trace data for the wrong block. The resolved block number is now forwarded instead, matching `debug_accountInfoAt`'s existing behavior.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -6605,7 +6605,14 @@ where
         if let Some(fork) = self.get_fork() {
             let number = self.ensure_block_number(Some(block_id)).await?;
             if fork.predates_fork_inclusive(number) {
-                return Ok(fork.trace_block_opcode_gas(block_id).await?);
+                // Delegate the resolved block number so tags (`latest`/`pending`/`safe`/
+                // `finalized`) are resolved against the fork's head instead of drifting with
+                // the upstream chain. Hashes are forwarded unchanged.
+                let resolved = match block_id {
+                    BlockId::Hash(_) => block_id,
+                    _ => BlockId::number(number),
+                };
+                return Ok(fork.trace_block_opcode_gas(resolved).await?);
             }
         }
 

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -147,6 +147,64 @@ async fn test_trace_block_opcode_gas_local() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_trace_block_opcode_gas_latest_at_fork_point() {
+    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let origin_accounts = origin_handle.dev_wallets().collect::<Vec<_>>();
+    let origin_signer: EthereumWallet = origin_accounts[0].clone().into();
+    let origin_provider = http_provider_with_signer(&origin_handle.http_endpoint(), origin_signer);
+    let storage = SimpleStorage::deploy(&origin_provider, "init value".to_string()).await.unwrap();
+    let receipt = storage
+        .setValue("fork point".to_string())
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let fork_point_number = receipt.block_number.unwrap();
+    let fork_point_hash = receipt.block_hash.unwrap();
+
+    let (_api, handle) =
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(origin_handle.http_endpoint()))).await;
+    let provider = handle.http_provider();
+
+    // Advance the upstream head after the fork captures its snapshot.
+    let advanced =
+        storage.setValue("advanced".to_string()).send().await.unwrap().get_receipt().await.unwrap();
+    assert!(advanced.block_number.unwrap() > fork_point_number);
+    assert_eq!(provider.get_block_number().await.unwrap(), fork_point_number);
+
+    let mut by_latest = provider
+        .raw_request::<_, Option<BlockOpcodeGas>>(
+            "trace_blockOpcodeGas".into(),
+            (BlockId::latest(),),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let mut by_number = provider
+        .raw_request::<_, Option<BlockOpcodeGas>>(
+            "trace_blockOpcodeGas".into(),
+            (BlockId::number(fork_point_number),),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(by_number.block_hash, fork_point_hash);
+    assert_eq!(by_number.block_number, fork_point_number);
+    assert_eq!(by_number.transactions.len(), 1);
+    assert_eq!(by_number.transactions[0].transaction_hash, receipt.transaction_hash);
+    assert_eq!(by_latest.block_number, by_number.block_number);
+    assert_eq!(by_latest.block_hash, by_number.block_hash);
+    // Opcode gas entries are collected from a map and have no stable order.
+    for transaction in by_latest.transactions.iter_mut().chain(&mut by_number.transactions) {
+        transaction.opcode_gas.sort_unstable_by(|a, b| a.opcode.cmp(&b.opcode));
+    }
+    assert_eq!(by_latest.transactions, by_number.transactions);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_trace_raw_transaction_local() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
`trace_blockOpcodeGas` resolves the requested `block_id` to a concrete block number via `ensure_block_number` (correctly resolved against anvil's own local chain state), but then forwards the ORIGINAL, unresolved `block_id` - which can still be a tag like `latest`/`pending`/`safe`/`finalized` - to `Fork::trace_block_opcode_gas`, which forwards it verbatim to the upstream RPC provider.

If the caller passes a tag and anvil's local chain hasn't advanced past the fork point (the request falls at or before the fork boundary), the UPSTREAM node resolves that tag against **its own current chain tip**, not the fork's snapshot - which can have advanced since the fork was taken. `trace_blockOpcodeGas("latest")` on a forked node can then silently return opcode-gas trace data for the wrong block.

This is the exact bug the sibling `debug_account_info_at` (right below it in the same file) already had fixed, with the same code shape and an explanatory comment: it resolves the tag to a concrete block number before delegating to the fork, leaving hash-based requests untouched. `trace_block_opcode_gas` never got the same treatment.

## Fix

Mirror `debug_account_info_at`'s resolved-block-id delegation in `trace_block_opcode_gas`.

## Verification

New regression test `test_trace_block_opcode_gas_latest_at_fork_point`: forks a node, advances the origin's chain past the fork point, then asserts `trace_blockOpcodeGas(latest)` on the forked node returns the same block (hash, number, opcode gas entries) as querying the fork's own resolved block number explicitly - not the origin's newer tip.

- Against the original code: fails (`left: 3, right: 2` block-number mismatch - the tag call picked up the origin's advanced tip instead of the fork point).
- With the fix: passes.
- Sibling tests (`test_trace_block_opcode_gas_local`, `test_debug_account_info_at_local`, `test_debug_account_info_at_delegates_pre_fork_block`, `test_debug_account_info_at_local_block_on_fork`) all still pass.
- `cargo check -p anvil` clean.

```
$ cargo test -p anvil --test it -- traces::test_trace_block_opcode_gas traces::test_debug_account_info_at --nocapture
running 5 tests
test traces::test_trace_block_opcode_gas_local ... ok
test traces::test_trace_block_opcode_gas_latest_at_fork_point ... ok
test traces::test_debug_account_info_at_local ... ok
test traces::test_debug_account_info_at_delegates_pre_fork_block ... ok
test traces::test_debug_account_info_at_local_block_on_fork ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 730 filtered out
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
