### PR TITLE
fix(ci): allow slower Tempo fork startup

### DIFF
--- a/.github/scripts/tempo-anvil.sh
+++ b/.github/scripts/tempo-anvil.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Wait for a live Anvil process to serve RPC, allowing time for upstream fork requests.
+wait_for_anvil() {
+  local pid="$1" port="$2" timeout="${3:-120}"
+  local deadline=$((SECONDS + timeout))
+
+  while (( SECONDS < deadline )); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "ERROR: Anvil exited before serving RPC on port $port" >&2
+      return 1
+    fi
+    if cast client --rpc-url "http://127.0.0.1:$port" --rpc-timeout 1 >/dev/null 2>&1; then
+      echo "Anvil started successfully on port $port"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "ERROR: Anvil did not serve RPC on port $port within ${timeout}s" >&2
+  return 1
+}

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 # Get the directory where this script lives
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+source "$SCRIPT_DIR/tempo-anvil.sh"
 
 # Non-verification tempo checks: local tests, fork tests, cast commands, DEX operations
 
@@ -901,18 +903,7 @@ ANVIL_PID=$!
 # Ensure anvil is stopped on script exit
 trap 'kill "$ANVIL_PID" 2>/dev/null || true' EXIT
 
-# Wait for anvil to be ready (max 10 seconds)
-for i in {1..10}; do
-  if cast client --rpc-url "http://127.0.0.1:$ANVIL_PORT" 2>/dev/null; then
-    echo "Anvil fork started successfully"
-    break
-  fi
-  if [[ $i -eq 10 ]]; then
-    echo "ERROR: Anvil fork failed to start"
-    exit 1
-  fi
-  sleep 1
-done
+wait_for_anvil "$ANVIL_PID" "$ANVIL_PORT"
 
 ALICE_PK="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
@@ -976,18 +967,7 @@ ANVIL_PID=$!
 # Ensure anvil is stopped on script exit
 trap 'kill "$ANVIL_PID" 2>/dev/null || true' EXIT
 
-# Wait for anvil to be ready (max 10 seconds)
-for i in {1..10}; do
-  if cast client --rpc-url "http://127.0.0.1:$ANVIL_PORT" 2>/dev/null; then
-    echo "Anvil fork started successfully"
-    break
-  fi
-  if [[ $i -eq 10 ]]; then
-    echo "ERROR: Anvil fork failed to start"
-    exit 1
-  fi
-  sleep 1
-done
+wait_for_anvil "$ANVIL_PID" "$ANVIL_PORT"
 
 echo -e "\n=== ANVIL FORK: CHECK CLIENT VERSION ==="
 cast client --rpc-url http://127.0.0.1:$ANVIL_PORT

--- a/.github/scripts/tests/test_tempo_anvil.py
+++ b/.github/scripts/tests/test_tempo_anvil.py
@@ -1,0 +1,66 @@
+import pathlib
+import subprocess
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "tempo-anvil.sh"
+
+
+class TempoAnvilTests(unittest.TestCase):
+    def run_wait(self, setup, timeout="120"):
+        return subprocess.run(
+            ["bash", "-c", r'''
+set -euo pipefail
+source "$1"
+sleep 60 &
+pid=$!
+trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+# Advance the clock without making the readiness scenarios take minutes.
+sleep() { SECONDS=$((SECONDS + $1)); }
+attempts=0
+cast() {
+  [[ "$*" == "client --rpc-url http://127.0.0.1:8547 --rpc-timeout 1" ]] || exit 99
+  attempts=$((attempts + 1))
+  (( attempts >= ready_after ))
+}
+eval "$2"
+if wait_for_anvil "$pid" 8547 "$3"; then
+  result=0
+else
+  result=$?
+fi
+echo "attempts=$attempts"
+exit "$result"
+''', "bash", str(SCRIPT), setup, timeout],
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+
+    def test_slow_fork_startup(self):
+        result = self.run_wait("ready_after=13")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Anvil started successfully on port 8547", result.stdout)
+        self.assertIn("attempts=13", result.stdout)
+
+    def test_ready_immediately(self):
+        result = self.run_wait("ready_after=1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("attempts=1", result.stdout)
+
+    def test_exited_process_is_not_mistaken_for_ready_rpc(self):
+        result = self.run_wait("ready_after=1; kill \"$pid\"; wait \"$pid\" || true")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Anvil exited before serving RPC", result.stderr)
+        self.assertIn("attempts=0", result.stdout)
+
+    def test_live_process_that_never_serves_rpc_times_out(self):
+        result = self.run_wait("ready_after=1000", timeout="3")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("within 3s", result.stderr)
+        self.assertIn("attempts=3", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tempo CI gives forked Anvil only about nine seconds to start, then kills it via the exit trap, despite configuring 60-second upstream RPC timeouts. The devnet check on #16752 hit this deadline ([run](https://github.com/foundry-rs/foundry/actions/runs/34342150465/job/102435800959)); its logs do not establish why startup was slow. Use a shared two-minute readiness deadline for local and forked Anvil, limit each readiness request to one second, and fail immediately if the child exits. This fixes premature startup timeouts and distinguishes them from process exits; the private devnet failure itself has not been reproduced locally.

This is CI-only; a maintainer must apply `L-ignore`. Implementation and tests were written with Codex assistance.
