### PR TITLE
chore: remove unused font-awesome license exception

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -78,8 +78,6 @@ exceptions = [
     { allow = ["CC0-1.0"], name = "notify" },
     { allow = ["CC0-1.0"], name = "dunce" },
     { allow = ["CC0-1.0"], name = "aurora-engine-modexp" },
-    # Rendered mdBook HTML source code includes attribution as required by CC-BY-4.0
-    { allow = ["CC-BY-4.0", "MIT"], name = "font-awesome-as-a-crate" },
 ]
 # copyleft = "deny"
 


### PR DESCRIPTION
Removes the license exception for `font-awesome-as-a-crate`, which is no longer a dependency.

Config change written by Codex.
