### PR TITLE
fix(ci): wait for Tempo fork readiness

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -58,6 +58,27 @@ wallet_json_field() {
   jq -r --arg field "$field" '(.data // .)[0][$field]' <<<"$wallet_json"
 }
 
+# Fork initialization can outlast a single upstream RPC's 60-second timeout.
+wait_for_anvil() {
+  local pid="$1" port="$2" timeout="${3:-120}"
+  local deadline=$((SECONDS + timeout))
+
+  while (( SECONDS < deadline )); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "ERROR: Anvil exited before serving RPC on port $port" >&2
+      return 1
+    fi
+    if cast client --rpc-url "http://127.0.0.1:$port" --rpc-timeout 1 >/dev/null 2>&1; then
+      echo "Anvil started successfully on port $port"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "ERROR: Anvil did not serve RPC on port $port within ${timeout}s" >&2
+  return 1
+}
+
 echo -e "\n=== INIT TEMPO PROJECT ==="
 tmp_dir=$(mktemp -d)
 cd "$tmp_dir"
@@ -901,18 +922,7 @@ ANVIL_PID=$!
 # Ensure anvil is stopped on script exit
 trap 'kill "$ANVIL_PID" 2>/dev/null || true' EXIT
 
-# Wait for anvil to be ready (max 10 seconds)
-for i in {1..10}; do
-  if cast client --rpc-url "http://127.0.0.1:$ANVIL_PORT" 2>/dev/null; then
-    echo "Anvil fork started successfully"
-    break
-  fi
-  if [[ $i -eq 10 ]]; then
-    echo "ERROR: Anvil fork failed to start"
-    exit 1
-  fi
-  sleep 1
-done
+wait_for_anvil "$ANVIL_PID" "$ANVIL_PORT"
 
 ALICE_PK="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
@@ -976,18 +986,7 @@ ANVIL_PID=$!
 # Ensure anvil is stopped on script exit
 trap 'kill "$ANVIL_PID" 2>/dev/null || true' EXIT
 
-# Wait for anvil to be ready (max 10 seconds)
-for i in {1..10}; do
-  if cast client --rpc-url "http://127.0.0.1:$ANVIL_PORT" 2>/dev/null; then
-    echo "Anvil fork started successfully"
-    break
-  fi
-  if [[ $i -eq 10 ]]; then
-    echo "ERROR: Anvil fork failed to start"
-    exit 1
-  fi
-  sleep 1
-done
+wait_for_anvil "$ANVIL_PID" "$ANVIL_PORT"
 
 echo -e "\n=== ANVIL FORK: CHECK CLIENT VERSION ==="
 cast client --rpc-url http://127.0.0.1:$ANVIL_PORT

--- a/.github/scripts/tests/test_tempo_check.py
+++ b/.github/scripts/tests/test_tempo_check.py
@@ -1,0 +1,64 @@
+import pathlib
+import re
+import subprocess
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "tempo-check.sh"
+
+
+class TempoAnvilReadinessTests(unittest.TestCase):
+    def run_wait(self, setup, timeout="120"):
+        # Load only the helper, without running the live-chain checks.
+        helper = re.search(r"^wait_for_anvil\(\) \{.*?^\}", SCRIPT.read_text(), re.M | re.S)
+        self.assertIsNotNone(helper)
+        return subprocess.run(
+            ["bash", "-c", helper.group() + r'''
+set -euo pipefail
+sleep 60 &
+pid=$!
+trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+# Advance the readiness clock without waiting for real RPC timeouts.
+sleep() { SECONDS=$((SECONDS + $1)); }
+attempts=0
+cast() {
+  [[ "$*" == "client --rpc-url http://127.0.0.1:8547 --rpc-timeout 1" ]] || exit 99
+  attempts=$((attempts + 1))
+  (( attempts >= ready_after ))
+}
+eval "$1"
+if wait_for_anvil "$pid" 8547 "$2"; then
+  result=0
+else
+  result=$?
+fi
+echo "attempts=$attempts"
+exit "$result"
+''', "bash", setup, timeout],
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+
+    def test_fork_startup_beyond_old_deadline(self):
+        result = self.run_wait("ready_after=13")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Anvil started successfully on port 8547", result.stdout)
+        self.assertIn("attempts=13", result.stdout)
+
+    def test_exited_child_fails_before_probing_rpc(self):
+        result = self.run_wait('ready_after=1; kill "$pid"; wait "$pid" || true')
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Anvil exited before serving RPC", result.stderr)
+        self.assertIn("attempts=0", result.stdout)
+
+    def test_unresponsive_child_times_out(self):
+        result = self.run_wait("ready_after=1000", timeout="3")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("within 3s", result.stderr)
+        self.assertIn("attempts=3", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Foundry's Tempo check kills forked Anvil after roughly nine seconds, despite allowing individual upstream RPC requests 60 seconds; this caused the [latest master failure](https://github.com/foundry-rs/foundry/actions/runs/34349442496). Allow two minutes for readiness, bound each probe to one second, and fail immediately when the child exits. Keep the helper in `tempo-check.sh` and cover slow startup, child exit, and timeout in the existing script test suite.

Adapts the approach from the closed, unmerged [#16756](https://github.com/foundry-rs/foundry/pull/16756), incorporating its inline-helper review feedback. This fixes the premature deadline; the logs do not establish the cause of upstream startup latency.

This is CI-only; a maintainer must apply `L-ignore`. Implementation and tests were prepared with Codex assistance.

Prompted by: @DaniPopes
