### PR TITLE
fix(symbolic): make vm.isContext honor the actual forge execution context

### DIFF
--- a/.changelog/symbolic-is-context.md
+++ b/.changelog/symbolic-is-context.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-cheatcodes: patch
+foundry-evm-symbolic: patch
+---
+
+Fixed symbolic `vm.isContext` to use the actual Forge execution context, including coverage and snapshot runs.

--- a/crates/cheatcodes/src/env.rs
+++ b/crates/cheatcodes/src/env.rs
@@ -9,6 +9,11 @@ use std::{env, sync::OnceLock};
 /// Stores the forge execution context for the duration of the program.
 pub static FORGE_CONTEXT: OnceLock<ForgeContext> = OnceLock::new();
 
+/// Returns the current forge execution context, if it has been set.
+pub fn current_execution_context() -> Option<ForgeContext> {
+    FORGE_CONTEXT.get().copied()
+}
+
 impl Cheatcode for setEnvCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
         let Self { name: key, value } = self;

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -43,7 +43,7 @@ mod crypto;
 mod version;
 
 mod env;
-pub use env::set_execution_context;
+pub use env::{current_execution_context, set_execution_context};
 
 mod evm;
 

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -1,4 +1,5 @@
 use foundry_cheatcodes_spec::Vm::*;
+use foundry_evm::inspectors::cheatcodes::current_execution_context;
 
 use super::*;
 
@@ -2444,9 +2445,13 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.isContext",
                 )?;
+                let context = u8::try_from(context)
+                    .ok()
+                    .and_then(|context| ForgeContext::try_from(context).ok())
+                    .ok_or(SymbolicError::Unsupported("symbolic vm.isContext invalid context"))?;
                 return Ok(CheatcodeOutcome::Continue(vec![SymExpr::constant(
                     &mut self.cx,
-                    U256::from(context == U256::ZERO || context == U256::from(1)),
+                    U256::from(current_execution_context() == Some(context)),
                 )]));
             }
             toString_0Call::SELECTOR => {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1,4 +1,9 @@
 use super::{abi::*, runtime::*, *};
+use foundry_evm::{
+    core::{backend::Backend, evm::EthEvmNetwork},
+    executors::ExecutorBuilder,
+    inspectors::cheatcodes::{ForgeContext, set_execution_context},
+};
 
 fn empty_state(cx: &mut SymCx) -> PathState {
     let calldata =
@@ -5798,4 +5803,68 @@ fn error_payload(message: &str) -> Vec<u8> {
     let padded_len = message.len().div_ceil(32) * 32;
     payload.resize(4 + 64 + padded_len, 0);
     payload
+}
+
+#[test]
+fn is_context_uses_actual_execution_context() {
+    set_execution_context(ForgeContext::Coverage);
+    let mut executor = ExecutorBuilder::<EthEvmNetwork>::new().build(
+        Default::default(),
+        Default::default(),
+        Backend::spawn(None).unwrap(),
+        Default::default(),
+    );
+    let target = Address::repeat_byte(0x11);
+    let function = Function::parse("check_context()").unwrap();
+
+    for (context, expected) in [
+        (1, false),
+        (2, true),
+        (0, true),
+        (3, false),
+        (4, false),
+        (5, false),
+        (6, false),
+        (7, false),
+        (8, false),
+    ] {
+        // Store isContext calldata, STATICCALL, and revert unless the result matches.
+        let mut code = vec![0x63];
+        code.extend_from_slice(&Vm::isContextCall::SELECTOR);
+        code.extend_from_slice(&[0x60, 0xe0, 0x1b, 0x5f, 0x52, 0x60, context, 0x60, 0x04, 0x52]);
+        code.extend_from_slice(&[0x60, 0x20, 0x5f, 0x60, 0x24, 0x5f, 0x73]);
+        code.extend_from_slice(CHEATCODE_ADDRESS.as_slice());
+        code.extend_from_slice(&[
+            0x62,
+            0x0f,
+            0x42,
+            0x40,
+            0xfa,
+            0x5f,
+            0x51,
+            0x60,
+            u8::from(expected),
+            0x14,
+            0x16,
+        ]);
+        let success_pc = u8::try_from(code.len() + 6).unwrap();
+        code.extend_from_slice(&[0x60, success_pc, 0x57, 0x5f, 0x5f, 0xfd, 0x5b, 0x00]);
+        executor.set_code(target, Bytecode::new_raw(code.into())).unwrap();
+
+        let result = SymbolicExecutor::new(SymbolicConfig::default()).run(SymbolicRunInput {
+            executor: &executor,
+            target,
+            sender: CALLER,
+            function: &function,
+            value: U256::ZERO,
+            ffi_enabled: false,
+            collect_success_input: false,
+            corpus_seeds: Vec::new(),
+            branch_target: None,
+        });
+        assert!(
+            matches!(result, SymbolicRunResult::Safe { .. }),
+            "context {context}, expected {expected}: {result:?}"
+        );
+    }
 }

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1,9 +1,4 @@
 use super::{abi::*, runtime::*, *};
-use foundry_evm::{
-    core::{backend::Backend, evm::EthEvmNetwork},
-    executors::ExecutorBuilder,
-    inspectors::cheatcodes::{ForgeContext, set_execution_context},
-};
 
 fn empty_state(cx: &mut SymCx) -> PathState {
     let calldata =
@@ -5803,68 +5798,4 @@ fn error_payload(message: &str) -> Vec<u8> {
     let padded_len = message.len().div_ceil(32) * 32;
     payload.resize(4 + 64 + padded_len, 0);
     payload
-}
-
-#[test]
-fn is_context_uses_actual_execution_context() {
-    set_execution_context(ForgeContext::Coverage);
-    let mut executor = ExecutorBuilder::<EthEvmNetwork>::new().build(
-        Default::default(),
-        Default::default(),
-        Backend::spawn(None).unwrap(),
-        Default::default(),
-    );
-    let target = Address::repeat_byte(0x11);
-    let function = Function::parse("check_context()").unwrap();
-
-    for (context, expected) in [
-        (1, false),
-        (2, true),
-        (0, true),
-        (3, false),
-        (4, false),
-        (5, false),
-        (6, false),
-        (7, false),
-        (8, false),
-    ] {
-        // Store isContext calldata, STATICCALL, and revert unless the result matches.
-        let mut code = vec![0x63];
-        code.extend_from_slice(&Vm::isContextCall::SELECTOR);
-        code.extend_from_slice(&[0x60, 0xe0, 0x1b, 0x5f, 0x52, 0x60, context, 0x60, 0x04, 0x52]);
-        code.extend_from_slice(&[0x60, 0x20, 0x5f, 0x60, 0x24, 0x5f, 0x73]);
-        code.extend_from_slice(CHEATCODE_ADDRESS.as_slice());
-        code.extend_from_slice(&[
-            0x62,
-            0x0f,
-            0x42,
-            0x40,
-            0xfa,
-            0x5f,
-            0x51,
-            0x60,
-            u8::from(expected),
-            0x14,
-            0x16,
-        ]);
-        let success_pc = u8::try_from(code.len() + 6).unwrap();
-        code.extend_from_slice(&[0x60, success_pc, 0x57, 0x5f, 0x5f, 0xfd, 0x5b, 0x00]);
-        executor.set_code(target, Bytecode::new_raw(code.into())).unwrap();
-
-        let result = SymbolicExecutor::new(SymbolicConfig::default()).run(SymbolicRunInput {
-            executor: &executor,
-            target,
-            sender: CALLER,
-            function: &function,
-            value: U256::ZERO,
-            ffi_enabled: false,
-            collect_success_input: false,
-            corpus_seeds: Vec::new(),
-            branch_target: None,
-        });
-        assert!(
-            matches!(result, SymbolicRunResult::Safe { .. }),
-            "context {context}, expected {expected}: {result:?}"
-        );
-    }
 }

--- a/crates/forge/tests/cli/context.rs
+++ b/crates/forge/tests/cli/context.rs
@@ -1,4 +1,6 @@
 //! Contains tests for checking forge execution context cheatcodes
+use std::process::Command;
+
 const FORGE_TEST_CONTEXT_CONTRACT: &str = r#"
 import "./test.sol";
 interface Vm {
@@ -62,6 +64,31 @@ forgetest!(can_set_forge_test_coverage_context, |prj, cmd| {
     prj.insert_ds_test();
     prj.add_source("ForgeContextTest.t.sol", FORGE_TEST_CONTEXT_CONTRACT);
     cmd.args(["coverage", "--match-test", "testForgeCoverageContext"]).assert_success();
+});
+
+forgetest!(symbolic_uses_actual_forge_context, |prj, cmd| {
+    if !Command::new("z3").arg("--version").output().is_ok_and(|output| output.status.success()) {
+        return;
+    }
+    prj.insert_ds_test();
+    prj.add_source(
+        "ForgeContextTest.t.sol",
+        &FORGE_TEST_CONTEXT_CONTRACT.replace("testForge", "checkForge"),
+    );
+    prj.update_config(|config| config.symbolic.enabled = true);
+    for (command, test) in [
+        ("test", "checkForgeTestContext"),
+        ("coverage", "checkForgeCoverageContext"),
+        ("snapshot", "checkForgeSnapshotContext"),
+    ] {
+        cmd.forge_fuse().args([command, "--match-test", test]).assert_success().stdout_eq(
+            foundry_test_utils::str![[r#"
+...
+[PASS] checkForge[..] (paths: [..])
+...
+"#]],
+        );
+    }
 });
 
 // tests that context properly set for `forge script` command


### PR DESCRIPTION
Symbolic `vm.isContext` hardcoded the test context, producing incorrect results during coverage and snapshot runs. Read the actual Forge context and reuse its existing comparison semantics.

Reuses the existing Solidity context fixture to check symbolic execution under `forge test`, `forge coverage`, and `forge snapshot`.

AI assistance: Claude Code contributed the fix; Codex simplified the regression coverage.
