### PR TITLE
refactor(symbolic): reuse pure EVM operations

### DIFF
--- a/.changelog/symbolic-pure-ops.md
+++ b/.changelog/symbolic-pure-ops.md
@@ -1,0 +1,5 @@
+---
+foundry-evm-symbolic: patch
+---
+
+Reuse revm signed arithmetic and U256 exponentiation and arithmetic shifts in symbolic execution.

--- a/crates/evm/symbolic/src/executor/constraints.rs
+++ b/crates/evm/symbolic/src/executor/constraints.rs
@@ -1,4 +1,5 @@
 use super::*;
+use foundry_evm::revm::interpreter::instructions::i256::i256_cmp;
 
 impl SymbolicExecutor {
     pub(super) fn handle_assume(
@@ -182,7 +183,10 @@ impl SymbolicExecutor {
         if let (Some(value), Some(min), Some(max)) =
             (value.as_const(), min.as_const(), max.as_const())
         {
-            if !slt(min, max) || slt(value, min) || slt(max, value) {
+            if !i256_cmp(&min, &max).is_lt()
+                || i256_cmp(&value, &min).is_lt()
+                || i256_cmp(&value, &max).is_gt()
+            {
                 return Ok(CheatcodeOutcome::Failure);
             }
             let bounded = if value == min { max } else { min };
@@ -190,7 +194,7 @@ impl SymbolicExecutor {
         }
 
         if let (Some(min), Some(max)) = (min.as_const(), max.as_const())
-            && !slt(min, max)
+            && !i256_cmp(&min, &max).is_lt()
         {
             return Ok(CheatcodeOutcome::Failure);
         }

--- a/crates/evm/symbolic/src/runtime/evm.rs
+++ b/crates/evm/symbolic/src/runtime/evm.rs
@@ -6,20 +6,6 @@ pub(crate) fn failed_slot() -> U256 {
     U256::from_be_bytes(bytes)
 }
 
-pub(crate) fn pow_mod(base: U256, exponent: U256) -> U256 {
-    let mut result = U256::from(1);
-    let mut base = base;
-    let mut exponent = exponent;
-    while !exponent.is_zero() {
-        if exponent & U256::from(1) == U256::from(1) {
-            result = result.wrapping_mul(base);
-        }
-        exponent >>= 1;
-        base = base.wrapping_mul(base);
-    }
-    result
-}
-
 pub(crate) fn exp_expr_for_concrete_exponent(
     cx: &mut SymCx,
     base: SymExpr,
@@ -29,7 +15,7 @@ pub(crate) fn exp_expr_for_concrete_exponent(
         return SymExpr::one(cx);
     }
     if let Some(base) = base.as_const() {
-        return SymExpr::constant(cx, pow_mod(base, U256::from(exponent)));
+        return SymExpr::constant(cx, base.wrapping_pow(U256::from(exponent)));
     }
 
     let mut expr = base.clone();
@@ -37,39 +23,6 @@ pub(crate) fn exp_expr_for_concrete_exponent(
         expr = SymExpr::binop(cx, SymBinOp::Mul, expr, base.clone());
     }
     expr
-}
-
-pub(crate) fn slt(left: U256, right: U256) -> bool {
-    let left_negative = (left >> 255) == U256::from(1);
-    let right_negative = (right >> 255) == U256::from(1);
-    match (left_negative, right_negative) {
-        (true, false) => true,
-        (false, true) => false,
-        _ => left < right,
-    }
-}
-
-pub(crate) fn signed_abs(value: U256) -> U256 {
-    if (value >> 255) == U256::from(1) { (!value).wrapping_add(U256::from(1)) } else { value }
-}
-
-pub(crate) fn sdiv(left: U256, right: U256) -> U256 {
-    if right.is_zero() {
-        return U256::ZERO;
-    }
-    let left_negative = (left >> 255) == U256::from(1);
-    let right_negative = (right >> 255) == U256::from(1);
-    let quotient = signed_abs(left) / signed_abs(right);
-    if left_negative ^ right_negative { (!quotient).wrapping_add(U256::from(1)) } else { quotient }
-}
-
-pub(crate) fn smod(left: U256, right: U256) -> U256 {
-    if right.is_zero() {
-        return U256::ZERO;
-    }
-    let left_negative = (left >> 255) == U256::from(1);
-    let remainder = signed_abs(left) % signed_abs(right);
-    if left_negative { (!remainder).wrapping_add(U256::from(1)) } else { remainder }
 }
 
 pub(crate) fn signextend(byte_index: U256, value: U256) -> U256 {
@@ -166,18 +119,6 @@ pub(crate) fn byte_expr(cx: &mut SymCx, index: usize, expr: &SymExpr) -> SymExpr
         return SymExpr::constant(cx, U256::from(byte));
     }
     expr.extracted_byte(cx, index)
-}
-
-pub(crate) fn sar(value: U256, shift: usize) -> U256 {
-    if shift >= 256 {
-        if (value >> 255) == U256::from(1) { U256::MAX } else { U256::ZERO }
-    } else if shift == 0 {
-        value
-    } else if (value >> 255) == U256::from(1) {
-        (value >> shift) | (U256::MAX << (256 - shift))
-    } else {
-        value >> shift
-    }
 }
 
 pub(crate) fn shift_left(cx: &mut SymCx, value: SymExpr, bits: usize) -> SymExpr {

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -1,4 +1,5 @@
 use super::{hashcons::HashConsed, *};
+use foundry_evm::revm::interpreter::instructions::i256::i256_cmp;
 
 /// Bounds both the number of distinct word nodes inspected by constant-ITE equality expansion and
 /// the unfolded size of the Boolean expression it could produce.
@@ -871,8 +872,8 @@ impl SymCmpOp {
             Self::Ugt => left > right,
             Self::Ule => left <= right,
             Self::Uge => left >= right,
-            Self::Slt => slt(left, right),
-            Self::Sgt => slt(right, left),
+            Self::Slt => i256_cmp(&left, &right).is_lt(),
+            Self::Sgt => i256_cmp(&left, &right).is_gt(),
         }
     }
 }

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -1,4 +1,5 @@
 use super::{hashcons::HashConsed, *};
+use foundry_evm::revm::interpreter::instructions::i256::{i256_div, i256_mod};
 
 // Boolean selector recovery is an optional expression rewrite. Bound it to one word's worth of
 // unique nodes so adversarial expression trees cannot make construction unbounded.
@@ -2206,8 +2207,8 @@ impl SymBinOp {
                     left % right
                 }
             }
-            Self::SDiv => sdiv(left, right),
-            Self::SRem => smod(left, right),
+            Self::SDiv => i256_div(left, right),
+            Self::SRem => i256_mod(left, right),
             Self::And => left & right,
             Self::Or => left | right,
             Self::Xor => left ^ right,
@@ -2227,9 +2228,9 @@ impl SymBinOp {
             }
             Self::Sar => {
                 if right >= U256::from(256) {
-                    sar(left, 256)
+                    left.arithmetic_shr(256)
                 } else {
-                    sar(left, usize::try_from(right).expect("checked word shift"))
+                    left.arithmetic_shr(usize::try_from(right).expect("checked word shift"))
                 }
             }
         }

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -609,7 +609,7 @@ impl PathState {
                 match kind {
                     ShiftKind::Shl => value << shift,
                     ShiftKind::Shr => value >> shift,
-                    ShiftKind::Sar => sar(value, shift),
+                    ShiftKind::Sar => value.arithmetic_shr(shift),
                 }
             };
             SymExpr::constant(cx, result)
@@ -630,7 +630,7 @@ impl PathState {
         let exponent = self.stack.pop()?;
         let result = if let Some(exponent) = self.constrained_word(cx, &exponent) {
             if let Some(base_value) = base.as_const() {
-                SymExpr::constant(cx, pow_mod(base_value, exponent))
+                SymExpr::constant(cx, base_value.wrapping_pow(exponent))
             } else if exponent <= U256::from(SYMBOLIC_EXP_CONCRETE_EXPONENT_LIMIT) {
                 exp_expr_for_concrete_exponent(
                     cx,

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -97,15 +97,53 @@ fn comparison_helpers_use_evm_operand_order() {
 }
 
 #[test]
+fn signed_arithmetic_preserves_evm_boundaries() {
+    let min = U256::from(1) << 255;
+    let negative_seven = U256::ZERO.wrapping_sub(U256::from(7));
+    let negative_three = U256::ZERO.wrapping_sub(U256::from(3));
+    for (left, right, quotient, remainder) in [
+        (min, U256::MAX, min, U256::ZERO),
+        (min, U256::from(1), min, U256::ZERO),
+        (min, min, U256::from(1), U256::ZERO),
+        (min, U256::ZERO, U256::ZERO, U256::ZERO),
+        (U256::ZERO, min, U256::ZERO, U256::ZERO),
+        (negative_seven, U256::from(3), U256::MAX - U256::from(1), U256::MAX),
+        (U256::from(7), negative_three, U256::MAX - U256::from(1), U256::from(1)),
+        (negative_seven, negative_three, U256::from(2), U256::MAX),
+    ] {
+        let mut cx = SymCx::new();
+        for (op, expected) in [(SymBinOp::SDiv, quotient), (SymBinOp::SRem, remainder)] {
+            let left = SymExpr::constant(&mut cx, left);
+            let right = SymExpr::constant(&mut cx, right);
+            assert_eq!(SymExpr::binop(&mut cx, op, left, right).as_const(), Some(expected));
+        }
+    }
+
+    let ordered = [min, negative_seven, U256::MAX, U256::ZERO, U256::from(1), min - U256::from(1)];
+    for (i, &left) in ordered.iter().enumerate() {
+        for (j, &right) in ordered.iter().enumerate() {
+            assert_eq!(SymCmpOp::Slt.eval(left, right), i < j);
+            assert_eq!(SymCmpOp::Sgt.eval(left, right), i > j);
+        }
+    }
+}
+
+#[test]
 fn exp_helper_uses_evm_operand_order() {
     let mut cx = SymCx::new();
-    let mut state = empty_state(&mut cx);
-    state.stack.push(SymExpr::constant(&mut cx, U256::ZERO)).unwrap();
-    state.stack.push(SymExpr::constant(&mut cx, U256::from(0x100))).unwrap();
-
-    state.exp_word(&mut cx).unwrap();
-
-    assert_eq!(state.stack.pop().unwrap(), SymExpr::constant(&mut cx, U256::from(1)));
+    for (base, exponent, expected) in [
+        (U256::from(0x100), U256::ZERO, U256::from(1)),
+        (U256::ZERO, U256::ZERO, U256::from(1)),
+        (U256::from(2), U256::from(256), U256::ZERO),
+        (U256::MAX, U256::from(2), U256::from(1)),
+        (U256::MAX, U256::MAX, U256::MAX),
+    ] {
+        let mut state = empty_state(&mut cx);
+        state.stack.push(SymExpr::constant(&mut cx, exponent)).unwrap();
+        state.stack.push(SymExpr::constant(&mut cx, base)).unwrap();
+        state.exp_word(&mut cx).unwrap();
+        assert_eq!(state.stack.pop().unwrap().as_const(), Some(expected));
+    }
 }
 
 #[test]
@@ -144,6 +182,35 @@ fn exp_helper_expands_bounded_symbolic_exponent() {
             .unwrap(),
         U256::from(243)
     );
+}
+
+#[test]
+fn arithmetic_shift_preserves_sign_at_word_boundaries() {
+    let mut cx = SymCx::new();
+    let min = U256::from(1) << 255;
+    for (value, shift, expected) in [
+        (min, U256::ZERO, min),
+        (min, U256::from(1), min | (min >> 1)),
+        (min, U256::from(255), U256::MAX),
+        (min, U256::from(256), U256::MAX),
+        (min, U256::MAX, U256::MAX),
+        (U256::from(4), U256::from(1), U256::from(2)),
+        (min - U256::from(1), U256::from(255), U256::ZERO),
+        (U256::from(4), U256::from(256), U256::ZERO),
+        (U256::from(4), U256::MAX, U256::ZERO),
+    ] {
+        let mut state = empty_state(&mut cx);
+        state.stack.push(SymExpr::constant(&mut cx, value)).unwrap();
+        state.stack.push(SymExpr::constant(&mut cx, shift)).unwrap();
+        state.shift_word(&mut cx, ShiftKind::Sar).unwrap();
+        assert_eq!(state.stack.pop().unwrap().as_const(), Some(expected));
+
+        let word = SymExpr::var(&mut cx, "word");
+        let amount = SymExpr::var(&mut cx, "amount");
+        let expr = SymExpr::binop(&mut cx, SymBinOp::Sar, word, amount);
+        let model = symbolic_model(&mut cx, [("word", value), ("amount", shift)]);
+        assert_eq!(expr.eval_model(&model).unwrap(), expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Reuse revm's signed division, remainder, and comparison helpers and U256's wrapping exponentiation and arithmetic right shift in the symbolic engine. This removes six local helpers while preserving concrete evaluation, symbolic expression construction, and execution bounds. Keep `SIGNEXTEND` local because there is no equivalent standalone dependency API.

Code and tests written with Codex, with an Omp/Astra consultation on dependency semantics.
