### PR TITLE
fix(deps): bump foundry-core for Rootstock

### DIFF
--- a/.changelog/rootstock-fork-block-id.md
+++ b/.changelog/rootstock-fork-block-id.md
@@ -1,0 +1,9 @@
+---
+anvil: patch
+forge: patch
+cast: patch
+chisel: patch
+foundry-evm-core: patch
+---
+
+Fixed anchored forks failing against Rootstock RPC nodes that reject a boolean `requireCanonical` block parameter.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5572,7 +5572,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=78e5b57f86986eabd969a5fdf238b8159f7086fd#78e5b57f86986eabd969a5fdf238b8159f7086fd"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=957d190a53f3e287911ff50cbb55b340a99c2c19#957d190a53f3e287911ff50cbb55b340a99c2c19"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5815,7 +5815,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=78e5b57f86986eabd969a5fdf238b8159f7086fd#78e5b57f86986eabd969a5fdf238b8159f7086fd"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=957d190a53f3e287911ff50cbb55b340a99c2c19#957d190a53f3e287911ff50cbb55b340a99c2c19"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5846,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=78e5b57f86986eabd969a5fdf238b8159f7086fd#78e5b57f86986eabd969a5fdf238b8159f7086fd"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=957d190a53f3e287911ff50cbb55b340a99c2c19#957d190a53f3e287911ff50cbb55b340a99c2c19"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5855,7 +5855,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=78e5b57f86986eabd969a5fdf238b8159f7086fd#78e5b57f86986eabd969a5fdf238b8159f7086fd"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=957d190a53f3e287911ff50cbb55b340a99c2c19#957d190a53f3e287911ff50cbb55b340a99c2c19"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=78e5b57f86986eabd969a5fdf238b8159f7086fd#78e5b57f86986eabd969a5fdf238b8159f7086fd"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=957d190a53f3e287911ff50cbb55b340a99c2c19#957d190a53f3e287911ff50cbb55b340a99c2c19"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5888,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=78e5b57f86986eabd969a5fdf238b8159f7086fd#78e5b57f86986eabd969a5fdf238b8159f7086fd"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=957d190a53f3e287911ff50cbb55b340a99c2c19#957d190a53f3e287911ff50cbb55b340a99c2c19"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=6cca44292db0817340a0e3129170ec2041301d75#6cca44292db0817340a0e3129170ec2041301d75"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=957d190a53f3e287911ff50cbb55b340a99c2c19#957d190a53f3e287911ff50cbb55b340a99c2c19"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6334,7 +6334,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=78e5b57f86986eabd969a5fdf238b8159f7086fd#78e5b57f86986eabd969a5fdf238b8159f7086fd"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=957d190a53f3e287911ff50cbb55b340a99c2c19#957d190a53f3e287911ff50cbb55b340a99c2c19"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -571,10 +571,10 @@ solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e91527
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "4237b97e9152721e4d2236d2304ae480fd18655c" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "78e5b57f86986eabd969a5fdf238b8159f7086fd" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "78e5b57f86986eabd969a5fdf238b8159f7086fd" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "78e5b57f86986eabd969a5fdf238b8159f7086fd" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "6cca44292db0817340a0e3129170ec2041301d75" }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "957d190a53f3e287911ff50cbb55b340a99c2c19" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "957d190a53f3e287911ff50cbb55b340a99c2c19" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "957d190a53f3e287911ff50cbb55b340a99c2c19" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "957d190a53f3e287911ff50cbb55b340a99c2c19" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }


### PR DESCRIPTION
Bumps the foundry-core revisions in `Cargo.toml` and `Cargo.lock` to `957d190a53f3e287911ff50cbb55b340a99c2c19`, picking up https://github.com/foundry-rs/foundry-core/pull/190 to fix anchored forks against Rootstock RPC nodes that reject boolean `requireCanonical` values.

Stacked on #16409 because this foundry-core revision requires revm 43. Closes #16769 once the stack reaches master.

Codex prepared the dependency bump, lockfile update, changelog entry, and PR description.
