### PR TITLE
fix(anvil): stop trace_call from drifting to the upstream tip on a fork

### DIFF
--- a/.changelog/pr-16745.md
+++ b/.changelog/pr-16745.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed `trace_call` resolving a block tag (`latest`/`pending`/`safe`/`finalized`) against the upstream fork's own current chain tip instead of the fork snapshot anvil resolved locally, when the requested block predates the fork point.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3570,7 +3570,14 @@ impl<N: Network> Backend<N> {
             && let Some(fork) = self.get_fork()
             && fork.predates_fork(*number)
         {
-            return Ok(fork.trace_call(request, trace_types, block_id).await?);
+            // Delegate the resolved block number so tags (`latest`/`pending`/`safe`/
+            // `finalized`) are resolved against the fork's head instead of drifting with
+            // the upstream chain. Hashes are forwarded unchanged.
+            let resolved = match block_id {
+                BlockId::Hash(_) => block_id,
+                _ => BlockId::number(*number),
+            };
+            return Ok(fork.trace_call(request, trace_types, resolved).await?);
         }
 
         self.with_database_at_and_context(Some(block_request), |state, block, mut monad_context| {

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -353,6 +353,100 @@ async fn test_trace_call_local() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_trace_call_safe_at_fork_point() {
+    let epoch = 1u64;
+    let (_origin_api, origin_handle) =
+        spawn(NodeConfig::test().with_slots_in_an_epoch(epoch)).await;
+    let origin_provider = origin_handle.http_provider();
+    let origin_accounts = origin_handle.dev_wallets().collect::<Vec<_>>();
+    let from = origin_accounts[0].address();
+    let to = origin_accounts[1].address();
+    let amount1 = U256::from(1_000);
+    let amount2 = U256::from(2_000);
+    let amount3 = U256::from(3_000);
+
+    // Block 1: `to` balance = genesis + amount1.
+    let tx1 = TransactionRequest::default().to(to).value(amount1).from(from);
+    origin_provider
+        .send_transaction(WithOtherFields::new(tx1))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    // Block 2: the fork point. `to` balance = genesis + amount1 + amount2.
+    let tx2 = TransactionRequest::default().to(to).value(amount2).from(from);
+    let receipt2 = origin_provider
+        .send_transaction(WithOtherFields::new(tx2))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let fork_point_number = receipt2.block_number.unwrap();
+    assert_eq!(fork_point_number, 2);
+
+    let (_api, handle) = spawn(
+        NodeConfig::test()
+            .with_slots_in_an_epoch(epoch)
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint())),
+    )
+    .await;
+    let provider = handle.http_provider();
+    assert_eq!(provider.get_block_number().await.unwrap(), fork_point_number);
+
+    // Advance the upstream head after the fork captures its snapshot: `to` balance becomes
+    // genesis + amount1 + amount2 + amount3 on the ORIGIN chain (block 3), while the forked
+    // node's own local chain has not advanced past the fork point.
+    let tx3 = TransactionRequest::default().to(to).value(amount3).from(from);
+    let receipt3 = origin_provider
+        .send_transaction(WithOtherFields::new(tx3))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert_eq!(receipt3.block_number.unwrap(), fork_point_number + 1);
+    assert_eq!(provider.get_block_number().await.unwrap(), fork_point_number);
+
+    let call_amount = U256::from(1);
+    let call =
+        WithOtherFields::new(TransactionRequest::default().to(to).value(call_amount).from(from));
+
+    // `safe` resolves locally (current=2, epoch=1) to block 1 - the fork's own snapshot,
+    // never the upstream chain's post-fork block 2.
+    let by_safe: TraceResults = provider
+        .client()
+        .request(
+            "trace_call",
+            (call.clone(), vec![TraceType::StateDiff], BlockId::Number(BlockNumberOrTag::Safe)),
+        )
+        .await
+        .unwrap();
+    let by_number: TraceResults = provider
+        .client()
+        .request("trace_call", (call, vec![TraceType::StateDiff], BlockId::number(1)))
+        .await
+        .unwrap();
+
+    let ChangedType { from: before_safe, to: after_safe } =
+        by_safe.state_diff.as_ref().unwrap().get(&to).unwrap().balance.as_changed().unwrap();
+    let ChangedType { from: before_number, to: after_number } =
+        by_number.state_diff.as_ref().unwrap().get(&to).unwrap().balance.as_changed().unwrap();
+
+    let expected_balance_at_block_1 = origin_handle.genesis_balance().saturating_add(amount1);
+    assert_eq!(*before_number, expected_balance_at_block_1);
+    assert_eq!(
+        *before_safe, expected_balance_at_block_1,
+        "trace_call(safe) drifted to the upstream tip's resolution instead of the fork's own \
+         local resolution"
+    );
+    assert_eq!(before_safe, before_number);
+    assert_eq!(after_safe, after_number);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_trace_call_many_local() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let wallets = handle.dev_wallets().collect::<Vec<_>>();


### PR DESCRIPTION
`trace_call`'s `EthApi` handler resolves the requested `block_id` to a concrete number via `ensure_block_number` (correctly resolved against anvil's own local chain state), then passes both that resolved number (as `block_request`) AND the original, unresolved `block_id` down to `Backend::trace_call`. `Backend::trace_call` used the resolved number only to decide *whether* to delegate to the fork, but then forwarded the **original** `block_id` - which can still be a tag like `latest`/`pending`/`safe`/`finalized` - to `Fork::trace_call`, which forwards it verbatim to the upstream RPC provider via `raw_request`.

If the caller passes a tag and anvil's local chain hasn't advanced past the fork point, the upstream node resolves that tag against **its own current chain tip** instead of the fork's snapshot - which can have advanced since the fork was taken. Result: `trace_call` with a tag on a forked node can silently execute the call against the wrong block's state.

This is the same bug class already fixed in `debug_account_info_at` and `trace_block_opcode_gas` (both in the same file, `crates/anvil/src/eth/backend/mem/mod.rs`), just never applied to `trace_call`. `trace_call_many` is unaffected - it never forwards a raw `block_id` to the fork RPC, it resolves state lazily through the local database abstraction instead.

Fix: mirror the established resolved-block-id delegation pattern - forward a concrete `BlockId::number` for any tag, leave hash-based requests untouched.

## Test

New regression test `test_trace_call_safe_at_fork_point`:
- Forks a node at block 2 (two funded transfers to `to`, so `to`'s balance differs block-to-block).
- Advances the **origin's** chain to block 3 after the fork snapshot is taken (one more transfer to `to`).
- Asserts `trace_call(safe)` on the forked node (which locally resolves `safe` to block 1 with `slots_in_an_epoch=1`) returns the same state-diff as querying block 1 explicitly - not the upstream's own drifted resolution of `safe` against its now-advanced chain (block 2).

Confirmed the test fails against the unfixed code with exactly the predicted drift:
```
thread 'traces::test_trace_call_safe_at_fork_point' panicked:
assertion `left == right` failed: trace_call(safe) drifted to the upstream tip's resolution instead of the fork's own local resolution
  left: 100000000000000003000
 right: 100000000000000001000
```
(the extra `amount2` = 2000 leaking into the traced balance - upstream resolved `safe` against block 2 instead of anvil's own block 1).

Local run on the fixed code, full `traces` module:
```
test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 704 filtered out
```

`cargo clippy -p anvil --tests --lib` and `cargo +nightly fmt -p anvil -- --check` both clean against this diff (2 pre-existing `missing_const_for_fn` warnings in unrelated monad-context functions, untouched by this change).

No tracking issue - found via code inspection of `crates/anvil/src/eth/backend/mem/mod.rs`'s `debug_*`/`trace_*` neighborhood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
