### PR TITLE
fix(symbolic): ignore bool invariant return values, matching concrete runner

### DIFF
--- a/.changelog/fix-symbolic-invariant-ignores-bool-return.md
+++ b/.changelog/fix-symbolic-invariant-ignores-bool-return.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Fixed symbolic invariant checks to ignore boolean return values, matching concrete Forge behavior. Invariants must use assertions or revert to indicate failure.

--- a/crates/evm/symbolic/src/executor/invariant.rs
+++ b/crates/evm/symbolic/src/executor/invariant.rs
@@ -28,12 +28,10 @@ impl SymbolicExecutor {
             self.prepare_invariant_call(executor, state, invariant_address, sender, invariant)?;
 
         let mut checked = Vec::new();
-        while let Some(mut outcome) =
+        while let Some(outcome) =
             self.execute_sequence_call_next(executor, &mut call, completed_paths)?
         {
-            if !matches!(outcome.status, CallStatus::Success)
-                || self.invariant_return_failed(invariant, &mut outcome.state)?
-            {
+            if !matches!(outcome.status, CallStatus::Success) {
                 return Ok(vec![InvariantCheckOutcome { failed: true, state: outcome.state }]);
             }
 
@@ -273,40 +271,6 @@ impl SymbolicExecutor {
         }
 
         Ok(())
-    }
-
-    fn invariant_return_failed(
-        &mut self,
-        invariant: &Function,
-        state: &mut PathState,
-    ) -> Result<bool, SymbolicError> {
-        if invariant.outputs.is_empty() {
-            return Ok(false);
-        }
-        if invariant.outputs.len() != 1 || invariant.outputs[0].selector_type().as_ref() != "bool" {
-            return Ok(false);
-        }
-        if state.return_data.len() < 32 {
-            return Ok(true);
-        }
-
-        let pass = state.return_data.load_word(&mut self.cx, 0)?.nonzero_bool(&mut self.cx);
-        let fail = pass.clone().not(&mut self.cx);
-        match fail.as_const() {
-            Some(true) => Ok(true),
-            Some(false) => Ok(false),
-            None => {
-                let mut constraints = state.constraints.clone();
-                constraints.push(fail);
-                if self.is_sat_with_state(state, &constraints)? {
-                    state.constraints = constraints;
-                    Ok(true)
-                } else {
-                    state.constraints.push(pass);
-                    Ok(false)
-                }
-            }
-        }
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/crates/evm/symbolic/src/runtime/memory.rs
+++ b/crates/evm/symbolic/src/runtime/memory.rs
@@ -1064,6 +1064,7 @@ impl SymReturnData {
         self.bytes.read_offset(cx, offset, size)
     }
 
+    #[cfg(test)]
     pub(crate) fn load_word(
         &self,
         cx: &mut SymCx,

--- a/crates/evm/symbolic/src/runtime/memory.rs
+++ b/crates/evm/symbolic/src/runtime/memory.rs
@@ -1064,18 +1064,6 @@ impl SymReturnData {
         self.bytes.read_offset(cx, offset, size)
     }
 
-    #[cfg(test)]
-    pub(crate) fn load_word(
-        &self,
-        cx: &mut SymCx,
-        offset: usize,
-    ) -> Result<SymExpr, SymbolicError> {
-        if offset.saturating_add(32) > self.len() {
-            return Err(SymbolicError::Unsupported("out-of-bounds symbolic returndata word"));
-        }
-        Ok(self.bytes.word_at(cx, offset))
-    }
-
     pub(crate) fn read_concrete(
         &self,
         cx: &mut SymCx,

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1430,7 +1430,8 @@ fn memory_return_data_accepts_symbolic_offsets() {
     memory.store_word(&mut cx, 7, value);
     let offset = SymExpr::var(&mut cx, "offset");
     let return_data = memory.return_data(&mut cx, offset, 32).unwrap();
-    let loaded = return_data.load_word(&mut cx, 0).unwrap();
+    let zero = SymExpr::zero(&mut cx);
+    let loaded = return_data.read_bytes_offset(&mut cx, zero, 32).word_at(&mut cx, 0);
 
     let model = symbolic_model(
         &mut cx,

--- a/crates/forge/tests/cli/test_cmd/symbolic_invariant.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_invariant.rs
@@ -65,6 +65,54 @@ invariant_counterStaysZero()
     );
 });
 
+forgetest_init!(symbolic_invariant_ignores_bool_return, |prj, cmd| {
+    skip_unless_z3!("symbolic_invariant_ignores_bool_return");
+    prj.update_config(|config| config.invariant.runs = 0);
+
+    prj.add_test(
+        "SymbolicInvariantBoolReturn.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicBoolReturnTarget {
+    uint256 public counter;
+
+    function bump() external {
+        counter = 1;
+    }
+}
+
+contract SymbolicInvariantBoolReturn is Test {
+    function setUp() public {
+        targetContract(address(new SymbolicBoolReturnTarget()));
+        targetSender(address(this));
+    }
+
+    /// forge-config: default.symbolic.invariant_depth = 1
+    function invariant_alwaysFalseButNeverAsserts() public pure returns (bool) {
+        return false;
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--json",
+            "--match-test",
+            "invariant_alwaysFalseButNeverAsserts",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+    let result = json_test_result(&output, "invariant_alwaysFalseButNeverAsserts()");
+    assert_eq!(result["status"], "Success");
+    assert_eq!(result["symbolic"]["status"], "pass", "{}", result["symbolic"]["incomplete"]);
+});
+
 forgetest_init!(symbolic_invariant_safe_still_runs_fuzz_campaign, |prj, cmd| {
     skip_unless_z3!("symbolic_invariant_safe_still_runs_fuzz_campaign");
 


### PR DESCRIPTION
Make symbolic invariant checks ignore boolean return values, matching the concrete Forge runner. Previously, returning `false` without reverting could produce a counterexample that failed concrete replay and was reported as incomplete. Invariants must use assertions or revert to indicate failure; the existing warning about ignored boolean returns remains unchanged.

Remove the unused return-data word loader and keep its existing test on the byte-reading API. Add a regression test for an invariant that returns `false` without asserting.

Developed with AI assistance (Claude Code and Codex).
