### PR TITLE
test(cast): fix default keystore test on Windows

### DIFF
--- a/crates/cast/tests/cli/wallet_keystore.rs
+++ b/crates/cast/tests/cli/wallet_keystore.rs
@@ -315,8 +315,9 @@ Created new encrypted keystore file: [..]
 
 // tests that `cast wallet new <name>` treats a bare account name like `cast wallet import <name>`
 casttest!(new_wallet_bare_account_name_uses_default_keystore, |prj, cmd| {
-    let account = "issue-16209-account";
-    cmd.env("HOME", prj.root());
+    // Windows resolves the home directory through the shell API, ignoring HOME.
+    // Use a unique account in the real default keystore directory on every platform.
+    let account = prj.root().file_name().unwrap().to_str().unwrap();
     cmd.args(["wallet", "new", account, "--unsafe-password", "test"])
         .assert_success()
         .stdout_eq(str![[r#"
@@ -329,8 +330,9 @@ Created new encrypted keystore file: [..]
 
 "#]]);
 
-    let keystore_path = prj.root().join(".foundry").join("keystores").join(account);
+    let keystore_path = dirs::home_dir().unwrap().join(".foundry").join("keystores").join(account);
     assert!(keystore_path.is_file(), "expected keystore at {}", keystore_path.display());
+    fs::remove_file(keystore_path).unwrap();
 });
 
 // tests that a missing path-like argument is still treated as a directory, not an account name


### PR DESCRIPTION
The [Windows test job](https://github.com/foundry-rs/foundry/actions/runs/34335113815/job/102413147301) fails because the regression test added in #16219 redirects `HOME`, but `dirs::home_dir()` uses the Windows shell profile API. Cast writes the keystore outside the temporary project, the path assertion fails, and retries collide with the fixed account name. Use the temporary project's unique directory name as the account, check the actual default keystore directory, and remove the generated file afterward so the same coverage runs on every platform.

This changes only test code; a maintainer must apply `L-ignore` for the changelog exemption. Windows execution remains for CI verification.

Codex diagnosed the failure and authored the test change and PR description.
