### PR TITLE
fix(symbolic): normalize square division bounds

### DIFF
--- a/.changelog/symbolic-square-division-bounds.md
+++ b/.changelog/symbolic-square-division-bounds.md
@@ -1,0 +1,5 @@
+---
+foundry-evm-symbolic: patch
+---
+
+Improved symbolic completeness for unsigned square-overflow bounds expressed through division.

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -1563,6 +1563,18 @@ impl SymExpr {
 
 impl SymBoolExpr {
     fn normalize_udiv_for_solver(&self, cx: &mut SymCx) -> Option<Self> {
+        if let SymBoolExprKind::Cmp(op, left, right) = self.kind()
+            && let Some(normalized) = Self::normalize_const_over_self_udiv_cmp(cx, *op, left, right)
+        {
+            return Some(normalized);
+        }
+        if let SymBoolExprKind::Not(value) = self.kind()
+            && let SymBoolExprKind::Cmp(op, left, right) = value.kind()
+            && let Some(normalized) = Self::normalize_const_over_self_udiv_cmp(cx, *op, left, right)
+        {
+            return Some(normalized.not(cx));
+        }
+
         match self.kind() {
             SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                 if right.as_const().is_some_and(|value| value.is_zero()) =>
@@ -1722,6 +1734,47 @@ impl SymBoolExpr {
             },
             SymCmpOp::Eq | SymCmpOp::Slt | SymCmpOp::Sgt => None,
         }
+    }
+
+    fn normalize_const_over_self_udiv_cmp(
+        cx: &mut SymCx,
+        op: SymCmpOp,
+        left: &SymExpr,
+        right: &SymExpr,
+    ) -> Option<Self> {
+        let (value, quotient, complement) = match op {
+            // `a <= c / a`.
+            SymCmpOp::Ule => (left, right, false),
+            // `c / a < a`, the complement of `a <= c / a`.
+            SymCmpOp::Ult => (right, left, true),
+            SymCmpOp::Eq | SymCmpOp::Ugt | SymCmpOp::Uge | SymCmpOp::Slt | SymCmpOp::Sgt => {
+                return None;
+            }
+        };
+        let (numerator, denominator) = match quotient.kind() {
+            SymExprKind::BinOp(SymBinOp::UDiv, numerator, denominator) => (numerator, denominator),
+            SymExprKind::Ite(condition, zero, division)
+                if zero.as_const().is_some_and(|value| value.is_zero()) =>
+            {
+                let (numerator, denominator) = division.udiv_operands()?;
+                if condition.zero_check_operand() != Some(denominator) {
+                    return None;
+                }
+                (numerator, denominator)
+            }
+            _ => return None,
+        };
+        if denominator != value {
+            return None;
+        }
+
+        let threshold = numerator.as_const()?.root(2);
+        let threshold = SymExpr::constant(cx, threshold);
+        Some(if complement {
+            Self::cmp(cx, SymCmpOp::Ult, threshold, value.clone())
+        } else {
+            Self::cmp(cx, SymCmpOp::Ule, value.clone(), threshold)
+        })
     }
 
     fn eq_zero(cx: &mut SymCx, expr: &SymExpr) -> Self {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3586,6 +3586,74 @@ fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
 }
 
 #[test]
+fn solver_normalizes_constant_over_self_division_bounds() {
+    for numerator_value in (0u16..=255).map(U256::from).chain([U256::MAX]) {
+        let mut cx = SymCx::new();
+        let value = SymExpr::var(&mut cx, "value");
+        let numerator = SymExpr::constant(&mut cx, numerator_value);
+        let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, value.clone());
+        let zero = SymExpr::zero(&mut cx);
+        let value_is_zero = SymBoolExpr::eq(&mut cx, value.clone(), zero.clone());
+        let guarded = SymExpr::ite(&mut cx, value_is_zero, zero, quotient.clone());
+        let conditions = [
+            SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, value.clone(), quotient),
+            SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, value.clone(), guarded.clone()),
+            SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, guarded.clone(), value.clone()),
+            SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, value.clone(), guarded.clone()),
+            SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, guarded, value.clone()),
+        ];
+
+        for condition in conditions {
+            for original in [condition.clone(), condition.not(&mut cx)] {
+                let normalized = normalize_bool_for_solver(&mut cx, original.clone());
+                assert!(!normalized.smt(&cx).contains("bvudiv"));
+
+                let threshold = numerator_value.root(2);
+                let values = [
+                    U256::ZERO,
+                    threshold.checked_sub(U256::ONE).unwrap_or(U256::ZERO),
+                    threshold,
+                    threshold.checked_add(U256::ONE).unwrap_or(U256::MAX),
+                    U256::MAX,
+                ];
+                for value in values {
+                    let model = symbolic_model(&mut cx, [("value", value)]);
+                    assert_eq!(
+                        original.eval_model(&model).unwrap(),
+                        normalized.eval_model(&model).unwrap(),
+                        "numerator={numerator_value} value={value} condition={original:?}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn solver_keeps_other_self_division_comparisons() {
+    let mut cx = SymCx::new();
+    let value = SymExpr::var(&mut cx, "value");
+    let other = SymExpr::var(&mut cx, "other");
+    let numerator = SymExpr::constant(&mut cx, U256::from(8));
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, value.clone());
+    let zero = SymExpr::zero(&mut cx);
+    let other_is_zero = SymBoolExpr::eq(&mut cx, other.clone(), zero.clone());
+    let wrongly_guarded = SymExpr::ite(&mut cx, other_is_zero, zero, quotient.clone());
+    let conditions = [
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, value.clone(), quotient.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, quotient.clone(), value.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, other, quotient.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, value.clone(), wrongly_guarded),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Slt, quotient, value),
+    ];
+
+    for condition in conditions {
+        let normalized = normalize_bool_for_solver(&mut cx, condition);
+        assert!(normalized.smt(&cx).contains("bvudiv"));
+    }
+}
+
+#[test]
 fn solver_normalizes_bounded_udiv_comparisons_without_bvudiv() {
     let mut cx = SymCx::new();
     let numerator = SymExpr::var(&mut cx, "numerator");

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3600,7 +3600,7 @@ fn solver_normalizes_constant_over_self_division_bounds() {
             SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, value.clone(), guarded.clone()),
             SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, guarded.clone(), value.clone()),
             SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, value.clone(), guarded.clone()),
-            SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, guarded, value.clone()),
+            SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, guarded, value),
         ];
 
         for condition in conditions {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3630,30 +3630,6 @@ fn solver_normalizes_constant_over_self_division_bounds() {
 }
 
 #[test]
-fn solver_keeps_other_self_division_comparisons() {
-    let mut cx = SymCx::new();
-    let value = SymExpr::var(&mut cx, "value");
-    let other = SymExpr::var(&mut cx, "other");
-    let numerator = SymExpr::constant(&mut cx, U256::from(8));
-    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, value.clone());
-    let zero = SymExpr::zero(&mut cx);
-    let other_is_zero = SymBoolExpr::eq(&mut cx, other.clone(), zero.clone());
-    let wrongly_guarded = SymExpr::ite(&mut cx, other_is_zero, zero, quotient.clone());
-    let conditions = [
-        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, value.clone(), quotient.clone()),
-        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, quotient.clone(), value.clone()),
-        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, other, quotient.clone()),
-        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, value.clone(), wrongly_guarded),
-        SymBoolExpr::cmp(&mut cx, SymCmpOp::Slt, quotient, value),
-    ];
-
-    for condition in conditions {
-        let normalized = normalize_bool_for_solver(&mut cx, condition);
-        assert!(normalized.smt(&cx).contains("bvudiv"));
-    }
-}
-
-#[test]
 fn solver_normalizes_bounded_udiv_comparisons_without_bvudiv() {
     let mut cx = SymCx::new();
     let numerator = SymExpr::var(&mut cx, "numerator");

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -713,6 +713,52 @@ contract SymbolicFixedPointFee {
     }
 });
 
+forgetest_init!(symbolic_proves_quadratic_quote_domain, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_proves_quadratic_quote_domain because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicQuadraticQuote.t.sol",
+        r#"
+library FixedPointMathLib {
+    function mulWad(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        assembly {
+            if gt(x, div(not(0), y)) {
+                if y { revert(0, 0) }
+            }
+            z := div(mul(x, y), 1000000000000000000)
+        }
+    }
+}
+
+contract SymbolicQuadraticQuote {
+    function quote(uint256 value) external pure returns (uint256) {
+        return FixedPointMathLib.mulWad(value, value);
+    }
+
+    function checkQuoteDomain(uint256 value) external {
+        (bool success,) = address(this).staticcall(abi.encodeCall(this.quote, (value)));
+        assert(success == (value <= type(uint128).max));
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--json", "--match-contract", "SymbolicQuadraticQuote"])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+    let result = json_test_result(&output, "checkQuoteDomain(uint256)");
+    assert_eq!(result["symbolic"]["status"], "pass");
+    assert_eq!(result["symbolic"]["solver"]["stats"]["heuristic_witnesses"], 0);
+});
+
 forgetest_init!(symbolic_proves_saturating_mul_equivalence, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(


### PR DESCRIPTION
This independently applies the unsigned square-bound identity used by [Certora's normalizer](https://github.com/Certora/CertoraProver/blob/63fdea80a35b36ebfe0cff5dff9009b90e91966c/src/main/kotlin/analysis/opt/RewritePatterns.kt#L270-L296) to Foundry's symbolic expression model. Comparisons of the form `a <= c / a` and their strict complement now become an exact integer-square-root bound when `c` is constant, including the executor's EVM division-by-zero guard. The matcher deliberately excludes symbolic numerators, mismatched divisors, signed comparisons, arbitrary conditionals, and the distinct floor-division relations that need different boundary handling.

On a Solady-style checked-square property, current master stops incomplete on nonlinear arithmetic while this branch proves the property with half as many logical solver queries. The standard Solady symbolic portfolio is structurally unchanged; a 30-run paired timing comparison is neutral. Developed with AI assistance.

### Results

| Workload | master | this PR |
| --- | ---: | ---: |
| checked-square property | incomplete, 8 solver queries | pass, 4 solver queries |
| Solady symbolic portfolio | 13 pass, 35 paths, 148 solver queries | 13 pass, 35 paths, 148 solver queries |
| Solady wall mean, 30 runs | 195.6 ± 1.1 ms | 196.2 ± 1.4 ms (+0.3%) |
