### PR TITLE
fix(ci): install libudev in Linux linking jobs

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -976,14 +976,19 @@ ANVIL_PID=$!
 # Ensure anvil is stopped on script exit
 trap 'kill "$ANVIL_PID" 2>/dev/null || true' EXIT
 
-# Wait for anvil to be ready (max 10 seconds)
-for i in {1..10}; do
-  if cast client --rpc-url "http://127.0.0.1:$ANVIL_PORT" 2>/dev/null; then
+# Fork initialization performs remote RPC calls and can take longer than local startup.
+for i in {1..120}; do
+  if ! kill -0 "$ANVIL_PID" 2>/dev/null; then
+    echo "ERROR: Anvil fork exited before becoming ready"
+    wait "$ANVIL_PID" || true
+    exit 1
+  fi
+  if cast client --rpc-url "http://127.0.0.1:$ANVIL_PORT" --rpc-timeout 2 2>/dev/null; then
     echo "Anvil fork started successfully"
     break
   fi
-  if [[ $i -eq 10 ]]; then
-    echo "ERROR: Anvil fork failed to start"
+  if [[ $i -eq 120 ]]; then
+    echo "ERROR: Anvil fork failed to start after 120 readiness attempts"
     exit 1
   fi
   sleep 1

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -976,19 +976,14 @@ ANVIL_PID=$!
 # Ensure anvil is stopped on script exit
 trap 'kill "$ANVIL_PID" 2>/dev/null || true' EXIT
 
-# Fork initialization performs remote RPC calls and can take longer than local startup.
-for i in {1..120}; do
-  if ! kill -0 "$ANVIL_PID" 2>/dev/null; then
-    echo "ERROR: Anvil fork exited before becoming ready"
-    wait "$ANVIL_PID" || true
-    exit 1
-  fi
-  if cast client --rpc-url "http://127.0.0.1:$ANVIL_PORT" --rpc-timeout 2 2>/dev/null; then
+# Wait for anvil to be ready (max 10 seconds)
+for i in {1..10}; do
+  if cast client --rpc-url "http://127.0.0.1:$ANVIL_PORT" 2>/dev/null; then
     echo "Anvil fork started successfully"
     break
   fi
-  if [[ $i -eq 120 ]]; then
-    echo "ERROR: Anvil fork failed to start after 120 readiness attempts"
+  if [[ $i -eq 10 ]]; then
+    echo "ERROR: Anvil fork failed to start"
     exit 1
   fi
   sleep 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           toolchain: stable
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
+      - name: Install Linux system dependencies
+        run: sudo apt-get update && sudo apt-get install --yes libudev-dev
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
@@ -75,6 +77,8 @@ jobs:
         with:
           toolchain: stable
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
+      - name: Install Linux system dependencies
+        run: sudo apt-get update && sudo apt-get install --yes libudev-dev
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
@@ -206,6 +210,8 @@ jobs:
         with:
           toolchain: stable
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
+      - name: Install Linux system dependencies
+        run: sudo apt-get update && sudo apt-get install --yes libudev-dev
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:


### PR DESCRIPTION
Install libudev-dev in the doctest, no-default-features, and forge-fmt jobs, extending #16599 to the remaining Linux linking jobs. These jobs fail on master and #16736 because the Depot runner lacks the Ledger HID linker dependency.

This CI-only change has the maintainer L-ignore changelog exemption.

Authored with assistance from Codex, including the PR text.
