### PR TITLE
fix(symbolic): refund retry depth on ambiguous mapping sstore forks

### DIFF
--- a/.changelog/symbolic-sstore-mapping-fork-depth.md
+++ b/.changelog/symbolic-sstore-mapping-fork-depth.md
@@ -1,0 +1,5 @@
+---
+foundry-evm-symbolic: patch
+---
+
+Fixed symbolic tests and invariant runs wasting execution depth on ambiguous mapping SSTORE forks, which could spuriously report Incomplete when reaching the depth limit.

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -990,9 +990,11 @@ impl SymbolicExecutor {
                         let store_pc = state.pc - 1;
                         let mut equality_state = state.clone();
                         equality_state.pc = store_pc;
+                        equality_state.depth = equality_state.depth.saturating_sub(1);
                         equality_state.constraints = equality;
                         let mut inequality_state = state.clone();
                         inequality_state.pc = store_pc;
+                        inequality_state.depth = inequality_state.depth.saturating_sub(1);
                         inequality_state.constraints = inequality;
                         worklist.push_back(equality_state);
                         worklist.push_back(inequality_state);
@@ -1563,6 +1565,10 @@ impl SymbolicExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use foundry_evm::{
+        core::{backend::Backend, evm::EthEvmNetwork},
+        executors::ExecutorBuilder,
+    };
 
     fn empty_state(executor: &mut SymbolicExecutor) -> PathState {
         let calldata =
@@ -1590,6 +1596,62 @@ mod tests {
         assert!(accepted);
         assert!(state.constraints.is_empty());
         assert!(state.satisfies_branch_target());
+    }
+
+    #[test]
+    fn sstore_mapping_fork_refunds_retry_depth() {
+        let mut executor = SymbolicExecutor::new(SymbolicConfig::default());
+        if let Err(err) = executor.solver.check_available() {
+            let _ = foundry_common::sh_eprintln!(
+                "skipping sstore_mapping_fork_refunds_retry_depth: {err}"
+            );
+            return;
+        }
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let concrete = ExecutorBuilder::default().build(
+            Default::default(),
+            Default::default(),
+            backend,
+            Default::default(),
+        );
+        let mut state = empty_state(&mut executor);
+        let original_depth = 7;
+        state.depth = original_depth;
+        state.mapping_storage_store_hooks.insert(
+            (state.storage_address, U256::ZERO),
+            SymbolicStorageHook {
+                callback_target: Address::repeat_byte(0x22),
+                callback_selector: [0x12, 0x34, 0x56, 0x78],
+            },
+        );
+        let preimage = vec![SymExpr::zero(&mut executor.cx); 64];
+        let hash = keccak_word(&mut executor.cx, preimage.clone());
+        state.mapping_hook_keccak_preimages.insert((state.storage_address, hash), preimage.into());
+        let key = state.fresh_word(&mut executor.cx, "storage_key");
+        state.stack.push(SymExpr::one(&mut executor.cx)).unwrap();
+        state.stack.push(key).unwrap();
+        let code = SymCode::concrete(&mut executor.cx, vec![opcode::SSTORE]);
+        let mut worklist = VecDeque::new();
+        let mut completed_paths = 0;
+
+        let outcome = executor
+            .step(
+                &concrete,
+                &code,
+                code.jump_table(),
+                &mut state,
+                &mut worklist,
+                &mut completed_paths,
+                opcode::SSTORE,
+            )
+            .unwrap();
+
+        assert!(matches!(outcome, StepOutcome::Forked));
+        assert_eq!(worklist.len(), 2);
+        for retry in worklist {
+            assert_eq!(retry.pc, 0);
+            assert_eq!(retry.depth, original_depth - 1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
tl;dr the SSTORE mapping-fork retry idiom forgot the depth refund its own sibling already does, so ambiguous mapping writes burn depth budget 2x and can spuriously report Incomplete.

## What's broken

`crates/evm/symbolic` bounds exploration of a single path via `PathState.depth`, incremented once per opcode-dispatch attempt in both driver loops (`executor/run.rs`, `executor/mod.rs`), regardless of the resulting `StepOutcome`.

Some opcode handlers defer a decision by cloning the state, rewinding `pc` back to the same instruction, and pushing the clone to the worklist to retry later - since the driver will charge `depth` again on that later re-dispatch, this idiom must also refund one `depth` unit before pushing, or the same logical instruction costs 2 units instead of 1.

`apply_memory_access_guard`'s `(true, true)` arm already does this correctly:

```rust
let mut valid = state.clone();
valid.pc = valid.pc.saturating_sub(1);
valid.depth = valid.depth.saturating_sub(1);   // the refund
...
worklist.push_back(valid);
```

SSTORE's mapping-storage-provenance fork case (same file) does the identical rewind-and-retry idiom - triggered when a SSTORE's key is symbolic and ambiguous relative to a previously-observed mapping slot (`classify_mapping_match` found both "key equals this slot's hash" and "key does not" independently satisfiable) - but refunds nothing on either pushed clone:

```rust
MappingStorageProvenance::Fork { equality, inequality } => {
    let store_pc = state.pc - 1;
    let mut equality_state = state.clone();
    equality_state.pc = store_pc;
    equality_state.constraints = equality;
    let mut inequality_state = state.clone();
    inequality_state.pc = store_pc;
    inequality_state.constraints = inequality;
    worklist.push_back(equality_state);
    worklist.push_back(inequality_state);
    return Ok(StepOutcome::Forked);
}
```

Unlike the memory-guard case (only `valid` is pushed; `state` continues live as an immediately-completing Revert), here BOTH clones are pushed and the original `state` (whose depth was already charged) is discarded entirely - so both clones need the refund.

Net effect: every SSTORE to an ambiguous-provenance mapping slot (a common pattern - `balances[user] = amount` with a symbolic `user`) burns 2 depth units per branch instead of 1, silently halving the effective depth budget for contracts exercising it. A contract whose real control-flow complexity would otherwise fit comfortably within the configured `execution_depth` can spuriously hit the depth limit and get reported `Incomplete`/`Stuck` instead of `Safe` or a real counterexample - no signal to the user that ambiguous mapping SSTOREs are the cause.

## Fix

Refund one `depth` unit on both forked clones, matching the sibling convention exactly.

## Testing

Added `sstore_mapping_fork_refunds_retry_depth` - real `step()` dispatch of a symbolic SSTORE against a registered mapping-storage hook with an ambiguous key, asserting `StepOutcome::Forked`, `worklist.len() == 2`, and every retry state's `depth == original_depth - 1`.

Revert-then-restore cycle (proving the test actually catches the bug):
- fix applied: `test result: ok. 1 passed`
- only the two `.saturating_sub(1)` lines reverted, test kept: `assertion left == right failed, left: 7, right: 6` -> FAILED
- fix restored: `test result: ok. 1 passed`

Full crate suite after restoring the fix: `test result: ok. 346 passed; 0 failed`. `cargo clippy -p foundry-evm-symbolic --all-targets --tests -- -D warnings` clean.

## Process note

Implemented via `codex exec -m gpt-6-astra` (independently re-derived and confirmed the diagnosis before touching code), reviewed by a second-opinion pass before opening. The reviewer raised a fair question - could refunding depth turn a re-forking SSTORE into an unbounded loop if the solver returns Unknown on a retry instead of resolving definitively? Checked: `classify_mapping_match`'s SAT checks go through `constraints_with_condition`, which propagates a solver-Unknown as a hard `Err` (aborting the run as `Incomplete`), not as "satisfiable" - so this fix carries no new non-termination risk on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)