### PR TITLE
feat(forge): inspect ERC-7201 storage layouts

### DIFF
--- a/.changelog/erc7201-storage-layout.md
+++ b/.changelog/erc7201-storage-layout.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Include ERC-7201 namespaces declared by a contract and its bases in `forge inspect storageLayout`, with Solidity packing and duplicate namespace checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5816,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5847,7 +5847,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5856,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5889,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6228,7 +6228,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6335,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5816,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5826,7 +5826,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.15.0",
+ "itertools 0.13.0",
  "path-slash",
  "rand 0.10.2",
  "rayon",
@@ -5847,7 +5847,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5856,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5889,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6228,7 +6228,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6335,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4b77ae974d7c2ad17402e9079b1ef777be2cfbbc#4b77ae974d7c2ad17402e9079b1ef777be2cfbbc"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=74e431abb9d6eb88e7c0101bd02199c433e028f3#74e431abb9d6eb88e7c0101bd02199c433e028f3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9533,7 +9533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -11899,7 +11899,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11915,7 +11915,7 @@ dependencies = [
 [[package]]
 name = "solar-cli"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -11946,7 +11946,7 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -11966,7 +11966,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-primitives",
  "idna_adapter",
@@ -11984,7 +11984,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11997,7 +11997,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "bumpalo",
  "diff",
@@ -12012,7 +12012,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream",
@@ -12020,7 +12020,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -12032,7 +12032,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -12040,7 +12040,7 @@ dependencies = [
 [[package]]
 name = "solar-lint"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "rayon",
  "solar-ast",
@@ -12051,7 +12051,7 @@ dependencies = [
 [[package]]
 name = "solar-lsp"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "arc-swap",
  "async-lsp",
@@ -12067,7 +12067,7 @@ dependencies = [
  "solar-interface",
  "solar-parse",
  "solar-sema",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "toml_edit",
@@ -12078,7 +12078,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12088,12 +12088,12 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint 0.5.1",
  "num-rational",
@@ -12109,7 +12109,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.2.0"
-source = "git+https://github.com/paradigmxyz/solar?rev=866584c05a475b4face83bd0fa3c56a55abe394a#866584c05a475b4face83bd0fa3c56a55abe394a"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -12566,7 +12566,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -562,10 +562,10 @@ solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "315cf80d7db9b
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "315cf80d7db9bff4e583c631c204d3fce69c0e1e" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "74e431abb9d6eb88e7c0101bd02199c433e028f3" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "74e431abb9d6eb88e7c0101bd02199c433e028f3" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "74e431abb9d6eb88e7c0101bd02199c433e028f3" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "74e431abb9d6eb88e7c0101bd02199c433e028f3" }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -556,16 +556,16 @@ snapbox = { version = "1.2", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }
-solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }
-solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }
-solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }
+solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "315cf80d7db9bff4e583c631c204d3fce69c0e1e" }
+solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "315cf80d7db9bff4e583c631c204d3fce69c0e1e" }
+solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "315cf80d7db9bff4e583c631c204d3fce69c0e1e" }
+solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "315cf80d7db9bff4e583c631c204d3fce69c0e1e" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "4b77ae974d7c2ad17402e9079b1ef777be2cfbbc" }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "74e431abb9d6eb88e7c0101bd02199c433e028f3" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "74e431abb9d6eb88e7c0101bd02199c433e028f3" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "74e431abb9d6eb88e7c0101bd02199c433e028f3" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "74e431abb9d6eb88e7c0101bd02199c433e028f3" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -137,10 +137,8 @@ impl InspectArgs {
                 print_json(&artifact.gas_estimates)?;
             }
             ContractArtifactField::StorageLayout => {
-                let mut layout = artifact
-                    .storage_layout
-                    .clone()
-                    .ok_or_else(|| missing_error("storage layout"))?;
+                let mut layout =
+                    artifact.storage_layout.ok_or_else(|| missing_error("storage layout"))?;
                 if is_solidity_source(&target_path) {
                     let namespaces = output
                         .parser_mut()

--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -1,3 +1,4 @@
+use self::erc7201::StorageNamespace;
 use alloy_json_abi::{Event, EventParam, InternalType, JsonAbi, Param};
 use clap::Parser;
 use comfy_table::{
@@ -23,13 +24,14 @@ use foundry_compilers::{
         },
     },
     solc::SolcLanguage,
-    storage_layout::StorageNamespace,
 };
 use path_slash::PathExt;
 use regex::Regex;
 use serde_json::{Map, Value};
 use solar::sema::interface::source_map::FileName;
 use std::{collections::BTreeMap, fmt, ops::ControlFlow, path::Path, str::FromStr, sync::LazyLock};
+
+mod erc7201;
 
 /// CLI arguments for `forge inspect`.
 #[derive(Clone, Debug, Parser)]
@@ -140,10 +142,11 @@ impl InspectArgs {
                 let mut layout =
                     artifact.storage_layout.ok_or_else(|| missing_error("storage layout"))?;
                 if is_solidity_source(&target_path) {
-                    let namespaces = output
-                        .parser_mut()
-                        .solc_mut()
-                        .erc7201_storage_layouts(&target_path, contract.name())?;
+                    let namespaces = erc7201::erc7201_storage_layouts(
+                        output.parser_mut().solc_mut().compiler_mut(),
+                        &target_path,
+                        contract.name(),
+                    )?;
                     merge_storage_namespaces(&mut layout, namespaces)?;
                 }
                 print_storage_layout(Some(&layout), "storage layout", wrap)?;

--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -23,6 +23,7 @@ use foundry_compilers::{
         },
     },
     solc::SolcLanguage,
+    storage_layout::StorageNamespace,
 };
 use path_slash::PathExt;
 use regex::Regex;
@@ -136,7 +137,18 @@ impl InspectArgs {
                 print_json(&artifact.gas_estimates)?;
             }
             ContractArtifactField::StorageLayout => {
-                print_storage_layout(artifact.storage_layout.as_ref(), "storage layout", wrap)?;
+                let mut layout = artifact
+                    .storage_layout
+                    .clone()
+                    .ok_or_else(|| missing_error("storage layout"))?;
+                if is_solidity_source(&target_path) {
+                    let namespaces = output
+                        .parser_mut()
+                        .solc_mut()
+                        .erc7201_storage_layouts(&target_path, contract.name())?;
+                    merge_storage_namespaces(&mut layout, namespaces)?;
+                }
+                print_storage_layout(Some(&layout), "storage layout", wrap)?;
             }
             ContractArtifactField::TransientStorageLayout => {
                 print_storage_layout(
@@ -347,6 +359,39 @@ fn internal_ty(ty: &InternalType) -> String {
         InternalType::Struct { contract, ty } => contract_ty(contract.as_deref(), ty),
         InternalType::Other { contract, ty } => contract_ty(contract.as_deref(), ty),
     }
+}
+
+/// Merges namespaces without allowing duplicate declarations or conflicting type definitions.
+fn merge_storage_namespaces(
+    layout: &mut StorageLayout,
+    namespaces: Vec<StorageNamespace>,
+) -> Result<()> {
+    let mut declarations = BTreeMap::new();
+    for namespace in namespaces {
+        if let Some(previous) = declarations.insert(namespace.root, namespace.declaration.clone()) {
+            eyre::bail!(
+                "Duplicate ERC-7201 namespace `{}` in `{previous}` and `{}`",
+                namespace.id,
+                namespace.declaration
+            );
+        }
+        for (id, ty) in namespace.layout.types {
+            if let Some(existing) = layout.types.get(&id) {
+                eyre::ensure!(
+                    existing == &ty,
+                    "Conflicting storage type `{id}` in namespace `{}`",
+                    namespace.id
+                );
+            } else {
+                layout.types.insert(id, ty);
+            }
+        }
+        for mut entry in namespace.layout.storage {
+            entry.label = format!("{}.{}", namespace.id, entry.label);
+            layout.storage.push(entry);
+        }
+    }
+    Ok(())
 }
 
 pub fn print_storage_layout(
@@ -838,6 +883,44 @@ fn missing_error(field: &str) -> eyre::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::U256;
+
+    #[test]
+    fn namespace_type_collisions() {
+        let layout: StorageLayout = serde_json::from_value(serde_json::json!({
+            "storage": [],
+            "types": {"erc7201(example)::t_uint256": {
+                "encoding": "inplace", "label": "uint256", "numberOfBytes": "32"
+            }}
+        }))
+        .unwrap();
+        let namespace = StorageNamespace {
+            id: "example".into(),
+            declaration: "test.sol:C.Data".into(),
+            root: U256::ZERO,
+            layout: layout.clone(),
+        };
+        let mut merged = layout.clone();
+        merge_storage_namespaces(&mut merged, vec![namespace.clone()]).unwrap();
+        assert_eq!(merged, layout);
+
+        let mut conflicting = namespace.clone();
+        conflicting.layout.types.values_mut().next().unwrap().number_of_bytes = "16".into();
+        assert_eq!(
+            merge_storage_namespaces(&mut merged, vec![conflicting]).unwrap_err().to_string(),
+            "Conflicting storage type `erc7201(example)::t_uint256` in namespace `example`"
+        );
+        assert_eq!(merged, layout);
+        assert_eq!(
+            merge_storage_namespaces(
+                &mut StorageLayout::default(),
+                vec![namespace.clone(), namespace]
+            )
+            .unwrap_err()
+            .to_string(),
+            "Duplicate ERC-7201 namespace `example` in `test.sol:C.Data` and `test.sol:C.Data`"
+        );
+    }
 
     #[test]
     fn contract_output_selection() {

--- a/crates/forge/src/cmd/inspect/erc7201.rs
+++ b/crates/forge/src/cmd/inspect/erc7201.rs
@@ -1,0 +1,430 @@
+//! ERC-7201 namespace discovery and conversion to solc-compatible storage layouts.
+//!
+//! Packing and type generation are delegated to Solar. Callers decide how to merge namespaces
+//! with conventional storage and how to handle duplicate namespace declarations.
+
+use alloy_primitives::{U256, keccak256};
+use foundry_compilers::{artifacts::StorageLayout, error::SolcError};
+use path_slash::PathExt;
+use solar::{
+    ast::NatSpecKind,
+    sema::{
+        Compiler, Gcx, hir,
+        interface::{Session, config::CompilerStage},
+    },
+};
+use std::{ops::ControlFlow, path::Path};
+
+/// Computes ERC-7201 layouts for a contract in the resolved project.
+///
+/// Lowering and analysis errors are returned rather than silently emitting incomplete layouts.
+pub fn erc7201_storage_layouts(
+    compiler: &mut Compiler,
+    target_path: &Path,
+    target_name: Option<&str>,
+) -> Result<Vec<StorageNamespace>, SolcError> {
+    compiler.enter_mut(|compiler| {
+        if !matches!(
+            compiler.gcx().stage(),
+            Some(CompilerStage::Lowering | CompilerStage::Analysis)
+        ) && !matches!(compiler.lower_asts(), Ok(ControlFlow::Continue(())))
+        {
+            return Err(solar_error(compiler.sess(), "lowering"));
+        }
+        if compiler.sess().dcx.has_errors().is_err() {
+            return Err(solar_error(compiler.sess(), "lowering"));
+        }
+        let gcx = compiler.gcx();
+        let mut matches = gcx.hir.contract_ids().filter(|&id| {
+            let contract = gcx.hir.contract(id);
+            target_name.is_none_or(|name| contract.name.as_str() == name)
+                && gcx
+                    .hir
+                    .source(contract.source)
+                    .file
+                    .name
+                    .as_real()
+                    .is_some_and(|path| path == target_path)
+        });
+        let target =
+            matches.next().ok_or_else(|| SolcError::msg("storage layout contract not found"))?;
+        if matches.next().is_some() {
+            return Err(SolcError::msg("multiple contracts found; specify <path>:<contract>"));
+        }
+        // Conventional layouts do not need semantic analysis. Inspect raw parsed tags before
+        // requesting validated NatSpec or type information.
+        let bases = gcx.hir.contract(target).linearized_bases;
+        let bases = if bases.is_empty() { std::slice::from_ref(&target) } else { bases };
+        let annotated = bases.iter().any(|&base| {
+            gcx.hir.contract(base).items.iter().any(|item| {
+                item.as_struct().is_some_and(|id| {
+                    let doc = gcx.hir.doc(gcx.hir.strukt(id).doc);
+                    doc.ast_comments().iter().any(|doc| {
+                        doc.natspec.iter().any(|tag| {
+                            matches!(tag.kind, NatSpecKind::Custom { name }
+                                    if name.as_str() == "storage-location")
+                                && tag.content().trim().starts_with("erc7201")
+                        })
+                    })
+                })
+            })
+        });
+        if !annotated {
+            return Ok(Vec::new());
+        }
+        if compiler.gcx().stage() != Some(CompilerStage::Analysis)
+            && !matches!(compiler.analysis(), Ok(ControlFlow::Continue(())))
+        {
+            return Err(solar_error(compiler.sess(), "analysis"));
+        }
+        collect_storage_layouts(compiler.gcx(), target)
+    })
+}
+
+/// A storage namespace declared by a struct in a contract or one of its bases.
+#[derive(Clone, Debug)]
+pub struct StorageNamespace {
+    /// The identifier following `erc7201:` in the storage-location annotation.
+    pub id: String,
+    /// The fully qualified name of the declaring struct.
+    pub declaration: String,
+    /// The ERC-7201 root slot.
+    pub root: U256,
+    /// The struct's fields at absolute slots, with nested members at relative slots.
+    ///
+    /// Type IDs are scoped to this namespace so they cannot alias solc-generated IDs.
+    /// AST IDs originate from Solar and are not solc AST IDs.
+    pub layout: StorageLayout,
+}
+
+/// Computes `keccak256(abi.encode(uint256(keccak256(id)) - 1)) & ~uint256(0xff)`.
+fn erc7201_root(id: &str) -> U256 {
+    let inner = U256::from_be_bytes(keccak256(id.as_bytes()).0).wrapping_sub(U256::from(1));
+    U256::from_be_bytes(keccak256(inner.to_be_bytes::<32>()).0) & !U256::from(0xff)
+}
+
+/// Returns namespaces declared in `contract` and its linearized bases, once per declaration.
+///
+/// The compiler must have completed lowering and semantic analysis. Unrelated contracts,
+/// imported libraries, and file-level structs are excluded: importing a declaration does not
+/// establish that the selected contract uses its storage. Unknown storage-location schemes
+/// are ignored; malformed ERC-7201 annotations are errors.
+fn collect_storage_layouts(
+    gcx: Gcx<'_>,
+    contract: hir::ContractId,
+) -> Result<Vec<StorageNamespace>, SolcError> {
+    if gcx.sess.dcx.has_errors().is_err() {
+        return Err(solar_error(gcx.sess, "analysis"));
+    }
+    let bases = gcx.hir.contract(contract).linearized_bases;
+    let bases = if bases.is_empty() { std::slice::from_ref(&contract) } else { bases };
+    let mut namespaces = Vec::new();
+    for &base in bases.iter().rev() {
+        for item in gcx.hir.contract(base).items {
+            if let Some(id) = item.as_struct() {
+                let strukt = gcx.hir.strukt(id);
+                let contract = gcx.hir.contract(base);
+                let file = &gcx.hir.source(contract.source).file.name;
+                let contract_name = if let Some(path) = file.as_real() {
+                    let path = gcx
+                        .sess
+                        .opts
+                        .base_path
+                        .as_ref()
+                        .and_then(|root| path.strip_prefix(root).ok())
+                        .unwrap_or(path);
+                    format!("{}:{}", path.to_slash_lossy(), contract.name)
+                } else {
+                    gcx.contract_fully_qualified_name(base).to_string()
+                };
+                let declaration = format!("{contract_name}.{}", strukt.name);
+                let mut namespace = None;
+                for tag in gcx.natspec_doc_comments(strukt.doc) {
+                    if let NatSpecKind::Custom { name } = tag.kind
+                        && name.as_str() == "storage-location"
+                        && let Some(id) = parse_namespace(tag.content())?
+                        && namespace.replace(id).is_some()
+                    {
+                        return Err(SolcError::msg(format!(
+                            "multiple ERC-7201 annotations on `{declaration}`"
+                        )));
+                    }
+                }
+                if let Some(namespace) = namespace {
+                    let root = erc7201_root(namespace);
+                    let mut output = gcx.storage_layout_for_struct(id, root);
+                    // Match solc's project-relative source names at every level of the type graph.
+                    for entry in &mut output.storage {
+                        entry.contract.clone_from(&contract_name);
+                    }
+                    if let Some(types) = &mut output.types {
+                        for member in types.values_mut().flat_map(|ty| &mut ty.members) {
+                            member.contract.clone_from(&contract_name);
+                        }
+                    }
+                    let mut layout: StorageLayout =
+                        serde_json::from_value(serde_json::to_value(output)?)?;
+                    scope_types(&mut layout, namespace);
+                    namespaces.push(StorageNamespace {
+                        id: namespace.to_owned(),
+                        declaration,
+                        root,
+                        layout,
+                    });
+                }
+            }
+        }
+    }
+    Ok(namespaces)
+}
+
+fn solar_error(sess: &Session, stage: &str) -> SolcError {
+    let diagnostics = sess.dcx.emitted_diagnostics().map(|d| d.to_string()).unwrap_or_default();
+    SolcError::msg(format!("Solar {stage} failed while inspecting ERC-7201 storage\n{diagnostics}"))
+}
+
+fn parse_namespace(annotation: &str) -> Result<Option<&str>, SolcError> {
+    let annotation = annotation.trim();
+    let Some(id) = annotation.strip_prefix("erc7201:") else {
+        if annotation.split_whitespace().next() == Some("erc7201") {
+            return Err(SolcError::msg("expected `erc7201:<namespace>` storage location"));
+        }
+        return Ok(None);
+    };
+    if id.is_empty() || id.chars().any(char::is_whitespace) {
+        return Err(SolcError::msg(
+            "ERC-7201 namespace must be nonempty and contain no whitespace",
+        ));
+    }
+    Ok(Some(id))
+}
+
+fn scope_types(layout: &mut StorageLayout, namespace: &str) {
+    let scope = |id: &str| format!("erc7201({namespace})::{id}");
+    for entry in &mut layout.storage {
+        entry.storage_type = scope(&entry.storage_type);
+    }
+    layout.types = std::mem::take(&mut layout.types)
+        .into_iter()
+        .map(|(id, mut ty)| {
+            for reference in [&mut ty.key, &mut ty.value].into_iter().flatten() {
+                *reference = scope(reference);
+            }
+            if let Some(serde_json::Value::String(base)) = ty.other.get_mut("base") {
+                *base = scope(base);
+            }
+            if let Some(serde_json::Value::Array(members)) = ty.other.get_mut("members") {
+                for member in members {
+                    if let Some(serde_json::Value::String(id)) = member.get_mut("type") {
+                        *id = scope(id);
+                    }
+                }
+            }
+            (scope(&id), ty)
+        })
+        .collect();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn parser_at(source: &str, path: &str) -> Compiler {
+        let mut compiler = Compiler::new(Session::builder().with_test_emitter().build());
+        compiler.enter_mut(|compiler| {
+            let file =
+                compiler.sess().source_map().new_source_file(PathBuf::from(path), source).unwrap();
+            let mut parser = compiler.parse();
+            parser.add_file(file);
+            parser.parse();
+        });
+        compiler
+    }
+
+    fn parser(source: &str) -> Compiler {
+        parser_at(source, "test.sol")
+    }
+
+    #[test]
+    fn project_relative_source_names() {
+        let mut parser = parser_at(
+            r#"contract C {
+            struct Inner { uint256 x; }
+            /// @custom:storage-location erc7201:example
+            struct Data { Inner inner; }
+        }"#,
+            "/project/src/test.sol",
+        );
+        parser.sess_mut().opts.base_path = Some(PathBuf::from("/project"));
+        let namespaces =
+            erc7201_storage_layouts(&mut parser, Path::new("/project/src/test.sol"), Some("C"))
+                .unwrap();
+        let namespace = &namespaces[0];
+        assert_eq!(namespace.declaration, "src/test.sol:C.Data");
+        assert_eq!(namespace.layout.storage[0].contract, "src/test.sol:C");
+        let ty = &namespace.layout.types[&namespace.layout.storage[0].storage_type];
+        assert_eq!(ty.other["members"][0]["contract"], "src/test.sol:C");
+    }
+
+    fn layouts(source: &str, contract: &str) -> Result<Vec<StorageNamespace>, SolcError> {
+        erc7201_storage_layouts(&mut parser(source), Path::new("test.sol"), Some(contract))
+    }
+
+    #[test]
+    fn repeated_inspection() {
+        let mut parser = parser(
+            r#"contract C {
+            /// @custom:storage-location erc7201:example
+            struct Data { uint256 value; }
+        }"#,
+        );
+        let first = erc7201_storage_layouts(&mut parser, Path::new("test.sol"), Some("C")).unwrap();
+        let second =
+            erc7201_storage_layouts(&mut parser, Path::new("test.sol"), Some("C")).unwrap();
+        assert_eq!(first[0].layout, second[0].layout);
+    }
+
+    #[test]
+    fn inherited_namespaces_and_type_graph() {
+        let namespaces = layouts(
+            r#"
+            type Amount is uint128;
+            contract Base {
+                enum State { Off, On }
+                struct Nested { uint128 x; bool y; }
+                /** @custom:storage-location erc7201:example.base */
+                struct Data {
+                    address owner;
+                    bool paused;
+                    Nested nested;
+                    uint128[3] fixedValues;
+                    mapping(address => Nested[]) accounts;
+                    bytes data;
+                    string name;
+                    Amount amount;
+                    State state;
+                    function() external callback;
+                }
+            }
+            contract Left is Base {}
+            contract Right is Base {}
+            contract Derived is Left, Right {
+                /// @custom:storage-location erc7201:example.derived
+                struct OtherData { uint256 value; }
+            }
+            contract Unrelated {
+                /// @custom:storage-location erc7201:example.base
+                struct Data { uint256 ignored; }
+            }
+        "#,
+            "Derived",
+        )
+        .unwrap();
+        assert_eq!(
+            namespaces.iter().map(|n| n.id.as_str()).collect::<Vec<_>>(),
+            ["example.base", "example.derived"]
+        );
+        assert_eq!(namespaces[0].declaration, "test.sol:Base.Data");
+        let layout = &namespaces[0].layout;
+        let root = namespaces[0].root;
+        assert_eq!(
+            layout
+                .storage
+                .iter()
+                .map(|s| (s.slot.parse::<U256>().unwrap() - root, s.offset))
+                .collect::<Vec<_>>(),
+            [(0, 0), (0, 20), (1, 0), (2, 0), (4, 0), (5, 0), (6, 0), (7, 0), (7, 16), (8, 0)]
+                .map(|(slot, offset)| (U256::from(slot), offset))
+        );
+        for ty in layout.types.values() {
+            for id in [&ty.key, &ty.value].into_iter().flatten() {
+                assert!(layout.types.contains_key(id), "missing {id}");
+            }
+            if let Some(base) = ty.other.get("base") {
+                assert!(layout.types.contains_key(base.as_str().unwrap()));
+            }
+            if let Some(members) = ty.other.get("members") {
+                for member in members.as_array().unwrap() {
+                    assert!(layout.types.contains_key(member["type"].as_str().unwrap()));
+                    assert_eq!(member["slot"], "0");
+                }
+            }
+        }
+        assert!(layout.types.keys().all(|id| id.starts_with("erc7201(example.base)::")));
+    }
+
+    #[test]
+    fn annotation_errors_and_non_namespaced_contracts() {
+        assert!(
+            layouts(
+                r#"contract C {
+            /// @custom:storage-location erc7201:example
+            struct Data { uint256 value; }
+            function invalid() public pure returns (uint256) { return true; }
+        }"#,
+                "C"
+            )
+            .is_err()
+        );
+        for annotation in ["erc7201:", "erc7201:two words", "erc7201"] {
+            assert!(layouts(&format!("contract C {{\n/// @custom:storage-location {annotation}\nstruct Data {{ uint256 x; }}\n}}"), "C").is_err());
+        }
+        assert!(
+            layouts(
+                r#"contract C {
+            /// @custom:storage-location erc7201:first
+            /// @custom:storage-location erc7201:second
+            struct Data { uint256 x; }
+        }"#,
+                "C"
+            )
+            .is_err()
+        );
+        assert!(
+            layouts(
+                r#"contract C {
+            /// @custom:storage-location other:example
+            struct Data { uint256 x; }
+            uint256 value;
+        }"#,
+                "C"
+            )
+            .unwrap()
+            .is_empty()
+        );
+        // Duplicate declarations are retained for the caller's collision policy.
+        assert_eq!(
+            layouts(
+                r#"contract C {
+            /// @custom:storage-location erc7201:same
+            struct A { uint256 x; }
+            /// @custom:storage-location erc7201:same
+            struct B { uint256 y; }
+        }"#,
+                "C"
+            )
+            .unwrap()
+            .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn root_and_annotations() {
+        assert_eq!(
+            erc7201_root("openzeppelin.storage.Initializable").to_string(),
+            U256::from_str_radix(
+                "f0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00",
+                16
+            )
+            .unwrap()
+            .to_string()
+        );
+        assert_eq!(parse_namespace(" erc7201:example.main \n").unwrap(), Some("example.main"));
+        assert_eq!(parse_namespace("erc9999:example.main").unwrap(), None);
+        for invalid in ["erc7201", "erc7201:", "erc7201:two words"] {
+            assert!(parse_namespace(invalid).is_err());
+        }
+    }
+}

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -32,6 +32,7 @@ mod multi_script;
 mod precompiles;
 mod script;
 mod soldeer;
+mod storage_layout;
 mod svm;
 mod test_cmd;
 mod verify;

--- a/crates/forge/tests/cli/storage_layout.rs
+++ b/crates/forge/tests/cli/storage_layout.rs
@@ -1,0 +1,97 @@
+//! ERC-7201 storage inspection through the CLI.
+
+forgetest!(erc7201_storage_layout, |prj, cmd| {
+    prj.add_source(
+        "Namespaced.sol",
+        r#"
+        contract Base {
+            /// @custom:storage-location erc7201:openzeppelin.storage.Initializable
+            struct Data { uint64 initialized; bool initializing; }
+        }
+        contract Left is Base {}
+        contract Right is Base {}
+        contract Namespaced is Left, Right { uint256 normal; }
+        contract Unrelated {
+            /// @custom:storage-location erc7201:openzeppelin.storage.Initializable
+            struct Data { uint256 ignored; }
+        }
+    "#,
+    );
+    // Both fresh and cached project resolution must retain inherited namespaces exactly once.
+    for attempt in 0..2 {
+        if attempt == 1 {
+            cmd.forge_fuse().args(["build", "--extra-output", "storageLayout"]).assert_success();
+        }
+        cmd.forge_fuse().args(["inspect", "Namespaced", "storageLayout", "--json"])
+            .assert_json_stdout(str![[r#"
+{
+  "storage": [
+    { "astId": "{...}", "contract": "src/Namespaced.sol:Namespaced", "label": "normal", "offset": 0, "slot": "0", "type": "t_uint256" },
+    { "astId": "{...}", "contract": "src/Namespaced.sol:Base", "label": "openzeppelin.storage.Initializable.initialized", "offset": 0, "slot": "108904022758810753673719992590105913556127789646572562039383141376366747609600", "type": "erc7201(openzeppelin.storage.Initializable)::t_uint64" },
+    { "astId": "{...}", "contract": "src/Namespaced.sol:Base", "label": "openzeppelin.storage.Initializable.initializing", "offset": 8, "slot": "108904022758810753673719992590105913556127789646572562039383141376366747609600", "type": "erc7201(openzeppelin.storage.Initializable)::t_bool" }
+  ],
+  "types": {
+    "t_uint256": { "encoding": "inplace", "label": "uint256", "numberOfBytes": "32" },
+    "erc7201(openzeppelin.storage.Initializable)::t_uint64": { "encoding": "inplace", "label": "uint64", "numberOfBytes": "8" },
+    "erc7201(openzeppelin.storage.Initializable)::t_bool": { "encoding": "inplace", "label": "bool", "numberOfBytes": "1" }
+  }
+}
+"#]]);
+    }
+    cmd.forge_fuse()
+        .args(["inspect", "Namespaced", "storageLayout", "--md"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+
+| Name                                            | Type    | Slot                                                                           | Offset | Bytes | Contract                      |
+|-------------------------------------------------|---------|--------------------------------------------------------------------------------|--------|-------|-------------------------------|
+| normal                                          | uint256 | 0                                                                              | 0      | 32    | src/Namespaced.sol:Namespaced |
+| openzeppelin.storage.Initializable.initialized  | uint64  | 108904022758810753673719992590105913556127789646572562039383141376366747609600 | 0      | 8     | src/Namespaced.sol:Base       |
+| openzeppelin.storage.Initializable.initializing | bool    | 108904022758810753673719992590105913556127789646572562039383141376366747609600 | 8      | 1     | src/Namespaced.sol:Base       |
+
+
+"#]]);
+    cmd.forge_fuse()
+        .args(["inspect", "Namespaced", "transientStorageLayout", "--json"])
+        .assert_json_stdout(str![[r#"{"storage": [], "types": {}}"#]]);
+});
+
+forgetest!(erc7201_duplicate_namespace, |prj, cmd| {
+    prj.add_source(
+        "Duplicate.sol",
+        r#"
+        contract Base {
+            /// @custom:storage-location erc7201:example
+            struct Data { uint256 value; }
+        }
+        contract Duplicate is Base {
+            /// @custom:storage-location erc7201:example
+            struct Other { uint256 value; }
+        }
+    "#,
+    );
+    cmd.args(["inspect", "Duplicate", "storageLayout", "--json"])
+        .assert_failure().stdout_eq("").stderr_eq(str![[r#"
+Error: Duplicate ERC-7201 namespace `example` in `src/Duplicate.sol:Base.Data` and `src/Duplicate.sol:Duplicate.Other`
+
+"#]]);
+});
+
+forgetest!(erc7201_malformed_namespace, |prj, cmd| {
+    prj.add_source(
+        "Malformed.sol",
+        r#"
+        contract Malformed {
+            /// @custom:storage-location erc7201:
+            struct Data { uint256 value; }
+        }
+    "#,
+    );
+    cmd.args(["inspect", "Malformed", "storageLayout", "--json"])
+        .assert_failure()
+        .stdout_eq("")
+        .stderr_eq(str![[r#"
+Error: ERC-7201 namespace must be nonempty and contain no whitespace
+
+"#]]);
+});


### PR DESCRIPTION
Include ERC-7201 namespaces in `forge inspect storageLayout` for the selected contract and its bases. For example, a `counter` field under `@custom:storage-location erc7201:example` appears as `example.counter` at its computed root in both JSON and table output. Conventional storage remains present, transient storage is unchanged, and duplicate namespace roots or conflicting type definitions produce errors.

This implements [Mablr's plan](https://github.com/foundry-rs/foundry/pull/15299#issuecomment-5317766666) with a two-repository split: namespace discovery, inheritance, hashing, and artifact conversion live in a dedicated Forge module, while packing uses the generic primitive in [Solar #1413](https://github.com/paradigmxyz/solar/pull/1413). The Solar commit is pinned so this draft can be built and reviewed. No foundry-core changes are required; its dependency revision remains unchanged from the base branch.

Code and tests were written by Centaur with AI assistance.

Prompted by: @DaniPopes
