### PR TITLE
refactor(lint): reuse Solar resolution queries

### DIFF
--- a/.changelog/lint-environment-gcx.md
+++ b/.changelog/lint-environment-gcx.md
@@ -1,0 +1,5 @@
+---
+forge-lint: patch
+---
+
+Reuse Solar's resolved call arguments and modifier dispatch in block environment capture lints.

--- a/crates/lint/src/sol/med/cheatcode_environment.rs
+++ b/crates/lint/src/sol/med/cheatcode_environment.rs
@@ -35,7 +35,7 @@ use solar::{
         Gcx,
         builtins::Builtin,
         eval::ConstValue,
-        hir::{self, Expr, ExprKind, Function, FunctionId, ItemId, Stmt, StmtKind, VariableId},
+        hir::{self, Expr, ExprKind, Function, FunctionId, Stmt, StmtKind, VariableId},
         ty::TyKind,
     },
 };
@@ -267,13 +267,12 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
             return Vec::new();
         }
         if let Some(modifier) = func.modifiers.get(index) {
-            let ItemId::Function(mut id) = modifier.id else { return Vec::new() };
-            // A qualified `Base.modifier` names that implementation exactly.
-            if modifier.span.lo() == modifier.name_span.lo()
-                && let Some(contract) = self.contract
-            {
-                id = self.gcx.resolve_virtual_function(contract, id);
-            }
+            let Some(id) = self.contract.map_or_else(
+                || modifier.id.as_function(),
+                |contract| self.gcx.resolve_modifier_target(contract, modifier),
+            ) else {
+                return Vec::new();
+            };
             let definition = self.gcx.hir.function(id);
             let Some(body) = definition.body else { return Vec::new() };
             let values: Vec<_> = definition
@@ -758,8 +757,11 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
                     let bindings = func
                         .parameters
                         .iter()
-                        .map(|&param| {
-                            let value = arg_for_param(&self.gcx.hir, func, param, args)
+                        .enumerate()
+                        .map(|(index, &param)| {
+                            let value = self
+                                .gcx
+                                .call_arg(expr, index)
                                 .and_then(|arg| arguments.iter().find(|(id, _)| *id == arg.id))
                                 .map(|(_, value)| value.clone())
                                 .unwrap_or_default();


### PR DESCRIPTION
Follow-up to #16727. Use Solar's `gcx.call_arg` for normal call argument binding and `gcx.resolve_modifier_target` for modifier dispatch, removing duplicated resolution logic from the block environment capture lints. Modifier arguments retain the existing helper because they are not call expressions. Lint policy and analysis limits are unchanged.

Developed with Codex assistance.
