### PR TITLE
refactor(symbolic): group module re-exports

### DIFF
--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -51,14 +51,13 @@ use tracing::{debug, trace, trace_span, warn};
 #[cfg(test)]
 use std::collections::BTreeMap;
 
-mod consts;
-pub use consts::BUILTIN_SYMBOLIC_SOLVERS;
-pub(crate) use consts::*;
-
 mod abi;
+mod consts;
 mod executor;
 mod runtime;
 
+pub use consts::BUILTIN_SYMBOLIC_SOLVERS;
+pub(crate) use consts::*;
 pub use runtime::{PortfolioDiagnostics, SymbolicBranchTarget, SymbolicError, SymbolicRunInput};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/evm/symbolic/src/runtime/expr/mod.rs
+++ b/crates/evm/symbolic/src/runtime/expr/mod.rs
@@ -6,6 +6,10 @@ pub(super) mod hashcons;
 #[path = "expr.rs"]
 mod word;
 
+pub(crate) use bool::*;
+pub(crate) use cx::*;
+pub(crate) use word::*;
+
 struct NoopModel;
 
 impl SymbolicModelLookup for NoopModel {
@@ -13,10 +17,6 @@ impl SymbolicModelLookup for NoopModel {
         None
     }
 }
-
-pub(crate) use bool::*;
-pub(crate) use cx::*;
-pub(crate) use word::*;
 
 /// Evaluates hash-consed expressions once per model.
 ///


### PR DESCRIPTION
Keeps local module declarations and their re-exports contiguous in the symbolic crate, instead of placing `NoopModel` and its implementation between them. It also applies the same ordering at the crate root. This is a behavior-neutral follow-up to #16738 and isolates the inherited ordering issue visible in #16741 from that performance change.

This internal-only refactor does not need a release-note entry; a maintainer should apply `L-ignore`.

AI assistance: Codex audited the symbolic crate for matching occurrences and implemented the mechanical reorder.
