### PR TITLE
perf(symbolic): memoize expression folds

### DIFF
--- a/.changelog/symbolic-dag-folds.md
+++ b/.changelog/symbolic-dag-folds.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Improved symbolic execution performance on shared expression graphs during solver normalization.

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -1,7 +1,7 @@
 use super::{hashcons::HashConsed, *};
 
 /// Bounds both the number of distinct word nodes inspected by constant-ITE equality expansion and
-/// the size of the Boolean tree that a later non-memoized fold could observe.
+/// the unfolded size of the Boolean expression it could produce.
 const MAX_CONSTANT_ITE_EQ_NODES: usize = 128;
 const MAX_CONSTANT_ITE_EQ_UNFOLDED_NODES: usize = 8 * 1024;
 
@@ -32,10 +32,6 @@ impl SymBoolExpr {
 
     pub(in crate::runtime) fn kind(&self) -> &SymBoolExprKind {
         self.kind.value()
-    }
-
-    pub(in crate::runtime) fn into_kind(self) -> SymBoolExprKind {
-        self.kind.into_value()
     }
 
     pub(in crate::runtime) fn from_kind(cx: &mut SymCx, kind: SymBoolExprKind) -> Self {
@@ -688,56 +684,91 @@ impl SymBoolExpr {
         }
     }
 
+    /// Rewrites each distinct Boolean node once in bottom-up order.
+    ///
+    /// The folder must return the same result for every occurrence of one hash-consed node.
     pub(crate) fn fold(
-        self,
+        &self,
         cx: &mut SymCx,
         folder: &mut impl FnMut(&mut SymCx, Self) -> Self,
     ) -> Self {
-        if matches!(self.kind(), SymBoolExprKind::Const(_)) {
-            return folder(cx, self);
-        }
-
-        let expr = match self.into_kind() {
-            SymBoolExprKind::Not(value) => {
-                let value = value.fold(cx, folder);
-                Self::not_bool(cx, value)
-            }
-            SymBoolExprKind::And(values) => {
-                let values = values.iter().cloned().map(|value| value.fold(cx, folder)).collect();
-                Self::and(cx, values)
-            }
-            SymBoolExprKind::Cmp(op, left, right) => Self::cmp(cx, op, left, right),
-            SymBoolExprKind::Const(_) => unreachable!("leaf boolean returned before folding"),
-        };
-        folder(cx, expr)
+        let mut folded = HashMap::default();
+        self.fold_cached(cx, folder, &mut folded)
     }
 
-    pub(crate) fn fold_exprs(
-        self,
+    fn fold_cached<'a>(
+        &'a self,
         cx: &mut SymCx,
-        folder: &mut impl FnMut(&mut SymCx, SymExpr) -> SymExpr,
+        folder: &mut impl FnMut(&mut SymCx, Self) -> Self,
+        folded: &mut HashMap<&'a Self, Self>,
     ) -> Self {
-        if matches!(self.kind(), SymBoolExprKind::Const(_)) {
-            return self;
+        if let Some(expr) = folded.get(self) {
+            return expr.clone();
         }
 
-        match self.into_kind() {
+        let expr = match self.kind() {
+            SymBoolExprKind::Const(_) => self.clone(),
             SymBoolExprKind::Not(value) => {
-                let value = value.fold_exprs(cx, folder);
+                let value = value.fold_cached(cx, folder, folded);
                 Self::not_bool(cx, value)
             }
             SymBoolExprKind::And(values) => {
                 let values =
-                    values.iter().cloned().map(|value| value.fold_exprs(cx, folder)).collect();
+                    values.iter().map(|value| value.fold_cached(cx, folder, folded)).collect();
                 Self::and(cx, values)
             }
             SymBoolExprKind::Cmp(op, left, right) => {
-                let left = left.fold(cx, folder);
-                let right = right.fold(cx, folder);
-                Self::cmp(cx, op, left, right)
+                Self::cmp(cx, *op, left.clone(), right.clone())
             }
-            SymBoolExprKind::Const(_) => unreachable!("leaf boolean returned before folding exprs"),
+        };
+        let expr = folder(cx, expr);
+        folded.insert(self, expr.clone());
+        expr
+    }
+
+    /// Rewrites each distinct word node once while rebuilding this Boolean expression.
+    ///
+    /// The folder must return the same result for every occurrence of one hash-consed node.
+    pub(crate) fn fold_exprs(
+        &self,
+        cx: &mut SymCx,
+        folder: &mut impl FnMut(&mut SymCx, SymExpr) -> SymExpr,
+    ) -> Self {
+        let mut folded = ExpressionFoldCache::default();
+        self.fold_exprs_cached(cx, folder, &mut folded)
+    }
+
+    pub(in crate::runtime::expr) fn fold_exprs_cached<'a>(
+        &'a self,
+        cx: &mut SymCx,
+        folder: &mut impl FnMut(&mut SymCx, SymExpr) -> SymExpr,
+        folded: &mut ExpressionFoldCache<'a>,
+    ) -> Self {
+        if let Some(expr) = folded.bools.get(self) {
+            return expr.clone();
         }
+
+        let expr = match self.kind() {
+            SymBoolExprKind::Const(_) => self.clone(),
+            SymBoolExprKind::Not(value) => {
+                let value = value.fold_exprs_cached(cx, folder, folded);
+                Self::not_bool(cx, value)
+            }
+            SymBoolExprKind::And(values) => {
+                let values = values
+                    .iter()
+                    .map(|value| value.fold_exprs_cached(cx, folder, folded))
+                    .collect();
+                Self::and(cx, values)
+            }
+            SymBoolExprKind::Cmp(op, left, right) => {
+                let left = left.fold_cached(cx, folder, folded);
+                let right = right.fold_cached(cx, folder, folded);
+                Self::cmp(cx, *op, left, right)
+            }
+        };
+        folded.bools.insert(self, expr.clone());
+        expr
     }
 
     #[cfg(test)]

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -370,10 +370,6 @@ impl SymExpr {
         }
     }
 
-    pub(in crate::runtime) fn into_kind(self) -> SymExprKind {
-        self.kind.into_value()
-    }
-
     pub(in crate::runtime) fn from_kind(cx: &mut SymCx, kind: SymExprKind) -> Self {
         cx.mk_expr_kind(kind)
     }
@@ -888,9 +884,9 @@ impl SymExpr {
 
     /// Checks the occurrence cost of a rewrite that places one operand in both ITE arms.
     ///
-    /// Hash-consing keeps the stored DAG compact, but solver normalization folds occurrences and
-    /// would revisit a shared operand twice after every rewrite. Count that unfolded result before
-    /// constructing it so a linear series of branchless operations cannot become exponential.
+    /// Hash-consing keeps the stored DAG compact, but the rewrite still places a shared operand in
+    /// both arms for downstream consumers. Count that unfolded result before constructing it so a
+    /// linear series of branchless operations cannot become exponential.
     fn duplicating_branchless_rewrite_fits(operand: &Self, conditional: &Self) -> bool {
         let mut counter = UnfoldedNodeCounter::new();
         let Some(operand_nodes) = counter.expr_nodes(operand) else {
@@ -1409,7 +1405,42 @@ impl SymExpr {
     }
 
     pub(crate) fn contains_ite(&self) -> bool {
-        self.visit_bool(|expr| matches!(expr.kind(), SymExprKind::Ite(_, _, _)))
+        let mut visited = HashSet::<&Self>::default();
+        self.contains_ite_cached(&mut visited, false)
+    }
+
+    fn contains_ite_cached<'a>(&'a self, visited: &mut HashSet<&'a Self>, memoize: bool) -> bool {
+        match self.kind() {
+            SymExprKind::Const(_) | SymExprKind::Var(_) | SymExprKind::GasLeft(_) => return false,
+            SymExprKind::Ite(_, _, _) => return true,
+            _ => {}
+        }
+        if memoize && !visited.insert(self) {
+            return false;
+        }
+
+        match self.kind() {
+            SymExprKind::Keccak { len, bytes, .. } => {
+                len.contains_ite_cached(visited, true)
+                    || bytes.iter().any(|byte| byte.contains_ite_cached(visited, true))
+            }
+            SymExprKind::Hash { bytes, .. } => {
+                bytes.iter().any(|byte| byte.contains_ite_cached(visited, true))
+            }
+            SymExprKind::Not(value) => value.contains_ite_cached(visited, true),
+            SymExprKind::BinOp(_, left, right) => {
+                left.contains_ite_cached(visited, true) || right.contains_ite_cached(visited, true)
+            }
+            SymExprKind::TernOp(_, left, right, modulus) => {
+                left.contains_ite_cached(visited, true)
+                    || right.contains_ite_cached(visited, true)
+                    || modulus.contains_ite_cached(visited, true)
+            }
+            SymExprKind::Const(_)
+            | SymExprKind::Var(_)
+            | SymExprKind::GasLeft(_)
+            | SymExprKind::Ite(_, _, _) => unreachable!("leaf expression handled before descent"),
+        }
     }
 
     pub(in crate::runtime) fn udiv_operands(&self) -> Option<(&Self, &Self)> {
@@ -1868,54 +1899,64 @@ impl SymExpr {
         .is_break()
     }
 
+    /// Rewrites each distinct word or nested Boolean node once in bottom-up order.
+    ///
+    /// The folder must return the same result for every occurrence of one hash-consed node.
     pub(crate) fn fold(
-        self,
+        &self,
         cx: &mut SymCx,
         folder: &mut impl FnMut(&mut SymCx, Self) -> Self,
     ) -> Self {
-        if matches!(
-            self.kind(),
-            SymExprKind::Const(_) | SymExprKind::Var(_) | SymExprKind::GasLeft(_)
-        ) {
-            return folder(cx, self);
+        let mut folded = ExpressionFoldCache::default();
+        self.fold_cached(cx, folder, &mut folded)
+    }
+
+    pub(in crate::runtime::expr) fn fold_cached<'a>(
+        &'a self,
+        cx: &mut SymCx,
+        folder: &mut impl FnMut(&mut SymCx, Self) -> Self,
+        folded: &mut ExpressionFoldCache<'a>,
+    ) -> Self {
+        if let Some(expr) = folded.words.get(self) {
+            return expr.clone();
         }
 
-        let expr = match self.into_kind() {
+        let expr = match self.kind() {
+            SymExprKind::Const(_) | SymExprKind::Var(_) | SymExprKind::GasLeft(_) => self.clone(),
             SymExprKind::Keccak { name, len, bytes } => {
-                let len = len.fold(cx, folder);
-                let bytes = bytes.iter().cloned().map(|byte| byte.fold(cx, folder)).collect();
-                Self::keccak_symbol(cx, name, len, bytes)
+                let len = len.fold_cached(cx, folder, folded);
+                let bytes = bytes.iter().map(|byte| byte.fold_cached(cx, folder, folded)).collect();
+                Self::keccak_symbol(cx, *name, len, bytes)
             }
             SymExprKind::Hash { name, algorithm, bytes } => {
-                let bytes = bytes.iter().cloned().map(|byte| byte.fold(cx, folder)).collect();
-                Self::hash_symbol(cx, name, algorithm, bytes)
+                let bytes = bytes.iter().map(|byte| byte.fold_cached(cx, folder, folded)).collect();
+                Self::hash_symbol(cx, *name, algorithm, bytes)
             }
             SymExprKind::Not(value) => {
-                let value = value.fold(cx, folder);
+                let value = value.fold_cached(cx, folder, folded);
                 Self::not(cx, value)
             }
             SymExprKind::BinOp(op, left, right) => {
-                let left = left.fold(cx, folder);
-                let right = right.fold(cx, folder);
-                Self::binop(cx, op, left, right)
+                let left = left.fold_cached(cx, folder, folded);
+                let right = right.fold_cached(cx, folder, folded);
+                Self::binop(cx, *op, left, right)
             }
             SymExprKind::TernOp(op, left, right, modulus) => {
-                let left = left.fold(cx, folder);
-                let right = right.fold(cx, folder);
-                let modulus = modulus.fold(cx, folder);
-                Self::ternop(cx, op, left, right, modulus)
+                let left = left.fold_cached(cx, folder, folded);
+                let right = right.fold_cached(cx, folder, folded);
+                let modulus = modulus.fold_cached(cx, folder, folded);
+                Self::ternop(cx, *op, left, right, modulus)
             }
             SymExprKind::Ite(condition, then_expr, else_expr) => {
-                let condition = condition.fold_exprs(cx, folder);
-                let then_expr = then_expr.fold(cx, folder);
-                let else_expr = else_expr.fold(cx, folder);
+                let condition = condition.fold_exprs_cached(cx, folder, folded);
+                let then_expr = then_expr.fold_cached(cx, folder, folded);
+                let else_expr = else_expr.fold_cached(cx, folder, folded);
                 Self::ite(cx, condition, then_expr, else_expr)
             }
-            SymExprKind::Const(_) | SymExprKind::Var(_) | SymExprKind::GasLeft(_) => {
-                unreachable!("leaf expression returned before folding children")
-            }
         };
-        folder(cx, expr)
+        let expr = folder(cx, expr);
+        folded.words.insert(self, expr.clone());
+        expr
     }
 
     #[cfg(test)]
@@ -1963,7 +2004,7 @@ impl SymExpr {
 }
 
 // Branchless expression rewrites are optional. Bound both the distinct DAG nodes inspected while
-// deciding whether to rewrite and the occurrences a later non-memoized solver fold could visit.
+// deciding whether to rewrite and the unfolded size of the expression they could produce.
 const MAX_BRANCHLESS_REWRITE_NODES: usize = 256;
 const MAX_BRANCHLESS_REWRITE_UNFOLDED_NODES: usize = 8 * 1024;
 

--- a/crates/evm/symbolic/src/runtime/expr/hashcons.rs
+++ b/crates/evm/symbolic/src/runtime/expr/hashcons.rs
@@ -43,17 +43,6 @@ impl<T> HashConsed<T> {
     pub(in crate::runtime) fn value(&self) -> &T {
         &self.inner.value
     }
-
-    #[inline]
-    pub(in crate::runtime) fn into_value(self) -> T
-    where
-        T: Clone,
-    {
-        match Arc::try_unwrap(self.inner) {
-            Ok(inner) => inner.value,
-            Err(inner) => inner.value.clone(),
-        }
-    }
 }
 
 impl<T> Clone for HashConsed<T> {

--- a/crates/evm/symbolic/src/runtime/expr/mod.rs
+++ b/crates/evm/symbolic/src/runtime/expr/mod.rs
@@ -18,6 +18,15 @@ pub(crate) use bool::*;
 pub(crate) use cx::*;
 pub(crate) use word::*;
 
+/// Results from one deterministic bottom-up expression fold.
+///
+/// Keys borrow the original DAG so the memo table does not add strong references to source nodes.
+#[derive(Default)]
+struct ExpressionFoldCache<'a> {
+    words: HashMap<&'a SymExpr, SymExpr>,
+    bools: HashMap<&'a SymBoolExpr, SymBoolExpr>,
+}
+
 /// Evaluates hash-consed expressions once per model.
 ///
 /// Symbolic expressions form a DAG, so recursively evaluating both operands without caching can

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -846,7 +846,7 @@ fn remove_witnessed_isolated_hash_constraints(
             else {
                 return Some(constraint);
             };
-            let abstracted = constraint.clone().fold_exprs(cx, &mut |cx, expr| match expr.kind() {
+            let abstracted = constraint.fold_exprs(cx, &mut |cx, expr| match expr.kind() {
                 SymExprKind::Keccak { name, .. } | SymExprKind::Hash { name, .. }
                     if *name == symbol =>
                 {


### PR DESCRIPTION
Symbolic expressions already share DAG nodes, but folding and ITE detection could revisit them repeatedly. Inspired by LLVM's handling of shared DAG nodes, this memoizes fold results within each traversal and skips revisited nodes during ITE detection.

### Results

| symbolic check | master median | PR median | change |
| --- | ---: | ---: | ---: |
| Solady `LibBit.fls(x) <= 256` | 28.44 ms | 20.45 ms | −28.1% |

Ten alternating runs using profiling builds; proof outcome and solver counters were unchanged. These are test execution times, excluding compilation and command startup. The usual symbolic suites and their peak RSS remained neutral.

AI assistance: Codex helped implement and benchmark this change.
