### PR TITLE
fix(anvil): preserve Arbitrum L1 block numbers

### DIFF
--- a/.changelog/anvil-arbitrum-l1-block-number.md
+++ b/.changelog/anvil-arbitrum-l1-block-number.md
@@ -2,4 +2,4 @@
 anvil: patch
 ---
 
-Preserved Arbitrum forks' L1 `block.number` during local mining, pending and historical calls, and snapshot restoration while keeping RPC and ArbSys block numbers on L2.
+Preserved Arbitrum forks' L1 `block.number` during local mining, pending and historical calls, `eth_simulateV1`, and snapshot restoration while keeping RPC and ArbSys block numbers on L2.

--- a/.changelog/anvil-arbitrum-l1-block-number.md
+++ b/.changelog/anvil-arbitrum-l1-block-number.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Preserved Arbitrum forks' L1 `block.number` during local mining, pending and historical calls, and snapshot restoration while keeping RPC and ArbSys block numbers on L2.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -2099,6 +2099,7 @@ latest block number: {latest_block}"
         let config = ClientForkConfig {
             fork_urls: self.fork_urls.clone(),
             block_number: fork_block_number,
+            evm_block_number: evm_env.block_env.number.saturating_to(),
             block_hash,
             transaction_hash: self.fork_choice.and_then(|fc| fc.transaction_hash()),
             provider,

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -136,6 +136,25 @@ impl<N: Network> ClientFork<N> {
         self.config.read().block_number
     }
 
+    /// Converts a local RPC block number to its EVM-visible number.
+    ///
+    /// Local mining advances both numbers once per block, preserving the fork root's offset.
+    pub fn evm_block_number(&self, rpc_number: u64) -> U256 {
+        let config = self.config.read();
+        U256::from(rpc_number)
+            .saturating_add(U256::from(config.evm_block_number))
+            .saturating_sub(U256::from(config.block_number))
+    }
+
+    /// Converts a local EVM-visible block number to its RPC number.
+    pub fn rpc_block_number(&self, evm_number: U256) -> u64 {
+        let config = self.config.read();
+        evm_number
+            .saturating_add(U256::from(config.block_number))
+            .saturating_sub(U256::from(config.evm_block_number))
+            .saturating_to()
+    }
+
     /// Returns the transaction hash we forked off of, if any.
     pub fn transaction_hash(&self) -> Option<B256> {
         self.config.read().transaction_hash
@@ -849,6 +868,8 @@ pub struct ClientForkConfig<N: Network = AnyNetwork> {
     pub fork_urls: Vec<String>,
     /// The block number of the forked block
     pub block_number: u64,
+    /// The EVM-visible block number of the fork root, which is the L1 number on Arbitrum.
+    pub evm_block_number: u64,
     /// The hash of the forked block
     pub block_hash: B256,
     /// The transaction hash we forked off of, if any.
@@ -898,12 +919,14 @@ impl<N: Network> ClientForkConfig<N> {
     pub fn update_block(
         &mut self,
         block_number: u64,
+        evm_block_number: u64,
         block_hash: B256,
         timestamp: u64,
         base_fee: Option<u128>,
         total_difficulty: U256,
     ) {
         self.block_number = block_number;
+        self.evm_block_number = evm_block_number;
         self.block_hash = block_hash;
         self.timestamp = timestamp;
         self.base_fee = base_fee;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -7992,6 +7992,10 @@ impl Backend<FoundryNetwork> {
                 if let Some(block_overrides) = block_overrides {
                     cache_db.apply_block_overrides(block_overrides, &mut block_env);
                 }
+                // Simulation overrides and RPC results use L2 numbers, while Arbitrum
+                // execution reads the corresponding L1 number through NUMBER.
+                let rpc_block_number = block_env.number.saturating_to();
+                block_env.number = self.evm_block_number(rpc_block_number);
                 let simulation_evm_env =
                     EvmEnv::new(self.evm_env.read().cfg_env.clone(), block_env.clone());
                 let spec_id = *simulation_evm_env.spec_id();
@@ -8384,7 +8388,7 @@ impl Backend<FoundryNetwork> {
                             .into_iter()
                             .map(|(idx, log)| Log {
                                 inner: log,
-                                block_number: Some(block_env.number.saturating_to()),
+                                block_number: Some(rpc_block_number),
                                 block_timestamp: Some(block_env.timestamp.saturating_to()),
                                 transaction_index: Some(req_idx as u64),
                                 log_index: Some(idx + log_index),
@@ -8444,7 +8448,7 @@ impl Backend<FoundryNetwork> {
                     beneficiary: block_env.beneficiary,
                     state_root,
                     difficulty: block_env.difficulty,
-                    number: block_env.number.saturating_to(),
+                    number: rpc_block_number,
                     gas_limit: block_env.gas_limit,
                     gas_used,
                     timestamp: block_env.timestamp.saturating_to(),
@@ -8504,13 +8508,16 @@ impl Backend<FoundryNetwork> {
                     });
                 }
 
-                let simulated_block = SimulatedBlock {
-                    inner: AnyRpcBlock::new(WithOtherFields::new(block)),
-                    calls: call_res,
-                };
+                let mut block = AnyRpcBlock::new(WithOtherFields::new(block));
+                if is_arbitrum(self.protocol_chain_id()) {
+                    block
+                        .other
+                        .insert("l1BlockNumber".to_string(), serde_json::json!(block_env.number));
+                }
+                let simulated_block = SimulatedBlock { inner: block, calls: call_res };
 
                 parent_hash = block_hash;
-                cache_db.cache.block_hashes.insert(block_env.number, block_hash);
+                cache_db.cache.block_hashes.insert(U256::from(rpc_block_number), block_hash);
                 inherited_block_env.beneficiary = block_env.beneficiary;
                 inherited_block_env.difficulty = block_env.difficulty;
                 inherited_block_env.gas_limit = block_env.gas_limit;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1657,6 +1657,19 @@ impl<N: Network> Backend<N> {
             .collect()
     }
 
+    /// Returns the EVM-visible number for a locally mined RPC block.
+    fn evm_block_number(&self, rpc_number: u64) -> U256 {
+        self.get_fork()
+            .map_or_else(|| U256::from(rpc_number), |fork| fork.evm_block_number(rpc_number))
+    }
+
+    /// Restores the execution number separately from the RPC header number.
+    fn block_env_from_header(&self, header: &impl BlockHeader) -> BlockEnv {
+        let mut block = block_env_from_header::<BlockEnv>(header);
+        block.number = self.evm_block_number(header.number());
+        block
+    }
+
     /// Returns the environment for the next block
     fn next_evm_env(&self) -> EvmEnv {
         let mut evm_env = self.evm_env.read().clone();
@@ -1671,7 +1684,7 @@ impl<N: Network> Backend<N> {
     /// Returns the environment for replaying transactions from a historical block.
     fn tx_replay_evm_env(&self, block: &Block) -> (EvmEnv, FoundryHardfork) {
         let mut evm_env = self.evm_env.read().clone();
-        evm_env.block_env = block_env_from_header(&block.header);
+        evm_env.block_env = self.block_env_from_header(&block.header);
         let hardfork = self.hardfork();
         #[cfg(feature = "monad")]
         let hardfork = if self.is_monad() {
@@ -2086,7 +2099,10 @@ impl<N: Network> Backend<N> {
         // If Arbitrum, apply chain specifics to converted block.
         if is_arbitrum(self.protocol_chain_id()) {
             // Set `l1BlockNumber` field.
-            block.other.insert("l1BlockNumber".to_string(), number.into());
+            block.other.insert(
+                "l1BlockNumber".to_string(),
+                serde_json::json!(self.evm_block_number(number)),
+            );
         }
 
         if let Some((
@@ -3363,8 +3379,11 @@ impl<N: Network> Backend<N> {
             return None;
         }
 
-        let env_block = evm_env.block_env.number.saturating_to();
-        Some(self.get_fork().map_or(env_block, |fork| fork.block_number().max(env_block)))
+        let env_block = evm_env.block_env.number;
+        Some(
+            self.get_fork()
+                .map_or_else(|| env_block.saturating_to(), |fork| fork.rpc_block_number(env_block)),
+        )
     }
 
     pub fn get_code_with_state(
@@ -4788,7 +4807,7 @@ impl<N: Network> Backend<N> {
         {
             let mut env = self.evm_env.write();
             env.block_env = BlockEnv {
-                number: U256::from(num),
+                number: self.evm_block_number(num),
                 timestamp: U256::from(block.header.timestamp()),
                 difficulty: block.header.difficulty(),
                 // ensures prevrandao is set
@@ -5058,11 +5077,7 @@ where
 
         let best_number = self.blockchain.storage.read().best_number;
         let block_number = best_number.saturating_add(1);
-        if arbitrum_block_numbers.is_some() {
-            evm_env.block_env.number = U256::from(block_number);
-        } else {
-            evm_env.block_env.number = evm_env.block_env.number.saturating_add(U256::from(1));
-        }
+        evm_env.block_env.number = evm_env.block_env.number.saturating_add(U256::from(1));
         evm_env.block_env.basefee = current_base_fee;
         evm_env.block_env.blob_excess_gas_and_price = current_excess_blob_gas_and_price;
         evm_env.block_env.timestamp = U256::from(timestamp);
@@ -5412,13 +5427,9 @@ where
 
             let block_number = self.blockchain.storage.read().best_number.saturating_add(1);
 
-            // increase block number for this block
-            if is_arbitrum(self.protocol_chain_id()) {
-                // Temporary set `env.block.number` to `block_number` for Arbitrum chains.
-                evm_env.block_env.number = U256::from(block_number);
-            } else {
-                evm_env.block_env.number = evm_env.block_env.number.saturating_add(U256::from(1));
-            }
+            // Advance the EVM number independently of the RPC header number. On Arbitrum
+            // forks this preserves the L1 number read by NUMBER while the header tracks L2.
+            evm_env.block_env.number = evm_env.block_env.number.saturating_add(U256::from(1));
 
             evm_env.block_env.basefee = current_base_fee;
             evm_env.block_env.blob_excess_gas_and_price = current_excess_blob_gas_and_price;
@@ -5721,7 +5732,7 @@ where
         let cache_db = cache_db.0;
 
         let state_root = cache_db.maybe_state_root().unwrap_or_default();
-        let block_number = evm_env.block_env.number.saturating_to();
+        let block_number = self.best_number().saturating_add(1);
         let block_info = self.build_block_info(
             &evm_env,
             parent_hash,
@@ -6192,7 +6203,7 @@ where
                 let result = self
                     .with_pending_block(pool_transactions, |state, block| {
                         let block = block.block;
-                        f(state, block_env_from_header(&block.header))
+                        f(state, self.block_env_from_header(&block.header))
                     })
                     .await?;
                 return Ok(result);
@@ -6216,12 +6227,12 @@ where
             {
                 let read_guard = self.states.upgradable_read();
                 if let Some(state_db) = read_guard.get_state(&block_hash) {
-                    return Ok(f(Box::new(state_db), block_env_from_header(&block.header)));
+                    return Ok(f(Box::new(state_db), self.block_env_from_header(&block.header)));
                 }
 
                 let mut write_guard = RwLockUpgradableReadGuard::upgrade(read_guard);
                 if let Some(state) = write_guard.get_on_disk_state(&block_hash) {
-                    return Ok(f(Box::new(state), block_env_from_header(&block.header)));
+                    return Ok(f(Box::new(state), self.block_env_from_header(&block.header)));
                 }
             }
 
@@ -6255,7 +6266,7 @@ where
                             &block_info.block,
                             block_info.block.body.transactions.len(),
                         )?;
-                        let block_env = block_env_from_header(&block_info.block.header);
+                        let block_env = self.block_env_from_header(&block_info.block.header);
                         f(state, block_env, context)
                     })
                     .await?;
@@ -6287,12 +6298,16 @@ where
             {
                 let read_guard = self.states.upgradable_read();
                 if let Some(state_db) = read_guard.get_state(&block_hash) {
-                    return f(Box::new(state_db), block_env_from_header(&block.header), context);
+                    return f(
+                        Box::new(state_db),
+                        self.block_env_from_header(&block.header),
+                        context,
+                    );
                 }
 
                 let mut write_guard = RwLockUpgradableReadGuard::upgrade(read_guard);
                 if let Some(state) = write_guard.get_on_disk_state(&block_hash) {
-                    return f(Box::new(state), block_env_from_header(&block.header), context);
+                    return f(Box::new(state), self.block_env_from_header(&block.header), context);
                 }
             }
 
@@ -6862,7 +6877,7 @@ where
 
             // Set environment back to common block
             let mut env = self.evm_env.write();
-            env.block_env.number = U256::from(common_block.header.number());
+            env.block_env.number = self.evm_block_number(common_block.header.number());
             env.block_env.timestamp = U256::from(common_block.header.timestamp());
             env.block_env.gas_limit = common_block.header.gas_limit();
             env.block_env.difficulty = common_block.header.difficulty();
@@ -7547,7 +7562,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         if let Some(block) = block_env.as_mut() {
             // Keep NUMBER aligned with the canonical local head chosen above. Arbitrum state dumps
             // can intentionally keep BlockEnv.number distinct from the best L2 block number.
-            if !is_arbitrum(self.chain_id().to())
+            if !is_arbitrum(self.protocol_chain_id())
                 && let Some((number, _)) = selected_head
             {
                 block.number = U256::from(number);
@@ -8533,7 +8548,7 @@ impl Backend<FoundryNetwork> {
                     };
                     simulate_at(
                         state,
-                        block_env_from_header(header),
+                        self.block_env_from_header(header),
                         header.number(),
                         header.timestamp(),
                         header.hash_slow(),

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -2508,16 +2508,16 @@ async fn flaky_test_arb_fork_mining() {
     assert_eq!(mined_blk_num, init_blk_num + 1);
 }
 
-// <https://github.com/foundry-rs/foundry/issues/16768>
-#[tokio::test(flavor = "multi_thread")]
-async fn test_arbitrum_fork_preserves_l1_block_number_after_mining() {
-    const L2_BLOCK: u64 = 503_433_721;
-    const L1_BLOCK: u64 = 25_941_231;
-    let target = Address::random();
+/// Serves an Arbitrum fork root with distinct L1 and L2 block numbers.
+async fn spawn_arbitrum_block_number_source(
+    target: Address,
+    l2_block: u64,
+    l1_block: u64,
+) -> (NodeHandle, String, tokio::task::JoinHandle<()>) {
     let (origin_api, origin) = spawn(
         NodeConfig::test()
             .with_chain_id(Some(NamedChain::Arbitrum as u64))
-            .with_genesis_block_number(Some(L2_BLOCK)),
+            .with_genesis_block_number(Some(l2_block)),
     )
     .await;
     // Store NUMBER in slot zero and return it, exercising both calls and mined transactions.
@@ -2546,7 +2546,7 @@ async fn test_arbitrum_fork_preserves_l1_block_number_after_mining() {
                 {
                     block.insert(
                         "l1BlockNumber".to_string(),
-                        Value::String(format!("0x{L1_BLOCK:x}")),
+                        Value::String(format!("0x{l1_block:x}")),
                     );
                 }
                 Json(response)
@@ -2557,11 +2557,23 @@ async fn test_arbitrum_fork_preserves_l1_block_number_after_mining() {
     let address = listener.local_addr().unwrap();
     let proxy = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
 
+    (origin, format!("http://{address}"), proxy)
+}
+
+// <https://github.com/foundry-rs/foundry/issues/16768>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_arbitrum_fork_preserves_l1_block_number_after_mining() {
+    const L2_BLOCK: u64 = 503_433_721;
+    const L1_BLOCK: u64 = 25_941_231;
+    let target = Address::random();
+    let (_origin, endpoint, proxy) =
+        spawn_arbitrum_block_number_source(target, L2_BLOCK, L1_BLOCK).await;
+
     for chain_id in [None, Some(1u64)] {
         let config = NodeConfig::test()
             .with_chain_id(chain_id)
             .with_no_storage_caching(true)
-            .with_eth_rpc_url(Some(format!("http://{address}")))
+            .with_eth_rpc_url(Some(endpoint.clone()))
             .with_fork_block_number(Some(L2_BLOCK));
         let (api, handle) = spawn(config).await;
         let provider = handle.http_provider();
@@ -2674,7 +2686,7 @@ async fn test_arbitrum_fork_preserves_l1_block_number_after_mining() {
             U256::from(L2_BLOCK + 3)
         );
         api.anvil_reset(Some(Forking {
-            json_rpc_url: Some(format!("http://{address}")),
+            json_rpc_url: Some(endpoint.clone()),
             block_number: Some(L2_BLOCK),
         }))
         .await
@@ -2684,6 +2696,83 @@ async fn test_arbitrum_fork_preserves_l1_block_number_after_mining() {
             U256::from_be_slice(&provider.call(request).block(BlockId::latest()).await.unwrap()),
             U256::from(L1_BLOCK + 1)
         );
+    }
+    proxy.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_arbitrum_fork_simulate_preserves_l1_and_l2_block_numbers() {
+    const L2_BLOCK: u64 = 503_433_721;
+    const L1_BLOCK: u64 = 25_941_231;
+    let target = Address::random();
+    let (_origin, endpoint, proxy) =
+        spawn_arbitrum_block_number_source(target, L2_BLOCK, L1_BLOCK).await;
+    let client = reqwest::Client::new();
+
+    for chain_id in [None, Some(1u64)] {
+        let (api, handle) = spawn(
+            NodeConfig::test()
+                .with_chain_id(chain_id)
+                .with_no_storage_caching(true)
+                .with_eth_rpc_url(Some(endpoint.clone()))
+                .with_fork_block_number(Some(L2_BLOCK)),
+        )
+        .await;
+        api.mine_one().await.unwrap();
+        api.mine_one().await.unwrap();
+
+        for (base, offset) in [
+            (serde_json::json!("latest"), 3),
+            (serde_json::json!("pending"), 4),
+            (serde_json::json!(format!("0x{:x}", L2_BLOCK + 1)), 2),
+        ] {
+            // Return and log NUMBER, while also calling ArbSys directly.
+            let calls = serde_json::json!([
+                {"to": target},
+                {"to": arbitrum::ARB_SYS_ADDRESS, "input": "0xa3b1b31d"}
+            ]);
+            let response = client.post(handle.http_endpoint()).json(&serde_json::json!({
+                "jsonrpc": "2.0", "id": 1, "method": "eth_simulateV1",
+                "params": [{
+                    "returnFullTransactions": true,
+                    "blockStateCalls": [
+                        {
+                            "stateOverrides": {target.to_string(): {
+                                "code": "0x4360005260206000a060206000f3"
+                            }},
+                            "calls": calls.clone()
+                        },
+                        {
+                            "blockOverrides": {"number": format!("0x{:x}", L2_BLOCK + offset + 2)},
+                            "calls": calls
+                        }
+                    ]
+                }, base]
+            })).send().await.unwrap().json::<Value>().await.unwrap();
+            assert!(response.get("error").is_none(), "{response}");
+            let blocks = response["result"].as_array().unwrap();
+            assert_eq!(blocks.len(), 3);
+            for (index, block) in blocks.iter().enumerate() {
+                let l2 = L2_BLOCK + offset + index as u64;
+                let l1 = L1_BLOCK + offset + index as u64;
+                assert_eq!(block["number"], serde_json::json!(format!("0x{l2:x}")));
+                assert_eq!(block["l1BlockNumber"], serde_json::json!(format!("0x{l1:x}")));
+                if index == 1 {
+                    assert_eq!(block["calls"], serde_json::json!([]));
+                    continue;
+                }
+                for (call, expected) in block["calls"].as_array().unwrap().iter().zip([l1, l2]) {
+                    assert_eq!(call["status"], "0x1");
+                    assert_eq!(call["returnData"], serde_json::json!(format!("0x{expected:064x}")));
+                }
+                assert_eq!(block["calls"][0]["logs"][0]["blockNumber"], block["number"]);
+                assert_eq!(block["calls"][0]["logs"][0]["data"], block["calls"][0]["returnData"]);
+                for tx in block["transactions"].as_array().unwrap() {
+                    assert_eq!(tx["blockNumber"], block["number"]);
+                }
+            }
+        }
+        assert_eq!(handle.http_provider().get_block_number().await.unwrap(), L2_BLOCK + 2);
     }
     proxy.abort();
 }

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -42,7 +42,7 @@ use axum::{Json, Router, routing::post};
 use foundry_common::provider::get_http_provider;
 use foundry_config::Config;
 use foundry_evm::hardfork::OpHardfork;
-use foundry_evm_networks::NetworkConfigs;
+use foundry_evm_networks::{NetworkConfigs, arbitrum};
 use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope};
 use foundry_test_utils::rpc::{
     self, next_http_rpc_endpoint, next_rpc_endpoint, spawn_rpc_proxy_internal_error_after,
@@ -2506,6 +2506,186 @@ async fn flaky_test_arb_fork_mining() {
     let mined_blk_num = api.block_number().unwrap().to::<u64>();
 
     assert_eq!(mined_blk_num, init_blk_num + 1);
+}
+
+// <https://github.com/foundry-rs/foundry/issues/16768>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_arbitrum_fork_preserves_l1_block_number_after_mining() {
+    const L2_BLOCK: u64 = 503_433_721;
+    const L1_BLOCK: u64 = 25_941_231;
+    let target = Address::random();
+    let (origin_api, origin) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(NamedChain::Arbitrum as u64))
+            .with_genesis_block_number(Some(L2_BLOCK)),
+    )
+    .await;
+    // Store NUMBER in slot zero and return it, exercising both calls and mined transactions.
+    origin_api.anvil_set_code(target, bytes!("436000554360005260206000f3")).await.unwrap();
+    let endpoint = origin.http_endpoint();
+    let client = reqwest::Client::new();
+    let router = Router::new().route(
+        "/",
+        post(move |Json(request): Json<Value>| {
+            let client = client.clone();
+            let endpoint = endpoint.clone();
+            async move {
+                let mut response = client
+                    .post(endpoint)
+                    .json(&request)
+                    .send()
+                    .await
+                    .unwrap()
+                    .json::<Value>()
+                    .await
+                    .unwrap();
+                if matches!(
+                    request.get("method").and_then(Value::as_str),
+                    Some("eth_getBlockByHash" | "eth_getBlockByNumber")
+                ) && let Some(block) = response.get_mut("result").and_then(Value::as_object_mut)
+                {
+                    block.insert(
+                        "l1BlockNumber".to_string(),
+                        Value::String(format!("0x{L1_BLOCK:x}")),
+                    );
+                }
+                Json(response)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let proxy = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+
+    for chain_id in [None, Some(1u64)] {
+        let config = NodeConfig::test()
+            .with_chain_id(chain_id)
+            .with_no_storage_caching(true)
+            .with_eth_rpc_url(Some(format!("http://{address}")))
+            .with_fork_block_number(Some(L2_BLOCK));
+        let (api, handle) = spawn(config).await;
+        let provider = handle.http_provider();
+        let request = WithOtherFields::new(TransactionRequest::default().with_to(target));
+        assert_eq!(
+            U256::from_be_slice(
+                &provider.call(request.clone()).block(BlockId::latest()).await.unwrap()
+            ),
+            U256::from(L1_BLOCK)
+        );
+        let arb_request = WithOtherFields::new(
+            TransactionRequest::default()
+                .with_to(arbitrum::ARB_SYS_ADDRESS)
+                .with_input(Bytes::copy_from_slice(&arbitrum::ARB_BLOCK_NUMBER_SELECTOR)),
+        );
+        let snapshot = api.evm_snapshot().await.unwrap();
+        api.mine_one().await.unwrap();
+        for offset in 1..=2 {
+            assert_eq!(provider.get_block_number().await.unwrap(), L2_BLOCK + offset);
+            for (block, expected_offset) in [
+                (BlockNumberOrTag::Latest, offset),
+                (BlockNumberOrTag::Pending, offset + 1),
+                (BlockNumberOrTag::Number(L2_BLOCK), 0),
+            ] {
+                assert_eq!(
+                    U256::from_be_slice(
+                        &provider.call(request.clone()).block(block.into()).await.unwrap()
+                    ),
+                    U256::from(L1_BLOCK + expected_offset),
+                    "NUMBER at {block}"
+                );
+                assert_eq!(
+                    U256::from_be_slice(
+                        &provider.call(arb_request.clone()).block(block.into()).await.unwrap()
+                    ),
+                    U256::from(L2_BLOCK + expected_offset),
+                    "ArbSys at {block}"
+                );
+            }
+            let block =
+                provider.get_block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+            assert_eq!(block.header.number, L2_BLOCK + offset);
+            assert_eq!(
+                serde_json::from_value::<U256>(block.other["l1BlockNumber"].clone()).unwrap(),
+                U256::from(L1_BLOCK + offset)
+            );
+            if offset == 1 {
+                let sender = provider.get_accounts().await.unwrap()[0];
+                let receipt = provider
+                    .send_transaction(WithOtherFields::new(
+                        TransactionRequest::default()
+                            .with_from(sender)
+                            .with_to(target)
+                            .with_gas_limit(100_000),
+                    ))
+                    .await
+                    .unwrap()
+                    .get_receipt()
+                    .await
+                    .unwrap();
+                assert!(receipt.status());
+                assert_eq!(receipt.block_number, Some(L2_BLOCK + 2));
+                assert_eq!(
+                    provider.get_storage_at(target, U256::ZERO).await.unwrap(),
+                    U256::from(L1_BLOCK + 2)
+                );
+            }
+        }
+        assert_eq!(
+            U256::from_be_slice(
+                &provider.call(request.clone()).block((L2_BLOCK + 1).into()).await.unwrap()
+            ),
+            U256::from(L1_BLOCK + 1)
+        );
+        let state = api.anvil_dump_state(Some(true)).await.unwrap();
+        assert!(api.evm_revert(snapshot).await.unwrap());
+        assert_eq!(provider.get_block_number().await.unwrap(), L2_BLOCK);
+        assert_eq!(
+            U256::from_be_slice(
+                &provider.call(request.clone()).block(BlockId::latest()).await.unwrap()
+            ),
+            U256::from(L1_BLOCK)
+        );
+        api.mine_one().await.unwrap();
+        assert_eq!(
+            U256::from_be_slice(
+                &provider.call(request.clone()).block(BlockId::latest()).await.unwrap()
+            ),
+            U256::from(L1_BLOCK + 1)
+        );
+        assert!(api.anvil_load_state(state).await.unwrap());
+        assert_eq!(provider.get_block_number().await.unwrap(), L2_BLOCK + 2);
+        assert_eq!(
+            U256::from_be_slice(
+                &provider.call(request.clone()).block(BlockId::latest()).await.unwrap()
+            ),
+            U256::from(L1_BLOCK + 2)
+        );
+        api.mine_one().await.unwrap();
+        assert_eq!(
+            U256::from_be_slice(
+                &provider.call(request.clone()).block(BlockId::latest()).await.unwrap()
+            ),
+            U256::from(L1_BLOCK + 3)
+        );
+        assert_eq!(
+            U256::from_be_slice(
+                &provider.call(arb_request.clone()).block(BlockId::latest()).await.unwrap()
+            ),
+            U256::from(L2_BLOCK + 3)
+        );
+        api.anvil_reset(Some(Forking {
+            json_rpc_url: Some(format!("http://{address}")),
+            block_number: Some(L2_BLOCK),
+        }))
+        .await
+        .unwrap();
+        api.mine_one().await.unwrap();
+        assert_eq!(
+            U256::from_be_slice(&provider.call(request).block(BlockId::latest()).await.unwrap()),
+            U256::from(L1_BLOCK + 1)
+        );
+    }
+    proxy.abort();
 }
 
 // <https://github.com/foundry-rs/foundry/issues/6749>


### PR DESCRIPTION
Fixes #16768.

Anvil replaced Arbitrum’s L1 `block.number` with the L2 height after mining a local block. This preserves the fork’s L1/L2 offset as local blocks advance, keeping RPC headers and ArbSys on L2 across mining, pending and historical calls, snapshots, and state restoration.

AI-assisted.
