### PR TITLE
fix(lint): reuse Solar semantic queries

### DIFF
--- a/.changelog/lint-solar-queries.md
+++ b/.changelog/lint-solar-queries.md
@@ -3,4 +3,4 @@ forge: patch
 forge-lint: patch
 ---
 
-Use Solar's resolved types, call targets, and inheritance queries in Solidity lints to avoid guessing overloads and reconstructing compiler results.
+Fix missed Solidity lint warnings and false positives involving overloads, inherited functions, named arguments, and function pointers.

--- a/.changelog/lint-solar-queries.md
+++ b/.changelog/lint-solar-queries.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-lint: patch
+---
+
+Use Solar's resolved types, call targets, and inheritance queries in Solidity lints to avoid guessing overloads and reconstructing compiler results.

--- a/crates/lint/docs/external-function.md
+++ b/crates/lint/docs/external-function.md
@@ -7,7 +7,6 @@
 
 Flags implemented `public` functions with reference-type `memory` parameters that are
 never called internally and do not modify their parameters. Overrides are excluded.
-Internal references and `super` calls count against the selected overload and inherited target.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/external-function.md
+++ b/crates/lint/docs/external-function.md
@@ -7,6 +7,7 @@
 
 Flags implemented `public` functions with reference-type `memory` parameters that are
 never called internally and do not modify their parameters. Overrides are excluded.
+Internal references and `super` calls count against the selected overload and inherited target.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/reentrancy-events.md
+++ b/crates/lint/docs/reentrancy-events.md
@@ -9,8 +9,8 @@ Reports events emitted after an external interaction, such as a state-changing c
 call, low-level `call` or `delegatecall`, ETH `send` or `transfer`, or contract creation.
 Static calls and `view` or `pure` calls are excluded.
 
-Calls in ordinary internal helpers and modifiers are followed, but interactions hidden in
-library-qualified or `using for` internal calls may be missed.
+Calls in ordinary internal helpers, modifiers, and library-qualified internal calls are
+followed. Interactions hidden in `using for` internal calls may be missed.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/reentrancy-events.md
+++ b/crates/lint/docs/reentrancy-events.md
@@ -9,8 +9,7 @@ Reports events emitted after an external interaction, such as a state-changing c
 call, low-level `call` or `delegatecall`, ETH `send` or `transfer`, or contract creation.
 Static calls and `view` or `pure` calls are excluded.
 
-Calls in ordinary internal helpers, modifiers, and library-qualified internal calls are
-followed. Interactions hidden in `using for` internal calls may be missed.
+Interactions hidden in `using for` internal calls may be missed.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/type-based-tautology.md
+++ b/crates/lint/docs/type-based-tautology.md
@@ -9,9 +9,8 @@ Flags comparisons that are always true or false because of an integer type's ran
 such as `uint256 x >= 0`. Also reports conditions that cover the entire range, such as
 `x > 0 || x == 0` for unsigned `x`.
 
-Single comparisons use the expression's checked integer type, including struct fields,
-array elements, and function return values. Combined comparisons must refer to the same
-local or state variable, optionally cast to an integer type.
+Comparisons include struct fields, array elements, and function return values.
+Combined comparisons must refer to the same local or state variable, optionally cast to an integer type.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/type-based-tautology.md
+++ b/crates/lint/docs/type-based-tautology.md
@@ -9,8 +9,9 @@ Flags comparisons that are always true or false because of an integer type's ran
 such as `uint256 x >= 0`. Also reports conditions that cover the entire range, such as
 `x > 0 || x == 0` for unsigned `x`.
 
-The compared value must be a local or state variable, optionally cast to an integer type.
-Struct fields and function return values are not checked.
+Single comparisons use the expression's checked integer type, including struct fields,
+array elements, and function return values. Combined comparisons must refer to the same
+local or state variable, optionally cast to an integer type.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/var-read-using-this.md
+++ b/crates/lint/docs/var-read-using-this.md
@@ -6,8 +6,7 @@
 ## What it does
 
 Reports calls through `this` to the contract's own public variable getters and `view`
-or `pure` functions, including inherited functions. Overloaded calls use the selected
-function's mutability.
+or `pure` functions, including inherited functions.
 
 Read state directly where possible: use `foo` instead of `this.foo()`, or `m[k]` instead
 of `this.m(k)`. Check that the replacement preserves the getter's return value and any

--- a/crates/lint/docs/var-read-using-this.md
+++ b/crates/lint/docs/var-read-using-this.md
@@ -6,7 +6,8 @@
 ## What it does
 
 Reports calls through `this` to the contract's own public variable getters and `view`
-or `pure` functions, including inherited functions.
+or `pure` functions, including inherited functions. Overloaded calls use the selected
+function's mutability.
 
 Read state directly where possible: use `foo` instead of `this.foo()`, or `m[k]` instead
 of `this.m(k)`. Check that the replacement preserves the getter's return value and any

--- a/crates/lint/src/sol/analysis/access_control.rs
+++ b/crates/lint/src/sol/analysis/access_control.rs
@@ -161,7 +161,7 @@ pub fn expr_reads_sender<'gcx>(
     aliases: &HashSet<VariableId>,
 ) -> bool {
     expr.visit(&mut |e| {
-        let reads = is_sender_member(e)
+        let reads = is_sender_member(gcx, e)
             || underlying_var(gcx, e).is_some_and(|v| aliases.contains(&v))
             || matches!(&e.kind, ExprKind::Call(callee, ..)
                 if matches!(callee.peel_parens().kind, ExprKind::Ident(_))
@@ -258,8 +258,8 @@ fn for_each_guard<'gcx>(
     for stmt in stmts {
         if let StmtKind::If(cond, then_stmt, else_stmt) = stmt.kind {
             let exits = match access_check_polarity(gcx, cond, &aliases) {
-                Some(false) => branch_always_exits(then_stmt),
-                Some(true) => else_stmt.is_some_and(branch_always_exits),
+                Some(false) => branch_always_exits(gcx, then_stmt),
+                Some(true) => else_stmt.is_some_and(|expr| branch_always_exits(gcx, expr)),
                 None => false,
             };
             if exits {
@@ -270,7 +270,7 @@ fn for_each_guard<'gcx>(
         let Some(expr) = stmt_expr(&gcx.hir, stmt) else { continue };
         expr.visit(&mut |e| {
             match &e.kind {
-                ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
+                ExprKind::Call(callee, args, _) if is_require_or_assert(gcx, callee) => {
                     if let Some(cond) = args.exprs().next()
                         && access_check_polarity(gcx, cond, &aliases) == Some(true)
                     {

--- a/crates/lint/src/sol/analysis/access_control.rs
+++ b/crates/lint/src/sol/analysis/access_control.rs
@@ -2,28 +2,35 @@
 //! the caller against contract state, and which state that check depends on.
 
 use super::{
-    branch_always_exits, function_ids, is_require_or_assert, is_sender_member, lhs_local_var,
-    loop_stmts, stmt_expr, underlying_var, visit_stmts,
+    branch_always_exits, is_require_or_assert, is_sender_member, lhs_local_var, loop_stmts,
+    stmt_expr, underlying_var, visit_stmts,
 };
-use solar::sema::hir::{
-    self, BinOpKind, Expr, ExprKind, FunctionId, Stmt, StmtKind, UnOpKind, VariableId,
+use solar::sema::{
+    Gcx,
+    hir::{self, BinOpKind, Expr, ExprKind, FunctionId, Stmt, StmtKind, UnOpKind, VariableId},
 };
 use std::{collections::HashSet, iter, ops::ControlFlow};
 
 /// True when the function or one of its modifiers contains a dominating access check.
-pub fn is_protected<'gcx>(hir: &'gcx hir::Hir<'gcx>, func_id: FunctionId) -> bool {
-    modifiers_and_self(hir, func_id).any(|id| has_access_guard(hir, id, &mut HashSet::new()))
+pub fn is_protected<'gcx>(gcx: Gcx<'gcx>, func_id: FunctionId) -> bool {
+    modifiers_and_self(gcx, func_id).any(|id| has_access_guard(gcx, id, &mut HashSet::new()))
 }
 
 /// The modifiers of `func_id` that resolve to functions, followed by `func_id` itself.
 pub fn modifiers_and_self<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     func_id: FunctionId,
 ) -> impl Iterator<Item = FunctionId> + 'gcx {
-    hir.function(func_id)
+    gcx.hir
+        .function(func_id)
         .modifiers
         .iter()
-        .filter_map(|modifier| modifier.id.as_function())
+        .filter_map(move |modifier| {
+            gcx.hir.function(func_id).contract.map_or_else(
+                || modifier.id.as_function(),
+                |contract| gcx.resolve_modifier_target(contract, modifier),
+            )
+        })
         .chain(iter::once(func_id))
 }
 
@@ -31,30 +38,30 @@ pub fn modifiers_and_self<'gcx>(
 /// guarding `if`, a `require`/`assert` on an access check, or a call into a function that does.
 /// Bodyless declarations (interface functions, virtual modifiers) fall back to a name heuristic.
 pub fn has_access_guard<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     func_id: FunctionId,
     seen: &mut HashSet<FunctionId>,
 ) -> bool {
     if !seen.insert(func_id) {
         return false;
     }
-    let func = hir.function(func_id);
+    let func = gcx.hir.function(func_id);
     match func.body {
-        Some(body) => for_each_guard(hir, body, seen, &mut |_| ControlFlow::Break(())).is_break(),
+        Some(body) => for_each_guard(gcx, body, seen, &mut |_| ControlFlow::Break(())).is_break(),
         None => looks_like_access_control(func),
     }
 }
 
 /// State variables the access checks of `func_id` and its modifiers (up to `_`) depend on.
-pub fn guard_vars<'gcx>(hir: &'gcx hir::Hir<'gcx>, func_id: FunctionId) -> HashSet<VariableId> {
+pub fn guard_vars<'gcx>(gcx: Gcx<'gcx>, func_id: FunctionId) -> HashSet<VariableId> {
     let mut out = HashSet::new();
-    for id in modifiers_and_self(hir, func_id) {
-        let Some(body) = hir.function(id).body else { continue };
+    for id in modifiers_and_self(gcx, func_id) {
+        let Some(body) = gcx.hir.function(id).body else { continue };
         let mut seen = HashSet::from([id]);
-        let _ = for_each_guard(hir, body, &mut HashSet::from([id]), &mut |guard| {
+        let _ = for_each_guard(gcx, body, &mut HashSet::from([id]), &mut |guard| {
             match guard {
-                Guard::Check(cond) => expr_state_vars(hir, cond, &mut seen, &mut out),
-                Guard::Call(callee_id) => function_state_vars(hir, callee_id, &mut seen, &mut out),
+                Guard::Check(cond) => expr_state_vars(gcx, cond, &mut seen, &mut out),
+                Guard::Call(callee_id) => function_state_vars(gcx, callee_id, &mut seen, &mut out),
             }
             ControlFlow::Continue(())
         });
@@ -83,24 +90,24 @@ pub fn looks_like_access_control(func: &hir::Function<'_>) -> bool {
 /// reads `msg.sender`/`tx.origin` (directly, through `aliases` or through a helper) and state
 /// (directly or through a helper).
 pub fn access_check_polarity<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     expr: &Expr<'_>,
     aliases: &HashSet<VariableId>,
 ) -> Option<bool> {
     let is_check = |sender: &Expr<'_>, authority: &Expr<'_>| {
-        expr_reads_sender(hir, sender, &mut HashSet::new(), aliases)
-            && expr_reads_state(hir, authority)
+        expr_reads_sender(gcx, sender, &mut HashSet::new(), aliases)
+            && expr_reads_state(gcx, authority)
     };
     match &expr.peel_parens().kind {
         ExprKind::Unary(op, inner) if op.kind == UnOpKind::Not => {
-            access_check_polarity(hir, inner, aliases).map(|polarity| !polarity)
+            access_check_polarity(gcx, inner, aliases).map(|polarity| !polarity)
         }
         ExprKind::Binary(lhs, op, rhs) if matches!(op.kind, BinOpKind::And | BinOpKind::Or) => {
             // `a && b` is authorized as soon as one side is; `a || b` is unauthorized as soon as
             // one side is. The opposite polarity needs both sides.
             let dominant = op.kind == BinOpKind::And;
-            let lhs = access_check_polarity(hir, lhs, aliases);
-            let rhs = access_check_polarity(hir, rhs, aliases);
+            let lhs = access_check_polarity(gcx, lhs, aliases);
+            let rhs = access_check_polarity(gcx, rhs, aliases);
             if lhs == Some(dominant) || rhs == Some(dominant) {
                 Some(dominant)
             } else if lhs == Some(!dominant) && rhs == Some(!dominant) {
@@ -121,22 +128,22 @@ pub fn access_check_polarity<'gcx>(
 
 /// Locals initialized or assigned from a value that reads `msg.sender`.
 pub fn sender_aliases<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     stmts: impl IntoIterator<Item = &'gcx Stmt<'gcx>>,
 ) -> HashSet<VariableId> {
     let mut aliases = HashSet::new();
-    let _ = visit_stmts(hir, stmts, |stmt| {
+    let _ = visit_stmts(&gcx.hir, stmts, |stmt| {
         let (var_id, value) = match stmt.kind {
-            StmtKind::DeclSingle(var_id) => (Some(var_id), hir.variable(var_id).initializer),
+            StmtKind::DeclSingle(var_id) => (Some(var_id), gcx.hir.variable(var_id).initializer),
             StmtKind::Expr(expr) => match &expr.peel_parens().kind {
-                ExprKind::Assign(lhs, _, rhs) => (lhs_local_var(hir, lhs), Some(*rhs)),
+                ExprKind::Assign(lhs, _, rhs) => (lhs_local_var(gcx, lhs), Some(*rhs)),
                 _ => (None, None),
             },
             _ => (None, None),
         };
         if let Some(var_id) = var_id
             && let Some(value) = value
-            && expr_reads_sender(hir, value, &mut HashSet::new(), &aliases)
+            && expr_reads_sender(gcx, value, &mut HashSet::new(), &aliases)
         {
             aliases.insert(var_id);
         }
@@ -148,16 +155,17 @@ pub fn sender_aliases<'gcx>(
 /// Whether `expr` reads `msg.sender`/`tx.origin`, one of `aliases`, or calls a user function that
 /// reads the sender.
 pub fn expr_reads_sender<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     expr: &Expr<'_>,
     seen: &mut HashSet<FunctionId>,
     aliases: &HashSet<VariableId>,
 ) -> bool {
     expr.visit(&mut |e| {
         let reads = is_sender_member(e)
-            || underlying_var(e).is_some_and(|v| aliases.contains(&v))
+            || underlying_var(gcx, e).is_some_and(|v| aliases.contains(&v))
             || matches!(&e.kind, ExprKind::Call(callee, ..)
-                if function_ids(callee).any(|id| function_reads_sender(hir, id, seen)));
+                if matches!(callee.peel_parens().kind, ExprKind::Ident(_))
+                    && gcx.resolved_function(callee).is_some_and(|id| function_reads_sender(gcx, id, seen)));
         if reads { ControlFlow::Break(()) } else { ControlFlow::Continue(()) }
     })
     .is_break()
@@ -165,15 +173,15 @@ pub fn expr_reads_sender<'gcx>(
 
 /// Whether the body of `func_id` reads `msg.sender`/`tx.origin`, following calls.
 pub fn function_reads_sender<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     func_id: FunctionId,
     seen: &mut HashSet<FunctionId>,
 ) -> bool {
     seen.insert(func_id)
-        && hir.function(func_id).body.is_some_and(|body| {
-            visit_stmts(hir, body.stmts, |stmt| {
-                let reads = stmt_expr(hir, stmt)
-                    .is_some_and(|expr| expr_reads_sender(hir, expr, seen, &HashSet::new()));
+        && gcx.hir.function(func_id).body.is_some_and(|body| {
+            visit_stmts(&gcx.hir, body.stmts, |stmt| {
+                let reads = stmt_expr(&gcx.hir, stmt)
+                    .is_some_and(|expr| expr_reads_sender(gcx, expr, seen, &HashSet::new()));
                 if reads { ControlFlow::Break(()) } else { ControlFlow::Continue(()) }
             })
             .is_break()
@@ -182,21 +190,22 @@ pub fn function_reads_sender<'gcx>(
 
 /// State variables read by `expr`, following calls into user functions.
 pub fn expr_state_vars<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     expr: &Expr<'_>,
     seen: &mut HashSet<FunctionId>,
     out: &mut HashSet<VariableId>,
 ) {
     let _ = expr.visit(&mut |e| {
-        if let Some(var_id) = underlying_var(e)
-            && hir.variable(var_id).kind.is_state()
+        if let Some(var_id) = underlying_var(gcx, e)
+            && gcx.hir.variable(var_id).kind.is_state()
         {
             out.insert(var_id);
         }
-        if let ExprKind::Call(callee, ..) = &e.kind {
-            for callee_id in function_ids(callee) {
-                function_state_vars(hir, callee_id, seen, out);
-            }
+        if let ExprKind::Call(callee, ..) = &e.kind
+            && matches!(callee.peel_parens().kind, ExprKind::Ident(_))
+            && let Some(callee_id) = gcx.resolved_function(callee)
+        {
+            function_state_vars(gcx, callee_id, seen, out);
         }
         ControlFlow::<()>::Continue(())
     });
@@ -204,26 +213,26 @@ pub fn expr_state_vars<'gcx>(
 
 /// State variables read by the body of `func_id`, following calls into user functions.
 pub fn function_state_vars<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     func_id: FunctionId,
     seen: &mut HashSet<FunctionId>,
     out: &mut HashSet<VariableId>,
 ) {
     if seen.insert(func_id)
-        && let Some(body) = hir.function(func_id).body
+        && let Some(body) = gcx.hir.function(func_id).body
     {
-        let _ = visit_stmts(hir, body.stmts, |stmt| {
-            if let Some(expr) = stmt_expr(hir, stmt) {
-                expr_state_vars(hir, expr, seen, out);
+        let _ = visit_stmts(&gcx.hir, body.stmts, |stmt| {
+            if let Some(expr) = stmt_expr(&gcx.hir, stmt) {
+                expr_state_vars(gcx, expr, seen, out);
             }
             ControlFlow::Continue(())
         });
     }
 }
 
-fn expr_reads_state<'gcx>(hir: &'gcx hir::Hir<'gcx>, expr: &Expr<'_>) -> bool {
+fn expr_reads_state<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'_>) -> bool {
     let mut vars = HashSet::new();
-    expr_state_vars(hir, expr, &mut HashSet::new(), &mut vars);
+    expr_state_vars(gcx, expr, &mut HashSet::new(), &mut vars);
     !vars.is_empty()
 }
 
@@ -238,17 +247,17 @@ enum Guard<'a> {
 /// Calls `f` for every access check that dominates `body` (runs unconditionally before the `_`
 /// placeholder) until it breaks. `seen` guards the recursion into called functions.
 fn for_each_guard<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     body: hir::Block<'gcx>,
     seen: &mut HashSet<FunctionId>,
     f: &mut impl FnMut(Guard<'_>) -> ControlFlow<()>,
 ) -> ControlFlow<()> {
     let mut stmts = Vec::new();
     let _ = dominating_stmts(body.stmts, &mut stmts);
-    let aliases = sender_aliases(hir, stmts.iter().copied());
+    let aliases = sender_aliases(gcx, stmts.iter().copied());
     for stmt in stmts {
         if let StmtKind::If(cond, then_stmt, else_stmt) = stmt.kind {
-            let exits = match access_check_polarity(hir, cond, &aliases) {
+            let exits = match access_check_polarity(gcx, cond, &aliases) {
                 Some(false) => branch_always_exits(then_stmt),
                 Some(true) => else_stmt.is_some_and(branch_always_exits),
                 None => false,
@@ -258,23 +267,24 @@ fn for_each_guard<'gcx>(
             }
             continue;
         }
-        let Some(expr) = stmt_expr(hir, stmt) else { continue };
+        let Some(expr) = stmt_expr(&gcx.hir, stmt) else { continue };
         expr.visit(&mut |e| {
             match &e.kind {
                 ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
                     if let Some(cond) = args.exprs().next()
-                        && access_check_polarity(hir, cond, &aliases) == Some(true)
+                        && access_check_polarity(gcx, cond, &aliases) == Some(true)
                     {
                         f(Guard::Check(cond))?;
                     }
                 }
-                ExprKind::Call(callee, ..) => {
-                    for callee_id in function_ids(callee) {
-                        if looks_like_access_control(hir.function(callee_id))
-                            || has_access_guard(hir, callee_id, seen)
-                        {
-                            f(Guard::Call(callee_id))?;
-                        }
+                ExprKind::Call(callee, ..)
+                    if matches!(callee.peel_parens().kind, ExprKind::Ident(_)) =>
+                {
+                    if let Some(callee_id) = gcx.resolved_function(callee)
+                        && (looks_like_access_control(gcx.hir.function(callee_id))
+                            || has_access_guard(gcx, callee_id, seen))
+                    {
+                        f(Guard::Call(callee_id))?;
                     }
                 }
                 _ => {}

--- a/crates/lint/src/sol/analysis/exprs.rs
+++ b/crates/lint/src/sol/analysis/exprs.rs
@@ -7,9 +7,10 @@ use solar::{
         Gcx,
         builtins::Builtin,
         hir::{
-            self, CallArgs, ContractKind, ElementaryType, Expr, ExprKind, FunctionId, ItemId, Res,
-            TypeKind, VariableId,
+            self, CallArgs, ElementaryType, Expr, ExprKind, FunctionId, ItemId, Res, TypeKind,
+            VariableId,
         },
+        ty::{CallableParamSource, TyKind},
     },
 };
 use std::ops::ControlFlow;
@@ -26,11 +27,6 @@ pub fn builtins<'a>(expr: &'a Expr<'a>) -> impl Iterator<Item = Builtin> + 'a {
         _ => &[],
     };
     reses.iter().filter_map(Res::as_builtin)
-}
-
-/// `this` or `super`.
-pub fn is_this_or_super(expr: &Expr<'_>) -> bool {
-    is_builtin(expr, sym::this) || is_builtin(expr, sym::super_)
 }
 
 /// `msg.sender`.
@@ -127,47 +123,51 @@ pub fn is_address_self(expr: &Expr<'_>) -> bool {
 
 /// The variable a bare identifier refers to, looking through parens, `payable(...)` and
 /// address-like casts (`address(x)`, `IFoo(x)`).
-pub fn underlying_var(expr: &Expr<'_>) -> Option<VariableId> {
+pub fn underlying_var(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<VariableId> {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().find_map(Res::as_variable),
+        ExprKind::Ident(_) => gcx.resolved_variable(expr),
         ExprKind::Call(callee, args, _) if is_address_like_cast(callee) => {
-            args.exprs().next().and_then(underlying_var)
+            args.exprs().next().and_then(|arg| underlying_var(gcx, arg))
         }
-        ExprKind::Payable(inner) => underlying_var(inner),
+        ExprKind::Payable(inner) => underlying_var(gcx, inner),
         _ => None,
     }
 }
 
 /// The local (non-state) variable a bare identifier refers to.
-pub fn lhs_local_var(hir: &hir::Hir<'_>, lhs: &Expr<'_>) -> Option<VariableId> {
-    let ExprKind::Ident(reses) = &lhs.peel_parens().kind else { return None };
-    reses.iter().filter_map(Res::as_variable).find(|v| !hir.variable(*v).kind.is_state())
+pub fn lhs_local_var(gcx: Gcx<'_>, lhs: &Expr<'_>) -> Option<VariableId> {
+    let ExprKind::Ident(_) = lhs.peel_parens().kind else { return None };
+    gcx.resolved_variable(lhs).filter(|&v| !gcx.hir.variable(v).kind.is_state())
 }
 
 /// State variables written by an lvalue: peels index/slice/member/payable/unary/delete wrappers
 /// and tuple destructuring. Duplicates are removed.
-pub fn state_lhs_vars(hir: &hir::Hir<'_>, lhs: &Expr<'_>) -> Vec<VariableId> {
+pub fn state_lhs_vars(gcx: Gcx<'_>, lhs: &Expr<'_>) -> Vec<VariableId> {
     let mut vars = Vec::new();
-    for_each_lhs_var(lhs, &mut |v| {
-        if hir.variable(v).kind.is_state() && !vars.contains(&v) {
+    for_each_lhs_var(gcx, lhs, &mut |v| {
+        if gcx.hir.variable(v).kind.is_state() && !vars.contains(&v) {
             vars.push(v);
         }
     });
     vars
 }
 
-/// Calls `f` for every variable resolution at the root of an lvalue, peeling
+/// Calls `f` for each resolved variable at the root of an lvalue, peeling
 /// index/slice/member/payable/unary/delete wrappers and tuple destructuring.
-pub fn for_each_lhs_var(expr: &Expr<'_>, f: &mut impl FnMut(VariableId)) {
+pub fn for_each_lhs_var(gcx: Gcx<'_>, expr: &Expr<'_>, f: &mut impl FnMut(VariableId)) {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().filter_map(Res::as_variable).for_each(f),
+        ExprKind::Ident(_) => {
+            if let Some(var) = gcx.resolved_variable(expr) {
+                f(var);
+            }
+        }
         ExprKind::Index(base, _)
         | ExprKind::Slice(base, ..)
         | ExprKind::Member(base, _)
         | ExprKind::Payable(base)
         | ExprKind::Unary(_, base)
-        | ExprKind::Delete(base) => for_each_lhs_var(base, f),
-        ExprKind::Tuple(exprs) => exprs.iter().flatten().for_each(|e| for_each_lhs_var(e, f)),
+        | ExprKind::Delete(base) => for_each_lhs_var(gcx, base, f),
+        ExprKind::Tuple(exprs) => exprs.iter().flatten().for_each(|e| for_each_lhs_var(gcx, e, f)),
         _ => {}
     }
 }
@@ -180,23 +180,20 @@ pub fn tuple_elems<'gcx>(expr: &'gcx Expr<'gcx>) -> Option<&'gcx [Option<&'gcx E
     }
 }
 
-/// The argument bound to `param` of `function` in `args`, positional or named.
+/// The argument bound to `param` of `function_id` in `args`, positional or named.
 pub fn arg_for_param<'gcx>(
-    hir: &hir::Hir<'gcx>,
-    function: &hir::Function<'gcx>,
+    gcx: Gcx<'gcx>,
+    function_id: FunctionId,
     param: VariableId,
     args: &CallArgs<'gcx>,
 ) -> Option<&'gcx Expr<'gcx>> {
+    let function = gcx.hir.function(function_id);
     let idx = function.parameters.iter().position(|p| *p == param)?;
-    let names: Vec<_> =
-        function.parameters.iter().map(|p| hir.variable(*p).name.map(|n| n.name)).collect();
+    let names = gcx.callable_param_names(CallableParamSource::Function {
+        id: function_id,
+        skips_receiver: false,
+    });
     args.argument_for_parameter(idx, Some(&names))
-}
-
-/// The single function the type checker resolved `expr` to (overloads, overrides, `super.`,
-/// `using for` and import aliases already accounted for).
-pub fn resolved_function(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<FunctionId> {
-    gcx.type_of_expr(expr.peel_parens().id)?.function_id()
 }
 
 /// The function an internal call made from within `contract_id` dispatches to: a virtual call
@@ -227,19 +224,11 @@ pub fn dispatched_function(
     }
 }
 
-/// All functions a bare identifier callee may resolve to (syntactic, overload-agnostic).
-pub fn function_ids<'a>(callee: &'a Expr<'a>) -> impl Iterator<Item = FunctionId> + 'a {
-    let reses: &[Res] = match &callee.peel_parens().kind {
-        ExprKind::Ident(reses) => reses,
-        _ => &[],
-    };
-    reses.iter().filter_map(Res::as_function)
-}
-
 /// The item a bare identifier refers to, if any.
-pub fn referenced_item(expr: &Expr<'_>) -> Option<ItemId> {
-    match &expr.peel_parens().kind {
-        ExprKind::Ident([Res::Item(id), ..]) => Some(*id),
+pub fn referenced_item(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<ItemId> {
+    let ExprKind::Ident(_) = expr.peel_parens().kind else { return None };
+    match gcx.resolved_expr(expr)? {
+        Res::Item(id) => Some(id),
         _ => None,
     }
 }
@@ -276,16 +265,11 @@ pub const fn is_low_level_call(expr: &ast::Expr<'_>) -> bool {
     false
 }
 
-/// `++x`, `x++`, `--x` or `x--`.
-pub const fn is_inc_dec(op: UnOpKind) -> bool {
-    matches!(op, UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec)
-}
-
 /// The lvalue written by an assignment, `delete` or increment/decrement expression.
 pub const fn write_target<'gcx>(expr: &'gcx Expr<'gcx>) -> Option<&'gcx Expr<'gcx>> {
     match &expr.kind {
         ExprKind::Assign(target, ..) | ExprKind::Delete(target) => Some(target),
-        ExprKind::Unary(op, target) if is_inc_dec(op.kind) => Some(target),
+        ExprKind::Unary(op, target) if op.kind.has_side_effects() => Some(target),
         _ => None,
     }
 }
@@ -376,55 +360,33 @@ pub fn any_subexpr(expr: &Expr<'_>, mut pred: impl FnMut(&Expr<'_>) -> bool) -> 
 pub fn has_side_effect(expr: &Expr<'_>) -> bool {
     any_subexpr(expr, |e| match &e.kind {
         ExprKind::Assign(..) | ExprKind::Delete(_) => true,
-        ExprKind::Unary(op, _) => is_inc_dec(op.kind),
+        ExprKind::Unary(op, _) => op.kind.has_side_effects(),
         _ => false,
-    })
-}
-
-/// Functions a callee may name: every overload of a bare identifier, or a library-static `Lib.f`.
-pub fn callee_fids(hir: &hir::Hir<'_>, callee: &Expr<'_>) -> Vec<FunctionId> {
-    match &callee.peel_parens().kind {
-        ExprKind::Member(base, member) => match referenced_item(base) {
-            Some(ItemId::Contract(cid)) if hir.contract(cid).kind == ContractKind::Library => hir
-                .contract(cid)
-                .functions()
-                .filter(|f| hir.function(*f).name.is_some_and(|n| n.name == member.name))
-                .collect(),
-            _ => Vec::new(),
-        },
-        _ => function_ids(callee).collect(),
-    }
-}
-
-/// Non-external functions a bare identifier callee may resolve to.
-pub fn resolved_internal_function_ids<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
-    callee: &'gcx Expr<'gcx>,
-) -> impl Iterator<Item = FunctionId> + 'gcx {
-    function_ids(callee).filter(move |&id| {
-        let func = hir.function(id);
-        func.kind.is_function() && func.visibility != ast::Visibility::External
     })
 }
 
 /// True when `callee` names a zero-parameter function whose body returns an expression matching
 /// `pred`.
 pub fn callee_no_arg_returns<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     callee: &'gcx Expr<'gcx>,
     mut pred: impl FnMut(&'gcx Expr<'gcx>) -> bool,
 ) -> bool {
-    callee_fids(hir, callee).into_iter().any(|fid| function_no_arg_returns(hir, fid, &mut pred))
+    gcx.type_of_expr(callee.peel_parens().id).is_some_and(
+        |ty| matches!(ty.kind, TyKind::Fn(f) if f.is_internal() || f.is_delegate_call()),
+    ) && gcx
+        .resolved_function(callee)
+        .is_some_and(|fid| function_no_arg_returns(gcx, fid, &mut pred))
 }
 
 /// True when `fid` takes no parameters and its body is `return e;` or `namedRet = e;` (optionally
 /// followed by a bare `return;`) with `pred(e)`.
 pub fn function_no_arg_returns<'gcx>(
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     fid: FunctionId,
     pred: &mut impl FnMut(&'gcx Expr<'gcx>) -> bool,
 ) -> bool {
-    let f = hir.function(fid);
+    let f = gcx.hir.function(fid);
     let Some(body) = f.body else { return false };
     let stmts = match body.stmts {
         [rest @ .., last] if matches!(last.kind, hir::StmtKind::Return(None)) => rest,
@@ -436,7 +398,7 @@ pub fn function_no_arg_returns<'gcx>(
             hir::StmtKind::Return(Some(e)) => pred(e),
             hir::StmtKind::Expr(e) => {
                 matches!(&e.peel_parens().kind, ExprKind::Assign(lhs, None, rhs)
-                if f.returns.len() == 1 && underlying_var(lhs) == Some(f.returns[0]) && pred(rhs))
+                if f.returns.len() == 1 && underlying_var(gcx, lhs) == Some(f.returns[0]) && pred(rhs))
             }
             _ => false,
         }

--- a/crates/lint/src/sol/analysis/exprs.rs
+++ b/crates/lint/src/sol/analysis/exprs.rs
@@ -15,41 +15,29 @@ use solar::{
 };
 use std::ops::ControlFlow;
 
-/// True if `expr` (through parens) is an identifier resolving to the given builtin name.
-pub fn is_builtin(expr: &Expr<'_>, name: Symbol) -> bool {
-    builtins(expr).any(|b| b.name() == name)
-}
-
-/// Iterator over the builtins `expr` (through parens) resolves to.
-pub fn builtins<'a>(expr: &'a Expr<'a>) -> impl Iterator<Item = Builtin> + 'a {
-    let reses: &[Res] = match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses,
-        _ => &[],
-    };
-    reses.iter().filter_map(Res::as_builtin)
+/// True if `expr` resolves to the given builtin name.
+pub fn is_builtin(gcx: Gcx<'_>, expr: &Expr<'_>, name: Symbol) -> bool {
+    gcx.resolved_builtin(expr).is_some_and(|builtin| builtin.name() == name)
 }
 
 /// `msg.sender`.
-pub fn is_msg_sender(expr: &Expr<'_>) -> bool {
-    matches!(&expr.peel_parens().kind, ExprKind::Member(base, name)
-        if name.name == sym::sender && is_builtin(base, sym::msg))
+pub fn is_msg_sender(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
+    gcx.resolved_builtin(expr) == Some(Builtin::MsgSender)
 }
 
 /// `msg.sender` or `tx.origin`.
-pub fn is_sender_member(expr: &Expr<'_>) -> bool {
-    is_msg_sender(expr)
-        || matches!(&expr.peel_parens().kind, ExprKind::Member(base, name)
-            if name.name == kw::Origin && is_builtin(base, sym::tx))
+pub fn is_sender_member(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
+    matches!(gcx.resolved_builtin(expr), Some(Builtin::MsgSender | Builtin::TxOrigin))
 }
 
 /// True if `callee` resolves to the builtin `require` or `assert`.
-pub fn is_require_or_assert(callee: &Expr<'_>) -> bool {
-    is_builtin(callee, sym::require) || is_builtin(callee, sym::assert)
+pub fn is_require_or_assert(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
+    matches!(gcx.resolved_builtin(callee), Some(Builtin::Require | Builtin::Assert))
 }
 
 /// `revert(...)`, `revert Err(...)`-style builtin revert call (any form).
-pub fn is_revert_call(expr: &Expr<'_>) -> bool {
-    matches!(&expr.peel_parens().kind, ExprKind::Call(callee, ..) if is_builtin(callee, kw::Revert))
+pub fn is_revert_call(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
+    matches!(&expr.peel_parens().kind, ExprKind::Call(callee, ..) if is_builtin(gcx, callee, kw::Revert))
 }
 
 /// A literal zero/false or an elementary cast or arithmetic negation of one.
@@ -72,11 +60,15 @@ pub fn is_zero_value(expr: &Expr<'_>) -> bool {
 }
 
 /// `revert(...)`, `selfdestruct(...)`, `require(false, ...)` or `assert(false)`.
-pub fn is_exit_call(expr: &Expr<'_>) -> bool {
+pub fn is_exit_call(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
-    is_builtin(callee, kw::Revert)
-        || builtins(callee).any(|b| b == Builtin::Selfdestruct)
-        || (is_require_or_assert(callee) && args.exprs().next().is_some_and(is_literal_false))
+    match gcx.resolved_builtin(callee) {
+        Some(Builtin::Revert | Builtin::RevertMsg | Builtin::Selfdestruct) => true,
+        Some(Builtin::Require | Builtin::Assert) => {
+            args.exprs().next().is_some_and(is_literal_false)
+        }
+        _ => false,
+    }
 }
 
 /// The boolean literal `false`.
@@ -99,25 +91,26 @@ pub fn is_address_cast(callee: &Expr<'_>) -> bool {
 }
 
 /// `IFoo(...)` contract / interface cast head.
-pub fn is_contract_cast(callee: &Expr<'_>) -> bool {
-    matches!(&callee.peel_parens().kind, ExprKind::Ident(reses)
-        if !reses.is_empty() && reses.iter().all(|r| matches!(r, Res::Item(ItemId::Contract(_)))))
+pub fn is_contract_cast(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
+    gcx.type_of_expr(callee.peel_parens().id).is_some_and(
+        |ty| matches!(ty.kind, TyKind::Type(inner) if matches!(inner.kind, TyKind::Contract(_))),
+    )
 }
 
 /// `address(...)` or `IFoo(...)` cast head.
-pub fn is_address_like_cast(callee: &Expr<'_>) -> bool {
-    is_address_cast(callee) || is_contract_cast(callee)
+pub fn is_address_like_cast(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
+    is_address_cast(callee) || is_contract_cast(gcx, callee)
 }
 
 /// `address(this)`, `payable(this)`, `IFoo(this)`, `IFoo(address(this))`, or bare `this`.
-pub fn is_address_self(expr: &Expr<'_>) -> bool {
+pub fn is_address_self(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let expr = expr.peel_parens();
     match &expr.kind {
-        ExprKind::Payable(inner) => is_address_self(inner),
-        ExprKind::Call(callee, args, _) if is_address_like_cast(callee) => {
-            args.exprs().next().is_some_and(is_address_self)
+        ExprKind::Payable(inner) => is_address_self(gcx, inner),
+        ExprKind::Call(callee, args, _) if is_address_like_cast(gcx, callee) => {
+            args.exprs().next().is_some_and(|expr| is_address_self(gcx, expr))
         }
-        _ => is_builtin(expr, sym::this),
+        _ => is_builtin(gcx, expr, sym::this),
     }
 }
 
@@ -126,7 +119,7 @@ pub fn is_address_self(expr: &Expr<'_>) -> bool {
 pub fn underlying_var(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<VariableId> {
     match &expr.peel_parens().kind {
         ExprKind::Ident(_) => gcx.resolved_variable(expr),
-        ExprKind::Call(callee, args, _) if is_address_like_cast(callee) => {
+        ExprKind::Call(callee, args, _) if is_address_like_cast(gcx, callee) => {
             args.exprs().next().and_then(|arg| underlying_var(gcx, arg))
         }
         ExprKind::Payable(inner) => underlying_var(gcx, inner),

--- a/crates/lint/src/sol/analysis/modifier_outcome.rs
+++ b/crates/lint/src/sol/analysis/modifier_outcome.rs
@@ -2,8 +2,9 @@
 
 use super::is_literal_false;
 use solar::sema::{
+    Gcx,
     builtins::Builtin,
-    hir::{Block, Expr, ExprKind, LoopSource, Res, Stmt, StmtKind},
+    hir::{Block, Expr, ExprKind, LoopSource, Stmt, StmtKind},
 };
 
 /// Summary of how control flow can leave a statement or block *without* having executed the
@@ -48,14 +49,14 @@ impl Outcome {
     }
 }
 
-pub fn block_outcome(block: Block<'_>) -> Outcome {
+pub fn block_outcome(gcx: Gcx<'_>, block: Block<'_>) -> Outcome {
     let mut outcome = Outcome::FALLTHROUGH;
     for stmt in block.stmts {
         // Once a statement cannot fall through, the rest of the block is unreachable.
         if !outcome.falls_through {
             return outcome;
         }
-        let stmt_outcome = stmt_outcome(stmt);
+        let stmt_outcome = stmt_outcome(gcx, stmt);
         outcome = Outcome {
             falls_through: stmt_outcome.falls_through,
             returns: outcome.returns || stmt_outcome.returns,
@@ -66,20 +67,21 @@ pub fn block_outcome(block: Block<'_>) -> Outcome {
     outcome
 }
 
-fn stmt_outcome(stmt: &Stmt<'_>) -> Outcome {
+fn stmt_outcome(gcx: Gcx<'_>, stmt: &Stmt<'_>) -> Outcome {
     match &stmt.kind {
         StmtKind::Placeholder => Outcome::COVERED,
         StmtKind::Return(_) => Outcome::RETURNS,
         StmtKind::Break => Outcome::BREAKS,
         StmtKind::Continue => Outcome::CONTINUES,
-        StmtKind::Expr(expr) => call_outcome(expr).unwrap_or(Outcome::FALLTHROUGH),
+        StmtKind::Expr(expr) => call_outcome(gcx, expr).unwrap_or(Outcome::FALLTHROUGH),
         StmtKind::Revert(_) => Outcome::COVERED,
         StmtKind::Block(block)
         | StmtKind::UncheckedBlock(block)
-        | StmtKind::AssemblyBlock(block) => block_outcome(*block),
+        | StmtKind::AssemblyBlock(block) => block_outcome(gcx, *block),
         StmtKind::If(_, then_stmt, else_stmt) => {
-            let then_outcome = stmt_outcome(then_stmt);
-            let else_outcome = else_stmt.map_or(Outcome::FALLTHROUGH, stmt_outcome);
+            let then_outcome = stmt_outcome(gcx, then_stmt);
+            let else_outcome =
+                else_stmt.map_or(Outcome::FALLTHROUGH, |stmt| stmt_outcome(gcx, stmt));
             then_outcome.merge(else_outcome)
         }
         StmtKind::Loop(block, source) => {
@@ -90,7 +92,7 @@ fn stmt_outcome(stmt: &Stmt<'_>) -> Outcome {
             // condition sits *after* the body, so a `continue` in the body also reaches it and can
             // exit the loop. `break`/`continue` are otherwise consumed by the loop; only `return`
             // keeps escaping toward the modifier's end.
-            let body = block_outcome(*block);
+            let body = block_outcome(gcx, *block);
             let falls_through =
                 body.breaks || (matches!(source, LoopSource::DoWhile) && body.continues);
             Outcome { falls_through, returns: body.returns, ..Outcome::COVERED }
@@ -101,7 +103,7 @@ fn stmt_outcome(stmt: &Stmt<'_>) -> Outcome {
             // path that skips all clauses, so start from `COVERED`.
             let mut outcome = Outcome::COVERED;
             for clause in try_stmt.clauses {
-                outcome = outcome.merge(block_outcome(clause.block));
+                outcome = outcome.merge(block_outcome(gcx, clause.block));
             }
             outcome
         }
@@ -111,7 +113,7 @@ fn stmt_outcome(stmt: &Stmt<'_>) -> Outcome {
             let has_default = switch.cases.last().is_some_and(|case| case.constant.is_none());
             let mut outcome = if has_default { Outcome::COVERED } else { Outcome::FALLTHROUGH };
             for case in switch.cases {
-                outcome = outcome.merge(block_outcome(case.body));
+                outcome = outcome.merge(block_outcome(gcx, case.body));
             }
             outcome
         }
@@ -131,24 +133,19 @@ fn stmt_outcome(stmt: &Stmt<'_>) -> Outcome {
 /// - Successful halts (Yul `return`/`stop`, `selfdestruct`) let the surrounding call finish
 ///   *without* running the modified function body, which is exactly what this lint flags, so they
 ///   behave like a `return` ([`Outcome::RETURNS`]).
-fn call_outcome(expr: &Expr<'_>) -> Option<Outcome> {
+fn call_outcome(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<Outcome> {
     let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return None };
-    let ExprKind::Ident(resolutions) = &callee.peel_parens().kind else { return None };
-    resolutions.iter().find_map(|res| match res {
-        Res::Builtin(
-            Builtin::Revert | Builtin::RevertMsg | Builtin::YulRevert | Builtin::YulInvalid,
-        ) => Some(Outcome::COVERED),
-        Res::Builtin(Builtin::Require | Builtin::Assert)
-            if args.exprs().next().is_some_and(is_literal_false) =>
-        {
+    match gcx.resolved_builtin(callee)? {
+        Builtin::Revert | Builtin::RevertMsg | Builtin::YulRevert | Builtin::YulInvalid => {
             Some(Outcome::COVERED)
         }
-        Res::Builtin(
-            Builtin::YulReturn
-            | Builtin::YulStop
-            | Builtin::YulSelfdestruct
-            | Builtin::Selfdestruct,
-        ) => Some(Outcome::RETURNS),
+        Builtin::Require | Builtin::Assert if args.exprs().next().is_some_and(is_literal_false) => {
+            Some(Outcome::COVERED)
+        }
+        Builtin::YulReturn
+        | Builtin::YulStop
+        | Builtin::YulSelfdestruct
+        | Builtin::Selfdestruct => Some(Outcome::RETURNS),
         _ => None,
-    })
+    }
 }

--- a/crates/lint/src/sol/analysis/stmts.rs
+++ b/crates/lint/src/sol/analysis/stmts.rs
@@ -3,7 +3,10 @@
 use super::is_exit_call;
 use solar::{
     ast::FunctionKind,
-    sema::hir::{self, Expr, FunctionId, LoopSource, Stmt, StmtKind, Visit},
+    sema::{
+        Gcx,
+        hir::{self, Expr, FunctionId, LoopSource, Stmt, StmtKind, Visit},
+    },
 };
 use std::ops::ControlFlow;
 
@@ -58,19 +61,23 @@ pub fn stmt_expr<'gcx>(
 /// `revert`, `selfdestruct`, `require(false, ..)` / `assert(false)`, a block containing any such
 /// statement, an `if` whose both arms exit, a `try` whose every clause exits, or a `do-while`
 /// whose body exits without `break`/`continue`.
-pub fn branch_always_exits(stmt: &Stmt<'_>) -> bool {
+pub fn branch_always_exits(gcx: Gcx<'_>, stmt: &Stmt<'_>) -> bool {
     match &stmt.kind {
         StmtKind::Return(_) | StmtKind::Revert(_) => true,
-        StmtKind::Expr(expr) => is_exit_call(expr),
-        StmtKind::Block(b) | StmtKind::UncheckedBlock(b) => b.stmts.iter().any(branch_always_exits),
-        StmtKind::If(_, t, Some(e)) => branch_always_exits(t) && branch_always_exits(e),
+        StmtKind::Expr(expr) => is_exit_call(gcx, expr),
+        StmtKind::Block(b) | StmtKind::UncheckedBlock(b) => {
+            b.stmts.iter().any(|expr| branch_always_exits(gcx, expr))
+        }
+        StmtKind::If(_, t, Some(e)) => branch_always_exits(gcx, t) && branch_always_exits(gcx, e),
         StmtKind::Loop(block, LoopSource::DoWhile) => {
             let user = do_while_user_stmts(block.stmts);
-            !stmts_break_or_continue(user) && user.iter().any(branch_always_exits)
+            !stmts_break_or_continue(user) && user.iter().any(|expr| branch_always_exits(gcx, expr))
         }
         StmtKind::Try(t) => {
             !t.clauses.is_empty()
-                && t.clauses.iter().all(|c| c.block.stmts.iter().any(branch_always_exits))
+                && t.clauses
+                    .iter()
+                    .all(|c| c.block.stmts.iter().any(|expr| branch_always_exits(gcx, expr)))
         }
         _ => false,
     }

--- a/crates/lint/src/sol/analysis/types.rs
+++ b/crates/lint/src/sol/analysis/types.rs
@@ -1,17 +1,9 @@
-//! Type probes: static types of HIR expressions and variables.
+//! Type probes using Solar's type-checker results.
 
-use super::{is_address_cast, is_this_or_super, referenced_item};
-use solar::{
-    ast::{DataLocation, LitKind, StrKind, TypeSize, UnOpKind},
-    interface::Symbol,
-    sema::{
-        Gcx, Ty,
-        hir::{
-            self, BinOpKind, CallArgs, ContractId, Expr, ExprKind, ItemId, Res, TypeKind,
-            VariableId,
-        },
-        ty::TyKind,
-    },
+use solar::sema::{
+    Gcx, Ty,
+    hir::{self, ContractId, Expr, TypeKind, VariableId},
+    ty::TyKind,
 };
 
 /// True if `vid` is typed as `address`/`address payable`.
@@ -43,156 +35,9 @@ pub fn expr_is_address<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
     gcx.type_of_expr(expr.peel_parens().id).is_some_and(ty_is_address)
 }
 
-/// `address`-typed expression, or an address cast / `payable(..)` wrap whose type is unknown.
-pub fn is_address_like<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
-    match &expr.peel_parens().kind {
-        ExprKind::Payable(_) => true,
-        ExprKind::Call(callee, ..) if is_address_cast(callee) => true,
-        _ => expr_ty(gcx, expr).is_some_and(ty_is_address),
-    }
-}
-
-/// Static contract type of a method-call receiver: a contract-typed expression, a direct
-/// contract/library reference, or an `IFoo(addr)` cast.
+/// Static contract type of a method-call receiver or direct contract/library reference.
 pub fn receiver_contract_id<'gcx>(gcx: Gcx<'gcx>, recv: &Expr<'gcx>) -> Option<ContractId> {
-    expr_ty(gcx, recv).and_then(ty_contract_id).or_else(|| direct_contract_id(recv))
-}
-
-fn direct_contract_id(expr: &Expr<'_>) -> Option<ContractId> {
-    match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().find_map(|r| match r {
-            Res::Item(ItemId::Contract(cid)) => Some(*cid),
-            _ => None,
-        }),
-        ExprKind::Call(callee, ..) => direct_contract_id(callee),
-        _ => None,
-    }
-}
-
-/// Data location of a variable, defaulting state variables to storage.
-pub fn variable_data_location(hir: &hir::Hir<'_>, var_id: VariableId) -> Option<DataLocation> {
-    let var = hir.variable(var_id);
-    var.data_location.or_else(|| var.kind.is_state().then_some(DataLocation::Storage))
-}
-
-/// Static type of `expr`. Uses the type checker's result when available and otherwise
-/// reconstructs the type structurally from the HIR (locations of storage-rooted lvalues are
-/// preserved). `this`/`super` and unresolvable expressions yield `None`.
-pub fn expr_ty<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> Option<Ty<'gcx>> {
-    let expr = expr.peel_parens();
-    if !is_this_or_super(expr)
-        && let Some(ty) = gcx.type_of_expr(expr.id)
-    {
-        return Some(ty);
-    }
-    match &expr.kind {
-        ExprKind::Call(callee, args, _) => match expr_ty(gcx, callee)?.kind {
-            TyKind::Fn(func) => Some(match func.returns {
-                [] => gcx.types.unit,
-                [ret] => *ret,
-                returns => gcx.mk_ty_tuple(returns),
-            }),
-            TyKind::Type(to) => Some(explicit_cast_ty(gcx, to, args)),
-            _ => None,
-        },
-        ExprKind::Ident(reses) => {
-            let res = unique(reses.iter().filter(|res| !matches!(res, Res::Err(_))).copied())
-                .or_else(|| {
-                    unique(
-                        reses.iter().filter_map(|r| r.as_variable().map(|v| Res::Item(v.into()))),
-                    )
-                })?;
-            if is_this_or_super(expr) {
-                return None;
-            }
-            let ty = gcx.type_of_res(res);
-            Some(match res.as_variable() {
-                Some(v) => ty.with_loc_if_ref_opt(gcx, variable_data_location(&gcx.hir, v)),
-                None => ty,
-            })
-        }
-        ExprKind::Index(lhs, index) => {
-            let lhs_ty = expr_ty(gcx, lhs)?;
-            if let Some(index) = index
-                && !expr_ty(gcx, index)?.convert_implicit_to(gcx.types.uint(256), gcx)
-            {
-                return None;
-            }
-            let loc = lhs_ty.loc().or_else(|| {
-                matches!(lhs_ty.kind, TyKind::Mapping(..)).then_some(DataLocation::Storage)
-            });
-            match lhs_ty.peel_refs().kind {
-                TyKind::Mapping(_, value) => Some(value.with_loc_if_ref_opt(gcx, loc)),
-                _ => lhs_ty.base_type(gcx),
-            }
-        }
-        ExprKind::Lit(lit) => Some(match &lit.kind {
-            LitKind::Str(StrKind::Hex, s, _) => {
-                let size = TypeSize::try_new_fb_bytes(s.as_byte_str().len().min(32) as u8)?;
-                gcx.types.fixed_bytes(size.bytes())
-            }
-            LitKind::Str(_, s, _) => gcx.mk_ty_string_literal(s.as_byte_str()),
-            LitKind::Number(int) => gcx.mk_ty_int_literal(false, int.bit_len() as _)?,
-            LitKind::Rational(_) | LitKind::Err(_) => return None,
-            LitKind::Address(_) => gcx.types.address,
-            LitKind::Bool(_) => gcx.types.bool,
-        }),
-        ExprKind::Member(base, member) => member_ty(gcx, base, member.name),
-        ExprKind::New(ty) | ExprKind::Type(ty) | ExprKind::TypeCall(ty) => {
-            Some(gcx.mk_ty(TyKind::Type(gcx.type_of_hir_ty(ty))))
-        }
-        ExprKind::Payable(inner) => expr_ty(gcx, inner)?
-            .convert_explicit_to(gcx.types.address_payable, gcx)
-            .then_some(gcx.types.address_payable),
-        ExprKind::Slice(lhs, ..) => {
-            let lhs_ty = expr_ty(gcx, lhs)?;
-            lhs_ty.is_sliceable().then(|| gcx.mk_ty(TyKind::Slice(lhs_ty)))
-        }
-        ExprKind::Tuple(exprs) => {
-            let tys = exprs.iter().map(|e| expr_ty(gcx, (*e)?)).collect::<Option<Vec<_>>>()?;
-            Some(gcx.mk_ty_tuple(gcx.mk_tys(&tys)))
-        }
-        ExprKind::Ternary(_, t, f) => expr_ty(gcx, t)?.common_type(expr_ty(gcx, f)?, gcx),
-        ExprKind::Unary(op, _) if op.kind == UnOpKind::Not => Some(gcx.types.bool),
-        ExprKind::Unary(_, inner) => expr_ty(gcx, inner),
-        ExprKind::Binary(_, op, _)
-            if matches!(
-                op.kind,
-                BinOpKind::Lt
-                    | BinOpKind::Le
-                    | BinOpKind::Gt
-                    | BinOpKind::Ge
-                    | BinOpKind::Eq
-                    | BinOpKind::Ne
-                    | BinOpKind::And
-                    | BinOpKind::Or
-            ) =>
-        {
-            Some(gcx.types.bool)
-        }
-        _ => None,
-    }
-}
-
-fn explicit_cast_ty<'gcx>(gcx: Gcx<'gcx>, to: Ty<'gcx>, args: &CallArgs<'gcx>) -> Ty<'gcx> {
-    match args.exprs().next().and_then(|arg| expr_ty(gcx, arg)) {
-        Some(from) => from.try_convert_explicit_to(to, gcx).unwrap_or(to),
-        None => to,
-    }
-}
-
-/// Type of `base.<member>`, resolved through Solar's member tables (unique match only).
-pub fn member_ty<'gcx>(gcx: Gcx<'gcx>, base: &Expr<'gcx>, member: Symbol) -> Option<Ty<'gcx>> {
-    if is_this_or_super(base) {
-        return None;
-    }
-    let base_ty = expr_ty(gcx, base)?;
-    let item = referenced_item(base);
-    let source = item
-        .map(|id| gcx.hir.item(id).source())
-        .unwrap_or_else(|| gcx.hir.sources_enumerated().next().expect("HIR has a source").0);
-    let contract = item.and_then(|id| gcx.hir.item(id).contract());
-    unique(gcx.members_of(base_ty, source, contract).filter(|m| m.name == member).map(|m| m.ty))
+    gcx.type_of_expr(recv.peel_parens().id).and_then(ty_contract_id)
 }
 
 /// The only element of `iter`, or `None` when it has zero or several.

--- a/crates/lint/src/sol/codesize/unwrapped_modifier_logic.rs
+++ b/crates/lint/src/sol/codesize/unwrapped_modifier_logic.rs
@@ -29,7 +29,7 @@ impl<'gcx> LateLintPass<'gcx> for UnwrappedModifierLogic {
         else {
             return;
         };
-        if block_outcome(body).can_skip_placeholder() {
+        if block_outcome(gcx, body).can_skip_placeholder() {
             return;
         }
         // Only a single, top-level placeholder can be split around: extracting a placeholder
@@ -57,7 +57,7 @@ impl<'gcx> LateLintPass<'gcx> for UnwrappedModifierLogic {
 fn is_plain_call(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let ExprKind::Call(callee, ..) = &expr.kind else { return false };
     match &callee.kind {
-        ExprKind::Ident(reses) => !reses.iter().any(|r| r.as_builtin().is_some()),
+        ExprKind::Ident(_) => gcx.resolved_builtin(callee).is_none(),
         ExprKind::Member(base, _) => {
             matches!(referenced_item(gcx, base), Some(ItemId::Contract(id))
             if gcx.hir.contract(id).kind == ContractKind::Library)

--- a/crates/lint/src/sol/codesize/unwrapped_modifier_logic.rs
+++ b/crates/lint/src/sol/codesize/unwrapped_modifier_logic.rs
@@ -11,7 +11,7 @@ use solar::{
     interface::diagnostics::Applicability,
     sema::{
         Gcx,
-        hir::{self, Expr, ExprKind, Function, ItemId, Res, Stmt, StmtKind, Visit as _},
+        hir::{self, Expr, ExprKind, Function, ItemId, Stmt, StmtKind, Visit as _},
     },
 };
 use std::ops::ControlFlow;
@@ -42,7 +42,7 @@ impl<'gcx> LateLintPass<'gcx> for UnwrappedModifierLogic {
             return;
         };
         let (before, after) = (&body.stmts[..idx], &body.stmts[idx + 1..]);
-        if let Some(suggestion) = snippet(ctx, &gcx.hir, func, name.as_str(), before, after) {
+        if let Some(suggestion) = snippet(ctx, gcx, func, name.as_str(), before, after) {
             ctx.emit_with_suggestion(
                 &UNWRAPPED_MODIFIER_LOGIC,
                 func.span.to(func.body_span),
@@ -54,12 +54,14 @@ impl<'gcx> LateLintPass<'gcx> for UnwrappedModifierLogic {
 
 /// A call to a non-builtin function or to a library function: the only statement cheap enough to
 /// leave inline.
-fn is_plain_call(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> bool {
+fn is_plain_call(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let ExprKind::Call(callee, ..) = &expr.kind else { return false };
     match &callee.kind {
         ExprKind::Ident(reses) => !reses.iter().any(|r| r.as_builtin().is_some()),
-        ExprKind::Member(base, _) => matches!(referenced_item(base), Some(ItemId::Contract(id))
-            if hir.contract(id).kind == ContractKind::Library),
+        ExprKind::Member(base, _) => {
+            matches!(referenced_item(gcx, base), Some(ItemId::Contract(id))
+            if gcx.hir.contract(id).kind == ContractKind::Library)
+        }
         _ => false,
     }
 }
@@ -67,12 +69,12 @@ fn is_plain_call(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> bool {
 /// Whether `stmts` should move into a helper: anything but a single plain call requires wrapping.
 /// Inline assembly is left alone; its authors know how to manage code size and have a reason to
 /// use it in a modifier.
-fn requires_wrapping(hir: &hir::Hir<'_>, stmts: &[Stmt<'_>]) -> bool {
+fn requires_wrapping(gcx: Gcx<'_>, stmts: &[Stmt<'_>]) -> bool {
     let (mut calls, mut other) = (0, false);
     for stmt in stmts {
         match &stmt.kind {
             StmtKind::Placeholder => {}
-            StmtKind::Expr(expr) if is_plain_call(hir, expr) => calls += 1,
+            StmtKind::Expr(expr) if is_plain_call(gcx, expr) => calls += 1,
             StmtKind::AssemblyBlock(_) | StmtKind::Switch(_) | StmtKind::Err(_) => return false,
             _ => other = true,
         }
@@ -82,13 +84,14 @@ fn requires_wrapping(hir: &hir::Hir<'_>, stmts: &[Stmt<'_>]) -> bool {
 
 fn snippet<'gcx>(
     ctx: &LintContext,
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     func: &'gcx Function<'gcx>,
     name: &str,
     before: &'gcx [Stmt<'gcx>],
     after: &'gcx [Stmt<'gcx>],
 ) -> Option<Suggestion> {
-    let (wrap_before, wrap_after) = (requires_wrapping(hir, before), requires_wrapping(hir, after));
+    let hir = &gcx.hir;
+    let (wrap_before, wrap_after) = (requires_wrapping(gcx, before), requires_wrapping(gcx, after));
     if !(wrap_before || wrap_after) {
         return None;
     }
@@ -113,7 +116,7 @@ fn snippet<'gcx>(
                 _ => None,
             };
             if let Some(lvalue) = lvalue {
-                for_each_lhs_var(lvalue, &mut |v| {
+                for_each_lhs_var(gcx, lvalue, &mut |v| {
                     if func.parameters.contains(&v) && !shared.contains(&v) {
                         shared.push(v);
                     }
@@ -122,10 +125,8 @@ fn snippet<'gcx>(
             false
         });
     }
-    if any_expr(hir, after, |expr| {
-        matches!(&expr.kind, ExprKind::Ident(reses)
-            if reses.iter().filter_map(Res::as_variable).any(|v| shared.contains(&v)))
-    }) {
+    if any_expr(hir, after, |expr| gcx.resolved_variable(expr).is_some_and(|v| shared.contains(&v)))
+    {
         return None;
     }
 

--- a/crates/lint/src/sol/gas/cache_array_length.rs
+++ b/crates/lint/src/sol/gas/cache_array_length.rs
@@ -1,18 +1,16 @@
 use super::CacheArrayLength;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        analysis::{for_each_lhs_var, function_ids},
-    },
+    sol::{Severity, SolLint, analysis::for_each_lhs_var},
 };
 use solar::{
     ast::ElementaryType,
-    interface::{Span, data_structures::Never, kw, sym},
+    interface::{Span, data_structures::Never, sym},
     sema::{
         Gcx,
+        builtins::Builtin,
         hir::{
-            self, BinOpKind, Expr, ExprKind, LoopSource, Res, StateMutability, Stmt, StmtKind,
+            self, BinOpKind, Expr, ExprKind, LoopSource, StateMutability, Stmt, StmtKind,
             VariableId, Visit as _,
         },
         ty::TyKind,
@@ -72,12 +70,7 @@ fn collect_length_reads<'gcx>(
             collect_length_reads(gcx, lhs, reads);
             collect_length_reads(gcx, rhs, reads);
         }
-        BinOpKind::Lt
-        | BinOpKind::Le
-        | BinOpKind::Gt
-        | BinOpKind::Ge
-        | BinOpKind::Eq
-        | BinOpKind::Ne => {
+        kind if kind.is_cmp() => {
             for (side, other) in [(lhs, rhs), (rhs, lhs)] {
                 let side = side.peel_parens();
                 if matches!(other.peel_parens().kind, ExprKind::Ident(_))
@@ -112,10 +105,10 @@ impl<'gcx> hir::Visit<'gcx> for LoopFacts<'gcx> {
         match &expr.kind {
             ExprKind::Assign(lhs, ..) | ExprKind::Delete(lhs) => {
                 self.skip |= is_array_like(self.gcx, lhs);
-                for_each_lhs_var(lhs, &mut |v| self.written.push(v));
+                for_each_lhs_var(self.gcx, lhs, &mut |v| self.written.push(v));
             }
             ExprKind::Unary(op, inner) if op.kind.has_side_effects() => {
-                for_each_lhs_var(inner, &mut |v| self.written.push(v));
+                for_each_lhs_var(self.gcx, inner, &mut |v| self.written.push(v));
             }
             ExprKind::Call(callee, ..) => {
                 self.skip |= call_may_mutate_state(self.gcx, callee);
@@ -132,10 +125,13 @@ fn call_may_mutate_state<'gcx>(gcx: Gcx<'gcx>, callee: &'gcx Expr<'gcx>) -> bool
     match &callee.kind {
         ExprKind::Type(_) => false,
         ExprKind::Ident(_) => {
-            function_ids(callee).next().is_none_or(|f| gcx.hir.function(f).mutates_state())
+            gcx.resolved_function(callee).is_none_or(|f| gcx.hir.function(f).mutates_state())
         }
-        ExprKind::Member(base, member)
-            if matches!(member.name, sym::push | kw::Pop) && is_array_like(gcx, base) =>
+        ExprKind::Member(..)
+            if matches!(
+                gcx.resolved_builtin(callee),
+                Some(Builtin::ArrayPush0 | Builtin::ArrayPush | Builtin::ArrayPop)
+            ) =>
         {
             true
         }
@@ -158,8 +154,7 @@ fn is_array_like<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
 /// The state variable `expr` names, if it is a dynamic array.
 fn state_dyn_array<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> Option<VariableId> {
     let expr = expr.peel_parens();
-    let ExprKind::Ident(reses) = &expr.kind else { return None };
-    let var = reses.iter().find_map(Res::as_variable)?;
+    let var = gcx.resolved_variable(expr)?;
     (gcx.hir.variable(var).is_state_variable()
         && matches!(
             gcx.type_of_expr(expr.id).map(|ty| ty.peel_refs().kind),

--- a/crates/lint/src/sol/gas/cache_array_length.rs
+++ b/crates/lint/src/sol/gas/cache_array_length.rs
@@ -124,9 +124,6 @@ fn call_may_mutate_state<'gcx>(gcx: Gcx<'gcx>, callee: &'gcx Expr<'gcx>) -> bool
     let callee = callee.peel_parens();
     match &callee.kind {
         ExprKind::Type(_) => false,
-        ExprKind::Ident(_) => {
-            gcx.resolved_function(callee).is_none_or(|f| gcx.hir.function(f).mutates_state())
-        }
         ExprKind::Member(..)
             if matches!(
                 gcx.resolved_builtin(callee),

--- a/crates/lint/src/sol/gas/costly_loop.rs
+++ b/crates/lint/src/sol/gas/costly_loop.rs
@@ -9,7 +9,7 @@ use solar::{
     sema::{
         Gcx, Hir,
         builtins::Builtin,
-        hir::{self, Expr, ExprKind, Function, Res, Stmt, StmtKind, Visit as _},
+        hir::{self, Expr, ExprKind, Function, Stmt, StmtKind, Visit as _},
     },
 };
 use std::ops::ControlFlow;
@@ -66,10 +66,9 @@ impl<'gcx> hir::Visit<'gcx> for LoopWriteFinder<'_, 'gcx> {
 fn lvalue_is_state_var(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let expr = expr.peel_parens();
     match &expr.kind {
-        ExprKind::Ident(reses) => reses
-            .iter()
-            .find_map(Res::as_variable)
-            .is_some_and(|id| gcx.hir.variable(id).is_state_variable()),
+        ExprKind::Ident(_) => {
+            gcx.resolved_variable(expr).is_some_and(|id| gcx.hir.variable(id).is_state_variable())
+        }
         ExprKind::Call(callee, ..) => {
             gcx.resolved_builtin(callee) == Some(Builtin::ArrayPush0)
                 || gcx

--- a/crates/lint/src/sol/gas/external_function.rs
+++ b/crates/lint/src/sol/gas/external_function.rs
@@ -1,20 +1,17 @@
 use super::ExternalFunction;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        analysis::{function_ids, is_builtin},
-    },
+    sol::{Severity, SolLint, analysis::is_builtin},
 };
 use solar::{
     ast::{ContractKind, DataLocation, Visibility},
-    interface::{Symbol, data_structures::Never, sym},
+    interface::{data_structures::Never, sym},
     sema::{
         Gcx,
         hir::{
-            self, ContractId, Expr, ExprKind, FunctionId, ItemId, Res, Stmt, StmtKind, VariableId,
-            Visit as _,
+            self, ContractId, Expr, ExprKind, FunctionId, Stmt, StmtKind, VariableId, Visit as _,
         },
+        ty::TyKind,
     },
 };
 use std::{
@@ -36,8 +33,8 @@ struct ProjectIndex {
     /// Functions referenced by name anywhere in the project: internal calls (`foo()`) and
     /// function pointers (`fn = foo;`).
     referenced: HashSet<FunctionId>,
-    /// Contracts containing a `super.<name>` access, keyed by `<name>`.
-    super_called: HashMap<Symbol, HashSet<ContractId>>,
+    /// Contracts containing a `super` access, keyed by its resolved function.
+    super_called: HashMap<FunctionId, HashSet<ContractId>>,
 }
 
 thread_local! {
@@ -46,16 +43,17 @@ thread_local! {
     static PROJECT_INDEX: RefCell<Option<(usize, Rc<ProjectIndex>)>> = const { RefCell::new(None) };
 }
 
-fn project_index<'gcx>(hir: &'gcx hir::Hir<'gcx>) -> Rc<ProjectIndex> {
-    let key = std::ptr::from_ref(hir) as usize;
+fn project_index(gcx: Gcx<'_>) -> Rc<ProjectIndex> {
+    let key = std::ptr::from_ref(&gcx.hir) as usize;
     PROJECT_INDEX.with_borrow_mut(|slot| match slot {
         Some((cached_key, index)) if *cached_key == key => index.clone(),
-        _ => slot.insert((key, Rc::new(build_project_index(hir)))).1.clone(),
+        _ => slot.insert((key, Rc::new(build_project_index(gcx)))).1.clone(),
     })
 }
 
-fn build_project_index<'gcx>(hir: &'gcx hir::Hir<'gcx>) -> ProjectIndex {
-    let mut builder = IndexBuilder { hir, index: ProjectIndex::default(), contract: None };
+fn build_project_index(gcx: Gcx<'_>) -> ProjectIndex {
+    let hir = &gcx.hir;
+    let mut builder = IndexBuilder { gcx, index: ProjectIndex::default(), contract: None };
     for func in hir.functions() {
         builder.contract = func.contract;
         let _ = builder.visit_function(func);
@@ -69,7 +67,7 @@ fn build_project_index<'gcx>(hir: &'gcx hir::Hir<'gcx>) -> ProjectIndex {
 }
 
 struct IndexBuilder<'gcx> {
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     index: ProjectIndex,
     /// Contract being walked, to attribute `super.<name>` accesses to the caller.
     contract: Option<ContractId>,
@@ -79,16 +77,24 @@ impl<'gcx> hir::Visit<'gcx> for IndexBuilder<'gcx> {
     type BreakValue = Never;
 
     fn hir(&self) -> &'gcx hir::Hir<'gcx> {
-        self.hir
+        &self.gcx.hir
     }
 
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         match &expr.kind {
-            ExprKind::Ident(_) => self.index.referenced.extend(function_ids(expr)),
-            ExprKind::Member(base, member) if is_builtin(base, sym::super_) => {
-                if let Some(cid) = self.contract {
-                    self.index.super_called.entry(member.name).or_default().insert(cid);
+            ExprKind::Ident(_) => self.index.referenced.extend(self.gcx.resolved_function(expr)),
+            ExprKind::Member(base, _) if is_builtin(base, sym::super_) => {
+                if let Some(cid) = self.contract
+                    && let Some(fid) = self.gcx.resolved_function(expr)
+                {
+                    self.index.super_called.entry(fid).or_default().insert(cid);
                 }
+            }
+            ExprKind::Member(base, _)
+                if matches!(self.gcx.type_of_expr(base.id).map(|ty| ty.kind),
+                    Some(TyKind::Type(ty)) if matches!(ty.kind, TyKind::Contract(_))) =>
+            {
+                self.index.referenced.extend(self.gcx.resolved_function(expr));
             }
             _ => {}
         }
@@ -112,7 +118,7 @@ impl<'gcx> LateLintPass<'gcx> for ExternalFunction {
         {
             return;
         }
-        let index = project_index(&gcx.hir);
+        let index = project_index(gcx);
 
         for fid in contract.functions() {
             let func = gcx.hir.function(fid);
@@ -127,34 +133,27 @@ impl<'gcx> LateLintPass<'gcx> for ExternalFunction {
                 continue;
             }
             // Only reference parameters currently in `memory` yield meaningful savings.
-            if !func.parameters.iter().any(|&p| is_memory_reference(gcx.hir.variable(p))) {
+            if !func.parameters.iter().any(|&p| is_memory_reference(gcx, p)) {
                 continue;
             }
-            let mut finder = ParamEscapeFinder { hir: &gcx.hir, params: func.parameters };
+            let mut finder = ParamEscapeFinder { gcx, params: func.parameters };
             if finder.visit_function(func).is_break() {
                 continue;
             }
-            // Only a `super.<name>` call from a strict descendant can resolve into this contract.
-            let super_called = index.super_called.get(&name.name).is_some_and(|callers| {
+            let super_called = index.super_called.iter().any(|(&target, callers)| {
                 callers.iter().any(|&caller| {
-                    caller != contract_id
-                        && gcx.hir.contract(caller).linearized_bases.contains(&contract_id)
+                    gcx.hir.contracts_enumerated().any(|(cid, contract)| {
+                        contract.linearized_bases.contains(&caller)
+                            && gcx.resolve_super_function(cid, caller, target) == fid
+                    })
                 })
             });
-            // A referenced same-name/arity function in this contract or a derivative conceptually
-            // targets the base's slot. Same-arity overloads are conflated (HIR types have no
-            // structural equality), yielding only false negatives.
+            // A reference to this function's virtual target in a descendant also uses its slot.
             let override_referenced = gcx
                 .hir
                 .contracts_enumerated()
                 .filter(|(cid, c)| *cid == contract_id || c.linearized_bases.contains(&contract_id))
-                .flat_map(|(_, c)| c.functions())
-                .filter(|fid| index.referenced.contains(fid))
-                .any(|fid| {
-                    let other = gcx.hir.function(fid);
-                    other.name.is_some_and(|n| n.name == name.name)
-                        && other.parameters.len() == func.parameters.len()
-                });
+                .any(|(cid, _)| index.referenced.contains(&gcx.resolve_virtual_function(cid, fid)));
             if !super_called && !override_referenced {
                 ctx.emit(&EXTERNAL_FUNCTION, name.span);
             }
@@ -165,13 +164,13 @@ impl<'gcx> LateLintPass<'gcx> for ExternalFunction {
 /// Breaks when a parameter is written, aliased, passed to a callee or modifier that could mutate
 /// it through the internal-call memory-reference aliasing rule.
 struct ParamEscapeFinder<'a, 'gcx> {
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     params: &'a [VariableId],
 }
 
 impl ParamEscapeFinder<'_, '_> {
     fn is_param(&self, expr: &Expr<'_>) -> bool {
-        root_var_is(expr, &|v| self.params.contains(&v))
+        root_var_is(self.gcx, expr, &|v| self.params.contains(&v))
     }
 }
 
@@ -179,7 +178,7 @@ impl<'gcx> hir::Visit<'gcx> for ParamEscapeFinder<'_, 'gcx> {
     type BreakValue = ();
 
     fn hir(&self) -> &'gcx hir::Hir<'gcx> {
-        self.hir
+        &self.gcx.hir
     }
 
     fn visit_modifier(&mut self, modifier: &'gcx hir::Modifier<'gcx>) -> ControlFlow<()> {
@@ -191,8 +190,8 @@ impl<'gcx> hir::Visit<'gcx> for ParamEscapeFinder<'_, 'gcx> {
 
     fn visit_stmt(&mut self, stmt: &'gcx Stmt<'gcx>) -> ControlFlow<()> {
         if let StmtKind::DeclSingle(vid) = &stmt.kind
-            && let var = self.hir.variable(*vid)
-            && is_memory_reference(var)
+            && let var = self.gcx.hir.variable(*vid)
+            && is_memory_reference(self.gcx, *vid)
             && var.initializer.is_some_and(|init| self.is_param(init))
         {
             return ControlFlow::Break(());
@@ -205,16 +204,19 @@ impl<'gcx> hir::Visit<'gcx> for ParamEscapeFinder<'_, 'gcx> {
             ExprKind::Assign(lhs, op, rhs) => {
                 self.is_param(lhs)
                     || (op.is_none()
-                        && root_var_is(lhs, &|v| {
-                            let var = self.hir.variable(v);
-                            var.is_local_variable() && is_memory_reference(var)
+                        && root_var_is(self.gcx, lhs, &|v| {
+                            let var = self.gcx.hir.variable(v);
+                            var.is_local_variable() && is_memory_reference(self.gcx, v)
                         })
                         && self.is_param(rhs))
             }
             ExprKind::Delete(inner) => self.is_param(inner),
             ExprKind::Unary(op, inner) => op.kind.has_side_effects() && self.is_param(inner),
             ExprKind::Call(callee, args, opts) => {
-                !is_type_conversion(callee)
+                !self
+                    .gcx
+                    .type_of_expr(callee.id)
+                    .is_some_and(|ty| matches!(ty.kind, TyKind::Type(_)))
                     && (args.exprs().any(|arg| self.is_param(arg))
                         || opts.is_some_and(|opts| {
                             opts.args.iter().any(|opt| self.is_param(&opt.value))
@@ -231,35 +233,19 @@ impl<'gcx> hir::Visit<'gcx> for ParamEscapeFinder<'_, 'gcx> {
     }
 }
 
-fn is_memory_reference(var: &hir::Variable<'_>) -> bool {
-    var.ty.kind.is_reference_type() && var.data_location == Some(DataLocation::Memory)
-}
-
-/// `T(...)`, `new T(...)`, or a struct/contract/enum/UDVT conversion.
-fn is_type_conversion(callee: &Expr<'_>) -> bool {
-    match &callee.peel_parens().kind {
-        ExprKind::Type(_) | ExprKind::TypeCall(_) | ExprKind::New(_) => true,
-        ExprKind::Ident(reses) => reses.iter().any(|r| {
-            matches!(
-                r,
-                Res::Item(
-                    ItemId::Struct(_) | ItemId::Contract(_) | ItemId::Enum(_) | ItemId::Udvt(_)
-                )
-            )
-        }),
-        _ => false,
-    }
+fn is_memory_reference(gcx: Gcx<'_>, var: VariableId) -> bool {
+    gcx.type_of_item(var.into()).loc() == Some(DataLocation::Memory)
 }
 
 /// Whether the variable at the root of `expr` (through parens, members, indexes and slices)
 /// satisfies `pred`.
-fn root_var_is(expr: &Expr<'_>, pred: &impl Fn(VariableId) -> bool) -> bool {
+fn root_var_is(gcx: Gcx<'_>, expr: &Expr<'_>, pred: &impl Fn(VariableId) -> bool) -> bool {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().filter_map(Res::as_variable).any(pred),
+        ExprKind::Ident(_) => gcx.resolved_variable(expr).is_some_and(pred),
         ExprKind::Member(base, _)
         | ExprKind::Payable(base)
         | ExprKind::Index(base, _)
-        | ExprKind::Slice(base, ..) => root_var_is(base, pred),
+        | ExprKind::Slice(base, ..) => root_var_is(gcx, base, pred),
         _ => false,
     }
 }

--- a/crates/lint/src/sol/gas/external_function.rs
+++ b/crates/lint/src/sol/gas/external_function.rs
@@ -83,7 +83,7 @@ impl<'gcx> hir::Visit<'gcx> for IndexBuilder<'gcx> {
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         match &expr.kind {
             ExprKind::Ident(_) => self.index.referenced.extend(self.gcx.resolved_function(expr)),
-            ExprKind::Member(base, _) if is_builtin(base, sym::super_) => {
+            ExprKind::Member(base, _) if is_builtin(self.gcx, base, sym::super_) => {
                 if let Some(cid) = self.contract
                     && let Some(fid) = self.gcx.resolved_function(expr)
                 {

--- a/crates/lint/src/sol/gas/immutable.rs
+++ b/crates/lint/src/sol/gas/immutable.rs
@@ -3,7 +3,7 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{builtins, for_each_lhs_var, is_contract_cast, loop_stmts},
+        analysis::{for_each_lhs_var, is_contract_cast, loop_stmts},
     },
 };
 use solar::{
@@ -174,7 +174,7 @@ fn is_compile_time_constant(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
         ExprKind::Ternary(c, t, f) => is_const(c) && is_const(t) && is_const(f),
         ExprKind::Tuple(exprs) => exprs.iter().flatten().all(|e| is_const(e)),
         ExprKind::Call(callee, args, opts) => {
-            is_constant_call(callee)
+            is_constant_call(gcx, callee)
                 && args.exprs().all(is_const)
                 && opts.is_none_or(|opts| opts.args.iter().all(|arg| is_const(&arg.value)))
         }
@@ -198,10 +198,10 @@ fn is_compile_time_constant(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
 }
 
 /// Type casts (`address(0xCAFE)`, `IToken(addr)`) and the hashing / modular arithmetic builtins.
-fn is_constant_call(callee: &Expr<'_>) -> bool {
+fn is_constant_call(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
     matches!(callee.kind, ExprKind::Type(_))
-        || is_contract_cast(callee)
-        || builtins(callee).any(|b| {
+        || is_contract_cast(gcx, callee)
+        || gcx.resolved_builtin(callee).is_some_and(|b| {
             matches!(
                 b.name(),
                 kw::Keccak256

--- a/crates/lint/src/sol/gas/immutable.rs
+++ b/crates/lint/src/sol/gas/immutable.rs
@@ -11,9 +11,7 @@ use solar::{
     interface::{data_structures::Never, kw, sym},
     sema::{
         Gcx,
-        hir::{
-            self, Expr, ExprKind, ItemId, Res, Stmt, StmtKind, TypeKind, VariableId, Visit as _,
-        },
+        hir::{self, Expr, ExprKind, ItemId, Stmt, StmtKind, TypeKind, VariableId, Visit as _},
     },
 };
 use std::{collections::HashSet, ops::ControlFlow};
@@ -77,15 +75,15 @@ impl<'gcx> LateLintPass<'gcx> for UnchangedStateVariables {
 
         // Writes performed as side effects of state variable initializers block `constant` but are
         // not valid `immutable` assignments, so they are tracked separately.
-        let mut initializer_writes = WriteCollector { hir: &gcx.hir, writes: HashSet::new() };
+        let mut initializer_writes = WriteCollector { gcx, writes: HashSet::new() };
         for id in candidates.clone() {
             if let Some(init) = gcx.hir.variable(id).initializer {
                 let _ = initializer_writes.visit_expr(init);
             }
         }
         // Modifier bodies are visited as ordinary functions, so their writes count as runtime.
-        let mut constructor_writes = WriteCollector { hir: &gcx.hir, writes: HashSet::new() };
-        let mut runtime_writes = WriteCollector { hir: &gcx.hir, writes: HashSet::new() };
+        let mut constructor_writes = WriteCollector { gcx, writes: HashSet::new() };
+        let mut runtime_writes = WriteCollector { gcx, writes: HashSet::new() };
         for function in functions {
             let collector = if function.is_constructor() {
                 &mut constructor_writes
@@ -102,13 +100,9 @@ impl<'gcx> LateLintPass<'gcx> for UnchangedStateVariables {
             let var = gcx.hir.variable(var_id);
             let span = var.name.map_or(var.span, |name| name.span);
             let constant_initializer =
-                var.initializer.is_some_and(|expr| is_compile_time_constant(&gcx.hir, expr));
+                var.initializer.is_some_and(|expr| is_compile_time_constant(gcx, expr));
             let written_in_constructor = constructor_writes.writes.contains(&var_id);
-            let immutable_type = match var.ty.kind {
-                TypeKind::Elementary(ty) => ty.is_value_type(),
-                TypeKind::Custom(ItemId::Contract(_)) => true,
-                _ => false,
-            };
+            let immutable_type = gcx.type_of_item(var_id.into()).is_value_type();
             if constant_initializer
                 && !written_in_constructor
                 && !initializer_writes.writes.contains(&var_id)
@@ -142,7 +136,7 @@ fn has_assembly_or_unknown(stmt: &Stmt<'_>) -> bool {
 
 /// Collects every variable at the root of an assigned, deleted or incremented lvalue.
 struct WriteCollector<'gcx> {
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     writes: HashSet<VariableId>,
 }
 
@@ -150,7 +144,7 @@ impl<'gcx> hir::Visit<'gcx> for WriteCollector<'gcx> {
     type BreakValue = Never;
 
     fn hir(&self) -> &'gcx hir::Hir<'gcx> {
-        self.hir
+        &self.gcx.hir
     }
 
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
@@ -160,7 +154,7 @@ impl<'gcx> hir::Visit<'gcx> for WriteCollector<'gcx> {
             _ => None,
         };
         if let Some(lvalue) = lvalue {
-            for_each_lhs_var(lvalue, &mut |v| {
+            for_each_lhs_var(self.gcx, lvalue, &mut |v| {
                 self.writes.insert(v);
             });
         }
@@ -168,17 +162,12 @@ impl<'gcx> hir::Visit<'gcx> for WriteCollector<'gcx> {
     }
 }
 
-fn is_compile_time_constant(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> bool {
-    let is_const = |e: &Expr<'_>| is_compile_time_constant(hir, e);
+fn is_compile_time_constant(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
+    let is_const = |e: &Expr<'_>| is_compile_time_constant(gcx, e);
     match &expr.kind {
         ExprKind::Lit(_) | ExprKind::Type(_) | ExprKind::TypeCall(_) => true,
-        // A constant variable, possibly sharing its name with functions.
-        ExprKind::Ident(reses) => {
-            reses.iter().any(|r| r.as_variable().is_some())
-                && reses.iter().all(|r| {
-                    matches!(r, Res::Item(ItemId::Function(_)))
-                        || r.as_variable().is_some_and(|v| hir.variable(v).is_constant())
-                })
+        ExprKind::Ident(_) => {
+            gcx.resolved_variable(expr).is_some_and(|v| gcx.hir.variable(v).is_constant())
         }
         ExprKind::Unary(op, inner) => !op.kind.has_side_effects() && is_const(inner),
         ExprKind::Binary(lhs, _, rhs) => is_const(lhs) && is_const(rhs),
@@ -200,7 +189,7 @@ fn is_compile_time_constant(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> bool {
             (ExprKind::TypeCall(ty), sym::interfaceId) => matches!(
                 ty.kind,
                 TypeKind::Custom(ItemId::Contract(cid))
-                    if hir.contract(cid).kind == ContractKind::Interface
+                    if gcx.hir.contract(cid).kind == ContractKind::Interface
             ),
             _ => false,
         },

--- a/crates/lint/src/sol/gas/keccak.rs
+++ b/crates/lint/src/sol/gas/keccak.rs
@@ -33,7 +33,7 @@ impl<'gcx> LateLintPass<'gcx> for AsmKeccak256 {
         if let Some(expr) = expr
             && let ExprKind::Call(callee, args, _) = &expr.kind
             && args.len() == 1
-            && is_builtin(callee, kw::Keccak256)
+            && is_builtin(gcx, callee, kw::Keccak256)
         {
             ctx.emit(&ASM_KECCAK256, expr.span);
         }

--- a/crates/lint/src/sol/gas/unused_state_variables.rs
+++ b/crates/lint/src/sol/gas/unused_state_variables.rs
@@ -8,7 +8,7 @@ use solar::{
     interface::data_structures::Never,
     sema::{
         Gcx,
-        hir::{self, ExprKind, Res, Visit as _},
+        hir::{self, Visit as _},
     },
 };
 use std::{collections::HashSet, ops::ControlFlow};
@@ -33,7 +33,7 @@ impl<'gcx> LateLintPass<'gcx> for UnusedStateVariables {
 
         // Functions (including modifier call args) and state variable initializers cover every
         // variable reference in the contract.
-        let mut collector = UsedVarCollector { hir: &gcx.hir, used: HashSet::new() };
+        let mut collector = UsedVarCollector { gcx, used: HashSet::new() };
         for func_id in contract.all_functions() {
             let _ = collector.visit_nested_function(func_id);
         }
@@ -52,7 +52,7 @@ impl<'gcx> LateLintPass<'gcx> for UnusedStateVariables {
 }
 
 struct UsedVarCollector<'gcx> {
-    hir: &'gcx hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     used: HashSet<hir::VariableId>,
 }
 
@@ -60,13 +60,11 @@ impl<'gcx> hir::Visit<'gcx> for UsedVarCollector<'gcx> {
     type BreakValue = Never;
 
     fn hir(&self) -> &'gcx hir::Hir<'gcx> {
-        self.hir
+        &self.gcx.hir
     }
 
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
-        if let ExprKind::Ident(reses) = &expr.kind {
-            self.used.extend(reses.iter().filter_map(Res::as_variable));
-        }
+        self.used.extend(self.gcx.resolved_variable(expr));
         self.walk_expr(expr)
     }
 }

--- a/crates/lint/src/sol/gas/var_read_using_this.rs
+++ b/crates/lint/src/sol/gas/var_read_using_this.rs
@@ -80,7 +80,7 @@ impl ThisReadFinder<'_, '_> {
     fn check_call(&self, expr: &Expr<'_>) {
         let ExprKind::Call(callee, args, opts) = &expr.kind else { return };
         let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return };
-        if !is_builtin(base, sym::this) {
+        if !is_builtin(self.gcx, base, sym::this) {
             return;
         }
         let Some(function_id) = self.gcx.resolved_function(callee) else { return };

--- a/crates/lint/src/sol/gas/var_read_using_this.rs
+++ b/crates/lint/src/sol/gas/var_read_using_this.rs
@@ -11,7 +11,7 @@ use solar::{
         hir::{self, CallArgs, Expr, ExprId, ExprKind, Function, Stmt, StmtKind, Visit as _},
     },
 };
-use std::{collections::HashMap, ops::ControlFlow};
+use std::ops::ControlFlow;
 
 declare_forge_lint!(
     VAR_READ_USING_THIS,
@@ -33,21 +33,7 @@ impl<'gcx> LateLintPass<'gcx> for VarReadUsingThis {
             return;
         }
 
-        // Externally callable functions reachable through `this.<name>(...)`, grouped by name so
-        // overloads and inherited overrides can be resolved by arity.
-        let mut callable = HashMap::<_, Vec<_>>::new();
-        for fid in
-            contract.linearized_bases.iter().flat_map(|&cid| gcx.hir.contract(cid).functions())
-        {
-            let func = gcx.hir.function(fid);
-            if let Some(name) = func.name
-                && func.is_part_of_external_interface()
-            {
-                callable.entry(name.name).or_default().push(func);
-            }
-        }
-
-        let mut finder = ThisReadFinder { ctx, hir: &gcx.hir, callable, try_target: None };
+        let mut finder = ThisReadFinder { ctx, gcx, try_target: None };
         // State variable initializers run in the synthesized constructor.
         for var_id in contract.variables() {
             let _ = finder.visit_nested_var(var_id);
@@ -61,8 +47,7 @@ impl<'gcx> LateLintPass<'gcx> for VarReadUsingThis {
 
 struct ThisReadFinder<'a, 'gcx> {
     ctx: &'a LintContext<'a, 'a>,
-    hir: &'gcx hir::Hir<'gcx>,
-    callable: HashMap<Symbol, Vec<&'gcx Function<'gcx>>>,
+    gcx: Gcx<'gcx>,
     /// The expression tried by the enclosing `try` statement, which must stay an external call.
     try_target: Option<ExprId>,
 }
@@ -71,7 +56,7 @@ impl<'gcx> hir::Visit<'gcx> for ThisReadFinder<'_, 'gcx> {
     type BreakValue = Never;
 
     fn hir(&self) -> &'gcx hir::Hir<'gcx> {
-        self.hir
+        &self.gcx.hir
     }
 
     fn visit_stmt(&mut self, stmt: &'gcx Stmt<'gcx>) -> ControlFlow<Self::BreakValue> {
@@ -98,17 +83,9 @@ impl ThisReadFinder<'_, '_> {
         if !is_builtin(base, sym::this) {
             return;
         }
-        let Some(candidates) = self.callable.get(&member.name) else { return };
-        // Solar's HIR `Member` is name-based, so overloads are resolved by arity. When same-arity
-        // overloads mix mutability (`f(uint256) view` vs `f(address)`), bail to avoid flagging
-        // the mutating one.
-        let same_arity: Vec<_> =
-            candidates.iter().filter(|f| f.parameters.len() == args.len()).collect();
-        let Some(func) = same_arity.first() else { return };
-        if !same_arity
-            .iter()
-            .all(|f| matches!(f.state_mutability, StateMutability::View | StateMutability::Pure))
-        {
+        let Some(function_id) = self.gcx.resolved_function(callee) else { return };
+        let func = self.gcx.hir.function(function_id);
+        if !matches!(func.state_mutability, StateMutability::View | StateMutability::Pure) {
             return;
         }
         // With call options like `{gas: ...}` the external call is deliberate: flag the gas waste

--- a/crates/lint/src/sol/gas/write_after_write.rs
+++ b/crates/lint/src/sol/gas/write_after_write.rs
@@ -6,9 +6,9 @@ use crate::{
 use solar::{
     interface::Span,
     sema::{
-        Gcx, Hir,
+        Gcx,
         hir::{
-            BinOpKind, Block, CallArgs, CallOptions, Expr, ExprKind, Function, Res, Stmt, StmtKind,
+            BinOpKind, Block, CallArgs, CallOptions, Expr, ExprKind, Function, Stmt, StmtKind,
             VariableId,
         },
     },
@@ -25,7 +25,7 @@ declare_forge_lint!(
 impl<'gcx> LateLintPass<'gcx> for WriteAfterWrite {
     fn check_function(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, func: &'gcx Function<'gcx>) {
         if let Some(body) = func.body {
-            Analyzer { ctx, hir: &gcx.hir, pending: HashMap::new() }.check_block(body);
+            Analyzer { ctx, gcx, pending: HashMap::new() }.check_block(body);
         }
     }
 }
@@ -34,7 +34,7 @@ impl<'gcx> LateLintPass<'gcx> for WriteAfterWrite {
 /// variable makes the pending one redundant.
 struct Analyzer<'a, 'gcx> {
     ctx: &'a LintContext<'a, 'a>,
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     pending: HashMap<VariableId, Span>,
 }
 
@@ -49,7 +49,7 @@ impl Analyzer<'_, '_> {
         match &stmt.kind {
             StmtKind::Expr(expr) => self.process_expr(expr),
             StmtKind::DeclSingle(var_id) => {
-                if let Some(init) = self.hir.variable(*var_id).initializer {
+                if let Some(init) = self.gcx.hir.variable(*var_id).initializer {
                     self.reads(init);
                 }
             }
@@ -181,8 +181,8 @@ impl Analyzer<'_, '_> {
     fn reads(&mut self, expr: &Expr<'_>) {
         let expr = expr.peel_parens();
         match &expr.kind {
-            ExprKind::Ident(reses) => {
-                for var in reses.iter().filter_map(Res::as_variable) {
+            ExprKind::Ident(_) => {
+                if let Some(var) = self.gcx.resolved_variable(expr) {
                     self.pending.remove(&var);
                 }
             }
@@ -246,10 +246,8 @@ impl Analyzer<'_, '_> {
 
     /// The state variable a bare identifier refers to.
     fn state_var(&self, expr: &Expr<'_>) -> Option<VariableId> {
-        let ExprKind::Ident(reses) = &expr.peel_parens().kind else { return None };
-        reses
-            .iter()
-            .filter_map(Res::as_variable)
-            .find(|&var| self.hir.variable(var).is_state_variable())
+        self.gcx
+            .resolved_variable(expr)
+            .filter(|&var| self.gcx.hir.variable(var).is_state_variable())
     }
 }

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -66,7 +66,7 @@ impl<'gcx> LateLintPass<'gcx> for ArbitrarySendErc20 {
         if func.modifiers.iter().any(|m| {
             m.id.as_function()
                 .and_then(|fid| modifier_prefix(&gcx.hir, fid))
-                .is_some_and(|p| p.iter().any(|s| branch_always_exits(s)))
+                .is_some_and(|p| p.iter().any(|s| branch_always_exits(gcx, s)))
         }) {
             return;
         }
@@ -276,8 +276,8 @@ impl<'gcx> Analyzer<'gcx> {
 
     /// `msg.sender`, `address(this)` or a tracked-safe variable.
     fn is_safe(&self, expr: &Expr<'_>) -> bool {
-        origin_matches(self.gcx, expr, HELPER_DEPTH, &self.state.safe_vars, |e| {
-            is_msg_sender(e) || is_address_self(e)
+        origin_matches(self.gcx, expr, HELPER_DEPTH, &self.state.safe_vars, |gcx, e| {
+            is_msg_sender(gcx, e) || is_address_self(gcx, e)
         })
     }
 
@@ -581,7 +581,7 @@ impl<'gcx> Analyzer<'gcx> {
             _ => {}
         }
         let _ = self.walk_stmt(stmt);
-        !branch_always_exits(stmt)
+        !branch_always_exits(self.gcx, stmt)
     }
 }
 
@@ -608,7 +608,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
                 let _ = self.visit_expr(rhs);
                 self.state = skipped.meet(&self.state);
             }
-            ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
+            ExprKind::Call(callee, args, _) if is_require_or_assert(self.gcx, callee) => {
                 // Sinks inside the predicate run before the guard takes effect.
                 let _ = self.walk_expr(expr);
                 if let Some(cond) = args.exprs().next() {
@@ -667,17 +667,17 @@ fn origin_matches(
     expr: &Expr<'_>,
     depth: u8,
     vars: &HashSet<VariableId>,
-    base: fn(&Expr<'_>) -> bool,
+    base: fn(Gcx<'_>, &Expr<'_>) -> bool,
 ) -> bool {
     let expr = expr.peel_parens();
     match &expr.kind {
         ExprKind::Payable(inner) => return origin_matches(gcx, inner, depth, vars, base),
-        ExprKind::Call(callee, args, _) if is_address_like_cast(callee) => {
+        ExprKind::Call(callee, args, _) if is_address_like_cast(gcx, callee) => {
             return args.exprs().next().is_some_and(|e| origin_matches(gcx, e, depth, vars, base));
         }
         _ => {}
     }
-    base(expr)
+    base(gcx, expr)
         || match &expr.kind {
             ExprKind::Ident(_) => gcx.resolved_variable(expr).is_some_and(|v| vars.contains(&v)),
             ExprKind::Ternary(_, t, f) => {
@@ -744,10 +744,10 @@ fn match_flash_loan_call<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> Option<Pend
     }
     let a = canonical_args(gcx, expr, 5)?;
     let cid = receiver_contract_id(gcx, recv)?;
-    if !contract_has_function(
-        &gcx.hir,
+    if !interface_has_function(
+        gcx,
         cid,
-        "onFlashLoan",
+        "onFlashLoan(address,address,uint256,uint256,bytes)",
         &["address", "address", "uint256", "uint256", "bytes"],
         &["bytes32"],
     ) {
@@ -772,15 +772,14 @@ fn match_sink<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> Option<Sink<'gcx>
     if matches!(name, "transferFrom" | "safeTransferFrom")
         && let Some(a) = canonical_args(gcx, expr, 3)
     {
-        let erc20 =
-            receiver_contract_id(gcx, recv).is_some_and(|cid| has_transfer_from(&gcx.hir, cid));
+        let erc20 = receiver_contract_id(gcx, recv).is_some_and(|cid| has_transfer_from(gcx, cid));
         let attached = gcx.resolved_call(expr).is_some_and(|resolved| {
             resolved.attached
                 && resolved
                     .res
                     .as_function()
                     .and_then(|fid| gcx.hir.function(fid).contract)
-                    .is_some_and(|cid| library_has_safe_transfer_from(&gcx.hir, cid))
+                    .is_some_and(|cid| library_has_safe_transfer_from(gcx, cid))
         });
         if erc20 || (name == "safeTransferFrom" && attached && expr_is_address(gcx, recv)) {
             return Some(Sink { from: a[0], to: a[1], amount: a[2], token: token_key(gcx, recv) });
@@ -790,7 +789,7 @@ fn match_sink<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> Option<Sink<'gcx>
         && let Some(a) = canonical_args(gcx, expr, 4)
         && let Some(cid) = receiver_contract_id(gcx, recv)
         && gcx.hir.contract(cid).kind == ContractKind::Library
-        && library_has_safe_transfer_from(&gcx.hir, cid)
+        && library_has_safe_transfer_from(gcx, cid)
     {
         return Some(Sink { from: a[1], to: a[2], amount: a[3], token: token_key(gcx, a[0]) });
     }
@@ -911,8 +910,8 @@ impl<'gcx> CallsiteCollector<'gcx> {
         };
         let none = HashSet::new();
         for ((safe, is_self), arg) in facts.iter_mut().zip::<Vec<_>>(call_args) {
-            *safe &= origin_matches(self.gcx, arg, HELPER_DEPTH, &none, |e| {
-                is_msg_sender(e) || is_address_self(e)
+            *safe &= origin_matches(self.gcx, arg, HELPER_DEPTH, &none, |gcx, e| {
+                is_msg_sender(gcx, e) || is_address_self(gcx, e)
             });
             *is_self &= origin_matches(self.gcx, arg, HELPER_DEPTH, &none, is_address_self);
         }
@@ -938,36 +937,43 @@ impl<'gcx> Visit<'gcx> for CallsiteCollector<'gcx> {
 }
 
 /// ERC20's `transferFrom(address,address,uint256) returns (bool)`.
-fn has_transfer_from(hir: &Hir<'_>, cid: ContractId) -> bool {
-    contract_has_function(hir, cid, "transferFrom", &["address", "address", "uint256"], &["bool"])
+fn has_transfer_from(gcx: Gcx<'_>, cid: ContractId) -> bool {
+    interface_has_function(
+        gcx,
+        cid,
+        "transferFrom(address,address,uint256)",
+        &["address", "address", "uint256"],
+        &["bool"],
+    )
 }
 
-fn contract_has_function(
-    hir: &Hir<'_>,
+fn interface_has_function(
+    gcx: Gcx<'_>,
     cid: ContractId,
-    name: &str,
+    signature: &str,
     params: &[&str],
     returns: &[&str],
 ) -> bool {
-    hir.contract(cid).functions().any(|fid| {
-        let f = hir.function(fid);
-        f.name.is_some_and(|n| n.name.as_str() == name)
+    gcx.interface_functions(cid).all().iter().any(|function| {
+        let f = gcx.hir.function(function.id);
+        gcx.item_signature(function.id.into()) == signature
             && f.parameters.len() == params.len()
             && f.returns.len() == returns.len()
-            && f.parameters.iter().zip(params).all(|(id, abi)| is_elementary(hir, *id, abi))
-            && f.returns.iter().zip(returns).all(|(id, abi)| is_elementary(hir, *id, abi))
+            && f.parameters.iter().zip(params).all(|(id, abi)| is_elementary(&gcx.hir, *id, abi))
+            && f.returns.iter().zip(returns).all(|(id, abi)| is_elementary(&gcx.hir, *id, abi))
     })
 }
 
 /// 4-arg `safeTransferFrom(token, address, address, uint256)` where `token` is `address` (Solady)
 /// or an ERC20 contract type (OpenZeppelin `SafeERC20`); ERC721/1155 helpers are excluded since
 /// their `transferFrom` has no return value.
-fn library_has_safe_transfer_from(hir: &Hir<'_>, cid: ContractId) -> bool {
+fn library_has_safe_transfer_from(gcx: Gcx<'_>, cid: ContractId) -> bool {
+    let hir = &gcx.hir;
     hir.contract(cid).functions().any(|fid| {
         let f = hir.function(fid);
         let [token, from, to, amount] = f.parameters else { return false };
         let token_ok = match hir.variable(*token).ty.kind {
-            TypeKind::Custom(ItemId::Contract(token_cid)) => has_transfer_from(hir, token_cid),
+            TypeKind::Custom(ItemId::Contract(token_cid)) => has_transfer_from(gcx, token_cid),
             _ => is_address_type(hir, *token),
         };
         f.name.is_some_and(|n| n.name.as_str() == "safeTransferFrom")

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -4,10 +4,10 @@ use crate::{
     sol::{
         Severity, SolLint,
         analysis::{
-            arg_for_param, branch_always_exits, expr_is_address, function_ids,
-            is_address_like_cast, is_address_self, is_address_type, is_elementary, is_msg_sender,
-            is_require_or_assert, loop_update, modifier_prefix, receiver_contract_id,
-            state_lhs_vars, tuple_elems, underlying_var,
+            arg_for_param, branch_always_exits, expr_is_address, is_address_like_cast,
+            is_address_self, is_address_type, is_elementary, is_msg_sender, is_require_or_assert,
+            loop_update, modifier_prefix, receiver_contract_id, state_lhs_vars, tuple_elems,
+            underlying_var,
         },
     },
 };
@@ -17,9 +17,8 @@ use solar::{
     sema::{
         Gcx,
         hir::{
-            self, CallArgs, CallArgsKind, ContractId, ContractKind, Expr, ExprKind, FunctionId,
-            FunctionKind, Hir, ItemId, LoopSource, Modifier, Res, Stmt, StmtKind, TypeKind,
-            VariableId, Visit,
+            self, CallArgs, ContractId, ContractKind, Expr, ExprKind, FunctionId, FunctionKind,
+            Hir, ItemId, LoopSource, Modifier, Stmt, StmtKind, TypeKind, VariableId, Visit,
         },
     },
 };
@@ -71,7 +70,7 @@ impl<'gcx> LateLintPass<'gcx> for ArbitrarySendErc20 {
         }) {
             return;
         }
-        let mut a = Analyzer::new(gcx, has_solady_safe_transfer_lib(&gcx.hir));
+        let mut a = Analyzer::new(gcx);
         if let Some(cid) = func.contract {
             a.seed_immutable_facts(cid);
         }
@@ -179,7 +178,6 @@ fn common_entries<K: Eq + Hash + Copy, V: PartialEq + Copy>(
 struct Analyzer<'gcx> {
     gcx: Gcx<'gcx>,
     /// Gates the `using ... for address` sink form on a Solady-shaped library being present.
-    has_solady_lib: bool,
     state: State,
     /// States at `break`/`continue` of each enclosing loop, innermost last.
     loop_exits: Vec<Vec<State>>,
@@ -189,10 +187,9 @@ struct Analyzer<'gcx> {
 }
 
 impl<'gcx> Analyzer<'gcx> {
-    fn new(gcx: Gcx<'gcx>, has_solady_lib: bool) -> Self {
+    fn new(gcx: Gcx<'gcx>) -> Self {
         Self {
             gcx,
-            has_solady_lib,
             state: State::default(),
             loop_exits: Vec::new(),
             written: HashSet::new(),
@@ -219,7 +216,7 @@ impl<'gcx> Analyzer<'gcx> {
         if let Some(ctor) = self.gcx.hir.contract(cid).ctor
             && let Some(body) = self.gcx.hir.function(ctor).body
         {
-            let mut a = Self::new(self.gcx, self.has_solady_lib);
+            let mut a = Self::new(self.gcx);
             a.visit_stmts(body.stmts);
             let is_state = |v: &&VariableId| self.gcx.hir.variable(**v).kind.is_state();
             self.state.safe_vars.extend(a.state.safe_vars.iter().filter(is_state));
@@ -233,7 +230,7 @@ impl<'gcx> Analyzer<'gcx> {
         if !is_internal_only(func) {
             return;
         }
-        let index = callsite_index(&self.gcx.hir);
+        let index = callsite_index(self.gcx);
         let Some((fid, _)) =
             self.gcx.hir.functions_enumerated().find(|(_, f)| std::ptr::eq(*f, func))
         else {
@@ -256,15 +253,15 @@ impl<'gcx> Analyzer<'gcx> {
         let Some(fid) = m.id.as_function() else { return };
         let Some(prefix) = modifier_prefix(&self.gcx.hir, fid) else { return };
         let modifier = self.gcx.hir.function(fid);
-        let mut a = Self::new(self.gcx, self.has_solady_lib);
+        let mut a = Self::new(self.gcx);
         for stmt in prefix {
             a.stmt(stmt);
         }
         for &param in modifier.parameters {
             // A fact about a rewritten parameter says nothing about the caller's variable.
             if !a.written.contains(&param)
-                && let Some(caller) =
-                    arg_for_param(&self.gcx.hir, modifier, param, &m.args).and_then(underlying_var)
+                && let Some(caller) = arg_for_param(self.gcx, fid, param, &m.args)
+                    .and_then(|expr| underlying_var(self.gcx, expr))
                 && self.is_safe_target(caller)
             {
                 if a.state.safe_vars.contains(&param) {
@@ -279,14 +276,14 @@ impl<'gcx> Analyzer<'gcx> {
 
     /// `msg.sender`, `address(this)` or a tracked-safe variable.
     fn is_safe(&self, expr: &Expr<'_>) -> bool {
-        origin_matches(&self.gcx.hir, expr, HELPER_DEPTH, &self.state.safe_vars, |e| {
+        origin_matches(self.gcx, expr, HELPER_DEPTH, &self.state.safe_vars, |e| {
             is_msg_sender(e) || is_address_self(e)
         })
     }
 
     /// `address(this)` or a tracked self alias.
     fn is_self_expr(&self, expr: &Expr<'_>) -> bool {
-        origin_matches(&self.gcx.hir, expr, HELPER_DEPTH, &self.state.self_vars, is_address_self)
+        origin_matches(self.gcx, expr, HELPER_DEPTH, &self.state.self_vars, is_address_self)
     }
 
     fn is_safe_target(&self, v: VariableId) -> bool {
@@ -329,8 +326,8 @@ impl<'gcx> Analyzer<'gcx> {
         Rhs {
             safe: self.is_safe(rhs),
             is_self: self.is_self_expr(rhs),
-            alias: underlying_var(rhs).map(|v| self.canonical(v)),
-            sum: sum_operands(rhs),
+            alias: underlying_var(self.gcx, rhs).map(|v| self.canonical(v)),
+            sum: sum_operands(self.gcx, rhs),
         }
     }
 
@@ -360,7 +357,7 @@ impl<'gcx> Analyzer<'gcx> {
     fn assign_lhs(&mut self, lhs: &Expr<'_>, rhs: Option<&Expr<'_>>) {
         // Writing `cfg.token` drops permits keyed on that field.
         if let ExprKind::Member(base, ident) = &lhs.peel_parens().kind
-            && let Some(base) = underlying_var(base)
+            && let Some(base) = underlying_var(self.gcx, base)
         {
             let key = TokenKey::Field(self.canonical(base), ident.name);
             self.state.permits.retain(|p| p.token != key);
@@ -374,11 +371,11 @@ impl<'gcx> Analyzer<'gcx> {
                 .map(|(i, l)| (*l, self.eval_rhs(rhs.and_then(|r| r.get(i).copied().flatten()))))
                 .collect();
             for (lhs, rhs) in slots {
-                if let Some(v) = lhs.and_then(underlying_var) {
+                if let Some(v) = lhs.and_then(|expr| underlying_var(self.gcx, expr)) {
                     self.assign_var(v, rhs);
                 }
             }
-        } else if let Some(v) = underlying_var(lhs) {
+        } else if let Some(v) = underlying_var(self.gcx, lhs) {
             let rhs = self.eval_rhs(rhs);
             self.assign_var(v, rhs);
         }
@@ -405,7 +402,7 @@ impl<'gcx> Analyzer<'gcx> {
                     self.state = after_lhs.meet(&self.state);
                 } else if op.kind == eq {
                     for (a, b) in [(lhs, rhs), (rhs, lhs)] {
-                        if let Some(v) = underlying_var(b)
+                        if let Some(v) = underlying_var(self.gcx, b)
                             && self.is_safe_target(v)
                         {
                             if self.is_safe(a) {
@@ -428,14 +425,11 @@ impl<'gcx> Analyzer<'gcx> {
     /// EIP-2612 `token.permit(owner, <self>, ...)` or the OpenZeppelin-style wrapper
     /// `Lib.safePermit(token, owner, <self>, ...)`.
     fn match_permit_call(&self, expr: &Expr<'gcx>) -> Option<PermitRecord> {
-        let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
+        let ExprKind::Call(callee, ..) = &expr.kind else { return None };
         let ExprKind::Member(recv, ident) = &callee.peel_parens().kind else { return None };
         let (token, owner, spender) = match ident.name.as_str() {
             "permit" => {
-                let a = canonical_args(
-                    args,
-                    &[&["owner"], &["spender"], &["value"], &["deadline"], &["v"], &["r"], &["s"]],
-                )?;
+                let a = canonical_args(self.gcx, expr, 7)?;
                 (*recv, a[0], a[1])
             }
             "safePermit"
@@ -443,19 +437,7 @@ impl<'gcx> Analyzer<'gcx> {
                     self.gcx.hir.contract(cid).kind == ContractKind::Library
                 }) =>
             {
-                let a = canonical_args(
-                    args,
-                    &[
-                        &["token"],
-                        &["owner"],
-                        &["spender"],
-                        &["value"],
-                        &["deadline"],
-                        &["v"],
-                        &["r"],
-                        &["s"],
-                    ],
-                )?;
+                let a = canonical_args(self.gcx, expr, 8)?;
                 (a[0], a[1], a[2])
             }
             _ => return None,
@@ -464,13 +446,13 @@ impl<'gcx> Analyzer<'gcx> {
             return None;
         }
         Some(PermitRecord {
-            token: self.canonical_key(token_key(token)?),
-            owner: self.canonical(underlying_var(owner)?),
+            token: self.canonical_key(token_key(self.gcx, token)?),
+            owner: self.canonical(underlying_var(self.gcx, owner)?),
         })
     }
 
     fn permit_covers(&self, sink: &Sink<'_>) -> bool {
-        let (Some(token), Some(owner)) = (sink.token, underlying_var(sink.from)) else {
+        let (Some(token), Some(owner)) = (sink.token, underlying_var(self.gcx, sink.from)) else {
             return false;
         };
         self.state.permits.contains(&PermitRecord {
@@ -481,15 +463,17 @@ impl<'gcx> Analyzer<'gcx> {
 
     /// `expr` is `amount + fee` (either order), or a local bound to that sum.
     fn amount_matches(&self, expr: &Expr<'_>, amount: VariableId, fee: VariableId) -> bool {
-        let sum = sum_operands(expr)
-            .or_else(|| underlying_var(expr).and_then(|v| self.state.sum_of.get(&v).copied()));
+        let sum = sum_operands(self.gcx, expr).or_else(|| {
+            underlying_var(self.gcx, expr).and_then(|v| self.state.sum_of.get(&v).copied())
+        });
         matches!(sum, Some(pair) if pair == (amount, fee) || pair == (fee, amount))
     }
 
     /// Consumes one pending repayment matched by a sink pulling `amount + fee` from the flash-loan
     /// receiver back to `address(this)`.
     fn consume_repayment(&mut self, sink: &Sink<'_>) -> bool {
-        let (Some(from), Some(TokenKey::Var(token))) = (underlying_var(sink.from), sink.token)
+        let (Some(from), Some(TokenKey::Var(token))) =
+            (underlying_var(self.gcx, sink.from), sink.token)
         else {
             return false;
         };
@@ -636,7 +620,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
                     *self.state.repayments.entry(rep).or_insert(0) += 1;
                 } else if let Some(permit) = self.match_permit_call(expr) {
                     self.state.permits.insert(permit);
-                } else if let Some(sink) = match_sink(self.gcx, self.has_solady_lib, expr)
+                } else if let Some(sink) = match_sink(self.gcx, expr)
                     && !self.is_safe(sink.from)
                     && !self.consume_repayment(&sink)
                 {
@@ -652,8 +636,10 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
                 // Arguments are evaluated before the callee runs: walk them first, then drop facts
                 // about state the callee writes.
                 let _ = self.walk_expr(expr);
-                if let Some(fid) = function_ids(callee).next() {
-                    for v in state_writes(&self.gcx.hir, fid) {
+                if let Some(fid) = self.gcx.resolved_function(callee)
+                    && matches!(callee.peel_parens().kind, ExprKind::Ident(_))
+                {
+                    for v in state_writes(self.gcx, fid) {
                         self.invalidate(v);
                     }
                 }
@@ -677,7 +663,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
 /// True when `expr` is `base(..)` or a variable in `vars`, through parens, `payable(..)`, casts,
 /// ternaries whose both arms qualify and no-arg helpers whose body returns such an expression.
 fn origin_matches(
-    hir: &Hir<'_>,
+    gcx: Gcx<'_>,
     expr: &Expr<'_>,
     depth: u8,
     vars: &HashSet<VariableId>,
@@ -685,82 +671,78 @@ fn origin_matches(
 ) -> bool {
     let expr = expr.peel_parens();
     match &expr.kind {
-        ExprKind::Payable(inner) => return origin_matches(hir, inner, depth, vars, base),
+        ExprKind::Payable(inner) => return origin_matches(gcx, inner, depth, vars, base),
         ExprKind::Call(callee, args, _) if is_address_like_cast(callee) => {
-            return args.exprs().next().is_some_and(|e| origin_matches(hir, e, depth, vars, base));
+            return args.exprs().next().is_some_and(|e| origin_matches(gcx, e, depth, vars, base));
         }
         _ => {}
     }
     base(expr)
         || match &expr.kind {
-            ExprKind::Ident(reses) => {
-                reses.iter().filter_map(Res::as_variable).any(|v| vars.contains(&v))
-            }
+            ExprKind::Ident(_) => gcx.resolved_variable(expr).is_some_and(|v| vars.contains(&v)),
             ExprKind::Ternary(_, t, f) => {
-                origin_matches(hir, t, depth, vars, base)
-                    && origin_matches(hir, f, depth, vars, base)
+                origin_matches(gcx, t, depth, vars, base)
+                    && origin_matches(gcx, f, depth, vars, base)
             }
-            ExprKind::Call(callee, args, _) if depth > 0 && args.exprs().next().is_none() => {
-                function_ids(callee).any(|fid| {
-                    let f = hir.function(fid);
+            ExprKind::Call(callee, args, _) if depth > 0 && args.exprs().next().is_none() => gcx
+                .resolved_function(callee)
+                .filter(|_| matches!(callee.peel_parens().kind, ExprKind::Ident(_)))
+                .is_some_and(|fid| {
+                    let f = gcx.hir.function(fid);
                     f.parameters.is_empty()
                         && matches!(f.body.map(|b| b.stmts), Some([stmt])
                             if matches!(&stmt.kind, StmtKind::Return(Some(e))
-                                if origin_matches(hir, e, depth - 1, vars, base)))
-                })
-            }
+                                if origin_matches(gcx, e, depth - 1, vars, base)))
+                }),
             _ => false,
         }
 }
 
 /// `a + b` with both operands variables.
-fn sum_operands(expr: &Expr<'_>) -> Option<(VariableId, VariableId)> {
+fn sum_operands(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<(VariableId, VariableId)> {
     match &expr.peel_parens().kind {
         ExprKind::Binary(lhs, op, rhs) if op.kind == BinOpKind::Add => {
-            underlying_var(lhs).zip(underlying_var(rhs))
+            underlying_var(gcx, lhs).zip(underlying_var(gcx, rhs))
         }
         _ => None,
     }
 }
 
 /// `token` or `cfg.token` receiver key, through casts and `payable(..)`.
-fn token_key(expr: &Expr<'_>) -> Option<TokenKey> {
-    if let Some(v) = underlying_var(expr) {
+fn token_key(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<TokenKey> {
+    if let Some(v) = underlying_var(gcx, expr) {
         return Some(TokenKey::Var(v));
     }
     match &expr.peel_parens().kind {
-        ExprKind::Member(base, ident) => Some(TokenKey::Field(underlying_var(base)?, ident.name)),
+        ExprKind::Member(base, ident) => {
+            Some(TokenKey::Field(underlying_var(gcx, base)?, ident.name))
+        }
         _ => None,
     }
 }
 
-/// Positional or named call arguments in declaration order; `slots[i]` lists the parameter names
-/// accepted for position `i`. `None` when the arity differs or a slot is unmatched.
+/// Call arguments in declaration order, with the expected arity.
 fn canonical_args<'gcx>(
-    args: &'gcx CallArgs<'gcx>,
-    slots: &[&[&str]],
+    gcx: Gcx<'gcx>,
+    expr: &Expr<'gcx>,
+    arity: usize,
 ) -> Option<Vec<&'gcx Expr<'gcx>>> {
-    if args.len() != slots.len() {
+    let ExprKind::Call(_, args, _) = &expr.kind else { return None };
+    if args.len() != arity {
         return None;
     }
-    match args.kind {
-        CallArgsKind::Unnamed(exprs) => Some(exprs.iter().collect()),
-        CallArgsKind::Named(named) => slots
-            .iter()
-            .map(|names| named.iter().find(|a| names.contains(&a.name.as_str())).map(|a| &a.value))
-            .collect(),
-    }
+    (0..arity).map(|index| gcx.call_arg(expr, index)).collect()
 }
 
 /// EIP-3156 `receiver.onFlashLoan(initiator, token, amount, fee, data)` on a receiver type
 /// declaring the exact signature. Literal arguments yield `None`.
 fn match_flash_loan_call<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> Option<PendingRepayment> {
-    let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
+    let ExprKind::Call(callee, ..) = &expr.kind else { return None };
     let ExprKind::Member(recv, ident) = &callee.peel_parens().kind else { return None };
     if ident.name.as_str() != "onFlashLoan" {
         return None;
     }
-    let a = canonical_args(args, &[&["initiator"], &["token"], &["amount"], &["fee"], &["data"]])?;
+    let a = canonical_args(gcx, expr, 5)?;
     let cid = receiver_contract_id(gcx, recv)?;
     if !contract_has_function(
         &gcx.hir,
@@ -772,10 +754,10 @@ fn match_flash_loan_call<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> Option<Pend
         return None;
     }
     Some(PendingRepayment {
-        receiver: underlying_var(recv)?,
-        token: underlying_var(a[1])?,
-        amount: underlying_var(a[2])?,
-        fee: underlying_var(a[3])?,
+        receiver: underlying_var(gcx, recv)?,
+        token: underlying_var(gcx, a[1])?,
+        amount: underlying_var(gcx, a[2])?,
+        fee: underlying_var(gcx, a[3])?,
     })
 }
 
@@ -783,40 +765,41 @@ fn match_flash_loan_call<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> Option<Pend
 /// declaring ERC20's `transferFrom(address,address,uint256) returns (bool)` (ERC721's same-named
 /// overload is excluded), `addr.safeTransferFrom(..)` via `using SafeTransferLib for address`,
 /// or the library form `Lib.safeTransferFrom(token, from, to, amt)`.
-fn match_sink<'gcx>(
-    gcx: Gcx<'gcx>,
-    has_solady_lib: bool,
-    expr: &'gcx Expr<'gcx>,
-) -> Option<Sink<'gcx>> {
-    let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
+fn match_sink<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> Option<Sink<'gcx>> {
+    let ExprKind::Call(callee, ..) = &expr.kind else { return None };
     let ExprKind::Member(recv, ident) = &callee.peel_parens().kind else { return None };
     let name = ident.name.as_str();
     if matches!(name, "transferFrom" | "safeTransferFrom")
-        && let Some(a) = canonical_args(args, &[&["from"], &["to"], &["value", "amount"]])
+        && let Some(a) = canonical_args(gcx, expr, 3)
     {
         let erc20 =
             receiver_contract_id(gcx, recv).is_some_and(|cid| has_transfer_from(&gcx.hir, cid));
-        // The HIR does not expose `using` bindings, so the `address` receiver form is accepted
-        // only when a Solady-shaped library is compiled in.
-        if erc20 || (name == "safeTransferFrom" && has_solady_lib && expr_is_address(gcx, recv)) {
-            return Some(Sink { from: a[0], to: a[1], amount: a[2], token: token_key(recv) });
+        let attached = gcx.resolved_call(expr).is_some_and(|resolved| {
+            resolved.attached
+                && resolved
+                    .res
+                    .as_function()
+                    .and_then(|fid| gcx.hir.function(fid).contract)
+                    .is_some_and(|cid| library_has_safe_transfer_from(&gcx.hir, cid))
+        });
+        if erc20 || (name == "safeTransferFrom" && attached && expr_is_address(gcx, recv)) {
+            return Some(Sink { from: a[0], to: a[1], amount: a[2], token: token_key(gcx, recv) });
         }
     }
     if name == "safeTransferFrom"
-        && let Some(a) =
-            canonical_args(args, &[&["token"], &["from"], &["to"], &["value", "amount"]])
+        && let Some(a) = canonical_args(gcx, expr, 4)
         && let Some(cid) = receiver_contract_id(gcx, recv)
         && gcx.hir.contract(cid).kind == ContractKind::Library
         && library_has_safe_transfer_from(&gcx.hir, cid)
     {
-        return Some(Sink { from: a[1], to: a[2], amount: a[3], token: token_key(a[0]) });
+        return Some(Sink { from: a[1], to: a[2], amount: a[3], token: token_key(gcx, a[0]) });
     }
     None
 }
 
 /// State variables written by `fid` or by the internal functions it calls (one level deep).
-fn state_writes<'gcx>(hir: &'gcx Hir<'gcx>, fid: FunctionId) -> HashSet<VariableId> {
-    let mut w = StateWrites { hir, out: HashSet::new(), callees: Vec::new() };
+fn state_writes<'gcx>(gcx: Gcx<'gcx>, fid: FunctionId) -> HashSet<VariableId> {
+    let mut w = StateWrites { gcx, out: HashSet::new(), callees: Vec::new() };
     w.scan(fid);
     for callee in std::mem::take(&mut w.callees) {
         w.scan(callee);
@@ -825,14 +808,14 @@ fn state_writes<'gcx>(hir: &'gcx Hir<'gcx>, fid: FunctionId) -> HashSet<Variable
 }
 
 struct StateWrites<'gcx> {
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     out: HashSet<VariableId>,
     callees: Vec<FunctionId>,
 }
 
 impl StateWrites<'_> {
     fn scan(&mut self, fid: FunctionId) {
-        if let Some(body) = self.hir.function(fid).body {
+        if let Some(body) = self.gcx.hir.function(fid).body {
             for stmt in body.stmts {
                 let _ = self.visit_stmt(stmt);
             }
@@ -844,15 +827,19 @@ impl<'gcx> Visit<'gcx> for StateWrites<'gcx> {
     type BreakValue = Never;
 
     fn hir(&self) -> &'gcx Hir<'gcx> {
-        self.hir
+        &self.gcx.hir
     }
 
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<Never> {
         match &expr.kind {
             ExprKind::Assign(lhs, ..) | ExprKind::Delete(lhs) => {
-                self.out.extend(state_lhs_vars(self.hir, lhs));
+                self.out.extend(state_lhs_vars(self.gcx, lhs));
             }
-            ExprKind::Call(callee, ..) => self.callees.extend(function_ids(callee).next()),
+            ExprKind::Call(callee, ..)
+                if matches!(callee.peel_parens().kind, ExprKind::Ident(_)) =>
+            {
+                self.callees.extend(self.gcx.resolved_function(callee));
+            }
             _ => {}
         }
         self.walk_expr(expr)
@@ -877,8 +864,8 @@ thread_local! {
 }
 
 /// The call-site index of `hir`, built once per compilation unit.
-fn callsite_index<'gcx>(hir: &'gcx Hir<'gcx>) -> Rc<CallsiteFacts> {
-    let key = std::ptr::from_ref(hir) as usize;
+fn callsite_index<'gcx>(gcx: Gcx<'gcx>) -> Rc<CallsiteFacts> {
+    let key = std::ptr::from_ref(&gcx.hir) as usize;
     CALLSITE_INDEX.with(|cell| {
         let mut slot = cell.borrow_mut();
         if let Some((cached_key, index)) = &*slot
@@ -886,8 +873,8 @@ fn callsite_index<'gcx>(hir: &'gcx Hir<'gcx>) -> Rc<CallsiteFacts> {
         {
             return index.clone();
         }
-        let mut c = CallsiteCollector { hir, out: HashMap::new() };
-        for (_, func) in hir.functions_enumerated() {
+        let mut c = CallsiteCollector { gcx, out: HashMap::new() };
+        for (_, func) in gcx.hir.functions_enumerated() {
             for m in func.modifiers {
                 if let ItemId::Function(fid) = m.id {
                     c.record(fid, &m.args);
@@ -904,17 +891,18 @@ fn callsite_index<'gcx>(hir: &'gcx Hir<'gcx>) -> Rc<CallsiteFacts> {
 }
 
 struct CallsiteCollector<'gcx> {
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     out: CallsiteFacts,
 }
 
 impl<'gcx> CallsiteCollector<'gcx> {
     fn record(&mut self, fid: FunctionId, args: &'gcx CallArgs<'gcx>) {
-        let f = self.hir.function(fid);
+        let f = self.gcx.hir.function(fid);
         if !is_internal_only(f) {
             return;
         }
-        let call_args = f.parameters.iter().map(|&p| arg_for_param(self.hir, f, p, args)).collect();
+        let call_args =
+            f.parameters.iter().map(|&p| arg_for_param(self.gcx, fid, p, args)).collect();
         let entry =
             self.out.entry(fid).or_insert_with(|| Some(vec![(true, true); f.parameters.len()]));
         let (Some(facts), Some(call_args)) = (entry.as_mut(), call_args) else {
@@ -923,10 +911,10 @@ impl<'gcx> CallsiteCollector<'gcx> {
         };
         let none = HashSet::new();
         for ((safe, is_self), arg) in facts.iter_mut().zip::<Vec<_>>(call_args) {
-            *safe &= origin_matches(self.hir, arg, HELPER_DEPTH, &none, |e| {
+            *safe &= origin_matches(self.gcx, arg, HELPER_DEPTH, &none, |e| {
                 is_msg_sender(e) || is_address_self(e)
             });
-            *is_self &= origin_matches(self.hir, arg, HELPER_DEPTH, &none, is_address_self);
+            *is_self &= origin_matches(self.gcx, arg, HELPER_DEPTH, &none, is_address_self);
         }
     }
 }
@@ -935,26 +923,18 @@ impl<'gcx> Visit<'gcx> for CallsiteCollector<'gcx> {
     type BreakValue = Never;
 
     fn hir(&self) -> &'gcx Hir<'gcx> {
-        self.hir
+        &self.gcx.hir
     }
 
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<Never> {
         if let ExprKind::Call(callee, args, _) = &expr.kind
-            && let Some(fid) = function_ids(callee).next()
+            && matches!(callee.peel_parens().kind, ExprKind::Ident(_))
+            && let Some(fid) = self.gcx.resolved_function(callee)
         {
             self.record(fid, args);
         }
         self.walk_expr(expr)
     }
-}
-
-/// Whether the sources declare a Solady-shaped `SafeTransferLib` library.
-fn has_solady_safe_transfer_lib(hir: &Hir<'_>) -> bool {
-    hir.contracts_enumerated().any(|(cid, c)| {
-        c.kind == ContractKind::Library
-            && c.name.as_str() == "SafeTransferLib"
-            && library_has_safe_transfer_from(hir, cid)
-    })
 }
 
 /// ERC20's `transferFrom(address,address,uint256) returns (bool)`.

--- a/crates/lint/src/sol/high/arbitrary_send_eth.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_eth.rs
@@ -5,17 +5,16 @@ use crate::{
         Severity, SolLint,
         analysis::{
             DEFAULT_HELPER_ANALYSIS_CACHE_LIMIT, HelperAnalysisCache, arg_for_param,
-            branch_always_exits, builtins, callee_no_arg_returns, expr_is_address,
-            function_no_arg_returns, is_address_like_cast, is_address_self, is_builtin,
-            is_contract_cast, is_literal_zero, is_msg_sender, is_require_or_assert, loop_stmts,
-            loop_update, modifier_prefix, referenced_item, tuple_elems, underlying_var,
-            var_is_address_like,
+            branch_always_exits, callee_no_arg_returns, function_no_arg_returns,
+            is_address_like_cast, is_address_self, is_builtin, is_contract_cast, is_literal_zero,
+            is_msg_sender, is_require_or_assert, is_sender_member, loop_stmts, loop_update,
+            modifier_prefix, referenced_item, tuple_elems, underlying_var, var_is_address_like,
         },
     },
 };
 use solar::{
     ast::{BinOpKind, LitKind, StateMutability, UnOpKind},
-    interface::{Span, data_structures::Never, kw, sym},
+    interface::{Span, data_structures::Never, sym},
     sema::{
         Gcx,
         builtins::Builtin,
@@ -153,16 +152,14 @@ impl<'gcx> Analyzer<'gcx> {
     }
 
     fn is_safe_inner(&self, expr: &'gcx Expr<'gcx>, depth: u8) -> bool {
-        let expr = peel_casts(expr);
+        let expr = peel_casts(self.gcx, expr);
         match &expr.kind {
-            ExprKind::Member(base, ident) => {
-                is_msg_sender(expr)
-                    || (ident.name == kw::Origin && is_builtin(base, sym::tx))
-                    || is_address_self(base)
+            ExprKind::Member(base, _) => {
+                is_sender_member(self.gcx, expr) || is_address_self(self.gcx, base)
             }
             ExprKind::Lit(_) => is_trusted_literal(expr),
             ExprKind::Ident(_) => {
-                is_builtin(expr, sym::this)
+                is_builtin(self.gcx, expr, sym::this)
                     || self.gcx.resolved_variable(expr).is_some_and(|v| self.is_safe_var(v))
             }
             ExprKind::Ternary(_, t, f) => {
@@ -339,7 +336,7 @@ impl<'gcx> Analyzer<'gcx> {
             _ => {}
         }
         let _ = self.walk_stmt(stmt);
-        !branch_always_exits(stmt)
+        !branch_always_exits(self.gcx, stmt)
     }
 }
 
@@ -376,7 +373,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
                 let _ = self.visit_expr(f);
                 self.state = after_t.meet(&self.state);
             }
-            ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
+            ExprKind::Call(callee, args, _) if is_require_or_assert(self.gcx, callee) => {
                 // Sinks inside the predicate run before the guard takes effect.
                 let _ = self.walk_expr(expr);
                 if let Some(cond) = args.exprs().next() {
@@ -414,23 +411,24 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
 fn match_sink<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> Option<&'gcx Expr<'gcx>> {
     let ExprKind::Call(callee, args, opts) = &expr.kind else { return None };
     let callee = callee.peel_parens();
-    if builtins(callee).any(|b| b == Builtin::Selfdestruct) {
-        return args.exprs().next().filter(|dest| !is_address_self(dest));
+    if gcx.resolved_builtin(callee) == Some(Builtin::Selfdestruct) {
+        return args.exprs().next().filter(|dest| !is_address_self(gcx, dest));
     }
     if opts.is_some_and(|o| {
         o.args.iter().any(|a| a.name.name == sym::value && !is_literal_zero(&a.value))
     }) {
         return match &callee.kind {
-            ExprKind::Member(recv, _) => (!is_address_self(recv)).then_some(recv),
+            ExprKind::Member(recv, _) => (!is_address_self(gcx, recv)).then_some(recv),
             _ => expr_is_function(gcx, callee).then_some(callee),
         };
     }
     let ExprKind::Member(recv, member) = &callee.kind else { return None };
-    if matches!(member.name, sym::transfer | sym::send)
-        && args.len() == 1
-        && expr_is_address(gcx, recv)
-    {
-        return (!is_address_self(recv) && !is_literal_zero(args.exprs().next()?)).then_some(recv);
+    if matches!(
+        gcx.resolved_builtin(callee),
+        Some(Builtin::AddressPayableTransfer | Builtin::AddressPayableSend)
+    ) {
+        return (!is_address_self(gcx, recv) && !is_literal_zero(args.exprs().next()?))
+            .then_some(recv);
     }
     match_eth_library_call(gcx, expr, recv, member.name.as_str(), args)
 }
@@ -467,7 +465,7 @@ fn match_eth_library_call<'gcx>(
     {
         return None;
     }
-    (!is_address_self(dest)).then_some(dest)
+    (!is_address_self(gcx, dest)).then_some(dest)
 }
 
 /// Recognises guards that restrict `msg.sender` to a deploy-time-fixed principal, backed by a
@@ -502,8 +500,8 @@ impl<'gcx> CallerGuards<'gcx> {
                 b.stmts.iter().any(|s| self.stmt_restricts(s))
             }
             StmtKind::If(cond, then, else_) => {
-                let then_exits = branch_always_exits(then);
-                let else_exits = else_.is_some_and(|e| branch_always_exits(e));
+                let then_exits = branch_always_exits(self.gcx, then);
+                let else_exits = else_.is_some_and(|e| branch_always_exits(self.gcx, e));
                 // `if (!guard) revert;` restricts by itself; otherwise every non-exiting branch
                 // must restrict.
                 (then_exits != else_exits && self.cond_restricts(cond, else_exits))
@@ -518,7 +516,7 @@ impl<'gcx> CallerGuards<'gcx> {
     /// the caller and cannot `return` early.
     fn expr_restricts(&mut self, expr: &'gcx Expr<'gcx>) -> bool {
         let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
-        if is_require_or_assert(callee) {
+        if is_require_or_assert(self.gcx, callee) {
             return args.exprs().next().is_some_and(|c| self.cond_restricts(c, true));
         }
         self.gcx
@@ -579,7 +577,7 @@ impl<'gcx> CallerGuards<'gcx> {
     /// state (or statically indexed state) that cannot alias `address(this)`, possibly behind a
     /// no-arg getter. Parameters, locals, `msg.sender`, `tx.origin` and `this` are rejected.
     fn is_trusted_principal(&mut self, expr: &'gcx Expr<'gcx>, depth: u8) -> bool {
-        let expr = peel_casts(expr);
+        let expr = peel_casts(self.gcx, expr);
         match &expr.kind {
             ExprKind::Lit(_) => is_trusted_literal(expr),
             ExprKind::Ident(_) => self.gcx.resolved_variable(expr).is_some_and(|v| {
@@ -662,7 +660,7 @@ impl<'gcx> CallerGuards<'gcx> {
         if depth == 0 {
             return false;
         }
-        let children: Vec<&'gcx Expr<'gcx>> = match &peel_casts(expr).kind {
+        let children: Vec<&'gcx Expr<'gcx>> = match &peel_casts(self.gcx, expr).kind {
             ExprKind::Call(_, args, _) => args.exprs().collect(),
             ExprKind::Ternary(_, t, f) => vec![t, f],
             ExprKind::Tuple(elems) => elems.iter().copied().flatten().collect(),
@@ -674,8 +672,8 @@ impl<'gcx> CallerGuards<'gcx> {
 
     /// True when `expr` may evaluate to `address(this)`.
     fn expr_resolves_to_self(&mut self, expr: &'gcx Expr<'gcx>, depth: u8) -> bool {
-        let expr = peel_casts(expr);
-        if is_address_self(expr) {
+        let expr = peel_casts(self.gcx, expr);
+        if is_address_self(self.gcx, expr) {
             return true;
         }
         if depth == 0 {
@@ -869,7 +867,7 @@ fn identity_helper_arg<'gcx>(
         let f = gcx.hir.function(fid);
         let [stmt] = f.body?.stmts else { return None };
         let StmtKind::Return(Some(ret)) = &stmt.kind else { return None };
-        let param = underlying_var(gcx, peel_casts(ret))?;
+        let param = underlying_var(gcx, peel_casts(gcx, ret))?;
         (f.parameters.len() == args.len() && f.returns.len() == 1 && f.parameters.contains(&param))
             .then(|| arg_for_param(gcx, fid, param, args))
             .flatten()
@@ -882,7 +880,7 @@ fn lhs_root_var(gcx: Gcx<'_>, lhs: &Expr<'_>) -> Option<VariableId> {
         ExprKind::Member(base, _) | ExprKind::Index(base, _) | ExprKind::Payable(base) => {
             lhs_root_var(gcx, base)
         }
-        ExprKind::Call(callee, args, _) if is_address_like_cast(callee) => {
+        ExprKind::Call(callee, args, _) if is_address_like_cast(gcx, callee) => {
             args.exprs().next().and_then(|expr| lhs_root_var(gcx, expr))
         }
         _ => underlying_var(gcx, lhs),
@@ -913,7 +911,7 @@ fn index_is_static(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
         }
         ExprKind::Call(callee, ..)
             if matches!(callee.peel_parens().kind, ExprKind::Type(_))
-                || is_contract_cast(callee) =>
+                || is_contract_cast(gcx, callee) =>
         {
             ControlFlow::Continue(())
         }
@@ -942,8 +940,8 @@ fn stmt_contains_return(stmt: &Stmt<'_>) -> bool {
 
 /// `msg.sender` modulo parens, casts, `payable(..)` and no-arg helpers such as `_msgSender()`.
 fn is_msg_sender_like<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>, depth: u8) -> bool {
-    let expr = peel_casts(expr);
-    is_msg_sender(expr)
+    let expr = peel_casts(gcx, expr);
+    is_msg_sender(gcx, expr)
         || matches!(&expr.kind, ExprKind::Call(callee, args, _)
             if depth > 0
                 && args.exprs().next().is_none()
@@ -951,14 +949,14 @@ fn is_msg_sender_like<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>, depth: u8) -
 }
 
 /// Looks through parens, `payable(..)`, address-like casts and integer casts.
-fn peel_casts<'a>(expr: &'a Expr<'a>) -> &'a Expr<'a> {
+fn peel_casts<'a>(gcx: Gcx<'_>, expr: &'a Expr<'a>) -> &'a Expr<'a> {
     let expr = expr.peel_parens();
     match &expr.kind {
-        ExprKind::Payable(inner) => peel_casts(inner),
+        ExprKind::Payable(inner) => peel_casts(gcx, inner),
         ExprKind::Call(callee, args, _)
-            if is_address_like_cast(callee) || is_numeric_cast(callee) =>
+            if is_address_like_cast(gcx, callee) || is_numeric_cast(callee) =>
         {
-            args.exprs().next().map_or(expr, peel_casts)
+            args.exprs().next().map_or(expr, |expr| peel_casts(gcx, expr))
         }
         _ => expr,
     }

--- a/crates/lint/src/sol/high/arbitrary_send_eth.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_eth.rs
@@ -5,11 +5,11 @@ use crate::{
         Severity, SolLint,
         analysis::{
             DEFAULT_HELPER_ANALYSIS_CACHE_LIMIT, HelperAnalysisCache, arg_for_param,
-            branch_always_exits, builtins, callee_fids, callee_no_arg_returns, expr_is_address,
-            expr_ty, function_ids, function_no_arg_returns, is_address_like_cast, is_address_self,
-            is_builtin, is_contract_cast, is_literal_zero, is_msg_sender, is_require_or_assert,
-            loop_stmts, loop_update, modifier_prefix, referenced_item, tuple_elems, underlying_var,
-            unique, var_is_address_like,
+            branch_always_exits, builtins, callee_no_arg_returns, expr_is_address,
+            function_no_arg_returns, is_address_like_cast, is_address_self, is_builtin,
+            is_contract_cast, is_literal_zero, is_msg_sender, is_require_or_assert, loop_stmts,
+            loop_update, modifier_prefix, referenced_item, tuple_elems, underlying_var,
+            var_is_address_like,
         },
     },
 };
@@ -20,9 +20,9 @@ use solar::{
         Gcx,
         builtins::Builtin,
         hir::{
-            self, CallArgs, CallArgsKind, ContractId, ContractKind, ElementaryType, Expr, ExprKind,
-            FunctionId, Hir, ItemId, LoopSource, Modifier, Res, Stmt, StmtKind, TypeKind, Variable,
-            VariableId, Visit,
+            self, CallArgs, ContractId, ContractKind, ElementaryType, Expr, ExprKind, FunctionId,
+            Hir, ItemId, LoopSource, Modifier, Res, Stmt, StmtKind, TypeKind, Variable, VariableId,
+            Visit,
         },
         ty::TyKind,
     },
@@ -136,8 +136,8 @@ impl<'gcx> Analyzer<'gcx> {
         for &param in modifier.parameters {
             if a.state.safe_vars.contains(&param)
                 && !a.written.contains(&param)
-                && let Some(caller) =
-                    arg_for_param(&self.gcx.hir, modifier, param, &m.args).and_then(underlying_var)
+                && let Some(caller) = arg_for_param(self.gcx, fid, param, &m.args)
+                    .and_then(|expr| underlying_var(self.gcx, expr))
                 && self.is_safe_target(caller)
             {
                 self.state.safe_vars.insert(caller);
@@ -161,9 +161,9 @@ impl<'gcx> Analyzer<'gcx> {
                     || is_address_self(base)
             }
             ExprKind::Lit(_) => is_trusted_literal(expr),
-            ExprKind::Ident(reses) => {
+            ExprKind::Ident(_) => {
                 is_builtin(expr, sym::this)
-                    || reses.iter().filter_map(Res::as_variable).any(|v| self.is_safe_var(v))
+                    || self.gcx.resolved_variable(expr).is_some_and(|v| self.is_safe_var(v))
             }
             ExprKind::Ternary(_, t, f) => {
                 self.is_safe_inner(t, depth) && self.is_safe_inner(f, depth)
@@ -171,9 +171,7 @@ impl<'gcx> Analyzer<'gcx> {
             ExprKind::Call(callee, args, _) => {
                 depth > 0
                     && args.exprs().next().is_none()
-                    && callee_no_arg_returns(&self.gcx.hir, callee, |e| {
-                        self.is_safe_inner(e, depth - 1)
-                    })
+                    && callee_no_arg_returns(self.gcx, callee, |e| self.is_safe_inner(e, depth - 1))
             }
             _ => false,
         }
@@ -210,7 +208,7 @@ impl<'gcx> Analyzer<'gcx> {
                     self.assign_lhs(lhs, rhs.and_then(|r| r.get(i).copied().flatten()));
                 }
             }
-        } else if let Some(v) = underlying_var(lhs) {
+        } else if let Some(v) = underlying_var(self.gcx, lhs) {
             self.assign_var(v, rhs);
         }
     }
@@ -237,7 +235,7 @@ impl<'gcx> Analyzer<'gcx> {
                 } else if op.kind == eq {
                     for (a, b) in [(lhs, rhs), (rhs, lhs)] {
                         if self.is_safe(a)
-                            && let Some(v) = underlying_var(b)
+                            && let Some(v) = underlying_var(self.gcx, b)
                             && self.is_safe_target(v)
                         {
                             self.state.safe_vars.insert(v);
@@ -434,13 +432,14 @@ fn match_sink<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> Option<&'gcx Expr
     {
         return (!is_address_self(recv) && !is_literal_zero(args.exprs().next()?)).then_some(recv);
     }
-    match_eth_library_call(gcx, recv, member.name.as_str(), args)
+    match_eth_library_call(gcx, expr, recv, member.name.as_str(), args)
 }
 
 /// Destination of an OpenZeppelin `Address` / Solady `SafeTransferLib` ETH helper, called either
 /// statically (`Lib.f(to, ...)`) or via `using ... for address` (`to.f(...)`).
 fn match_eth_library_call<'gcx>(
     gcx: Gcx<'gcx>,
+    call: &Expr<'gcx>,
     recv: &'gcx Expr<'gcx>,
     name: &str,
     args: &'gcx CallArgs<'gcx>,
@@ -456,29 +455,19 @@ fn match_eth_library_call<'gcx>(
         "trySafeTransferAllETH" => (None, &[2]),
         _ => return None,
     };
-    let using = expr_is_address(gcx, recv);
-    let is_lib = matches!(referenced_item(recv), Some(ItemId::Contract(cid))
+    let using = gcx.resolved_call(call).is_some_and(|resolved| resolved.attached);
+    let is_lib = matches!(referenced_item(gcx, recv), Some(ItemId::Contract(cid))
         if gcx.hir.contract(cid).kind == ContractKind::Library);
     if (!using && !is_lib) || !arities.contains(&(args.len() + usize::from(using))) {
         return None;
     }
-    let dest = if using { recv } else { arg(args, 0, &["to", "target", "recipient"])? };
+    let dest = if using { recv } else { gcx.call_arg(call, 0)? };
     if let Some(i) = amount
-        && is_literal_zero(arg(args, i - usize::from(using), &["amount", "value"])?)
+        && is_literal_zero(gcx.call_arg(call, i - usize::from(using))?)
     {
         return None;
     }
     (!is_address_self(dest)).then_some(dest)
-}
-
-/// Call-site argument at position `pos`, or bound to any of `names` in the named form.
-fn arg<'gcx>(args: &'gcx CallArgs<'gcx>, pos: usize, names: &[&str]) -> Option<&'gcx Expr<'gcx>> {
-    match args.kind {
-        CallArgsKind::Unnamed(exprs) => exprs.get(pos),
-        CallArgsKind::Named(named) => {
-            named.iter().find(|a| names.contains(&a.name.as_str())).map(|a| &a.value)
-        }
-    }
 }
 
 /// Recognises guards that restrict `msg.sender` to a deploy-time-fixed principal, backed by a
@@ -532,26 +521,29 @@ impl<'gcx> CallerGuards<'gcx> {
         if is_require_or_assert(callee) {
             return args.exprs().next().is_some_and(|c| self.cond_restricts(c, true));
         }
-        function_ids(callee).any(|fid| {
-            if self.stack.contains(&fid) {
-                return false;
-            }
-            let Some(body) = self.gcx.hir.function(fid).body else { return false };
-            // A trailing bare `return;` is a normal exit and cannot bypass an earlier guard.
-            let mut stmts = body.stmts;
-            while let [rest @ .., last] = stmts
-                && matches!(last.kind, StmtKind::Return(None))
-            {
-                stmts = rest;
-            }
-            if stmts.iter().any(stmt_contains_return) {
-                return false;
-            }
-            self.stack.push(fid);
-            let restricts = stmts.iter().any(|s| self.stmt_restricts(s));
-            self.stack.pop();
-            restricts
-        })
+        self.gcx
+            .resolved_function(callee)
+            .filter(|_| matches!(callee.peel_parens().kind, ExprKind::Ident(_)))
+            .is_some_and(|fid| {
+                if self.stack.contains(&fid) {
+                    return false;
+                }
+                let Some(body) = self.gcx.hir.function(fid).body else { return false };
+                // A trailing bare `return;` is a normal exit and cannot bypass an earlier guard.
+                let mut stmts = body.stmts;
+                while let [rest @ .., last] = stmts
+                    && matches!(last.kind, StmtKind::Return(None))
+                {
+                    stmts = rest;
+                }
+                if stmts.iter().any(stmt_contains_return) {
+                    return false;
+                }
+                self.stack.push(fid);
+                let restricts = stmts.iter().any(|s| self.stmt_restricts(s));
+                self.stack.pop();
+                restricts
+            })
     }
 
     /// True when `cond` (holding iff `holds`) entails `msg.sender == <trusted>` on every path.
@@ -569,7 +561,7 @@ impl<'gcx> CallerGuards<'gcx> {
                     self.cond_restricts(lhs, holds) && self.cond_restricts(rhs, holds)
                 } else if op.kind == eq {
                     [(lhs, rhs), (rhs, lhs)].into_iter().any(|(a, b)| {
-                        is_msg_sender_like(&self.gcx.hir, a, HELPER_DEPTH)
+                        is_msg_sender_like(self.gcx, a, HELPER_DEPTH)
                             && self.is_trusted_principal(b, HELPER_DEPTH)
                     })
                 } else {
@@ -590,19 +582,19 @@ impl<'gcx> CallerGuards<'gcx> {
         let expr = peel_casts(expr);
         match &expr.kind {
             ExprKind::Lit(_) => is_trusted_literal(expr),
-            ExprKind::Ident(reses) => reses.iter().filter_map(Res::as_variable).any(|v| {
+            ExprKind::Ident(_) => self.gcx.resolved_variable(expr).is_some_and(|v| {
                 self.gcx.hir.variable(v).kind.is_state()
                     && !self.state_var_aliases_self(v, SELF_ALIAS_DEPTH)
             }),
             ExprKind::Member(base, _) => self.is_trusted_principal(base, depth),
             ExprKind::Index(base, idx) => {
                 self.is_trusted_principal(base, depth)
-                    && idx.is_none_or(|i| index_is_static(&self.gcx.hir, i))
+                    && idx.is_none_or(|i| index_is_static(self.gcx, i))
             }
             ExprKind::Call(callee, args, _) => {
                 depth > 0
                     && args.exprs().next().is_none()
-                    && callee_no_arg_returns(&self.gcx.hir, callee, |e| {
+                    && callee_no_arg_returns(self.gcx, callee, |e| {
                         self.is_trusted_principal(e, depth - 1)
                     })
             }
@@ -649,7 +641,7 @@ impl<'gcx> CallerGuards<'gcx> {
     ) -> bool {
         if var_is_address_like(target) {
             self.expr_resolves_to_self(rhs, depth)
-                || lhs_root_var(rhs).is_some_and(|v| locals.contains(&v))
+                || lhs_root_var(self.gcx, rhs).is_some_and(|v| locals.contains(&v))
         } else {
             self.expr_may_contain_self(rhs, depth, locals)
         }
@@ -663,7 +655,7 @@ impl<'gcx> CallerGuards<'gcx> {
         locals: &HashSet<VariableId>,
     ) -> bool {
         if self.expr_resolves_to_self(expr, depth)
-            || lhs_root_var(expr).is_some_and(|v| locals.contains(&v))
+            || lhs_root_var(self.gcx, expr).is_some_and(|v| locals.contains(&v))
         {
             return true;
         }
@@ -691,16 +683,16 @@ impl<'gcx> CallerGuards<'gcx> {
         }
         match &expr.kind {
             ExprKind::Ident(_) | ExprKind::Member(..) | ExprKind::Index(..) => {
-                lhs_root_var(expr).is_some_and(|v| self.state_var_aliases_self(v, depth))
+                lhs_root_var(self.gcx, expr).is_some_and(|v| self.state_var_aliases_self(v, depth))
             }
             ExprKind::Call(callee, args, _) if args.exprs().next().is_none() => {
-                callee_fids(&self.gcx.hir, callee).into_iter().any(|fid| {
-                    function_no_arg_returns(&self.gcx.hir, fid, &mut |e| {
+                self.gcx.resolved_function(callee).is_some_and(|fid| {
+                    function_no_arg_returns(self.gcx, fid, &mut |e| {
                         self.expr_resolves_to_self(e, depth - 1)
                     })
                 })
             }
-            ExprKind::Call(callee, args, _) => identity_helper_arg(&self.gcx.hir, callee, args)
+            ExprKind::Call(callee, args, _) => identity_helper_arg(self.gcx, callee, args)
                 .is_some_and(|a| self.expr_resolves_to_self(a, depth - 1)),
             ExprKind::Ternary(_, t, f) => {
                 self.expr_resolves_to_self(t, depth - 1) || self.expr_resolves_to_self(f, depth - 1)
@@ -760,7 +752,7 @@ impl<'gcx> SelfAssignScan<'_, 'gcx> {
                     self.assign(lhs, rhs);
                 }
             }
-        } else if let Some(v) = lhs_root_var(lhs) {
+        } else if let Some(v) = lhs_root_var(self.guards.gcx, lhs) {
             if v == self.target {
                 let var = self.guards.gcx.hir.variable(v);
                 self.found |= self.guards.rhs_carries_self(var, rhs, self.depth, &self.locals);
@@ -780,7 +772,7 @@ impl<'gcx> SelfAssignScan<'_, 'gcx> {
         let saved = self.locals.clone();
         for &param in f.parameters {
             if let Some(arg) =
-                args.and_then(|args| arg_for_param(&self.guards.gcx.hir, f, param, args))
+                args.and_then(|args| arg_for_param(self.guards.gcx, fid, param, args))
                 && self.may_contain_self(arg)
             {
                 self.locals.insert(param);
@@ -839,7 +831,7 @@ impl<'gcx> Visit<'gcx> for SelfAssignScan<'_, 'gcx> {
                 // `target.push(<self>)` on an array / bytes state variable.
                 ExprKind::Member(recv, member) => {
                     if member.name.as_str() == "push"
-                        && lhs_root_var(recv) == Some(self.target)
+                        && lhs_root_var(self.guards.gcx, recv) == Some(self.target)
                         && expr_is_array_or_bytes(self.guards.gcx, recv)
                         && args.exprs().any(|a| self.may_contain_self(a))
                     {
@@ -847,7 +839,7 @@ impl<'gcx> Visit<'gcx> for SelfAssignScan<'_, 'gcx> {
                     }
                 }
                 _ => {
-                    if let Some(fid) = unique(function_ids(callee)) {
+                    if let Some(fid) = self.guards.gcx.resolved_function(callee) {
                         self.scan_function(fid, Some(args));
                     }
                 }
@@ -869,37 +861,37 @@ fn invoked_function(hir: &Hir<'_>, m: &Modifier<'_>) -> Option<FunctionId> {
 
 /// Argument returned verbatim (modulo casts) by an identity helper call `id(x)` / `Lib.id(x)`.
 fn identity_helper_arg<'gcx>(
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     callee: &'gcx Expr<'gcx>,
     args: &'gcx CallArgs<'gcx>,
 ) -> Option<&'gcx Expr<'gcx>> {
-    callee_fids(hir, callee).into_iter().find_map(|fid| {
-        let f = hir.function(fid);
+    gcx.resolved_function(callee).and_then(|fid| {
+        let f = gcx.hir.function(fid);
         let [stmt] = f.body?.stmts else { return None };
         let StmtKind::Return(Some(ret)) = &stmt.kind else { return None };
-        let param = underlying_var(peel_casts(ret))?;
+        let param = underlying_var(gcx, peel_casts(ret))?;
         (f.parameters.len() == args.len() && f.returns.len() == 1 && f.parameters.contains(&param))
-            .then(|| arg_for_param(hir, f, param, args))
+            .then(|| arg_for_param(gcx, fid, param, args))
             .flatten()
     })
 }
 
 /// Variable at the root of an lvalue, through member / index accesses and address casts.
-fn lhs_root_var(lhs: &Expr<'_>) -> Option<VariableId> {
+fn lhs_root_var(gcx: Gcx<'_>, lhs: &Expr<'_>) -> Option<VariableId> {
     match &lhs.peel_parens().kind {
         ExprKind::Member(base, _) | ExprKind::Index(base, _) | ExprKind::Payable(base) => {
-            lhs_root_var(base)
+            lhs_root_var(gcx, base)
         }
         ExprKind::Call(callee, args, _) if is_address_like_cast(callee) => {
-            args.exprs().next().and_then(lhs_root_var)
+            args.exprs().next().and_then(|expr| lhs_root_var(gcx, expr))
         }
-        _ => underlying_var(lhs),
+        _ => underlying_var(gcx, lhs),
     }
 }
 
 /// True when an index expression only depends on literals and state: no locals, parameters,
 /// builtins (`msg.sender`) or non-cast calls.
-fn index_is_static(hir: &Hir<'_>, expr: &Expr<'_>) -> bool {
+fn index_is_static(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     expr.visit(&mut |e| match &e.kind {
         ExprKind::Lit(_)
         | ExprKind::Type(_)
@@ -910,9 +902,9 @@ fn index_is_static(hir: &Hir<'_>, expr: &Expr<'_>) -> bool {
         | ExprKind::Index(..)
         | ExprKind::Ternary(..)
         | ExprKind::Tuple([Some(_)]) => ControlFlow::Continue(()),
-        ExprKind::Ident(reses)
-            if reses.iter().all(|r| match r {
-                Res::Item(ItemId::Variable(v)) => hir.variable(*v).kind.is_state(),
+        ExprKind::Ident(_)
+            if gcx.resolved_expr(e).is_some_and(|res| match res {
+                Res::Item(ItemId::Variable(v)) => gcx.hir.variable(v).kind.is_state(),
                 Res::Builtin(_) => false,
                 _ => true,
             }) =>
@@ -949,13 +941,13 @@ fn stmt_contains_return(stmt: &Stmt<'_>) -> bool {
 }
 
 /// `msg.sender` modulo parens, casts, `payable(..)` and no-arg helpers such as `_msgSender()`.
-fn is_msg_sender_like<'gcx>(hir: &'gcx Hir<'gcx>, expr: &'gcx Expr<'gcx>, depth: u8) -> bool {
+fn is_msg_sender_like<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>, depth: u8) -> bool {
     let expr = peel_casts(expr);
     is_msg_sender(expr)
         || matches!(&expr.kind, ExprKind::Call(callee, args, _)
             if depth > 0
                 && args.exprs().next().is_none()
-                && callee_no_arg_returns(hir, callee, |e| is_msg_sender_like(hir, e, depth - 1)))
+                && callee_no_arg_returns(gcx, callee, |e| is_msg_sender_like(gcx, e, depth - 1)))
 }
 
 /// Looks through parens, `payable(..)`, address-like casts and integer casts.
@@ -990,11 +982,12 @@ fn is_trusted_literal(expr: &Expr<'_>) -> bool {
 }
 
 fn expr_is_function<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> bool {
-    expr_ty(gcx, expr).is_some_and(|ty| matches!(ty.peel_refs().kind, TyKind::Fn(_)))
+    gcx.type_of_expr(expr.peel_parens().id)
+        .is_some_and(|ty| matches!(ty.peel_refs().kind, TyKind::Fn(_)))
 }
 
 fn expr_is_array_or_bytes<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> bool {
-    expr_ty(gcx, expr).is_some_and(|ty| {
+    gcx.type_of_expr(expr.peel_parens().id).is_some_and(|ty| {
         matches!(
             ty.peel_refs().kind,
             TyKind::Array(..) | TyKind::DynArray(_) | TyKind::Elementary(ElementaryType::Bytes)

--- a/crates/lint/src/sol/high/controlled_delegatecall.rs
+++ b/crates/lint/src/sol/high/controlled_delegatecall.rs
@@ -5,9 +5,9 @@ use crate::{
         Severity, SolLint,
         analysis::{
             arg_for_param, branch_always_exits, count_placeholders, do_while_user_stmts,
-            expr_is_address, function_ids, has_side_effect, is_address_like_cast,
-            is_loop_termination_if, is_require_or_assert, loop_update, stmts_before_placeholder,
-            stmts_break_or_continue, tuple_elems, unique, var_is_address_like,
+            expr_is_address, has_side_effect, is_address_like_cast, is_loop_termination_if,
+            is_require_or_assert, loop_update, stmts_before_placeholder, stmts_break_or_continue,
+            tuple_elems, var_is_address_like,
         },
     },
 };
@@ -96,11 +96,11 @@ impl<'gcx> Analyzer<'gcx> {
                 LitKind::Number(n) => n.is_zero(),
                 _ => false,
             },
-            ExprKind::Ident(reses) => reses.iter().any(|res| match res {
+            ExprKind::Ident(_) => self.gcx.resolved_expr(expr).is_some_and(|res| match res {
                 Res::Builtin(builtin) => builtin.name() == sym::this,
                 Res::Item(ItemId::Variable(vid)) => {
-                    let var = self.gcx.hir.variable(*vid);
-                    (var.is_constant() && var_is_address_like(var)) || self.safe_vars.contains(vid)
+                    let var = self.gcx.hir.variable(vid);
+                    (var.is_constant() && var_is_address_like(var)) || self.safe_vars.contains(&vid)
                 }
                 _ => false,
             }),
@@ -140,7 +140,7 @@ impl<'gcx> Analyzer<'gcx> {
     }
 
     fn assign_expr(&mut self, lhs: &'gcx Expr<'gcx>, rhs: Option<&'gcx Expr<'gcx>>) {
-        if let Some(var) = underlying_var(lhs) {
+        if let Some(var) = underlying_var(self.gcx, lhs) {
             self.assign(var, rhs.is_some_and(|rhs| self.is_trusted_target(rhs)));
         }
     }
@@ -199,7 +199,7 @@ impl<'gcx> Analyzer<'gcx> {
                 } else if op.kind == eq {
                     for (safe, candidate) in [(lhs, rhs), (rhs, lhs)] {
                         if self.is_trusted_target(safe)
-                            && let Some(var) = underlying_var(candidate)
+                            && let Some(var) = underlying_var(self.gcx, candidate)
                             && self.is_trusted_fact_target(var)
                         {
                             self.safe_vars.insert(var);
@@ -382,7 +382,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
             }
             ExprKind::Delete(target) => {
                 // `delete` zeroes the target, and the zero address is trusted.
-                if let Some(var) = underlying_var(target) {
+                if let Some(var) = underlying_var(self.gcx, target) {
                     self.assign(var, true);
                 }
                 self.walk_expr(expr)
@@ -394,13 +394,13 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
 
 /// The variable a bare identifier refers to, looking through parens, `payable(...)` and
 /// address-like or numeric casts.
-fn underlying_var(expr: &Expr<'_>) -> Option<VariableId> {
+fn underlying_var(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<VariableId> {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().find_map(Res::as_variable),
+        ExprKind::Ident(_) => gcx.resolved_variable(expr),
         ExprKind::Call(callee, args, _) if is_cast(callee) => {
-            args.exprs().next().and_then(underlying_var)
+            args.exprs().next().and_then(|expr| underlying_var(gcx, expr))
         }
-        ExprKind::Payable(inner) => underlying_var(inner),
+        ExprKind::Payable(inner) => underlying_var(gcx, inner),
         _ => None,
     }
 }
@@ -425,7 +425,9 @@ fn no_arg_helper_return<'gcx>(
     gcx: Gcx<'gcx>,
     callee: &'gcx Expr<'gcx>,
 ) -> Option<&'gcx Expr<'gcx>> {
-    let fid = unique(function_ids(callee))?;
+    let fid = gcx
+        .resolved_function(callee)
+        .filter(|_| matches!(callee.peel_parens().kind, ExprKind::Ident(_)))?;
     let func = gcx.hir.function(fid);
     if func.virtual_ || func.override_ || !func.parameters.is_empty() {
         return None;
@@ -440,7 +442,7 @@ fn no_arg_helper_return<'gcx>(
         StmtKind::Return(Some(expr)) => Some(expr),
         StmtKind::Expr(expr) => match &expr.peel_parens().kind {
             ExprKind::Assign(lhs, None, rhs)
-                if func.returns.len() == 1 && underlying_var(lhs) == Some(func.returns[0]) =>
+                if func.returns.len() == 1 && underlying_var(gcx, lhs) == Some(func.returns[0]) =>
             {
                 Some(rhs)
             }
@@ -470,8 +472,8 @@ fn modifier_safe_vars<'gcx>(
         .parameters
         .iter()
         .filter_map(|&param| {
-            let arg = arg_for_param(&gcx.hir, modifier, param, &invocation.args)?;
-            Some((param, underlying_var(arg)?))
+            let arg = arg_for_param(gcx, fid, param, &invocation.args)?;
+            Some((param, underlying_var(gcx, arg)?))
         })
         .collect();
     if bindings.is_empty() {

--- a/crates/lint/src/sol/high/controlled_delegatecall.rs
+++ b/crates/lint/src/sol/high/controlled_delegatecall.rs
@@ -5,17 +5,18 @@ use crate::{
         Severity, SolLint,
         analysis::{
             arg_for_param, branch_always_exits, count_placeholders, do_while_user_stmts,
-            expr_is_address, has_side_effect, is_address_like_cast, is_loop_termination_if,
-            is_require_or_assert, loop_update, stmts_before_placeholder, stmts_break_or_continue,
-            tuple_elems, var_is_address_like,
+            has_side_effect, is_address_like_cast, is_loop_termination_if, is_require_or_assert,
+            loop_update, stmts_before_placeholder, stmts_break_or_continue, tuple_elems,
+            var_is_address_like,
         },
     },
 };
 use solar::{
     ast::{BinOpKind, LitKind, UnOpKind},
-    interface::{Span, kw, sym},
+    interface::{Span, sym},
     sema::{
         Gcx,
+        builtins::Builtin,
         hir::{
             self, ElementaryType, Expr, ExprKind, FunctionKind, ItemId, LoopSource, Res, Stmt,
             StmtKind, TypeKind, VariableId, Visit,
@@ -104,7 +105,7 @@ impl<'gcx> Analyzer<'gcx> {
                 }
                 _ => false,
             }),
-            ExprKind::Call(callee, args, _) if is_cast(callee) => {
+            ExprKind::Call(callee, args, _) if is_cast(self.gcx, callee) => {
                 args.exprs().next().is_some_and(|arg| self.is_trusted_target_inner(arg, depth))
             }
             ExprKind::Payable(inner) => self.is_trusted_target_inner(inner, depth),
@@ -164,9 +165,8 @@ impl<'gcx> Analyzer<'gcx> {
 
     fn is_controlled_delegatecall(&self, expr: &'gcx Expr<'gcx>) -> bool {
         let ExprKind::Call(callee, ..) = &expr.peel_parens().kind else { return false };
-        let ExprKind::Member(receiver, member) = &callee.peel_parens().kind else { return false };
-        member.name == kw::Delegatecall
-            && expr_is_address(self.gcx, receiver)
+        let ExprKind::Member(receiver, _) = &callee.peel_parens().kind else { return false };
+        self.gcx.resolved_builtin(callee) == Some(Builtin::AddressDelegatecall)
             && !self.is_trusted_target(receiver)
     }
 
@@ -336,7 +336,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
             }
             _ => {
                 let _ = self.walk_stmt(stmt);
-                if branch_always_exits(stmt) {
+                if branch_always_exits(self.gcx, stmt) {
                     ControlFlow::Break(())
                 } else {
                     ControlFlow::Continue(())
@@ -365,7 +365,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
                 let false_state = self.visit_arm(cond, true, |this| this.visit_expr(if_false));
                 self.join(true_state, false_state)
             }
-            ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
+            ExprKind::Call(callee, args, _) if is_require_or_assert(self.gcx, callee) => {
                 let _ = self.walk_expr(expr);
                 let mut args = args.exprs();
                 if let Some(cond) = args.next()
@@ -397,7 +397,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
 fn underlying_var(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<VariableId> {
     match &expr.peel_parens().kind {
         ExprKind::Ident(_) => gcx.resolved_variable(expr),
-        ExprKind::Call(callee, args, _) if is_cast(callee) => {
+        ExprKind::Call(callee, args, _) if is_cast(gcx, callee) => {
             args.exprs().next().and_then(|expr| underlying_var(gcx, expr))
         }
         ExprKind::Payable(inner) => underlying_var(gcx, inner),
@@ -406,8 +406,8 @@ fn underlying_var(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<VariableId> {
 }
 
 /// `address(..)`, `IFoo(..)`, `uintN(..)`, `intN(..)` or `bytes(..)` cast head.
-fn is_cast(callee: &Expr<'_>) -> bool {
-    is_address_like_cast(callee)
+fn is_cast(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
+    is_address_like_cast(gcx, callee)
         || matches!(
             &callee.peel_parens().kind,
             ExprKind::Type(hir::Type {

--- a/crates/lint/src/sol/high/encode_packed_collision.rs
+++ b/crates/lint/src/sol/high/encode_packed_collision.rs
@@ -1,16 +1,13 @@
 use super::EncodedPackedCollision;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        analysis::{expr_ty, is_builtin},
-    },
+    sol::{Severity, SolLint},
 };
 use solar::{
     ast::LitKind,
-    interface::sym,
     sema::{
         Gcx,
+        builtins::Builtin,
         hir::{Expr, ExprKind},
     },
 };
@@ -25,8 +22,7 @@ declare_forge_lint!(
 impl<'gcx> LateLintPass<'gcx> for EncodedPackedCollision {
     fn check_expr(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) {
         let ExprKind::Call(callee, args, _) = &expr.kind else { return };
-        let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return };
-        if member.name != sym::encodePacked || !is_builtin(base, sym::abi) {
+        if gcx.resolved_builtin(callee) != Some(Builtin::AbiEncodePacked) {
             return;
         }
         // Only non-literal dynamic args count: a top-level string/hex/unicode literal is a
@@ -45,14 +41,5 @@ fn is_str_lit(expr: &Expr<'_>) -> bool {
 }
 
 fn is_dynamic_arg<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
-    match &expr.peel_parens().kind {
-        // String literals (and multi-line/hex string sequences) are always dynamic.
-        ExprKind::Lit(_) => is_str_lit(expr),
-        // Ternary: dynamic when both branches are dynamic. Handled here so that literal branches
-        // (which have no checked type) are correctly identified as dynamic.
-        ExprKind::Ternary(_, then, else_) => {
-            is_dynamic_arg(gcx, then) && is_dynamic_arg(gcx, else_)
-        }
-        _ => expr_ty(gcx, expr).is_some_and(|ty| ty.peel_refs().is_dynamically_sized()),
-    }
+    gcx.type_of_expr(expr.peel_parens().id).is_some_and(|ty| ty.peel_refs().is_dynamically_sized())
 }

--- a/crates/lint/src/sol/high/enumerable_loop_removal.rs
+++ b/crates/lint/src/sol/high/enumerable_loop_removal.rs
@@ -163,7 +163,7 @@ impl<'gcx> LoopFinder<'_, '_, '_, 'gcx> {
     fn analyze_loop(&mut self, body: impl Iterator<Item = &'gcx Stmt<'gcx>> + Clone) {
         // Control flow would make the corruption depend on the path taken, which is not tracked;
         // without an ascending index there is no upward walk for swap-and-pop to disturb.
-        if !body_is_straight_line(body.clone()) {
+        if !body_is_straight_line(self.gcx, body.clone()) {
             return;
         }
         let cadence = ascending_cadence(self.gcx, body.clone());
@@ -284,12 +284,15 @@ fn user_body<'gcx>(body: &'gcx [Stmt<'gcx>]) -> &'gcx [Stmt<'gcx>] {
 /// statement, inline assembly or nested loop (bare blocks are transparent). Any of these could
 /// let control skip a removal or the cadence step, or leave the loop before a shifted slot is
 /// read, none of which this detector tracks.
-fn body_is_straight_line<'gcx>(stmts: impl IntoIterator<Item = &'gcx Stmt<'gcx>>) -> bool {
+fn body_is_straight_line<'gcx>(
+    gcx: Gcx<'_>,
+    stmts: impl IntoIterator<Item = &'gcx Stmt<'gcx>>,
+) -> bool {
     stmts.into_iter().all(|stmt| {
-        !branch_always_exits(stmt)
+        !branch_always_exits(gcx, stmt)
             && match &stmt.kind {
                 StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
-                    body_is_straight_line(block.stmts)
+                    body_is_straight_line(gcx, block.stmts)
                 }
                 StmtKind::If(..)
                 | StmtKind::Try(..)

--- a/crates/lint/src/sol/high/enumerable_loop_removal.rs
+++ b/crates/lint/src/sol/high/enumerable_loop_removal.rs
@@ -3,7 +3,7 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{branch_always_exits, loop_update, resolved_function, write_target},
+        analysis::{branch_always_exits, loop_update, write_target},
     },
 };
 use alloy_primitives::U256;
@@ -13,10 +13,9 @@ use solar::{
     sema::{
         Gcx,
         hir::{
-            self, BinOpKind, CallArgs, CallArgsKind, Expr, ExprKind, FunctionId, Hir, LoopSource,
-            Res, Stmt, StmtKind, VarKind, VariableId, Visit,
+            self, BinOpKind, Expr, ExprKind, Hir, LoopSource, Stmt, StmtKind, VarKind, VariableId,
+            Visit,
         },
-        ty::TyKind,
     },
 };
 use std::{convert::Infallible, ops::ControlFlow};
@@ -131,7 +130,7 @@ impl<'gcx> LoopFinder<'_, '_, '_, 'gcx> {
         self.poison_writes(std::slice::from_ref(stmt));
         let bindings = &mut self.bindings;
         let mut bind = |var: VariableId, value: &Expr<'_>| {
-            let path = set_path(&self.gcx.hir, value, bindings, &mut Vec::new());
+            let path = set_path(self.gcx, value, bindings, &mut Vec::new());
             bindings.push((var, path));
         };
         match &stmt.kind {
@@ -142,11 +141,10 @@ impl<'gcx> LoopFinder<'_, '_, '_, 'gcx> {
             }
             StmtKind::Expr(expr) => {
                 if let ExprKind::Assign(target, None, value) = &expr.peel_parens().kind
-                    && let ExprKind::Ident(reses) = &target.peel_parens().kind
+                    && let ExprKind::Ident(_) = &target.peel_parens().kind
+                    && let Some(var) = self.gcx.resolved_variable(target)
                 {
-                    for var in reses.iter().filter_map(Res::as_variable) {
-                        bind(var, value);
-                    }
+                    bind(var, value);
                 }
             }
             _ => {}
@@ -156,7 +154,7 @@ impl<'gcx> LoopFinder<'_, '_, '_, 'gcx> {
     /// Marks everything the statements write as no longer naming one thing.
     fn poison_writes(&mut self, stmts: impl IntoIterator<Item = &'gcx Stmt<'gcx>>) {
         let mut written = Vec::new();
-        collect_writes(&self.gcx.hir, stmts, &mut written);
+        collect_writes(self.gcx, stmts, &mut written);
         self.bindings.extend(written.into_iter().map(|var| (var, None)));
     }
 
@@ -168,7 +166,7 @@ impl<'gcx> LoopFinder<'_, '_, '_, 'gcx> {
         if !body_is_straight_line(body.clone()) {
             return;
         }
-        let cadence = ascending_cadence(&self.gcx.hir, body.clone());
+        let cadence = ascending_cadence(self.gcx, body.clone());
         if cadence.is_empty() {
             return;
         }
@@ -308,17 +306,17 @@ fn body_is_straight_line<'gcx>(stmts: impl IntoIterator<Item = &'gcx Stmt<'gcx>>
 /// on the straight line of the body (bare blocks included) is a supported ascending step. A
 /// reset, a no-op step, a decrement or composite arithmetic disqualifies the variable.
 fn ascending_cadence<'gcx>(
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     body: impl IntoIterator<Item = &'gcx Stmt<'gcx>>,
 ) -> Vec<VariableId> {
     let (mut cadence, mut other_writes) = (Vec::new(), Vec::new());
-    collect_cadence_writes(hir, body, &mut cadence, &mut other_writes);
+    collect_cadence_writes(gcx, body, &mut cadence, &mut other_writes);
     cadence.retain(|var| !other_writes.contains(var));
     cadence
 }
 
 fn collect_cadence_writes<'gcx>(
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     stmts: impl IntoIterator<Item = &'gcx Stmt<'gcx>>,
     cadence: &mut Vec<VariableId>,
     other_writes: &mut Vec<VariableId>,
@@ -326,16 +324,16 @@ fn collect_cadence_writes<'gcx>(
     for stmt in stmts {
         let mut written = match &stmt.kind {
             StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
-                collect_cadence_writes(hir, block.stmts, cadence, other_writes);
+                collect_cadence_writes(gcx, block.stmts, cadence, other_writes);
                 continue;
             }
             StmtKind::DeclSingle(var) => vec![*var],
             StmtKind::DeclMulti(vars, _) => vars.iter().flatten().copied().collect(),
             _ => Vec::new(),
         };
-        collect_writes(hir, std::slice::from_ref(stmt), &mut written);
+        collect_writes(gcx, std::slice::from_ref(stmt), &mut written);
         let ascending = match &stmt.kind {
-            StmtKind::Expr(expr) => ascending_step(expr.peel_parens()),
+            StmtKind::Expr(expr) => ascending_step(gcx, expr.peel_parens()),
             _ => None,
         };
         for var in written {
@@ -350,22 +348,26 @@ fn collect_cadence_writes<'gcx>(
 
 /// The bare identifier an expression steps upward by one of the simple ascending forms:
 /// `i++`/`++i`, `i += <positive literal>`, `i = i + <positive literal>` or its commutation.
-fn ascending_step<'gcx>(expr: &'gcx Expr<'gcx>) -> Option<VariableId> {
+fn ascending_step<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> Option<VariableId> {
+    let variable = |expr: &Expr<'_>| {
+        gcx.resolved_variable(expr)
+            .filter(|_| matches!(expr.peel_parens().kind, ExprKind::Ident(_)))
+    };
     match &expr.kind {
         ExprKind::Unary(op, operand) if matches!(op.kind, UnOpKind::PreInc | UnOpKind::PostInc) => {
-            operand.as_variable()
+            variable(operand)
         }
         ExprKind::Assign(lhs, Some(op), rhs)
             if op.kind == BinOpKind::Add && is_positive_literal(rhs) =>
         {
-            lhs.as_variable()
+            variable(lhs)
         }
         ExprKind::Assign(lhs, None, rhs) => {
-            let target = lhs.as_variable()?;
+            let target = variable(lhs)?;
             let ExprKind::Binary(left, op, right) = &rhs.peel_parens().kind else { return None };
             (op.kind == BinOpKind::Add
-                && ((left.as_variable() == Some(target) && is_positive_literal(right))
-                    || (is_positive_literal(left) && right.as_variable() == Some(target))))
+                && ((variable(left) == Some(target) && is_positive_literal(right))
+                    || (is_positive_literal(left) && variable(right) == Some(target))))
             .then_some(target)
         }
         _ => None,
@@ -391,25 +393,25 @@ fn literal_bool(expr: &Expr<'_>) -> Option<bool> {
 /// assignments (tuple targets included), increments, decrements and deletes. Member and indexed
 /// targets do not write their base variable.
 fn collect_writes<'gcx>(
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     stmts: impl IntoIterator<Item = &'gcx Stmt<'gcx>>,
     out: &mut Vec<VariableId>,
 ) {
-    fn lvalue_variables(expr: &Expr<'_>, out: &mut Vec<VariableId>) {
+    fn lvalue_variables(gcx: Gcx<'_>, expr: &Expr<'_>, out: &mut Vec<VariableId>) {
         match &expr.peel_parens().kind {
-            ExprKind::Ident(reses) => out.extend(reses.iter().filter_map(Res::as_variable)),
+            ExprKind::Ident(_) => out.extend(gcx.resolved_variable(expr)),
             ExprKind::Tuple(exprs) => {
-                exprs.iter().flatten().for_each(|expr| lvalue_variables(expr, out));
+                exprs.iter().flatten().for_each(|expr| lvalue_variables(gcx, expr, out));
             }
             _ => {}
         }
     }
     let mut writes = ExprWalker {
-        hir,
+        hir: &gcx.hir,
         prune_unreachable: false,
         f: |expr: &Expr<'_>| {
             if let Some(target) = write_target(expr) {
-                lvalue_variables(target, out)
+                lvalue_variables(gcx, target, out)
             }
         },
     };
@@ -440,8 +442,8 @@ fn enumerable_set_call<'gcx>(
     bindings: &Bindings,
     expr: &'gcx Expr<'gcx>,
 ) -> Option<SetCall<'gcx>> {
-    let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
-    let function_id = resolved_function(gcx, callee)?;
+    let ExprKind::Call(callee, ..) = &expr.kind else { return None };
+    let function_id = gcx.resolved_function(callee)?;
     let function = gcx.hir.function(function_id);
     let contract = gcx.hir.contract(function.contract?);
     if !contract.kind.is_library() || contract.name.as_str() != "EnumerableSet" {
@@ -455,15 +457,17 @@ fn enumerable_set_call<'gcx>(
     // The set operand is the bound receiver in the method form and the first argument in the
     // library-qualified form; the index of `at` sits right after it.
     let (set_expr, index_arg) = match &callee.peel_parens().kind {
-        ExprKind::Member(receiver, _) if is_enumerable_set_value(gcx, receiver) => {
+        ExprKind::Member(receiver, _)
+            if gcx.resolved_call(expr).is_some_and(|resolved| resolved.attached) =>
+        {
             (Some(&**receiver), 0)
         }
-        _ => (nth_argument(&gcx.hir, function_id, args, 0, 0), 1),
+        _ => (gcx.call_arg(expr, 0), 1),
     };
     Some(SetCall {
         op,
-        set: set_expr.and_then(|expr| set_path(&gcx.hir, expr, bindings, &mut Vec::new())),
-        index: nth_argument(&gcx.hir, function_id, args, index_arg, 1),
+        set: set_expr.and_then(|expr| set_path(gcx, expr, bindings, &mut Vec::new())),
+        index: gcx.call_arg(expr, index_arg),
     })
 }
 
@@ -490,19 +494,19 @@ type Bindings = [(VariableId, Option<SetPath>)];
 /// call result, a reference without one straight-line binding, anything the analysis would have
 /// to evaluate.
 fn set_path(
-    hir: &Hir<'_>,
+    gcx: Gcx<'_>,
     expr: &Expr<'_>,
     bindings: &Bindings,
     seen: &mut Vec<VariableId>,
 ) -> Option<SetPath> {
     match &expr.peel_parens().kind {
         ExprKind::Ident(_) => {
-            let var = expr.as_variable()?;
+            let var = gcx.resolved_variable(expr)?;
             if seen.contains(&var) {
                 return None;
             }
             seen.push(var);
-            let variable = hir.variable(var);
+            let variable = gcx.hir.variable(var);
             if !matches!(variable.kind, VarKind::Statement) {
                 return Some(SetPath { base: var, steps: Vec::new() });
             }
@@ -511,52 +515,21 @@ fn set_path(
             // anew each turn; a tuple-destructured one has neither and may name any set.
             match bindings.iter().rev().find(|(bound, _)| *bound == var) {
                 Some((_, binding)) => binding.clone(),
-                None => set_path(hir, variable.initializer?, bindings, seen),
+                None => set_path(gcx, variable.initializer?, bindings, seen),
             }
         }
         ExprKind::Member(base, field) => {
-            let mut path = set_path(hir, base, bindings, seen)?;
+            let mut path = set_path(gcx, base, bindings, seen)?;
             path.steps.push(Step::Field(field.name));
             Some(path)
         }
         ExprKind::Index(base, Some(index)) => {
             let ExprKind::Lit(lit) = &index.peel_parens().kind else { return None };
             let LitKind::Number(key) = &lit.kind else { return None };
-            let mut path = set_path(hir, base, bindings, seen)?;
+            let mut path = set_path(gcx, base, bindings, seen)?;
             path.steps.push(Step::Key(*key));
             Some(path)
         }
         _ => None,
     }
-}
-
-/// The argument at position `arg` of a positional call, or the one a named call binds to the
-/// callee's parameter at position `parameter`. In the method form the bound receiver fills the
-/// first parameter, so positional arguments sit one position before the parameters they fill.
-fn nth_argument<'gcx>(
-    hir: &'gcx Hir<'gcx>,
-    function_id: FunctionId,
-    args: &'gcx CallArgs<'gcx>,
-    arg: usize,
-    parameter: usize,
-) -> Option<&'gcx Expr<'gcx>> {
-    match &args.kind {
-        CallArgsKind::Unnamed(exprs) => exprs.get(arg),
-        CallArgsKind::Named(named) => {
-            let parameter = *hir.function(function_id).parameters.get(parameter)?;
-            let name = hir.variable(parameter).name?;
-            named.iter().find(|argument| argument.name.name == name.name).map(|arg| &arg.value)
-        }
-    }
-}
-
-/// Whether `receiver` is a value of a struct declared in a library (or contract) named
-/// `EnumerableSet`, which tells the bound method form apart from the library-qualified form.
-fn is_enumerable_set_value(gcx: Gcx<'_>, receiver: &Expr<'_>) -> bool {
-    let Some(ty) = gcx.type_of_expr(receiver.peel_parens().id) else { return false };
-    let TyKind::Struct(id) = ty.peel_refs().kind else { return false };
-    gcx.hir
-        .strukt(id)
-        .contract
-        .is_some_and(|c| gcx.hir.contract(c).name.as_str() == "EnumerableSet")
 }

--- a/crates/lint/src/sol/high/function_selector_collision.rs
+++ b/crates/lint/src/sol/high/function_selector_collision.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{
         Severity, SolLint,
         analysis::{
-            arg_for_param, branch_always_exits, expr_is_address, is_address_cast, is_builtin,
+            arg_for_param, branch_always_exits, expr_is_address, is_address_cast,
             is_require_or_assert, ty_contract_id,
         },
     },
@@ -12,7 +12,7 @@ use crate::{
 use alloy_primitives::Selector;
 use solar::{
     ast::{LitKind, UnOpKind},
-    interface::{Symbol, data_structures::Never, kw, sym},
+    interface::{data_structures::Never, kw, sym},
     sema::{
         Gcx,
         builtins::Builtin,
@@ -565,7 +565,7 @@ impl<'gcx> Visit<'gcx> for DelegateTargetCollector<'gcx> {
                     let _ = self.visit_expr(&arg.value);
                 }
                 let mut args = args.exprs();
-                if is_require_or_assert(callee) {
+                if is_require_or_assert(self.gcx, callee) {
                     let Some(condition) = args.next() else { return ControlFlow::Continue(()) };
                     let args: Vec<_> = args.collect();
                     let (true_paths, false_paths) = self.visit_condition(condition);
@@ -685,7 +685,7 @@ impl<'gcx> Visit<'gcx> for DelegateTargetCollector<'gcx> {
             }
             _ => {
                 let _ = self.walk_stmt(stmt);
-                if branch_always_exits(stmt) {
+                if branch_always_exits(self.gcx, stmt) {
                     self.paths.clear();
                 }
             }
@@ -702,9 +702,9 @@ fn selector_guard(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<(Selector, bool)> {
         BinOpKind::Ne => false,
         _ => return None,
     };
-    let selector = if is_msg_member(lhs, sym::sig) {
+    let selector = if gcx.resolved_builtin(lhs) == Some(Builtin::MsgSig) {
         rhs
-    } else if is_msg_member(rhs, sym::sig) {
+    } else if gcx.resolved_builtin(rhs) == Some(Builtin::MsgSig) {
         lhs
     } else {
         return None;
@@ -718,12 +718,6 @@ fn selector_guard(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<(Selector, bool)> {
     }
     let function = gcx.resolved_function(function)?;
     Some((gcx.function_selector(function), matches))
-}
-
-/// `msg.<name>`.
-fn is_msg_member(expr: &Expr<'_>, name: Symbol) -> bool {
-    matches!(&expr.peel_parens().kind, ExprKind::Member(base, member)
-        if member.name == name && is_builtin(base, sym::msg))
 }
 
 /// The statically typed implementation contract of a proxy-style `<addr>.delegatecall(<full
@@ -769,7 +763,7 @@ fn full_calldata_source(
     expr: &Expr<'_>,
     full_calldata_inputs: &[CalldataInput],
 ) -> Option<Option<CalldataInput>> {
-    if is_msg_member(expr, sym::data) {
+    if gcx.resolved_builtin(expr) == Some(Builtin::MsgData) {
         return Some(None);
     }
     let ExprKind::Ident(_) = &expr.peel_parens().kind else { return None };

--- a/crates/lint/src/sol/high/function_selector_collision.rs
+++ b/crates/lint/src/sol/high/function_selector_collision.rs
@@ -17,8 +17,8 @@ use solar::{
         Gcx,
         builtins::Builtin,
         hir::{
-            self, BinOpKind, ContractId, ContractKind, Expr, ExprKind, LoopSource, Res, Stmt,
-            StmtKind, VariableId, Visit,
+            self, BinOpKind, ContractId, ContractKind, Expr, ExprKind, LoopSource, Stmt, StmtKind,
+            VariableId, Visit,
         },
     },
 };
@@ -49,6 +49,7 @@ impl<'gcx> LateLintPass<'gcx> for FunctionSelectorCollision {
 
         let mut collector = DelegateTargetCollector {
             gcx,
+            contract_id: proxy_id,
             current_inputs: Vec::new(),
             paths: vec![PathState::default()],
             placeholder: None,
@@ -189,11 +190,11 @@ struct Continuation<'gcx> {
     body_input: Option<CalldataInput>,
 }
 
-fn lvalue_contains_var(expr: &Expr<'_>, target: VariableId) -> bool {
+fn lvalue_contains_var(gcx: Gcx<'_>, expr: &Expr<'_>, target: VariableId) -> bool {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().any(|res| res.as_variable() == Some(target)),
+        ExprKind::Ident(_) => gcx.resolved_variable(expr) == Some(target),
         ExprKind::Tuple(exprs) => {
-            exprs.iter().flatten().any(|expr| lvalue_contains_var(expr, target))
+            exprs.iter().flatten().any(|expr| lvalue_contains_var(gcx, expr, target))
         }
         _ => false,
     }
@@ -214,6 +215,7 @@ fn dedup(paths: &mut Vec<PathState>) {
 
 struct DelegateTargetCollector<'gcx> {
     gcx: Gcx<'gcx>,
+    contract_id: ContractId,
     /// Full-calldata inputs visible in the block being visited.
     current_inputs: Vec<CalldataInput>,
     /// Live path states; empty means the current point is unreachable.
@@ -234,7 +236,8 @@ impl<'gcx> DelegateTargetCollector<'gcx> {
             for arg in invocation.args.exprs() {
                 let _ = self.visit_expr(arg);
             }
-            if let Some(modifier_id) = invocation.id.as_function()
+            if let Some(modifier_id) =
+                self.gcx.resolve_modifier_target(self.contract_id, invocation)
                 && let Some(modifier_body) = self.gcx.hir.function(modifier_id).body
             {
                 let modifier = self.gcx.hir.function(modifier_id);
@@ -248,8 +251,8 @@ impl<'gcx> DelegateTargetCollector<'gcx> {
                     .iter()
                     .filter_map(|&param| {
                         let arg =
-                            arg_for_param(&self.gcx.hir, modifier, param.var, &invocation.args)?;
-                        Some((param, full_calldata_source(arg, &self.current_inputs)?))
+                            arg_for_param(self.gcx, modifier_id, param.var, &invocation.args)?;
+                        Some((param, full_calldata_source(self.gcx, arg, &self.current_inputs)?))
                     })
                     .collect();
                 for path in &mut self.paths {
@@ -596,7 +599,7 @@ impl<'gcx> Visit<'gcx> for DelegateTargetCollector<'gcx> {
                         .current_inputs
                         .iter()
                         .copied()
-                        .filter(|input| lvalue_contains_var(lhs, input.var))
+                        .filter(|input| lvalue_contains_var(self.gcx, lhs, input.var))
                         .collect(),
                     _ => Vec::new(),
                 };
@@ -713,9 +716,7 @@ fn selector_guard(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<(Selector, bool)> {
     {
         return None;
     }
-    let Res::Item(hir::ItemId::Function(function)) = gcx.resolved_expr(function)? else {
-        return None;
-    };
+    let function = gcx.resolved_function(function)?;
     Some((gcx.function_selector(function), matches))
 }
 
@@ -734,7 +735,7 @@ fn delegated_contract<'gcx>(
 ) -> Option<(ContractId, Option<CalldataInput>)> {
     let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return None };
     let ExprKind::Member(receiver, member) = &callee.peel_parens().kind else { return None };
-    let required_input = full_calldata_source(args.exprs().next()?, full_calldata_inputs)?;
+    let required_input = full_calldata_source(gcx, args.exprs().next()?, full_calldata_inputs)?;
     if member.name != kw::Delegatecall
         || gcx.resolved_builtin(callee) != Some(Builtin::AddressDelegatecall)
         || !expr_is_address(gcx, receiver)
@@ -764,15 +765,14 @@ fn typed_contract_behind_address_cast<'gcx>(
 /// `Some(None)` for `msg.data`, `Some(Some(input))` for a known full-calldata input, `None`
 /// otherwise.
 fn full_calldata_source(
+    gcx: Gcx<'_>,
     expr: &Expr<'_>,
     full_calldata_inputs: &[CalldataInput],
 ) -> Option<Option<CalldataInput>> {
     if is_msg_member(expr, sym::data) {
         return Some(None);
     }
-    let ExprKind::Ident(reses) = &expr.peel_parens().kind else { return None };
-    reses
-        .iter()
-        .filter_map(Res::as_variable)
-        .find_map(|id| full_calldata_inputs.iter().copied().find(|input| input.var == id).map(Some))
+    let ExprKind::Ident(_) = &expr.peel_parens().kind else { return None };
+    let id = gcx.resolved_variable(expr)?;
+    full_calldata_inputs.iter().copied().find(|input| input.var == id).map(Some)
 }

--- a/crates/lint/src/sol/high/protected_vars.rs
+++ b/crates/lint/src/sol/high/protected_vars.rs
@@ -10,8 +10,8 @@ use crate::{
     sol::{
         Severity, SolLint,
         analysis::{
-            branch_always_exits, builtins, function_ids, is_builtin, is_loop_termination_if,
-            lhs_local_var, loop_update, runtime_entry_points, unique,
+            branch_always_exits, builtins, is_builtin, is_loop_termination_if, lhs_local_var,
+            loop_update, runtime_entry_points,
         },
     },
 };
@@ -25,7 +25,7 @@ use solar::{
             self, CallArgs, ContractId, ExprId, ExprKind, FunctionId, ItemId, LoopSource,
             NatSpecKind, Res, StmtKind, VariableId,
         },
-        ty::{Ty, TyAbiPrinter, TyAbiPrinterMode, TyKind},
+        ty::{CallableParamSource, Ty, TyAbiPrinter, TyAbiPrinterMode, TyKind},
     },
 };
 use std::collections::{HashMap, HashSet};
@@ -455,7 +455,9 @@ impl<'gcx> EntryAnalyzer<'gcx> {
         }
 
         let Some(declared_id) = modifier.id.as_function() else { return false };
-        let modifier_id = self.dispatch_function(declared_id);
+        let Some(modifier_id) = self.gcx.resolve_modifier_target(self.bases[0], modifier) else {
+            return false;
+        };
         self.guards.insert(modifier_id);
         let arguments = self.ordered_call_arguments(declared_id, modifier.args, None);
         let bound = self.argument_aliases(modifier_id, &arguments);
@@ -790,11 +792,15 @@ impl<'gcx> EntryAnalyzer<'gcx> {
                     self.record_roots(roots);
                 }
 
-                if let Some((declared_id, function_id, receiver)) =
-                    self.resolved_internal_call(callee)
-                {
+                if let Some((_, function_id, receiver)) = self.resolved_internal_call(callee) {
                     self.guards.insert(function_id);
-                    let arguments = self.ordered_call_arguments(declared_id, *args, receiver);
+                    let arguments = receiver
+                        .into_iter()
+                        .chain(
+                            (0..args.len())
+                                .filter_map(|index| self.gcx.call_arg(expression, index)),
+                        )
+                        .collect::<Vec<_>>();
                     let summary = self.analyze_call(function_id, &arguments);
                     self.store_call_returns(expression.id, summary.returns);
                     return summary.completes;
@@ -909,7 +915,7 @@ impl<'gcx> EntryAnalyzer<'gcx> {
             // `pointer.slot := x` retargets a storage pointer.
             ExprKind::YulMember(base, member)
                 if member.as_str() == "slot"
-                    && let Some(local) = lhs_local_var(&self.gcx.hir, base) =>
+                    && let Some(local) = lhs_local_var(self.gcx, base) =>
             {
                 let roots = self.slot_roots(rhs);
                 self.set_storage_alias(local, roots);
@@ -917,7 +923,7 @@ impl<'gcx> EntryAnalyzer<'gcx> {
             ExprKind::Tuple(expressions) => {
                 for (index, expression) in expressions.iter().enumerate() {
                     let Some(expression) = expression else { continue };
-                    if let Some(local) = lhs_local_var(&self.gcx.hir, expression) {
+                    if let Some(local) = lhs_local_var(self.gcx, expression) {
                         let roots = self.storage_roots_for_output(rhs, index, expressions.len());
                         self.alias_local(local, roots);
                     } else {
@@ -925,7 +931,7 @@ impl<'gcx> EntryAnalyzer<'gcx> {
                     }
                 }
             }
-            _ => match lhs_local_var(&self.gcx.hir, lhs) {
+            _ => match lhs_local_var(self.gcx, lhs) {
                 Some(local) => self.alias_local_from_expr(local, rhs),
                 None => self.record_write(lhs),
             },
@@ -1006,13 +1012,11 @@ impl<'gcx> EntryAnalyzer<'gcx> {
         arguments: CallArgs<'gcx>,
         receiver: Option<&'gcx hir::Expr<'gcx>>,
     ) -> Vec<&'gcx hir::Expr<'gcx>> {
-        let parameters = self.gcx.hir.function(declared_id).parameters;
-        let parameters = &parameters[usize::from(receiver.is_some())..];
-        let names: Vec<_> = parameters
-            .iter()
-            .map(|&parameter| self.gcx.hir.variable(parameter).name.map(|name| name.name))
-            .collect();
-        let arguments = (0..parameters.len())
+        let names = self.gcx.callable_param_names(CallableParamSource::Function {
+            id: declared_id,
+            skips_receiver: receiver.is_some(),
+        });
+        let arguments = (0..names.len())
             .filter_map(|index| arguments.argument_for_parameter(index, Some(&names)));
         receiver.into_iter().chain(arguments).collect()
     }
@@ -1024,10 +1028,9 @@ impl<'gcx> EntryAnalyzer<'gcx> {
         &self,
         callee: &'gcx hir::Expr<'gcx>,
     ) -> Option<(FunctionId, FunctionId, Option<&'gcx hir::Expr<'gcx>>)> {
-        let (function_id, attached) = match self.gcx.resolved_callee(callee.id) {
-            Some(resolved) => (resolved.res.as_function()?, resolved.attached),
-            None => (unique(function_ids(callee))?, false),
-        };
+        let resolved = self.gcx.resolved_callee(callee.peel_parens().id)?;
+        let function_id = resolved.res.as_function()?;
+        let attached = resolved.attached;
         match &callee.peel_parens().kind {
             ExprKind::Ident(_) => Some((function_id, self.dispatch_function(function_id), None)),
             ExprKind::Member(base, _) if attached => Some((function_id, function_id, Some(base))),
@@ -1050,19 +1053,7 @@ impl<'gcx> EntryAnalyzer<'gcx> {
 
     /// The most-derived override of a virtual function or modifier in the analyzed hierarchy.
     fn dispatch_function(&self, function_id: FunctionId) -> FunctionId {
-        let function = self.gcx.hir.function(function_id);
-        if !function.virtual_ {
-            return function_id;
-        }
-        let signature = callable_signature(self.gcx, function_id);
-        self.bases
-            .iter()
-            .flat_map(|&contract_id| self.gcx.hir.contract(contract_id).functions())
-            .find(|&candidate_id| {
-                self.gcx.hir.function(candidate_id).kind == function.kind
-                    && callable_signature(self.gcx, candidate_id) == signature
-            })
-            .unwrap_or(function_id)
+        self.gcx.resolve_virtual_function(self.bases[0], function_id)
     }
 
     /// State variables an lvalue may write: state roots, aliased storage pointers and
@@ -1076,8 +1067,8 @@ impl<'gcx> EntryAnalyzer<'gcx> {
     fn collect_storage_roots(&self, expression: &hir::Expr<'_>, roots: &mut StorageRoots) {
         let expression = expression.peel_parens();
         match &expression.kind {
-            ExprKind::Ident(resolutions) => {
-                for variable_id in resolutions.iter().filter_map(Res::as_variable) {
+            ExprKind::Ident(_) => {
+                if let Some(variable_id) = self.gcx.resolved_variable(expression) {
                     if self.gcx.hir.variable(variable_id).kind.is_state() {
                         roots.insert(variable_id);
                     } else if let Some(aliases) = self.aliases.storage.get(&variable_id) {
@@ -1118,11 +1109,11 @@ impl<'gcx> EntryAnalyzer<'gcx> {
     fn collect_slot_roots(&self, expression: &hir::Expr<'_>, roots: &mut StorageRoots) {
         let expression = expression.peel_parens();
         match &expression.kind {
-            ExprKind::Ident(resolutions) => {
-                for variable_id in resolutions.iter().filter_map(Res::as_variable) {
-                    if let Some(aliases) = self.aliases.slots.get(&variable_id) {
-                        roots.extend(aliases);
-                    }
+            ExprKind::Ident(_) => {
+                if let Some(variable_id) = self.gcx.resolved_variable(expression)
+                    && let Some(aliases) = self.aliases.slots.get(&variable_id)
+                {
+                    roots.extend(aliases);
                 }
             }
             ExprKind::YulMember(base, member) if member.as_str() == "slot" => {

--- a/crates/lint/src/sol/high/protected_vars.rs
+++ b/crates/lint/src/sol/high/protected_vars.rs
@@ -10,13 +10,13 @@ use crate::{
     sol::{
         Severity, SolLint,
         analysis::{
-            branch_always_exits, builtins, is_builtin, is_loop_termination_if, lhs_local_var,
-            loop_update, runtime_entry_points,
+            branch_always_exits, is_builtin, is_loop_termination_if, lhs_local_var, loop_update,
+            runtime_entry_points,
         },
     },
 };
 use solar::{
-    ast::{BinOpKind, ContractKind, DataLocation, ElementaryType, FunctionKind},
+    ast::{BinOpKind, ContractKind, DataLocation, FunctionKind},
     interface::sym,
     sema::{
         Gcx,
@@ -414,7 +414,7 @@ impl<'gcx> EntryAnalyzer<'gcx> {
         self.return_stack.push(empty_returns());
         self.return_flow.push(None);
         let completes = self.analyze_modifier_chain(function.modifiers, 0, body);
-        if completes && !body.stmts.iter().any(branch_always_exits) {
+        if completes && !body.stmts.iter().any(|expr| branch_always_exits(self.gcx, expr)) {
             self.capture_named_returns();
         }
         let returned = self.return_flow.pop().expect("return flow frame").is_some();
@@ -590,7 +590,7 @@ impl<'gcx> EntryAnalyzer<'gcx> {
                 true
             }
             StmtKind::Emit(expression) | StmtKind::Expr(expression) => {
-                self.analyze_expr(expression) && !branch_always_exits(statement)
+                self.analyze_expr(expression) && !branch_always_exits(self.gcx, statement)
             }
             StmtKind::Revert(expression) => {
                 self.analyze_expr(expression);
@@ -774,18 +774,19 @@ impl<'gcx> EntryAnalyzer<'gcx> {
                     return false;
                 }
 
-                if let ExprKind::Member(base, member) = &callee.peel_parens().kind
-                    && matches!(member.as_str(), "push" | "pop")
-                    && is_dynamic_array_or_bytes(self.gcx, base)
+                if let ExprKind::Member(base, _) = &callee.peel_parens().kind
+                    && let Some(
+                        builtin @ (Builtin::ArrayPush0 | Builtin::ArrayPush | Builtin::ArrayPop),
+                    ) = self.gcx.resolved_builtin(callee)
                 {
                     self.record_write(base);
-                    if member.as_str() == "push" && args.is_empty() {
+                    if builtin == Builtin::ArrayPush0 {
                         let roots = self.storage_roots(base);
                         self.store_call_returns(expression.id, vec![roots]);
                     }
                 }
 
-                if builtins(callee).any(|builtin| builtin == Builtin::YulSstore)
+                if self.gcx.resolved_builtin(callee) == Some(Builtin::YulSstore)
                     && let Some(slot) = args.exprs().next()
                 {
                     let roots = self.slot_roots(slot);
@@ -1035,7 +1036,8 @@ impl<'gcx> EntryAnalyzer<'gcx> {
             ExprKind::Ident(_) => Some((function_id, self.dispatch_function(function_id), None)),
             ExprKind::Member(base, _) if attached => Some((function_id, function_id, Some(base))),
             ExprKind::Member(base, _)
-                if self.is_library_function(function_id) || is_static_internal_base(base) =>
+                if self.is_library_function(function_id)
+                    || is_static_internal_base(self.gcx, base) =>
             {
                 Some((function_id, function_id, None))
             }
@@ -1172,19 +1174,10 @@ impl<'gcx> EntryAnalyzer<'gcx> {
 }
 
 /// `super.f`, `Base.f` or `Lib.f`: a statically dispatched internal call.
-fn is_static_internal_base(base: &hir::Expr<'_>) -> bool {
-    is_builtin(base, sym::super_)
-        || matches!(&base.peel_parens().kind, ExprKind::Ident(resolutions)
-        if resolutions.iter().any(|resolution| {
-            matches!(resolution, Res::Item(ItemId::Contract(_)) | Res::Namespace(_))
-        }))
-}
-
-fn is_dynamic_array_or_bytes(gcx: Gcx<'_>, expression: &hir::Expr<'_>) -> bool {
-    gcx.type_of_expr(expression.peel_parens().id).is_some_and(|ty| {
-        matches!(
-            ty.peel_refs().kind,
-            TyKind::DynArray(_) | TyKind::Elementary(ElementaryType::Bytes)
+fn is_static_internal_base(gcx: Gcx<'_>, base: &hir::Expr<'_>) -> bool {
+    is_builtin(gcx, base, sym::super_)
+        || matches!(
+            gcx.resolved_expr(base),
+            Some(Res::Item(ItemId::Contract(_)) | Res::Namespace(_))
         )
-    })
 }

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -17,6 +17,7 @@ use solar::{
     interface::{Span, Symbol, data_structures::Never, kw, sym},
     sema::{
         Gcx,
+        builtins::Builtin,
         hir::{
             self, CallArgs, CallOptions, Expr, ExprKind, FunctionId, ItemId, LoopSource, Stmt,
             StmtKind, VariableId, Visit,
@@ -542,8 +543,8 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             StmtKind::If(cond, then_stmt, else_stmt) => {
                 self.analyze_expr(cond, state);
                 if self.reentrancy_balance_enabled
-                    && (branch_stops_current_path(then_stmt)
-                        || else_stmt.is_some_and(branch_stops_current_path))
+                    && (branch_stops_current_path(self.gcx, then_stmt)
+                        || else_stmt.is_some_and(|expr| branch_stops_current_path(self.gcx, expr)))
                 {
                     self.emit_balance_calls(cond, state);
                 }
@@ -686,7 +687,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                 }
 
                 if self.reentrancy_balance_enabled
-                    && is_require_or_assert(callee)
+                    && is_require_or_assert(self.gcx, callee)
                     && let Some(cond) = args.exprs().next()
                 {
                     self.emit_balance_calls(cond, state);
@@ -1217,7 +1218,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                 .and_then(|values| values.first())
                 .map(|value| constrain_paths(&value.self_address_paths, &state.path_predicates))
                 .unwrap_or_default(),
-            ExprKind::Ident(_) if is_builtin(expr, sym::this) => {
+            ExprKind::Ident(_) if is_builtin(self.gcx, expr, sym::this) => {
                 BTreeSet::from([state.path_predicates.clone()])
             }
             ExprKind::Ident(_) => self
@@ -1561,7 +1562,7 @@ fn static_internal_callee(gcx: Gcx<'_>, callee: &Expr<'_>) -> Option<FunctionId>
     let callee = callee.peel_parens();
     let direct = match &callee.kind {
         ExprKind::Ident(_) => true,
-        ExprKind::Member(base, _) => is_builtin(base, sym::super_),
+        ExprKind::Member(base, _) => is_builtin(gcx, base, sym::super_),
         _ => false,
     };
     let TyKind::Fn(function) = gcx.type_of_expr(callee.id).filter(|_| direct)?.kind else {
@@ -1734,7 +1735,7 @@ fn is_uncapped_value_call(gcx: Gcx<'_>, callee: &Expr<'_>, opts: Option<&CallOpt
         && call_sends_eth(gcx, opts)
         && call_option(opts, kw::Gas).is_none_or(|gas| {
             matches!(&gas.peel_parens().kind, ExprKind::Call(callee, args, None)
-                if args.is_empty() && is_builtin(callee, sym::gasleft))
+                if args.is_empty() && is_builtin(gcx, callee, sym::gasleft))
         })
 }
 
@@ -1755,16 +1756,16 @@ fn is_zero_value(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
 }
 
 /// `break`/`continue` or anything that exits the function, so the current path stops here.
-fn branch_stops_current_path(stmt: &Stmt<'_>) -> bool {
+fn branch_stops_current_path(gcx: Gcx<'_>, stmt: &Stmt<'_>) -> bool {
     match &stmt.kind {
         StmtKind::Break | StmtKind::Continue => true,
         StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
-            block.stmts.iter().any(branch_stops_current_path)
+            block.stmts.iter().any(|expr| branch_stops_current_path(gcx, expr))
         }
         StmtKind::If(_, then_stmt, Some(else_stmt)) => {
-            branch_stops_current_path(then_stmt) && branch_stops_current_path(else_stmt)
+            branch_stops_current_path(gcx, then_stmt) && branch_stops_current_path(gcx, else_stmt)
         }
-        _ => branch_always_exits(stmt),
+        _ => branch_always_exits(gcx, stmt),
     }
 }
 
@@ -1858,12 +1859,12 @@ fn stmt_rejects_lock_value(
     match stmt.kind {
         StmtKind::Expr(expr) => {
             let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
-            is_require_or_assert(callee)
+            is_require_or_assert(gcx, callee)
                 && args.exprs().next().is_some_and(|cond| eval(cond) == Some(false))
         }
         StmtKind::If(cond, then_stmt, else_stmt) => match eval(cond) {
-            Some(true) => branch_always_exits(then_stmt),
-            Some(false) => else_stmt.is_some_and(branch_always_exits),
+            Some(true) => branch_always_exits(gcx, then_stmt),
+            Some(false) => else_stmt.is_some_and(|expr| branch_always_exits(gcx, expr)),
             None => false,
         },
         _ => false,
@@ -1971,8 +1972,8 @@ fn guard_locks(gcx: Gcx<'_>, function: &hir::Function<'_>) -> Vec<VariableId> {
 /// `delegatecall`/`callcode`, which run the callee in the caller's storage context.
 fn call_uses_delegate_context(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
     let callee = callee.peel_parens();
-    matches!(&callee.kind, ExprKind::Member(_, member)
-        if matches!(member.name, kw::Callcode | kw::Delegatecall))
+    gcx.resolved_builtin(callee) == Some(Builtin::AddressDelegatecall)
+        || matches!(&callee.kind, ExprKind::Member(_, member) if member.name == kw::Callcode)
         || gcx.type_of_expr(callee.id).is_some_and(
             |ty| matches!(ty.kind, TyKind::Fn(function) if function.is_delegate_call()),
         )
@@ -1982,17 +1983,18 @@ fn call_uses_delegate_context(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
 /// `delegatecall` on an address, or a state-changing external function call.
 fn callee_can_reenter<'gcx>(gcx: Gcx<'gcx>, callee: &Expr<'gcx>) -> bool {
     let callee = callee.peel_parens();
+    match gcx.resolved_builtin(callee) {
+        Some(Builtin::AddressCall | Builtin::AddressDelegatecall) => return true,
+        Some(Builtin::AddressStaticcall) => return false,
+        _ => {}
+    }
     match &callee.kind {
         ExprKind::Member(receiver, member)
-            if expr_is_address(gcx, receiver)
-                && matches!(
-                    member.name,
-                    kw::Call | kw::Callcode | kw::Delegatecall | kw::Staticcall
-                ) =>
+            if expr_is_address(gcx, receiver) && member.name == kw::Callcode =>
         {
-            member.name != kw::Staticcall
+            true
         }
-        ExprKind::Member(receiver, _) if is_builtin(receiver, sym::super_) => false,
+        ExprKind::Member(receiver, _) if is_builtin(gcx, receiver, sym::super_) => false,
         _ => {
             let Some(TyKind::Fn(function)) = gcx.type_of_expr(callee.id).map(|ty| ty.kind) else {
                 return false;

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -5,10 +5,9 @@ use crate::{
         Severity, SolLint,
         analysis::{
             DEFAULT_HELPER_ANALYSIS_CACHE_LIMIT, HelperAnalysisCache, arg_for_param,
-            branch_always_exits, cast_type, count_placeholders, expr_ty, for_each_child,
-            for_each_lhs_var, function_ids, is_address_cast, is_address_like, is_builtin,
-            is_inc_dec, is_require_or_assert, lhs_local_var, loop_update, state_lhs_vars,
-            stmts_before_placeholder, tuple_elems, unique,
+            branch_always_exits, cast_type, count_placeholders, expr_is_address, for_each_child,
+            for_each_lhs_var, is_address_cast, is_builtin, is_require_or_assert, lhs_local_var,
+            loop_update, state_lhs_vars, stmts_before_placeholder, tuple_elems,
         },
     },
 };
@@ -19,8 +18,8 @@ use solar::{
     sema::{
         Gcx,
         hir::{
-            self, CallArgs, CallOptions, ElementaryType, Expr, ExprKind, FunctionId, ItemId,
-            LoopSource, Res, Stmt, StmtKind, VariableId, Visit,
+            self, CallArgs, CallOptions, Expr, ExprKind, FunctionId, ItemId, LoopSource, Stmt,
+            StmtKind, VariableId, Visit,
         },
         ty::{TyFnKind, TyKind},
     },
@@ -436,11 +435,11 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             return self.analyze_modifier_chain(modifiers, index + 1, body, state);
         };
 
-        self.seed_balance_parameters(modifier_func, &modifier.args, state);
+        self.seed_balance_parameters(modifier_id, &modifier.args, state);
         self.call_stack.push(modifier_id);
         let balance_guard = self
             .reentrancy_balance_enabled
-            .then(|| standard_reentrancy_guard_lock(&self.gcx.hir, modifier_func))
+            .then(|| standard_reentrancy_guard_lock(self.gcx, modifier_func))
             .flatten();
         let continuation = Some((modifiers, index + 1, body, balance_guard));
         let falls_through = self.analyze_block(modifier_body, continuation, state);
@@ -608,7 +607,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         else_state: &mut FlowState,
     ) -> (bool, bool) {
         let predicate =
-            self.reentrancy_balance_enabled.then(|| path_predicate(&self.gcx.hir, cond)).flatten();
+            self.reentrancy_balance_enabled.then(|| path_predicate(self.gcx, cond)).flatten();
         let Some((predicate, value)) = predicate else { return (true, true) };
         (
             then_state.constrain_path((predicate, value)),
@@ -625,7 +624,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                 self.analyze_expr(rhs, state);
                 self.analyze_lhs_indices(lhs, state);
                 self.record_write(lhs, state);
-                if let Some(var_id) = lhs_local_var(&self.gcx.hir, lhs) {
+                if let Some(var_id) = lhs_local_var(self.gcx, lhs) {
                     if op.is_none() {
                         self.update_internal_function_target(state, var_id, rhs);
                     } else {
@@ -636,9 +635,9 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                     let targets = match tuple_elems(lhs) {
                         Some(elems) => elems
                             .iter()
-                            .map(|e| e.and_then(|e| lhs_local_var(&self.gcx.hir, e)))
+                            .map(|e| e.and_then(|e| lhs_local_var(self.gcx, e)))
                             .collect(),
-                        None => vec![lhs_local_var(&self.gcx.hir, lhs)],
+                        None => vec![lhs_local_var(self.gcx, lhs)],
                     };
                     self.bind_locals(state, &targets, rhs, op.map(|op| op.kind));
                 }
@@ -646,7 +645,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             ExprKind::Delete(inner) => {
                 self.analyze_lhs_indices(inner, state);
                 self.record_write(inner, state);
-                if let Some(var_id) = lhs_local_var(&self.gcx.hir, inner) {
+                if let Some(var_id) = lhs_local_var(self.gcx, inner) {
                     state.internal_function_targets.remove(&var_id);
                     if self.reentrancy_balance_enabled {
                         self.clear_local(state, var_id);
@@ -655,10 +654,10 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             }
             ExprKind::Unary(op, inner) => {
                 self.analyze_expr(inner, state);
-                if is_inc_dec(op.kind) {
+                if op.kind.has_side_effects() {
                     self.record_write(inner, state);
                     if self.reentrancy_balance_enabled
-                        && let Some(var_id) = lhs_local_var(&self.gcx.hir, inner)
+                        && let Some(var_id) = lhs_local_var(self.gcx, inner)
                     {
                         self.set_self_address_paths(state, var_id, PathAlternatives::new());
                     }
@@ -703,7 +702,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                     state.push_call(expr.span, kind);
                 }
                 if self.reentrancy_balance_enabled
-                    && call_options_allow_reentrancy(&self.gcx.hir, *opts)
+                    && call_options_allow_reentrancy(self.gcx, *opts)
                     && callee_can_reenter(self.gcx, callee)
                     && !self.balance_guard_blocks_call(state, callee)
                 {
@@ -721,9 +720,9 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                 let rhs_outcome = op.kind == BinOpKind::And;
                 let (mut short_state, mut rhs_state) = (state.clone(), state.clone());
                 let short_reachable =
-                    constrain_boolean_outcome(&self.gcx.hir, lhs, !rhs_outcome, &mut short_state);
+                    constrain_boolean_outcome(self.gcx, lhs, !rhs_outcome, &mut short_state);
                 let rhs_reachable =
-                    constrain_boolean_outcome(&self.gcx.hir, lhs, rhs_outcome, &mut rhs_state);
+                    constrain_boolean_outcome(self.gcx, lhs, rhs_outcome, &mut rhs_state);
                 if rhs_reachable {
                     self.analyze_expr(rhs, &mut rhs_state);
                 }
@@ -748,10 +747,10 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                     [true_reachable.then_some(true_state), false_reachable.then_some(false_state)],
                 );
             }
-            ExprKind::Ident(reses) => state.state_reads.extend(
-                reses
-                    .iter()
-                    .filter_map(Res::as_variable)
+            ExprKind::Ident(_) => state.state_reads.extend(
+                self.gcx
+                    .resolved_variable(expr)
+                    .into_iter()
                     .filter(|v| self.gcx.hir.variable(*v).kind.is_state()),
             ),
             _ => for_each_child(expr, &mut |child| self.analyze_expr(child, state)),
@@ -788,12 +787,12 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
     /// Handles a write to `lhs`: reports pending reentrant calls that read the written state,
     /// invalidates written guard locks and forgets path facts about written locals.
     fn record_write(&mut self, lhs: &'gcx Expr<'gcx>, state: &mut FlowState) {
-        let written = state_lhs_vars(&self.gcx.hir, lhs);
+        let written = state_lhs_vars(self.gcx, lhs);
         self.emit_pending_calls(state, &written);
         state
             .invalidated_balance_guards
             .extend(written.iter().filter(|v| self.active_balance_guards.contains(v)));
-        for_each_lhs_var(lhs, &mut |var_id| {
+        for_each_lhs_var(self.gcx, lhs, &mut |var_id| {
             if !self.gcx.hir.variable(var_id).kind.is_state() {
                 forget_path_predicates(state, var_id);
             }
@@ -811,13 +810,13 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             return Vec::new();
         };
 
-        self.seed_balance_parameters(func, args, state);
+        self.seed_balance_parameters(func_id, args, state);
         let parameter_predicates = if self.reentrancy_balance_enabled {
             func.parameters
                 .iter()
                 .map(|&param| {
-                    arg_for_param(&self.gcx.hir, func, param, args)
-                        .and_then(|arg| path_predicate(&self.gcx.hir, arg))
+                    arg_for_param(self.gcx, func_id, param, args)
+                        .and_then(|arg| path_predicate(self.gcx, arg))
                 })
                 .collect()
         } else {
@@ -884,8 +883,8 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         callee: &'gcx Expr<'gcx>,
         state: &FlowState,
     ) -> BTreeSet<FunctionId> {
-        if let Some(targets) = lhs_local_var(&self.gcx.hir, callee)
-            .and_then(|v| state.internal_function_targets.get(&v))
+        if let Some(targets) =
+            lhs_local_var(self.gcx, callee).and_then(|v| state.internal_function_targets.get(&v))
         {
             return targets.clone();
         }
@@ -1022,12 +1021,8 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                     return true;
                 }
                 let mut rhs_state = state.clone();
-                constrain_boolean_outcome(
-                    &self.gcx.hir,
-                    lhs,
-                    op.kind == BinOpKind::And,
-                    &mut rhs_state,
-                ) && recurse(rhs, &rhs_state)
+                constrain_boolean_outcome(self.gcx, lhs, op.kind == BinOpKind::And, &mut rhs_state)
+                    && recurse(rhs, &rhs_state)
             }
             ExprKind::Binary(lhs, op, rhs) => {
                 let is_comparison = matches!(
@@ -1082,7 +1077,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
                     values.iter().any(|value| value.stale_comparisons.contains(&span))
                 }),
             },
-            ExprKind::Ident(reses) => reses.iter().filter_map(Res::as_variable).any(|var_id| {
+            ExprKind::Ident(_) => self.gcx.resolved_variable(expr).is_some_and(|var_id| {
                 state
                     .balance_comparison_locals
                     .get(&var_id)
@@ -1225,9 +1220,10 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             ExprKind::Ident(_) if is_builtin(expr, sym::this) => {
                 BTreeSet::from([state.path_predicates.clone()])
             }
-            ExprKind::Ident(reses) => reses
-                .iter()
-                .filter_map(Res::as_variable)
+            ExprKind::Ident(_) => self
+                .gcx
+                .resolved_variable(expr)
+                .into_iter()
                 .filter_map(|v| state.self_address_local_paths.get(&v))
                 .flat_map(|paths| constrain_paths(paths, &state.path_predicates))
                 .collect(),
@@ -1254,9 +1250,10 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         }
         let recurse = |e| self.expr_balance_paths(e, state);
         match &expr.kind {
-            ExprKind::Ident(reses) => reses
-                .iter()
-                .filter_map(Res::as_variable)
+            ExprKind::Ident(_) => self
+                .gcx
+                .resolved_variable(expr)
+                .into_iter()
                 .filter_map(|v| state.balance_local_paths.get(&v))
                 .flat_map(|paths| constrain_paths(paths, &state.path_predicates))
                 .collect(),
@@ -1304,9 +1301,10 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             ExprKind::Call(..) if let Some(args) = cast_args(expr) => {
                 args.exprs().flat_map(recurse).collect()
             }
-            ExprKind::Ident(reses) => reses
-                .iter()
-                .filter_map(Res::as_variable)
+            ExprKind::Ident(_) => self
+                .gcx
+                .resolved_variable(expr)
+                .into_iter()
                 .filter_map(|var| state.balance_local_dependencies.get(&var))
                 .flatten()
                 .filter_map(|form| form.constrained(&state.path_predicates))
@@ -1346,8 +1344,8 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         };
         match &expr.kind {
             ExprKind::Lit(_) => independent(),
-            ExprKind::Ident(reses) => {
-                let Some(var) = unique(reses.iter().filter_map(Res::as_variable)) else {
+            ExprKind::Ident(_) => {
+                let Some(var) = self.gcx.resolved_variable(expr) else {
                     return BTreeSet::new();
                 };
                 match state.balance_local_forms.get(&var) {
@@ -1388,18 +1386,16 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             }
             ExprKind::Call(callee, args, _) if cast_type(callee).is_some() && args.len() == 1 => {
                 let inner = args.exprs().next().expect("one argument");
-                let preserving = match (expr_ty(self.gcx, inner), expr_ty(self.gcx, expr)) {
-                    (Some(from), Some(to)) => match (from.kind, to.kind) {
-                        (
-                            TyKind::Elementary(ElementaryType::UInt(from)),
-                            TyKind::Elementary(ElementaryType::UInt(to)),
-                        )
-                        | (
-                            TyKind::Elementary(ElementaryType::Int(from)),
-                            TyKind::Elementary(ElementaryType::Int(to)),
-                        ) => from.bits() <= to.bits(),
-                        _ => false,
-                    },
+                let preserving = match (
+                    self.gcx.type_of_expr(inner.peel_parens().id),
+                    self.gcx.type_of_expr(expr.peel_parens().id),
+                ) {
+                    (Some(from), Some(to)) => {
+                        from.is_integer()
+                            && to.is_integer()
+                            && from.is_signed() == to.is_signed()
+                            && from.convert_implicit_to(to, self.gcx)
+                    }
                     _ => false,
                 };
                 self.balance_forms(inner, state)
@@ -1423,15 +1419,15 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
     /// Binds the balance facts of the call arguments to the callee's parameters.
     fn seed_balance_parameters(
         &mut self,
-        func: &'gcx hir::Function<'gcx>,
+        func_id: FunctionId,
         args: &CallArgs<'gcx>,
         state: &mut FlowState,
     ) {
         if !self.reentrancy_balance_enabled {
             return;
         }
-        for &param in func.parameters {
-            match arg_for_param(&self.gcx.hir, func, param, args) {
+        for &param in self.gcx.hir.function(func_id).parameters {
+            match arg_for_param(self.gcx, func_id, param, args) {
                 Some(arg) => self.bind_locals(state, &[Some(param)], arg, None),
                 None => self.clear_local(state, param),
             }
@@ -1504,10 +1500,10 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         callee: &'gcx Expr<'gcx>,
         opts: Option<&CallOptions<'gcx>>,
     ) -> Option<ReentrantCallKind> {
-        if self.reentrancy_eth_enabled && is_uncapped_value_call(&self.gcx.hir, callee, opts) {
+        if self.reentrancy_eth_enabled && is_uncapped_value_call(self.gcx, callee, opts) {
             Some(ReentrantCallKind::Eth)
         } else if self.reentrancy_no_eth_enabled
-            && !call_sends_eth(&self.gcx.hir, opts)
+            && !call_sends_eth(self.gcx, opts)
             && callee_can_reenter(self.gcx, callee)
         {
             Some(ReentrantCallKind::NoEth)
@@ -1581,14 +1577,14 @@ fn owned_by(hir: &hir::Hir<'_>, func_id: FunctionId) -> impl Fn(VariableId) -> b
 
 /// The boolean fact `expr` establishes when it evaluates to `true`: a local flag, its negation,
 /// or an `==`/`!=` between locals and literals.
-fn path_predicate(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> Option<(PathPredicate, bool)> {
+fn path_predicate(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<(PathPredicate, bool)> {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(_) => Some((PathPredicate::Boolean(lhs_local_var(hir, expr)?), true)),
+        ExprKind::Ident(_) => Some((PathPredicate::Boolean(lhs_local_var(gcx, expr)?), true)),
         ExprKind::Unary(op, inner) if op.kind == UnOpKind::Not => {
-            path_predicate(hir, inner).map(|(predicate, value)| (predicate, !value))
+            path_predicate(gcx, inner).map(|(predicate, value)| (predicate, !value))
         }
         ExprKind::Binary(lhs, op, rhs) if matches!(op.kind, BinOpKind::Eq | BinOpKind::Ne) => {
-            let (lhs, rhs) = (predicate_operand(hir, lhs)?, predicate_operand(hir, rhs)?);
+            let (lhs, rhs) = (predicate_operand(gcx, lhs)?, predicate_operand(gcx, rhs)?);
             let predicate = PathPredicate::Equality(lhs.min(rhs), lhs.max(rhs));
             Some((predicate, op.kind == BinOpKind::Eq))
         }
@@ -1596,9 +1592,9 @@ fn path_predicate(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> Option<(PathPredicate,
     }
 }
 
-fn predicate_operand(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> Option<Operand> {
+fn predicate_operand(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<Operand> {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(_) => Some(Operand::Variable(lhs_local_var(hir, expr)?)),
+        ExprKind::Ident(_) => Some(Operand::Variable(lhs_local_var(gcx, expr)?)),
         ExprKind::Lit(lit) => match lit.kind {
             LitKind::Number(value) => Some(Operand::Number(value)),
             LitKind::Bool(value) => Some(Operand::Boolean(value)),
@@ -1610,12 +1606,12 @@ fn predicate_operand(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> Option<Operand> {
 
 /// Records in `state` that `expr` evaluated to `outcome`; returns `false` if that is impossible.
 fn constrain_boolean_outcome(
-    hir: &hir::Hir<'_>,
+    gcx: Gcx<'_>,
     expr: &Expr<'_>,
     outcome: bool,
     state: &mut FlowState,
 ) -> bool {
-    if let Some((predicate, value)) = path_predicate(hir, expr) {
+    if let Some((predicate, value)) = path_predicate(gcx, expr) {
         return state.constrain_path((predicate, value == outcome));
     }
     match &expr.peel_parens().kind {
@@ -1623,8 +1619,8 @@ fn constrain_boolean_outcome(
         ExprKind::Binary(lhs, op, rhs)
             if op.kind == if outcome { BinOpKind::And } else { BinOpKind::Or } =>
         {
-            constrain_boolean_outcome(hir, lhs, outcome, state)
-                && constrain_boolean_outcome(hir, rhs, outcome, state)
+            constrain_boolean_outcome(gcx, lhs, outcome, state)
+                && constrain_boolean_outcome(gcx, rhs, outcome, state)
         }
         _ => true,
     }
@@ -1728,18 +1724,14 @@ fn call_option<'a>(opts: Option<&'a CallOptions<'a>>, name: Symbol) -> Option<&'
     opts?.args.iter().find(|opt| opt.name.name == name).map(|opt| &opt.value)
 }
 
-fn call_sends_eth(hir: &hir::Hir<'_>, opts: Option<&CallOptions<'_>>) -> bool {
-    call_option(opts, sym::value).is_some_and(|value| !is_zero_value(hir, value))
+fn call_sends_eth(gcx: Gcx<'_>, opts: Option<&CallOptions<'_>>) -> bool {
+    call_option(opts, sym::value).is_some_and(|value| !is_zero_value(gcx, value))
 }
 
 /// `.call{value: v}(...)` with a non-zero value and no gas cap other than `gasleft()`.
-fn is_uncapped_value_call(
-    hir: &hir::Hir<'_>,
-    callee: &Expr<'_>,
-    opts: Option<&CallOptions<'_>>,
-) -> bool {
+fn is_uncapped_value_call(gcx: Gcx<'_>, callee: &Expr<'_>, opts: Option<&CallOptions<'_>>) -> bool {
     matches!(&callee.peel_parens().kind, ExprKind::Member(_, member) if member.name == kw::Call)
-        && call_sends_eth(hir, opts)
+        && call_sends_eth(gcx, opts)
         && call_option(opts, kw::Gas).is_none_or(|gas| {
             matches!(&gas.peel_parens().kind, ExprKind::Call(callee, args, None)
                 if args.is_empty() && is_builtin(callee, sym::gasleft))
@@ -1747,10 +1739,10 @@ fn is_uncapped_value_call(
 }
 
 /// True unless a `gas:` option provably leaves the callee too little gas to reenter.
-fn call_options_allow_reentrancy(hir: &hir::Hir<'_>, opts: Option<&CallOptions<'_>>) -> bool {
+fn call_options_allow_reentrancy(gcx: Gcx<'_>, opts: Option<&CallOptions<'_>>) -> bool {
     let Some(gas) = call_option(opts, kw::Gas) else { return true };
-    let sends_eth = call_sends_eth(hir, opts);
-    match const_value(hir, gas, None, &mut BTreeSet::new()) {
+    let sends_eth = call_sends_eth(gcx, opts);
+    match const_value(gcx, gas, None, &mut BTreeSet::new()) {
         Some(Operand::Number(gas)) => {
             gas > U256::from(REENTRANCY_GAS_STIPEND) || (sends_eth && !gas.is_zero())
         }
@@ -1758,8 +1750,8 @@ fn call_options_allow_reentrancy(hir: &hir::Hir<'_>, opts: Option<&CallOptions<'
     }
 }
 
-fn is_zero_value(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> bool {
-    matches!(const_value(hir, expr, None, &mut BTreeSet::new()), Some(Operand::Number(n)) if n.is_zero())
+fn is_zero_value(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
+    matches!(const_value(gcx, expr, None, &mut BTreeSet::new()), Some(Operand::Number(n)) if n.is_zero())
 }
 
 /// `break`/`continue` or anything that exits the function, so the current path stops here.
@@ -1779,7 +1771,7 @@ fn branch_stops_current_path(stmt: &Stmt<'_>) -> bool {
 /// The lock state variable of a standard reentrancy guard modifier: it rejects re-entry, sets
 /// the lock, runs `_` exactly once and restores the lock right after.
 fn standard_reentrancy_guard_lock(
-    hir: &hir::Hir<'_>,
+    gcx: Gcx<'_>,
     modifier: &hir::Function<'_>,
 ) -> Option<VariableId> {
     if !matches!(modifier.kind, FunctionKind::Modifier) || !modifier.modifiers.is_empty() {
@@ -1791,74 +1783,74 @@ fn standard_reentrancy_guard_lock(
     }
     let mut activation = Vec::new();
     stmts_before_placeholder(stmts, &mut activation)?;
-    let (lock_var, entered) = guard_activation(hir, &activation, &mut BTreeSet::new())?;
+    let (lock_var, entered) = guard_activation(gcx, &activation, &mut BTreeSet::new())?;
     let index = stmts.iter().position(|s| count_placeholders(std::slice::from_ref(s)) == 1)?;
-    let (restored_var, restored) = guard_restoration(hir, stmts.get(index + 1)?)?;
+    let (restored_var, restored) = guard_restoration(gcx, stmts.get(index + 1)?)?;
     (lock_var == restored_var && entered != restored).then_some(lock_var)
 }
 
 /// The lock and value set by the last of `stmts` (directly or via an argument-less helper), if
 /// an earlier statement rejects that value.
 fn guard_activation(
-    hir: &hir::Hir<'_>,
+    gcx: Gcx<'_>,
     stmts: &[&Stmt<'_>],
     seen: &mut BTreeSet<FunctionId>,
 ) -> Option<(VariableId, Operand)> {
     let (activation, prefix) = stmts.split_last()?;
-    if let Some((lock_var, entered)) = state_lock_assignment(hir, activation) {
+    if let Some((lock_var, entered)) = state_lock_assignment(gcx, activation) {
         return prefix
             .iter()
-            .any(|stmt| stmt_rejects_lock_value(hir, stmt, lock_var, entered))
+            .any(|stmt| stmt_rejects_lock_value(gcx, stmt, lock_var, entered))
             .then_some((lock_var, entered));
     }
-    let helper_id = simple_internal_call(activation)?;
-    let helper = hir.function(helper_id);
+    let helper_id = simple_internal_call(gcx, activation)?;
+    let helper = gcx.hir.function(helper_id);
     if !helper.modifiers.is_empty() || !seen.insert(helper_id) {
         return None;
     }
     let body = helper.body?.stmts.iter().collect::<Vec<_>>();
-    let result = guard_activation(hir, &body, seen);
+    let result = guard_activation(gcx, &body, seen);
     seen.remove(&helper_id);
     result
 }
 
 /// The lock and value restored by `stmt` (directly or via a single-statement helper).
-fn guard_restoration(hir: &hir::Hir<'_>, stmt: &Stmt<'_>) -> Option<(VariableId, Operand)> {
-    state_lock_assignment(hir, stmt).or_else(|| {
-        let helper = hir.function(simple_internal_call(stmt)?);
+fn guard_restoration(gcx: Gcx<'_>, stmt: &Stmt<'_>) -> Option<(VariableId, Operand)> {
+    state_lock_assignment(gcx, stmt).or_else(|| {
+        let helper = gcx.hir.function(simple_internal_call(gcx, stmt)?);
         let [stmt] = helper.modifiers.is_empty().then_some(helper.body?.stmts)? else {
             return None;
         };
-        state_lock_assignment(hir, stmt)
+        state_lock_assignment(gcx, stmt)
     })
 }
 
 /// `f();` naming exactly one function.
-fn simple_internal_call(stmt: &Stmt<'_>) -> Option<FunctionId> {
+fn simple_internal_call(gcx: Gcx<'_>, stmt: &Stmt<'_>) -> Option<FunctionId> {
     let StmtKind::Expr(expr) = stmt.kind else { return None };
     let ExprKind::Call(callee, args, None) = &expr.peel_parens().kind else { return None };
-    args.is_empty().then(|| unique(function_ids(callee))).flatten()
+    (args.is_empty() && matches!(callee.peel_parens().kind, ExprKind::Ident(_)))
+        .then(|| gcx.resolved_function(callee))
+        .flatten()
 }
 
 /// `lock = <constant>;` on a state variable.
-fn state_lock_assignment(hir: &hir::Hir<'_>, stmt: &Stmt<'_>) -> Option<(VariableId, Operand)> {
+fn state_lock_assignment(gcx: Gcx<'_>, stmt: &Stmt<'_>) -> Option<(VariableId, Operand)> {
     let StmtKind::Expr(expr) = stmt.kind else { return None };
     let ExprKind::Assign(lhs, None, rhs) = &expr.peel_parens().kind else { return None };
-    let ExprKind::Ident(reses) = &lhs.peel_parens().kind else { return None };
-    let lock_var = unique(
-        reses.iter().filter_map(Res::as_variable).filter(|v| hir.variable(*v).kind.is_state()),
-    )?;
-    Some((lock_var, const_value(hir, rhs, None, &mut BTreeSet::new())?))
+    let ExprKind::Ident(_) = &lhs.peel_parens().kind else { return None };
+    let lock_var = gcx.resolved_variable(lhs).filter(|&v| gcx.hir.variable(v).kind.is_state())?;
+    Some((lock_var, const_value(gcx, rhs, None, &mut BTreeSet::new())?))
 }
 
 /// True if `stmt` reverts whenever `lock_var` holds `entered`.
 fn stmt_rejects_lock_value(
-    hir: &hir::Hir<'_>,
+    gcx: Gcx<'_>,
     stmt: &Stmt<'_>,
     lock_var: VariableId,
     entered: Operand,
 ) -> bool {
-    let eval = |cond| match const_value(hir, cond, Some((lock_var, entered)), &mut BTreeSet::new())
+    let eval = |cond| match const_value(gcx, cond, Some((lock_var, entered)), &mut BTreeSet::new())
     {
         Some(Operand::Boolean(value)) => Some(value),
         _ => None,
@@ -1881,7 +1873,7 @@ fn stmt_rejects_lock_value(
 /// Constant-folds `expr` over literals, `constant` variables, casts, `!` and `==`/`!=`; `lock`
 /// supplies the value of the lock variable.
 fn const_value(
-    hir: &hir::Hir<'_>,
+    gcx: Gcx<'_>,
     expr: &Expr<'_>,
     lock: Option<(VariableId, Operand)>,
     seen: &mut BTreeSet<VariableId>,
@@ -1893,35 +1885,35 @@ fn const_value(
             LitKind::Number(value) => Some(Operand::Number(value)),
             _ => None,
         },
-        ExprKind::Ident(reses) => {
-            let var_id = unique(reses.iter().filter_map(Res::as_variable))?;
+        ExprKind::Ident(_) => {
+            let var_id = gcx.resolved_variable(expr)?;
             if let Some((lock_var, entered)) = lock
                 && lock_var == var_id
             {
                 return Some(entered);
             }
-            let var = hir.variable(var_id);
+            let var = gcx.hir.variable(var_id);
             if !var.is_constant() || !seen.insert(var_id) {
                 return None;
             }
-            let value = const_value(hir, var.initializer?, lock, seen);
+            let value = const_value(gcx, var.initializer?, lock, seen);
             seen.remove(&var_id);
             value
         }
         ExprKind::Unary(op, inner) if op.kind == UnOpKind::Not => {
-            match const_value(hir, inner, lock, seen)? {
+            match const_value(gcx, inner, lock, seen)? {
                 Operand::Boolean(value) => Some(Operand::Boolean(!value)),
                 _ => None,
             }
         }
         ExprKind::Binary(lhs, op, rhs) if matches!(op.kind, BinOpKind::Eq | BinOpKind::Ne) => {
-            let lhs = const_value(hir, lhs, lock, seen)?;
-            let rhs = const_value(hir, rhs, lock, seen)?;
+            let lhs = const_value(gcx, lhs, lock, seen)?;
+            let rhs = const_value(gcx, rhs, lock, seen)?;
             Some(Operand::Boolean((lhs == rhs) == (op.kind == BinOpKind::Eq)))
         }
         ExprKind::Call(..) => {
             let args = cast_args(expr).filter(|args| args.len() == 1)?;
-            const_value(hir, args.exprs().next()?, lock, seen)
+            const_value(gcx, args.exprs().next()?, lock, seen)
         }
         _ => None,
     }
@@ -1935,7 +1927,7 @@ fn balance_reentry_lock<'gcx>(
 ) -> Option<VariableId> {
     let entry_id = gcx.hir.function_ids().find(|&id| std::ptr::eq(gcx.hir.function(id), entry))?;
     let defining_contract = entry.contract?;
-    guard_locks(&gcx.hir, entry).into_iter().find(|&lock_var| {
+    guard_locks(gcx, entry).into_iter().find(|&lock_var| {
         let mut deployed = false;
         for contract_id in gcx.hir.contract_ids() {
             let contract = gcx.hir.contract(contract_id);
@@ -1956,7 +1948,7 @@ fn balance_reentry_lock<'gcx>(
                 .map(|f| gcx.hir.function(f.id))
                 .filter(|f| !is_view_or_pure(f.state_mutability))
                 .chain(special().map(|id| gcx.hir.function(id)))
-                .all(|f| guard_locks(&gcx.hir, f).contains(&lock_var));
+                .all(|f| guard_locks(gcx, f).contains(&lock_var));
             if !guarded {
                 return false;
             }
@@ -1966,13 +1958,13 @@ fn balance_reentry_lock<'gcx>(
 }
 
 /// Locks of the standard reentrancy guards among `function`'s modifiers.
-fn guard_locks(hir: &hir::Hir<'_>, function: &hir::Function<'_>) -> Vec<VariableId> {
+fn guard_locks(gcx: Gcx<'_>, function: &hir::Function<'_>) -> Vec<VariableId> {
     function
         .modifiers
         .iter()
         .filter(|modifier| modifier.args.is_empty())
         .filter_map(|modifier| modifier.id.as_function())
-        .filter_map(|id| standard_reentrancy_guard_lock(hir, hir.function(id)))
+        .filter_map(|id| standard_reentrancy_guard_lock(gcx, gcx.hir.function(id)))
         .collect()
 }
 
@@ -1982,7 +1974,7 @@ fn call_uses_delegate_context(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
     matches!(&callee.kind, ExprKind::Member(_, member)
         if matches!(member.name, kw::Callcode | kw::Delegatecall))
         || gcx.type_of_expr(callee.id).is_some_and(
-            |ty| matches!(ty.kind, TyKind::Fn(function) if function.kind == TyFnKind::DelegateCall),
+            |ty| matches!(ty.kind, TyKind::Fn(function) if function.is_delegate_call()),
         )
 }
 
@@ -1992,7 +1984,7 @@ fn callee_can_reenter<'gcx>(gcx: Gcx<'gcx>, callee: &Expr<'gcx>) -> bool {
     let callee = callee.peel_parens();
     match &callee.kind {
         ExprKind::Member(receiver, member)
-            if is_address_like(gcx, receiver)
+            if expr_is_address(gcx, receiver)
                 && matches!(
                     member.name,
                     kw::Call | kw::Callcode | kw::Delegatecall | kw::Staticcall

--- a/crates/lint/src/sol/high/unchecked_calls.rs
+++ b/crates/lint/src/sol/high/unchecked_calls.rs
@@ -52,8 +52,10 @@ fn is_erc20_transfer_call<'gcx>(gcx: Gcx<'gcx>, expr: &hir::Expr<'gcx>) -> bool 
         ("transferFrom", 3) => &["address", "address", "uint256"],
         _ => return false,
     };
-    let Some(cid) = receiver_contract_id(gcx, receiver) else { return false };
-    gcx.hir.contract_item_ids(cid).filter_map(|item| item.as_function()).any(|fid| {
+    if receiver_contract_id(gcx, receiver).is_none() {
+        return false;
+    }
+    gcx.resolved_function(callee).is_some_and(|fid| {
         let func = gcx.hir.function(fid);
         func.name.is_some_and(|name| name.name == func_ident.name)
             && func.kind.is_function()

--- a/crates/lint/src/sol/high/unprotected_initializer.rs
+++ b/crates/lint/src/sol/high/unprotected_initializer.rs
@@ -3,17 +3,18 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{builtins, function_ids, is_builtin, runtime_entry_points},
+        analysis::{is_builtin, runtime_entry_points},
     },
 };
 use alloy_primitives::map::HashSet;
 use solar::{
-    ast::{ContractKind, DataLocation, StateMutability},
-    interface::{kw, sym},
+    ast::{ContractKind, DataLocation},
+    interface::sym,
     sema::{
         Gcx,
         builtins::Builtin,
-        hir::{self, ContractId, Expr, ExprKind, FunctionId, ItemId, Res, Visit},
+        hir::{self, ContractId, Expr, ExprKind, FunctionId, Visit},
+        ty::TyKind,
     },
 };
 use std::ops::ControlFlow;
@@ -52,7 +53,7 @@ impl<'gcx> LateLintPass<'gcx> for UnprotectedInitializer {
         let locked = bases.iter().filter_map(|&cid| gcx.hir.contract(cid).ctor).any(|ctor| {
             reaches(gcx, bases, ctor, |expr| {
                 let ExprKind::Call(callee, ..) = &expr.kind else { return false };
-                callees(&gcx.hir, callee, bases).into_iter().any(|fid| {
+                gcx.resolved_function(callee).is_some_and(|fid| {
                     let func = gcx.hir.function(fid);
                     func.contract.is_some_and(|cid| bases.contains(&cid))
                         && func.name.is_some_and(|name| name.as_str() == "_disableInitializers")
@@ -64,7 +65,7 @@ impl<'gcx> LateLintPass<'gcx> for UnprotectedInitializer {
         }
         let destructive = entries.iter().any(|&fid| {
             !has_modifier_named(&gcx.hir, gcx.hir.function(fid), "onlyProxy")
-                && reaches(gcx, bases, fid, is_destructive_call)
+                && reaches(gcx, bases, fid, |expr| is_destructive_call(gcx, expr))
         });
         if !destructive {
             return;
@@ -73,7 +74,7 @@ impl<'gcx> LateLintPass<'gcx> for UnprotectedInitializer {
         for fid in entries {
             let func = gcx.hir.function(fid);
             if func.is_part_of_external_interface()
-                && !matches!(func.state_mutability, StateMutability::Pure | StateMutability::View)
+                && func.mutates_state()
                 && has_initializer_modifier(&gcx.hir, func)
                 && !has_modifier_named(&gcx.hir, func, "onlyProxy")
                 && reaches(gcx, bases, fid, |expr| writes_state(gcx, expr))
@@ -105,12 +106,15 @@ fn reaches<'gcx>(
     fid: FunctionId,
     hit: impl FnMut(&'gcx Expr<'gcx>) -> bool,
 ) -> bool {
-    Reach { gcx, bases, visited: HashSet::default(), hit }.visit_function_body(fid).is_break()
+    Reach { gcx, bases, defining_contract: None, visited: HashSet::default(), hit }
+        .visit_function_body(fid)
+        .is_break()
 }
 
 struct Reach<'gcx, F> {
     gcx: Gcx<'gcx>,
     bases: &'gcx [ContractId],
+    defining_contract: Option<ContractId>,
     // The predicate and dispatch context are fixed for the entire reachability check.
     visited: HashSet<FunctionId>,
     hit: F,
@@ -124,7 +128,11 @@ impl<'gcx, F: FnMut(&'gcx Expr<'gcx>) -> bool> Reach<'gcx, F> {
         let Some(body) = self.gcx.hir.function(fid).body else {
             return ControlFlow::Continue(());
         };
-        body.stmts.iter().try_for_each(|stmt| self.visit_stmt(stmt))
+        let previous = self.defining_contract;
+        self.defining_contract = self.gcx.hir.function(fid).contract;
+        let result = body.stmts.iter().try_for_each(|stmt| self.visit_stmt(stmt));
+        self.defining_contract = previous;
+        result
     }
 }
 
@@ -139,47 +147,45 @@ impl<'gcx, F: FnMut(&'gcx Expr<'gcx>) -> bool> Visit<'gcx> for Reach<'gcx, F> {
         if (self.hit)(expr) {
             return ControlFlow::Break(());
         }
-        if let ExprKind::Call(callee, ..) = &expr.kind {
-            for fid in callees(&self.gcx.hir, callee, self.bases) {
-                self.visit_function_body(fid)?;
-            }
+        if let ExprKind::Call(callee, ..) = &expr.kind
+            && let Some(fid) =
+                internal_callee(self.gcx, callee, self.bases[0], self.defining_contract)
+        {
+            self.visit_function_body(fid)?;
         }
         self.walk_expr(expr)
     }
 }
 
-/// Functions an internal call may dispatch to: bare identifiers (all overloads), `super.f` (every
-/// base `f`) and `Contract.f`.
-fn callees(hir: &hir::Hir<'_>, callee: &Expr<'_>, bases: &[ContractId]) -> Vec<FunctionId> {
-    let ExprKind::Member(base, method) = &callee.peel_parens().kind else {
-        return function_ids(callee).collect();
-    };
-    let ExprKind::Ident(reses) = &base.peel_parens().kind else { return Vec::new() };
-    let contracts = if is_builtin(base, sym::super_) {
-        bases.get(1..).unwrap_or_default().to_vec()
-    } else {
-        reses
-            .iter()
-            .filter_map(|res| match res {
-                Res::Item(ItemId::Contract(cid)) => Some(*cid),
-                _ => None,
-            })
-            .collect()
-    };
-    contracts
-        .into_iter()
-        .flat_map(|cid| hir.contract(cid).all_functions())
-        .filter(|&fid| hir.function(fid).name.is_some_and(|name| name.name == method.name))
-        .collect()
+/// The selected internal function in the analyzed contract's dispatch context.
+fn internal_callee(
+    gcx: Gcx<'_>,
+    callee: &Expr<'_>,
+    contract: ContractId,
+    defining_contract: Option<ContractId>,
+) -> Option<FunctionId> {
+    let callee = callee.peel_parens();
+    let fid = gcx.resolved_function(callee)?;
+    let TyKind::Fn(function) = gcx.type_of_expr(callee.id)?.kind else { return None };
+    if !function.is_internal() {
+        return None;
+    }
+    Some(match &callee.kind {
+        ExprKind::Ident(_) => gcx.resolve_virtual_function(contract, fid),
+        ExprKind::Member(base, _) if is_builtin(base, sym::super_) => {
+            gcx.resolve_super_function(contract, defining_contract?, fid)
+        }
+        _ => fid,
+    })
 }
 
-/// `x.delegatecall(..)`, `x.callcode(..)` or `selfdestruct(..)`.
-fn is_destructive_call(expr: &Expr<'_>) -> bool {
+/// `x.delegatecall(..)` or `selfdestruct(..)`.
+fn is_destructive_call(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let ExprKind::Call(callee, ..) = &expr.kind else { return false };
-    match &callee.peel_parens().kind {
-        ExprKind::Member(_, member) => matches!(member.name, kw::Delegatecall | kw::Callcode),
-        _ => builtins(callee).any(|builtin| builtin == Builtin::Selfdestruct),
-    }
+    matches!(
+        gcx.resolved_builtin(callee),
+        Some(Builtin::AddressDelegatecall | Builtin::Selfdestruct)
+    )
 }
 
 /// An assignment, `delete`, `++`/`--` or `push`/`pop` whose target lives in contract storage.
@@ -198,8 +204,8 @@ fn writes_state(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
 /// A state variable, or a member/index of an expression that denotes contract storage.
 fn lhs_writes_state(gcx: Gcx<'_>, lhs: &Expr<'_>) -> bool {
     match &lhs.peel_parens().kind {
-        ExprKind::Ident(reses) => {
-            reses.iter().filter_map(Res::as_variable).any(|v| gcx.hir.variable(v).kind.is_state())
+        ExprKind::Ident(_) => {
+            gcx.resolved_variable(lhs).is_some_and(|v| gcx.hir.variable(v).kind.is_state())
         }
         ExprKind::Index(base, _) | ExprKind::Slice(base, ..) | ExprKind::Member(base, _) => {
             references_storage(gcx, base)
@@ -211,7 +217,7 @@ fn lhs_writes_state(gcx: Gcx<'_>, lhs: &Expr<'_>) -> bool {
 
 fn references_storage(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().filter_map(Res::as_variable).any(|v| {
+        ExprKind::Ident(_) => gcx.resolved_variable(expr).is_some_and(|v| {
             let var = gcx.hir.variable(v);
             var.kind.is_state() || var.data_location == Some(DataLocation::Storage)
         }),

--- a/crates/lint/src/sol/high/unprotected_initializer.rs
+++ b/crates/lint/src/sol/high/unprotected_initializer.rs
@@ -53,6 +53,11 @@ impl<'gcx> LateLintPass<'gcx> for UnprotectedInitializer {
         let locked = bases.iter().filter_map(|&cid| gcx.hir.contract(cid).ctor).any(|ctor| {
             reaches(gcx, bases, ctor, |expr| {
                 let ExprKind::Call(callee, ..) = &expr.kind else { return false };
+                if !gcx.type_of_expr(callee.peel_parens().id).is_some_and(
+                    |ty| matches!(ty.kind, TyKind::Fn(function) if function.is_internal()),
+                ) {
+                    return false;
+                }
                 gcx.resolved_function(callee).is_some_and(|fid| {
                     let func = gcx.hir.function(fid);
                     func.contract.is_some_and(|cid| bases.contains(&cid))
@@ -172,7 +177,7 @@ fn internal_callee(
     }
     Some(match &callee.kind {
         ExprKind::Ident(_) => gcx.resolve_virtual_function(contract, fid),
-        ExprKind::Member(base, _) if is_builtin(base, sym::super_) => {
+        ExprKind::Member(base, _) if is_builtin(gcx, base, sym::super_) => {
             gcx.resolve_super_function(contract, defining_contract?, fid)
         }
         _ => fid,

--- a/crates/lint/src/sol/info/function_init_state.rs
+++ b/crates/lint/src/sol/info/function_init_state.rs
@@ -1,17 +1,13 @@
 use super::FunctionInitState;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        analysis::{resolved_function, ty_contract_id},
-    },
+    sol::{Severity, SolLint},
 };
 use solar::{
     ast::StateMutability,
-    interface::Symbol,
     sema::{
         Gcx,
-        hir::{self, ContractId, Expr, ExprKind, FunctionId, Hir, ItemId, VariableId, Visit},
+        hir::{ContractId, Expr, FunctionId, Hir, VariableId, Visit},
     },
 };
 use std::{convert::Infallible, ops::ControlFlow};
@@ -38,13 +34,7 @@ impl<'gcx> LateLintPass<'gcx> for FunctionInitState {
                 && !variable.is_constant()
                 && let Some(initializer) = variable.initializer
             {
-                let mut finder = ImpureRefFinder {
-                    gcx,
-                    source: contract.source,
-                    contract: id,
-                    callee: None,
-                    found: false,
-                };
+                let mut finder = ImpureRefFinder { gcx, found: false };
                 let _ = finder.visit_expr(initializer);
                 if finder.found {
                     ctx.emit(&FUNCTION_INIT_STATE, variable.span);
@@ -58,12 +48,6 @@ impl<'gcx> LateLintPass<'gcx> for FunctionInitState {
 /// an initializer expression, arguments of nested calls included.
 struct ImpureRefFinder<'gcx> {
     gcx: Gcx<'gcx>,
-    /// The source and contract of the initializer, the viewpoint for `using for` lookups.
-    source: hir::SourceId,
-    contract: ContractId,
-    /// The callee of the call being walked: its target was already judged through the type
-    /// checker's resolution, so it must not be re-judged by name matching.
-    callee: Option<hir::ExprId>,
     found: bool,
 }
 
@@ -75,83 +59,16 @@ impl<'gcx> Visit<'gcx> for ImpureRefFinder<'gcx> {
     }
 
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
-        let is_callee = self.callee == Some(expr.id);
-        match &expr.kind {
-            // The type checker already resolved the one function a call dispatches to (overload
-            // selection, override shadowing, `super.`, the qualified and `using for` forms).
-            ExprKind::Call(callee, ..) => {
-                if let Some(function_id) = resolved_function(self.gcx, callee) {
-                    self.judge_function(function_id);
-                }
-                self.callee = Some(callee.peel_parens().id);
-            }
-            // A callee name can also resolve to a variable: a call through a function pointer
-            // stored in state reads that variable.
-            ExprKind::Ident(resolutions) => {
-                for res in *resolutions {
-                    match res.as_variable() {
-                        Some(variable_id) => self.judge_variable(variable_id),
-                        None => {
-                            if !is_callee && let Some(function_id) = res.as_function() {
-                                self.judge_function(function_id);
-                            }
-                        }
-                    }
-                }
-            }
-            // A member reference used as a value has a resolved target too (`x.f` selects an
-            // override like `x.f()` would); scan by name only when there is none.
-            ExprKind::Member(base, member) if !is_callee => {
-                match resolved_function(self.gcx, expr) {
-                    Some(function_id) => self.judge_function(function_id),
-                    None => self.judge_member(base, member.name),
-                }
-            }
-            _ => {}
+        if let Some(variable_id) = self.gcx.resolved_variable(expr) {
+            self.judge_variable(variable_id);
+        } else if let Some(function_id) = self.gcx.resolved_function(expr) {
+            self.judge_function(function_id);
         }
         self.walk_expr(expr)
     }
 }
 
 impl ImpureRefFinder<'_> {
-    /// Judges a member read with no resolved function type (`Base.stateVar`): the member ident
-    /// carries no resolution, so type the base and scan by name.
-    fn judge_member(&mut self, base: &Expr<'_>, member: Symbol) {
-        let gcx = self.gcx;
-        let Some(ty) = gcx.type_of_expr(base.peel_parens().id) else { return };
-        if let Some(contract_id) = ty_contract_id(ty) {
-            // Walk the linearization: an inherited function or getter is not among the
-            // contract's own items.
-            for &base_id in gcx.hir.contract(contract_id).linearized_bases {
-                for &item_id in gcx.hir.contract(base_id).items {
-                    match item_id {
-                        ItemId::Variable(id)
-                            if gcx.hir.variable(id).name.is_some_and(|n| n.name == member) =>
-                        {
-                            self.judge_variable(id)
-                        }
-                        ItemId::Function(id)
-                            if gcx.hir.function(id).name.is_some_and(|n| n.name == member) =>
-                        {
-                            self.judge_function(id)
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        } else {
-            // A `using for` binding read as a value: the bound library function is a member of
-            // the value type. `members_of` needs reference types to keep their data location.
-            for entry in gcx.members_of(ty, self.source, Some(self.contract)) {
-                if entry.name == member
-                    && let Some(function_id) = entry.ty.function_id()
-                {
-                    self.judge_function(function_id);
-                }
-            }
-        }
-    }
-
     /// A read of another state variable: its initializer may not have run yet.
     fn judge_variable(&mut self, variable_id: VariableId) {
         let variable = self.gcx.hir.variable(variable_id);

--- a/crates/lint/src/sol/info/internal_function_used_once.rs
+++ b/crates/lint/src/sol/info/internal_function_used_once.rs
@@ -1,7 +1,7 @@
 use super::InternalFunctionUsedOnce;
 use crate::{
     linter::{Lint, ProjectLintEmitter, ProjectLintPass, ProjectSource},
-    sol::{Severity, SolLint, analysis::resolved_function},
+    sol::{Severity, SolLint},
 };
 use solar::{
     interface::{data_structures::Never, source_map::FileName},
@@ -159,7 +159,7 @@ impl<'gcx> hir::Visit<'gcx> for ReferenceCounter<'gcx> {
         match &expr.kind {
             hir::ExprKind::Call(callee, ..) => self.callee = Some(callee.peel_parens().id),
             hir::ExprKind::Ident(..) | hir::ExprKind::Member(..) => {
-                if let Some(function_id) = resolved_function(self.gcx, expr) {
+                if let Some(function_id) = self.gcx.resolved_function(expr) {
                     let is_call = self.callee == Some(expr.id);
                     let info = self.refs.entry(function_id).or_default();
                     if self.current == Some(function_id) {

--- a/crates/lint/src/sol/info/literal_instead_of_constant.rs
+++ b/crates/lint/src/sol/info/literal_instead_of_constant.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloy_primitives::{Address, U256};
 use solar::{
-    ast::{BinOpKind, LitKind, StrKind, UnOpKind},
+    ast::{LitKind, StrKind, UnOpKind},
     interface::Span,
     sema::{
         Gcx,
@@ -30,7 +30,7 @@ impl<'gcx> LateLintPass<'gcx> for LiteralInsteadOfConstant {
         // the header. Parameter and return types stay out, so a fixed array size in a signature
         // is a type annotation rather than a repeated value.
         let mut collector = LiteralCollector { gcx, groups: HashMap::new() };
-        let functions = gcx.hir.contract(id).items.iter().filter_map(|item| item.as_function());
+        let functions = gcx.hir.contract(id).functions();
         for function in functions.map(|id| gcx.hir.function(id)) {
             for modifier in function.modifiers {
                 let _ = collector.visit_modifier(modifier);
@@ -114,8 +114,6 @@ impl<'gcx> Visit<'gcx> for LiteralCollector<'gcx> {
     }
 
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
-        let is_shift =
-            |op: &hir::BinOp| matches!(op.kind, BinOpKind::Shl | BinOpKind::Shr | BinOpKind::Sar);
         let is_value_changing =
             |op: &hir::UnOp| matches!(op.kind, UnOpKind::Neg | UnOpKind::BitNot);
         match &expr.kind {
@@ -138,7 +136,7 @@ impl<'gcx> Visit<'gcx> for LiteralCollector<'gcx> {
             // A bare literal shift amount (`x << 128`, `acc >>= 128`) and bare slice bounds
             // (`d[555:600]`) are structural too: slices only exist on array-like values.
             ExprKind::Binary(lhs, op, rhs) | ExprKind::Assign(lhs, Some(op), rhs)
-                if is_shift(op) =>
+                if op.kind.is_shift() =>
             {
                 let _ = self.visit_expr(lhs);
                 self.visit_unless_bare_lit(rhs);

--- a/crates/lint/src/sol/info/named_struct_fields.rs
+++ b/crates/lint/src/sol/info/named_struct_fields.rs
@@ -20,17 +20,15 @@ declare_forge_lint!(
 
 impl<'gcx> LateLintPass<'gcx> for NamedStructFields {
     fn check_expr(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) {
-        let ExprKind::Call(
-            Expr { kind: ExprKind::Ident([Res::Item(ItemId::Struct(struct_id))]), span, .. },
-            CallArgs { kind: CallArgsKind::Unnamed(args), .. },
-            _,
-        ) = &expr.kind
+        let ExprKind::Call(callee, CallArgs { kind: CallArgsKind::Unnamed(args), .. }, _) =
+            &expr.kind
         else {
             return;
         };
+        let Some(Res::Item(ItemId::Struct(struct_id))) = gcx.resolved_expr(callee) else { return };
         // A fix needs one argument per field and every snippet available; otherwise the
         // diagnostic is emitted without a suggestion.
-        let fields = gcx.hir.strukt(*struct_id).fields;
+        let fields = gcx.hir.strukt(struct_id).fields;
         let fix = (!fields.is_empty() && fields.len() == args.len()).then(|| {
             let assignments = fields
                 .iter()
@@ -43,7 +41,7 @@ impl<'gcx> LateLintPass<'gcx> for NamedStructFields {
                     ))
                 })
                 .collect::<Option<Vec<_>>>()?;
-            Some(format!("{}({{ {} }})", ctx.span_to_snippet(*span)?, assignments.join(", ")))
+            Some(format!("{}({{ {} }})", ctx.span_to_snippet(callee.span)?, assignments.join(", ")))
         });
         match fix.flatten() {
             Some(fix) => ctx.emit_with_suggestion(

--- a/crates/lint/src/sol/info/unused_error.rs
+++ b/crates/lint/src/sol/info/unused_error.rs
@@ -4,11 +4,10 @@ use crate::{
 };
 use solar::{
     ast::ContractKind,
-    interface::{Symbol, data_structures::Never, source_map::FileName},
+    interface::{data_structures::Never, source_map::FileName},
     sema::{
         Gcx,
         hir::{self, Visit as _},
-        ty::{Ty, TyKind},
     },
 };
 use std::{
@@ -40,9 +39,8 @@ impl<'ast> ProjectLintPass<'ast> for UnusedError {
             return;
         }
 
-        let mut collector = UsedErrorCollector { gcx, current_source: None, used: HashSet::new() };
+        let mut collector = UsedErrorCollector { gcx, used: HashSet::new() };
         for source_id in gcx.hir.source_ids() {
-            collector.current_source = Some(source_id);
             let _ = collector.visit_nested_source(source_id);
         }
 
@@ -64,27 +62,9 @@ impl<'ast> ProjectLintPass<'ast> for UnusedError {
     }
 }
 
-/// A named scope a qualified member can resolve against.
-enum MemberScope {
-    /// A contract or library: its declared items.
-    Contract(hir::ContractId),
-    /// A module alias: Solar's resolved scope for that source.
-    Module(hir::SourceId),
-}
-
 /// Collects every error referenced by an expression anywhere in the unit.
-///
-/// Resolved identifiers cover almost every use: the lowering resolves the full path of
-/// `revert Lib.Err(...)` into a single `Ident`, and `require(cond, Err(...))` or `Err.selector`
-/// reference the error through a resolved `Ident` as well. The one exception is a qualified
-/// member access such as `Lib.Err.selector`: the inner `Err` segment carries no resolution in
-/// the HIR, so it is resolved against the scope its base designates: the items of a contract,
-/// or, for a module alias, Solar's resolved source scope, which binds exactly the names the
-/// file declares and imports (aliases included).
 struct UsedErrorCollector<'gcx> {
     gcx: Gcx<'gcx>,
-    /// The source being walked: module member lookups are made from its viewpoint.
-    current_source: Option<hir::SourceId>,
     used: HashSet<hir::ErrorId>,
 }
 
@@ -96,96 +76,9 @@ impl<'gcx> hir::Visit<'gcx> for UsedErrorCollector<'gcx> {
     }
 
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
-        let hir = self.hir();
-        match &expr.kind {
-            // Symbols can be overloaded: consider every resolution.
-            hir::ExprKind::Ident(resolutions) => {
-                self.used.extend(resolutions.iter().filter_map(|res| match res {
-                    hir::Res::Item(hir::ItemId::Error(error_id)) => Some(*error_id),
-                    _ => None,
-                }));
-            }
-            hir::ExprKind::Member(base, member) => {
-                for scope in self.base_scopes(base) {
-                    match scope {
-                        MemberScope::Contract(contract_id) => {
-                            self.used.extend(hir.contract(contract_id).items.iter().filter_map(
-                                |item| match item {
-                                    hir::ItemId::Error(id)
-                                        if hir.error(*id).name.name == member.name =>
-                                    {
-                                        Some(*id)
-                                    }
-                                    _ => None,
-                                },
-                            ));
-                        }
-                        // In the resolved scope an import alias binds under its local name to
-                        // the exact declaration: mark that error, not a same-name lookalike.
-                        MemberScope::Module(source_id) => {
-                            for ty in self.module_members_named(source_id, member.name) {
-                                if let TyKind::Error(_, error_id) = ty.kind {
-                                    self.used.insert(error_id);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            _ => {}
+        if let Some(hir::Res::Item(hir::ItemId::Error(error_id))) = self.gcx.resolved_expr(expr) {
+            self.used.insert(error_id);
         }
         self.walk_expr(expr)
-    }
-}
-
-impl<'gcx> UsedErrorCollector<'gcx> {
-    /// The types of the members named `name` in the resolved scope of module `source_id`: the
-    /// file's own declarations plus the names its imports bind, under their local names.
-    fn module_members_named(&self, source_id: hir::SourceId, name: Symbol) -> Vec<Ty<'gcx>> {
-        let module_ty = self.gcx.type_of_res(hir::Res::Namespace(source_id));
-        let Some(current_source) = self.current_source else { return Vec::new() };
-        self.gcx
-            .members_of(module_ty, current_source, None)
-            .filter_map(|member| (member.name == name).then_some(member.ty))
-            .collect()
-    }
-
-    /// The named scopes `expr` can designate: a contract or library through a resolved
-    /// identifier, a module alias, or a member chain leading to one (`NS.Lib`, `NS.Inner`).
-    fn base_scopes(&self, expr: &hir::Expr<'_>) -> Vec<MemberScope> {
-        match &expr.kind {
-            hir::ExprKind::Ident(resolutions) => resolutions
-                .iter()
-                .filter_map(|res| match res {
-                    hir::Res::Item(hir::ItemId::Contract(id)) => Some(MemberScope::Contract(*id)),
-                    hir::Res::Namespace(id) => Some(MemberScope::Module(*id)),
-                    _ => None,
-                })
-                .collect(),
-            // Contracts do not nest named scopes, so only module bases descend. A contract is a
-            // type-namespace item, so its member type comes wrapped as `Type(Contract(..))`; a
-            // nested module alias comes as a bare `Module(..)`.
-            hir::ExprKind::Member(inner_base, name) => self
-                .base_scopes(inner_base)
-                .into_iter()
-                .filter_map(|scope| match scope {
-                    MemberScope::Module(source_id) => Some(source_id),
-                    MemberScope::Contract(_) => None,
-                })
-                .flat_map(|source_id| self.module_members_named(source_id, name.name))
-                .filter_map(|ty| {
-                    let ty = match ty.kind {
-                        TyKind::Type(inner) => inner,
-                        _ => ty,
-                    };
-                    match ty.kind {
-                        TyKind::Contract(id) => Some(MemberScope::Contract(id)),
-                        TyKind::Module(id) => Some(MemberScope::Module(id)),
-                        _ => None,
-                    }
-                })
-                .collect(),
-            _ => Vec::new(),
-        }
     }
 }

--- a/crates/lint/src/sol/low/block_timestamp.rs
+++ b/crates/lint/src/sol/low/block_timestamp.rs
@@ -3,14 +3,11 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{
-            any_subexpr, branch_always_exits, builtins, is_builtin, loop_stmts, tuple_elems,
-        },
+        analysis::{any_subexpr, branch_always_exits, loop_stmts, tuple_elems},
     },
 };
 use solar::{
     ast::Visibility,
-    interface::{kw, sym},
     sema::{
         Gcx, Hir,
         builtins::Builtin,
@@ -38,7 +35,7 @@ impl<'gcx> LateLintPass<'gcx> for BlockTimestamp {
             .filter(|&id| {
                 let helper = gcx.hir.function(id);
                 matches!(helper.visibility, Visibility::Internal | Visibility::Private)
-                    && helper.body.is_some_and(|body| returns_timestamp(body.stmts))
+                    && helper.body.is_some_and(|body| returns_timestamp(gcx, body.stmts))
             })
             .collect();
         Checker { ctx, gcx, helpers, aliases: HashSet::new() }.block(body.stmts);
@@ -60,7 +57,7 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
     fn block(&mut self, stmts: impl IntoIterator<Item = &'gcx Stmt<'gcx>>) {
         for stmt in stmts {
             let _ = self.visit_stmt(stmt);
-            if branch_always_exits(stmt) {
+            if branch_always_exits(self.gcx, stmt) {
                 break;
             }
         }
@@ -77,7 +74,7 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
         let saved = self.aliases.clone();
         walk(self);
         let aliases = std::mem::replace(&mut self.aliases, saved);
-        if !stmts.into_iter().any(branch_always_exits) {
+        if !stmts.into_iter().any(|expr| branch_always_exits(self.gcx, expr)) {
             merged.extend(aliases);
         }
     }
@@ -138,7 +135,7 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
 
     /// `block.timestamp`, a call to a helper returning it, or an alias of either.
     fn is_source(&self, expr: &Expr<'_>) -> bool {
-        is_block_timestamp(expr)
+        is_block_timestamp(self.gcx, expr)
             || self.gcx.resolved_variable(expr).is_some_and(|var| self.aliases.contains(&var))
             || matches!(&expr.peel_parens().kind, ExprKind::Call(callee, ..)
                 if self.gcx.resolved_function(callee).is_some_and(|id| self.helpers.contains(&id)))
@@ -281,20 +278,20 @@ const fn is_cmp(kind: BinOpKind) -> bool {
 }
 
 /// `block.timestamp`, or the Yul `timestamp()` builtin.
-fn is_block_timestamp(expr: &Expr<'_>) -> bool {
-    matches!(&expr.peel_parens().kind, ExprKind::Member(base, member)
-        if member.name == kw::Timestamp && is_builtin(base, sym::block))
-        || builtins(expr).any(|b| b == Builtin::BlockTimestamp)
+fn is_block_timestamp(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
+    gcx.resolved_builtin(expr) == Some(Builtin::BlockTimestamp)
 }
 
 /// True if a `return` reachable through plain blocks and `if` arms mentions `block.timestamp`.
-fn returns_timestamp(stmts: &[Stmt<'_>]) -> bool {
+fn returns_timestamp(gcx: Gcx<'_>, stmts: &[Stmt<'_>]) -> bool {
     stmts.iter().any(|stmt| match &stmt.kind {
-        StmtKind::Return(Some(expr)) => any_subexpr(expr, is_block_timestamp),
-        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => returns_timestamp(block.stmts),
+        StmtKind::Return(Some(expr)) => any_subexpr(expr, |expr| is_block_timestamp(gcx, expr)),
+        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+            returns_timestamp(gcx, block.stmts)
+        }
         StmtKind::If(_, then_stmt, else_stmt) => {
-            returns_timestamp(std::slice::from_ref(*then_stmt))
-                || else_stmt.is_some_and(|e| returns_timestamp(std::slice::from_ref(e)))
+            returns_timestamp(gcx, std::slice::from_ref(*then_stmt))
+                || else_stmt.is_some_and(|e| returns_timestamp(gcx, std::slice::from_ref(e)))
         }
         _ => false,
     })

--- a/crates/lint/src/sol/low/block_timestamp.rs
+++ b/crates/lint/src/sol/low/block_timestamp.rs
@@ -4,8 +4,7 @@ use crate::{
     sol::{
         Severity, SolLint,
         analysis::{
-            any_subexpr, branch_always_exits, builtins, function_ids, is_builtin, loop_stmts,
-            tuple_elems,
+            any_subexpr, branch_always_exits, builtins, is_builtin, loop_stmts, tuple_elems,
         },
     },
 };
@@ -15,9 +14,7 @@ use solar::{
     sema::{
         Gcx, Hir,
         builtins::Builtin,
-        hir::{
-            BinOpKind, Expr, ExprKind, Function, FunctionId, Res, Stmt, StmtKind, VariableId, Visit,
-        },
+        hir::{BinOpKind, Expr, ExprKind, Function, FunctionId, Stmt, StmtKind, VariableId, Visit},
     },
 };
 use std::{collections::HashSet, convert::Infallible, ops::ControlFlow};
@@ -90,8 +87,8 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
     fn bind(&mut self, lhs: &Expr<'_>, is_source: bool) {
         match &lhs.peel_parens().kind {
             ExprKind::Tuple(elems) => elems.iter().flatten().for_each(|e| self.bind(e, is_source)),
-            ExprKind::Ident(reses) => {
-                for var in reses.iter().filter_map(Res::as_variable) {
+            ExprKind::Ident(_) => {
+                if let Some(var) = self.gcx.resolved_variable(lhs) {
                     self.set_alias(var, is_source);
                 }
             }
@@ -142,9 +139,9 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
     /// `block.timestamp`, a call to a helper returning it, or an alias of either.
     fn is_source(&self, expr: &Expr<'_>) -> bool {
         is_block_timestamp(expr)
-            || expr.as_variable().is_some_and(|var| self.aliases.contains(&var))
+            || self.gcx.resolved_variable(expr).is_some_and(|var| self.aliases.contains(&var))
             || matches!(&expr.peel_parens().kind, ExprKind::Call(callee, ..)
-                if function_ids(callee).any(|id| self.helpers.contains(&id)))
+                if self.gcx.resolved_function(callee).is_some_and(|id| self.helpers.contains(&id)))
     }
 }
 

--- a/crates/lint/src/sol/low/calls_loop.rs
+++ b/crates/lint/src/sol/low/calls_loop.rs
@@ -6,15 +6,15 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{is_address_like, is_builtin},
+        analysis::{expr_is_address, is_builtin},
     },
 };
 use solar::{
-    ast::{StateMutability, Visibility},
+    ast::StateMutability,
     interface::{kw, sym},
     sema::{
         Gcx, Ty,
-        hir::{ContractId, Expr, ExprKind, Function, FunctionId},
+        hir::{Expr, ExprKind, Function},
         ty::TyKind,
     },
 };
@@ -57,7 +57,7 @@ fn classify<'gcx>(gcx: Gcx<'gcx>, callee: &Expr<'gcx>) -> Option<ExternalCall> {
     if matches!(
         member.name,
         kw::Call | kw::Delegatecall | kw::Staticcall | sym::send | sym::transfer
-    ) && is_address_like(gcx, base)
+    ) && expr_is_address(gcx, base)
     {
         let external =
             if member.name == kw::Staticcall { ExternalCall::Static } else { ExternalCall::Opaque };
@@ -88,28 +88,4 @@ pub(super) fn is_state_mutating_external_call<'gcx>(gcx: Gcx<'gcx>, callee: &Exp
         }
         Some(ExternalCall::Static) | None => false,
     }
-}
-
-/// The base-chain function `super.<member>(..)` dispatches to from `enclosing_contract`: the first
-/// arity-matching `internal`/`public` function of that name in its linearization.
-pub(super) fn resolved_super_function_ids<'gcx>(
-    gcx: Gcx<'gcx>,
-    enclosing_contract: Option<ContractId>,
-    callee: &'gcx Expr<'gcx>,
-    explicit_arg_count: usize,
-) -> impl Iterator<Item = FunctionId> + 'gcx {
-    let target = || {
-        let ExprKind::Member(base, member) = &callee.peel_parens().kind else { return None };
-        if !is_builtin(base, sym::super_) {
-            return None;
-        }
-        let bases = gcx.hir.contract(enclosing_contract?).linearized_bases;
-        bases.iter().skip(1).flat_map(|&id| gcx.hir.contract(id).functions()).find(|&id| {
-            let func = gcx.hir.function(id);
-            func.name.is_some_and(|name| name.name == member.name)
-                && func.parameters.len() == explicit_arg_count
-                && matches!(func.visibility, Visibility::Internal | Visibility::Public)
-        })
-    };
-    target().into_iter()
 }

--- a/crates/lint/src/sol/low/calls_loop.rs
+++ b/crates/lint/src/sol/low/calls_loop.rs
@@ -4,18 +4,15 @@ use super::{
 };
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        analysis::{expr_is_address, is_builtin},
-    },
+    sol::{Severity, SolLint},
 };
 use solar::{
     ast::StateMutability,
-    interface::{kw, sym},
     sema::{
-        Gcx, Ty,
+        Gcx,
+        builtins::Builtin,
         hir::{Expr, ExprKind, Function},
-        ty::TyKind,
+        ty::{TyFnKind, TyKind},
     },
 };
 
@@ -36,40 +33,35 @@ impl<'gcx> LateLintPass<'gcx> for CallsLoop {
 
 /// An interaction with another contract.
 enum ExternalCall {
-    /// `new C(..)`, or `.call`/`.delegatecall`/`.send`/`.transfer` on an address.
+    /// Contract creation or a mutating address builtin.
     Opaque,
     /// `.staticcall` on an address.
     Static,
-    /// High-level call on a contract-typed receiver (`this` included), with the callee's state
-    /// mutability when the type checker knows it.
-    Member(Option<StateMutability>),
+    /// High-level external or library call, including an external function pointer.
+    Member(StateMutability),
 }
 
-/// Classifies `callee` when calling it leaves the contract. `using for` bindings and `super`
-/// dispatch run in this contract and are not external.
+/// Classifies calls by their checked function kind, including function pointers and library
+/// delegate calls. Internal `using for` bindings and `super` dispatch stay internal.
 fn classify<'gcx>(gcx: Gcx<'gcx>, callee: &Expr<'gcx>) -> Option<ExternalCall> {
     let callee = callee.peel_parens();
-    if let ExprKind::New(ty) = &callee.kind {
-        return matches!(gcx.type_of_hir_ty(ty).kind, TyKind::Contract(_))
-            .then_some(ExternalCall::Opaque);
-    }
-    let ExprKind::Member(base, member) = &callee.kind else { return None };
     if matches!(
-        member.name,
-        kw::Call | kw::Delegatecall | kw::Staticcall | sym::send | sym::transfer
-    ) && expr_is_address(gcx, base)
-    {
-        let external =
-            if member.name == kw::Staticcall { ExternalCall::Static } else { ExternalCall::Opaque };
-        return Some(external);
+        gcx.resolved_builtin(callee),
+        Some(Builtin::AddressPayableSend | Builtin::AddressPayableTransfer)
+    ) {
+        return Some(ExternalCall::Opaque);
     }
-    let contract_receiver = is_builtin(base, sym::this)
-        || gcx
-            .type_of_expr(base.peel_parens().id)
-            .is_some_and(|ty| matches!(ty.kind, TyKind::Contract(_)));
-    let attached = gcx.resolved_callee(callee.id).is_some_and(|c| c.attached);
-    (contract_receiver && !attached)
-        .then(|| ExternalCall::Member(gcx.type_of_expr(callee.id).and_then(Ty::state_mutability)))
+    let TyKind::Fn(function) = gcx.type_of_expr(callee.id)?.kind else { return None };
+    match function.kind() {
+        TyFnKind::External | TyFnKind::DelegateCall => {
+            Some(ExternalCall::Member(function.state_mutability))
+        }
+        TyFnKind::BareStaticCall => Some(ExternalCall::Static),
+        TyFnKind::BareCall | TyFnKind::BareDelegateCall | TyFnKind::Creation => {
+            Some(ExternalCall::Opaque)
+        }
+        _ => None,
+    }
 }
 
 /// True if calling `callee` interacts with another contract (or deploys one).
@@ -78,13 +70,12 @@ pub(super) fn is_external_call<'gcx>(gcx: Gcx<'gcx>, callee: &Expr<'gcx>) -> boo
 }
 
 /// Like [`is_external_call`], but excludes calls that cannot affect log ordering or observable
-/// state: `staticcall` and high-level `view`/`pure` callees (including `this.*`). Unknown
-/// callees are conservatively treated as state-mutating.
+/// state: `staticcall` and high-level `view`/`pure` callees (including `this.*`).
 pub(super) fn is_state_mutating_external_call<'gcx>(gcx: Gcx<'gcx>, callee: &Expr<'gcx>) -> bool {
     match classify(gcx, callee) {
         Some(ExternalCall::Opaque) => true,
         Some(ExternalCall::Member(mutability)) => {
-            !matches!(mutability, Some(StateMutability::View | StateMutability::Pure))
+            !matches!(mutability, StateMutability::View | StateMutability::Pure)
         }
         Some(ExternalCall::Static) | None => false,
     }

--- a/crates/lint/src/sol/low/delegatecall_loop.rs
+++ b/crates/lint/src/sol/low/delegatecall_loop.rs
@@ -1,14 +1,12 @@
 use super::{DelegatecallLoop, payable_loop::for_each_payable_loop_expr};
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{Severity, SolLint, analysis::expr_is_address},
+    sol::{Severity, SolLint},
 };
-use solar::{
-    interface::kw,
-    sema::{
-        Gcx,
-        hir::{ExprKind, Function},
-    },
+use solar::sema::{
+    Gcx,
+    builtins::Builtin,
+    hir::{ExprKind, Function},
 };
 
 declare_forge_lint!(
@@ -21,12 +19,8 @@ declare_forge_lint!(
 impl<'gcx> LateLintPass<'gcx> for DelegatecallLoop {
     fn check_function(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, func: &'gcx Function<'gcx>) {
         for_each_payable_loop_expr(gcx, func, |expr| {
-            // Only `<address>.delegatecall(..)`: user functions named `delegatecall` on
-            // contract-typed receivers are ordinary calls.
             if let ExprKind::Call(callee, ..) = &expr.kind
-                && let ExprKind::Member(receiver, member) = &callee.peel_parens().kind
-                && member.name == kw::Delegatecall
-                && expr_is_address(gcx, receiver)
+                && gcx.resolved_builtin(callee) == Some(Builtin::AddressDelegatecall)
             {
                 ctx.emit(&DELEGATECALL_LOOP, expr.span);
             }

--- a/crates/lint/src/sol/low/deprecated_oz_function.rs
+++ b/crates/lint/src/sol/low/deprecated_oz_function.rs
@@ -3,7 +3,7 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{OPENZEPPELIN_ROOTS, resolved_function, source_in_package},
+        analysis::{OPENZEPPELIN_ROOTS, source_in_package},
     },
 };
 use solar::sema::{
@@ -24,7 +24,7 @@ impl<'gcx> LateLintPass<'gcx> for DeprecatedOzFunction {
         // used as a value: judge the single declaration the type checker selected (overloads,
         // overrides, `super.`, `using for` and import aliases already accounted for).
         if matches!(expr.kind, ExprKind::Ident(..) | ExprKind::Member(..))
-            && let Some(function_id) = resolved_function(gcx, expr)
+            && let Some(function_id) = gcx.resolved_function(expr)
             && is_deprecated_oz(gcx, function_id)
         {
             ctx.emit(&DEPRECATED_OZ_FUNCTION, expr.span);

--- a/crates/lint/src/sol/low/incorrect_modifier.rs
+++ b/crates/lint/src/sol/low/incorrect_modifier.rs
@@ -16,9 +16,9 @@ declare_forge_lint!(
 );
 
 impl<'gcx> LateLintPass<'gcx> for IncorrectModifier {
-    fn check_function(&mut self, ctx: &LintContext, _gcx: Gcx<'gcx>, func: &'gcx Function<'gcx>) {
+    fn check_function(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, func: &'gcx Function<'gcx>) {
         if func.kind == FunctionKind::Modifier
-            && func.body.is_some_and(|body| block_outcome(body).can_skip_placeholder())
+            && func.body.is_some_and(|body| block_outcome(gcx, body).can_skip_placeholder())
         {
             ctx.emit(&INCORRECT_MODIFIER, func.span);
         }

--- a/crates/lint/src/sol/low/missing_events_access_control.rs
+++ b/crates/lint/src/sol/low/missing_events_access_control.rs
@@ -4,8 +4,8 @@ use crate::{
     sol::{
         Severity, SolLint,
         analysis::{
-            branch_always_exits, for_each_lhs_var, function_ids, guard_vars, is_protected,
-            is_sender_member, is_zero_value, lhs_local_var, referenced_item, underlying_var,
+            branch_always_exits, for_each_lhs_var, guard_vars, is_protected, is_sender_member,
+            is_zero_value, lhs_local_var, referenced_item, underlying_var,
         },
     },
 };
@@ -45,8 +45,7 @@ impl<'gcx> LateLintPass<'gcx> for MissingEventsAccessControl {
 
         // Every state variable some access check in the contract depends on.
         let functions: Vec<_> = contract.all_functions().collect();
-        let targets: HashSet<_> =
-            functions.iter().flat_map(|&id| guard_vars(&gcx.hir, id)).collect();
+        let targets: HashSet<_> = functions.iter().flat_map(|&id| guard_vars(gcx, id)).collect();
         if targets.is_empty() {
             return;
         }
@@ -58,11 +57,11 @@ impl<'gcx> LateLintPass<'gcx> for MissingEventsAccessControl {
                 && !func.is_constructor()
                 && !func.is_special()
                 && !matches!(func.state_mutability, StateMutability::Pure | StateMutability::View);
-            if !is_entry_point || !is_protected(&gcx.hir, func_id) {
+            if !is_entry_point || !is_protected(gcx, func_id) {
                 continue;
             }
 
-            let guard_targets = guard_vars(&gcx.hir, func_id);
+            let guard_targets = guard_vars(gcx, func_id);
             let mut analyzer = WriteAnalyzer {
                 gcx,
                 targets: &targets,
@@ -212,7 +211,7 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
             if is_sender_member(e) {
                 out.insert(Source::Sender);
             }
-            if let Some(var_id) = underlying_var(e) {
+            if let Some(var_id) = underlying_var(self.gcx, e) {
                 if self.gcx.hir.variable(var_id).kind.is_state() {
                     out.insert(Source::Var(var_id));
                 }
@@ -228,7 +227,7 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
     /// State variables written through `lhs`, resolving storage pointers to their roots.
     fn lhs_state_vars(&self, lhs: &Expr<'_>) -> Vec<VariableId> {
         let mut vars = Vec::new();
-        for_each_lhs_var(lhs, &mut |var_id| {
+        for_each_lhs_var(self.gcx, lhs, &mut |var_id| {
             let root = if self.gcx.hir.variable(var_id).kind.is_state() {
                 Some(var_id)
             } else {
@@ -282,7 +281,7 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
     /// Marks pending writes covered by `emit`: the event must mention the variable and share a
     /// source with the write (or the write must be a fixed clear).
     fn mark_event(&mut self, expr: &Expr<'_>) {
-        let Some(event_id) = emitted_event_id(expr) else { return };
+        let Some(event_id) = emitted_event_id(self.gcx, expr) else { return };
         let event_sources = self.value_sources(expr);
         for write in &mut self.state.writes {
             if !write.evented
@@ -355,7 +354,7 @@ impl<'gcx> Visit<'gcx> for WriteAnalyzer<'_, 'gcx> {
                     sources.extend(self.value_sources(lhs));
                 }
                 self.record_writes(lhs, &sources, is_zero_value(rhs));
-                if let Some(local) = lhs_local_var(&self.gcx.hir, lhs) {
+                if let Some(local) = lhs_local_var(self.gcx, lhs) {
                     self.set_local(local, sources, rhs);
                 }
                 ControlFlow::Continue(())
@@ -368,7 +367,9 @@ impl<'gcx> Visit<'gcx> for WriteAnalyzer<'_, 'gcx> {
             }
             ExprKind::Call(callee, args, _) => {
                 self.walk_expr(expr)?;
-                for callee_id in function_ids(callee) {
+                if matches!(callee.peel_parens().kind, ExprKind::Ident(_))
+                    && let Some(callee_id) = self.gcx.resolved_function(callee)
+                {
                     self.analyze_call(callee_id, args);
                 }
                 ControlFlow::Continue(())
@@ -415,9 +416,9 @@ fn merge_branches(
     State { taint, storage_aliases, writes }
 }
 
-fn emitted_event_id(expr: &Expr<'_>) -> Option<EventId> {
+fn emitted_event_id(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<EventId> {
     let ExprKind::Call(callee, ..) = &expr.peel_parens().kind else { return None };
-    match referenced_item(callee)? {
+    match referenced_item(gcx, callee)? {
         ItemId::Event(event_id) => Some(event_id),
         _ => None,
     }

--- a/crates/lint/src/sol/low/missing_events_access_control.rs
+++ b/crates/lint/src/sol/low/missing_events_access_control.rs
@@ -173,7 +173,7 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
         for modifier in func.modifiers {
             if let Some(modifier_id) = modifier.id.as_function() {
                 let _ = self.visit_call_args(&modifier.args);
-                self.analyze_call(modifier_id, &modifier.args);
+                self.analyze_call(modifier_id, |index| modifier.args.exprs().nth(index));
             }
         }
         for stmt in body.stmts {
@@ -182,18 +182,22 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
         self.call_stack.pop();
     }
 
-    /// Inlines `callee_id` with its parameters bound to the sources of `args`; locals and storage
+    /// Inlines `callee_id` with its parameters bound to argument sources; locals and storage
     /// aliases are callee-private, pending writes flow back to the caller.
-    fn analyze_call(&mut self, callee_id: FunctionId, args: &hir::CallArgs<'gcx>) {
+    fn analyze_call(
+        &mut self,
+        callee_id: FunctionId,
+        mut argument: impl FnMut(usize) -> Option<&'gcx Expr<'gcx>>,
+    ) {
         let params = self
             .gcx
             .hir
             .function(callee_id)
             .parameters
             .iter()
-            .zip(args.exprs())
-            .filter_map(|(&param, arg)| {
-                let sources = self.value_sources(arg);
+            .enumerate()
+            .filter_map(|(index, &param)| {
+                let sources = self.value_sources(argument(index)?);
                 (!sources.is_empty()).then_some((param, sources))
             })
             .collect();
@@ -208,7 +212,7 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
     fn value_sources(&self, expr: &Expr<'_>) -> Sources {
         let mut out = Sources::new();
         let _ = expr.visit(&mut |e| {
-            if is_sender_member(e) {
+            if is_sender_member(self.gcx, e) {
                 out.insert(Source::Sender);
             }
             if let Some(var_id) = underlying_var(self.gcx, e) {
@@ -330,8 +334,8 @@ impl<'gcx> Visit<'gcx> for WriteAnalyzer<'_, 'gcx> {
                     base,
                     then_state,
                     else_state,
-                    branch_always_exits(then_stmt),
-                    else_stmt.is_some_and(branch_always_exits),
+                    branch_always_exits(self.gcx, then_stmt),
+                    else_stmt.is_some_and(|expr| branch_always_exits(self.gcx, expr)),
                 );
             }
             StmtKind::Emit(expr) => {
@@ -365,12 +369,13 @@ impl<'gcx> Visit<'gcx> for WriteAnalyzer<'_, 'gcx> {
                 self.record_writes(inner, &sources, true);
                 self.walk_expr(expr)
             }
-            ExprKind::Call(callee, args, _) => {
+            ExprKind::Call(callee, ..) => {
                 self.walk_expr(expr)?;
                 if matches!(callee.peel_parens().kind, ExprKind::Ident(_))
                     && let Some(callee_id) = self.gcx.resolved_function(callee)
                 {
-                    self.analyze_call(callee_id, args);
+                    let gcx = self.gcx;
+                    self.analyze_call(callee_id, |index| gcx.call_arg(expr, index));
                 }
                 ControlFlow::Continue(())
             }

--- a/crates/lint/src/sol/low/missing_events_arithmetic.rs
+++ b/crates/lint/src/sol/low/missing_events_arithmetic.rs
@@ -17,7 +17,7 @@ use solar::{
         builtins::Builtin,
         hir::{
             self, BinOpKind, ContractId, ElementaryType, Expr, ExprKind, FunctionId, StmtKind,
-            TypeKind, UnOpKind, VariableId, Visit,
+            TypeKind, VariableId, Visit,
         },
     },
 };
@@ -73,7 +73,7 @@ impl<'gcx> LateLintPass<'gcx> for MissingEventsArithmetic {
             .all()
             .iter()
             .map(|func| func.id)
-            .partition(|&id| is_protected(&gcx.hir, id));
+            .partition(|&id| is_protected(gcx, id));
         let entry_points: Vec<_> = protected
             .into_iter()
             .filter(|&id| {
@@ -141,10 +141,6 @@ const fn is_arithmetic_op(kind: BinOpKind) -> bool {
     )
 }
 
-const fn is_inc_dec_op(kind: UnOpKind) -> bool {
-    matches!(kind, UnOpKind::PreInc | UnOpKind::PostInc | UnOpKind::PreDec | UnOpKind::PostDec)
-}
-
 // --- Arithmetic uses --------------------------------------------------------------------------
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -208,7 +204,7 @@ impl<'gcx> UseAnalyzer<'_, 'gcx> {
     fn sources(&mut self, expr: &Expr<'gcx>) -> HashSet<VariableId> {
         let mut out = HashSet::new();
         let _ = expr.visit(&mut |e| {
-            if let Some(var_id) = underlying_var(e) {
+            if let Some(var_id) = underlying_var(self.gcx, e) {
                 if self.targets.contains(&var_id) {
                     out.insert(var_id);
                 }
@@ -280,7 +276,7 @@ impl<'gcx> Visit<'gcx> for UseAnalyzer<'_, 'gcx> {
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         match &expr.kind {
             ExprKind::Assign(lhs, _, rhs) => {
-                if let Some(local) = lhs_local_var(&self.gcx.hir, lhs) {
+                if let Some(local) = lhs_local_var(self.gcx, lhs) {
                     let sources = self.sources(rhs);
                     self.set_taint(local, sources);
                 }
@@ -485,11 +481,11 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
                     if dynamic || op.is_some_and(|op| is_arithmetic_op(op.kind)) {
                         self.record_writes(state, lhs);
                     }
-                    if let Some(local) = lhs_local_var(&self.gcx.hir, lhs) {
+                    if let Some(local) = lhs_local_var(self.gcx, lhs) {
                         self.set_dynamic(state, local, rhs);
                     }
                 }
-                ExprKind::Unary(op, inner) if is_inc_dec_op(op.kind) => {
+                ExprKind::Unary(op, inner) if op.kind.has_side_effects() => {
                     self.record_writes(state, inner);
                 }
                 ExprKind::Call(callee, args, _) => {
@@ -531,7 +527,7 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
     }
 
     fn record_writes(&self, state: &mut WriteState, lhs: &Expr<'_>) {
-        for var_id in state_lhs_vars(&self.gcx.hir, lhs) {
+        for var_id in state_lhs_vars(self.gcx, lhs) {
             if self.targets.contains(&var_id) {
                 state.writes.push(StateWrite { var_id, span: lhs.span });
             }
@@ -555,7 +551,7 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
                 ExprKind::Member(base, _) => {
                     builtins(base).any(|b| matches!(b, Builtin::Block | Builtin::Msg | Builtin::Tx))
                 }
-                _ => underlying_var(e).is_some_and(|var_id| {
+                _ => underlying_var(self.gcx, e).is_some_and(|var_id| {
                     let var = self.gcx.hir.variable(var_id);
                     state.dynamic.contains(&var_id)
                         || (var.kind.is_state() && !var.is_constant() && !var.is_immutable())

--- a/crates/lint/src/sol/low/missing_events_arithmetic.rs
+++ b/crates/lint/src/sol/low/missing_events_arithmetic.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{
         Severity, SolLint,
         analysis::{
-            builtins, dispatched_function, is_protected, lhs_local_var, loop_stmts, state_lhs_vars,
+            dispatched_function, is_protected, lhs_local_var, loop_stmts, state_lhs_vars,
             underlying_var,
         },
     },
@@ -177,9 +177,9 @@ impl<'gcx> UseAnalyzer<'_, 'gcx> {
         self.call_stack.pop();
     }
 
-    /// Analyzes `callee_id` with its parameters bound to the sources of `args`, restoring the
+    /// Analyzes `callee_id` with its parameters bound to the call's argument sources, restoring the
     /// caller's taint afterwards.
-    fn analyze_call(&mut self, callee_id: FunctionId, args: &hir::CallArgs<'gcx>) {
+    fn analyze_call(&mut self, callee_id: FunctionId, call: &Expr<'gcx>) {
         if self.call_stack.contains(&callee_id) {
             return;
         }
@@ -189,9 +189,9 @@ impl<'gcx> UseAnalyzer<'_, 'gcx> {
             .function(callee_id)
             .parameters
             .iter()
-            .zip(args.exprs())
-            .filter_map(|(&param, arg)| {
-                let sources = self.sources(arg);
+            .enumerate()
+            .filter_map(|(index, &param)| {
+                let sources = self.sources(self.gcx.call_arg(call, index)?);
                 (!sources.is_empty()).then_some((param, sources))
             })
             .collect();
@@ -212,24 +212,20 @@ impl<'gcx> UseAnalyzer<'_, 'gcx> {
                     out.extend(sources);
                 }
             }
-            if let ExprKind::Call(callee, args, _) = &e.kind
+            if let ExprKind::Call(callee, ..) = &e.kind
                 && let Some(callee_id) = dispatched_function(self.gcx, self.contract_id, callee)
             {
-                out.extend(self.return_sources(callee_id, args));
+                out.extend(self.return_sources(callee_id, e));
             }
             ControlFlow::<()>::Continue(())
         });
         out
     }
 
-    fn return_sources(
-        &mut self,
-        callee_id: FunctionId,
-        args: &hir::CallArgs<'gcx>,
-    ) -> HashSet<VariableId> {
+    fn return_sources(&mut self, callee_id: FunctionId, call: &Expr<'gcx>) -> HashSet<VariableId> {
         let outer_mode = std::mem::replace(&mut self.mode, Mode::Returns);
         let outer_returned = std::mem::take(&mut self.returned);
-        self.analyze_call(callee_id, args);
+        self.analyze_call(callee_id, call);
         self.mode = outer_mode;
         std::mem::replace(&mut self.returned, outer_returned)
     }
@@ -289,10 +285,10 @@ impl<'gcx> Visit<'gcx> for UseAnalyzer<'_, 'gcx> {
                 let sources = self.sources(rhs);
                 self.used.extend(sources);
             }
-            ExprKind::Call(callee, args, _) if self.mode == Mode::Uses => {
+            ExprKind::Call(callee, ..) if self.mode == Mode::Uses => {
                 self.walk_expr(expr)?;
                 if let Some(callee_id) = dispatched_function(self.gcx, self.contract_id, callee) {
-                    self.analyze_call(callee_id, args);
+                    self.analyze_call(callee_id, expr);
                 }
                 return ControlFlow::Continue(());
             }
@@ -488,10 +484,10 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
                 ExprKind::Unary(op, inner) if op.kind.has_side_effects() => {
                     self.record_writes(state, inner);
                 }
-                ExprKind::Call(callee, args, _) => {
+                ExprKind::Call(callee, ..) => {
                     if let Some(callee_id) = dispatched_function(self.gcx, self.contract_id, callee)
                     {
-                        self.analyze_call(callee_id, args, state);
+                        self.analyze_call(callee_id, e, state);
                     }
                 }
                 _ => {}
@@ -502,12 +498,7 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
 
     /// Inlines `callee_id` with its parameters marked dynamic when the matching argument is; the
     /// callee's pending writes (and any `emit` clearing them) flow back into the caller.
-    fn analyze_call(
-        &mut self,
-        callee_id: FunctionId,
-        args: &hir::CallArgs<'gcx>,
-        state: &mut WriteState,
-    ) {
+    fn analyze_call(&mut self, callee_id: FunctionId, call: &Expr<'gcx>, state: &mut WriteState) {
         let callee_state = WriteState {
             dynamic: self
                 .gcx
@@ -515,9 +506,11 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
                 .function(callee_id)
                 .parameters
                 .iter()
-                .zip(args.exprs())
-                .filter(|(_, arg)| self.is_dynamic(state, arg))
-                .map(|(&param, _)| param)
+                .enumerate()
+                .filter(|(index, _)| {
+                    self.gcx.call_arg(call, *index).is_some_and(|arg| self.is_dynamic(state, arg))
+                })
+                .map(|(_, &param)| param)
                 .collect(),
             writes: state.writes.clone(),
         };
@@ -549,7 +542,10 @@ impl<'gcx> WriteAnalyzer<'_, 'gcx> {
             let dynamic = match &e.kind {
                 ExprKind::Call(..) => true,
                 ExprKind::Member(base, _) => {
-                    builtins(base).any(|b| matches!(b, Builtin::Block | Builtin::Msg | Builtin::Tx))
+                    matches!(
+                        self.gcx.resolved_builtin(base),
+                        Some(Builtin::Block | Builtin::Msg | Builtin::Tx)
+                    )
                 }
                 _ => underlying_var(self.gcx, e).is_some_and(|var_id| {
                     let var = self.gcx.hir.variable(var_id);

--- a/crates/lint/src/sol/low/missing_zero_check.rs
+++ b/crates/lint/src/sol/low/missing_zero_check.rs
@@ -201,8 +201,8 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
 
                 // A guard in an exiting branch holds for everything after the `if`; otherwise it
                 // must hold on both branches.
-                let then_exits = branch_always_exits(then);
-                let else_exits = else_.is_some_and(branch_always_exits);
+                let then_exits = branch_always_exits(self.gcx, then);
+                let else_exits = else_.is_some_and(|expr| branch_always_exits(self.gcx, expr));
                 self.guarded = match (then_exits, else_exits) {
                     (true, true) => &then_guards | &else_guards,
                     (true, false) => else_guards,
@@ -237,7 +237,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         match &expr.kind {
             // `require(cond, ..)` / `assert(cond)`: only the first arg is a guard predicate.
-            ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
+            ExprKind::Call(callee, args, _) if is_require_or_assert(self.gcx, callee) => {
                 let mut iter = args.exprs();
                 if let Some(cond) = iter.next() {
                     self.guarded.extend(self.nonzero_facts(cond, false));

--- a/crates/lint/src/sol/low/missing_zero_check.rs
+++ b/crates/lint/src/sol/low/missing_zero_check.rs
@@ -62,7 +62,7 @@ impl<'gcx> LateLintPass<'gcx> for MissingZeroCheck {
                 .iter()
                 .zip(m.args.exprs())
                 .filter_map(|(&mp, arg)| {
-                    let caller = underlying_var(arg).filter(|v| params.contains(v))?;
+                    let caller = underlying_var(gcx, arg).filter(|v| params.contains(v))?;
                     Some((mp, caller))
                 })
                 .collect();
@@ -143,7 +143,7 @@ impl<'gcx> Analyzer<'gcx> {
                 for (candidate, zero) in [(lhs, rhs), (rhs, lhs)] {
                     if is_zero_value(zero)
                         && let Some(sources) =
-                            underlying_var(candidate).and_then(|v| self.taint.get(&v))
+                            underlying_var(self.gcx, candidate).and_then(|v| self.taint.get(&v))
                     {
                         facts.extend(sources);
                     }
@@ -157,7 +157,7 @@ impl<'gcx> Analyzer<'gcx> {
     fn taint_sources(&self, expr: &hir::Expr<'_>) -> HashSet<VariableId> {
         let mut out = HashSet::new();
         let _ = expr.visit(&mut |e| {
-            if let Some(srcs) = underlying_var(e).and_then(|v| self.taint.get(&v)) {
+            if let Some(srcs) = underlying_var(self.gcx, e).and_then(|v| self.taint.get(&v)) {
                 out.extend(srcs);
             }
             ControlFlow::<Never>::Continue(())
@@ -259,7 +259,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
             }
             ExprKind::Assign(lhs, _, rhs) => {
                 // Sink: assignment to an address state variable.
-                if let Some(v) = underlying_var(lhs)
+                if let Some(v) = underlying_var(self.gcx, lhs)
                     && self.gcx.hir.variable(v).kind.is_state()
                     && is_address_type(&self.gcx.hir, v)
                 {
@@ -268,13 +268,14 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
                     self.sink_depth -= 1;
                     return ControlFlow::Continue(());
                 }
-                if let Some(local) = lhs_local_var(&self.gcx.hir, lhs) {
+                if let Some(local) = lhs_local_var(self.gcx, lhs) {
                     self.propagate(local, rhs);
                 }
             }
             ExprKind::Ident(_) => {
                 if self.sink_depth > 0
-                    && let Some(srcs) = underlying_var(expr).and_then(|v| self.taint.get(&v))
+                    && let Some(srcs) =
+                        underlying_var(self.gcx, expr).and_then(|v| self.taint.get(&v))
                 {
                     self.sinks.extend(srcs.iter().filter(|src| !self.guarded.contains(src)));
                 }

--- a/crates/lint/src/sol/low/msg_value_loop.rs
+++ b/crates/lint/src/sol/low/msg_value_loop.rs
@@ -1,15 +1,9 @@
 use super::{MsgValueLoop, payable_loop::for_each_payable_loop_expr};
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{Severity, SolLint, analysis::is_builtin},
+    sol::{Severity, SolLint},
 };
-use solar::{
-    interface::sym,
-    sema::{
-        Gcx,
-        hir::{ExprKind, Function},
-    },
-};
+use solar::sema::{Gcx, builtins::Builtin, hir::Function};
 
 declare_forge_lint!(
     MSG_VALUE_LOOP,
@@ -21,10 +15,7 @@ declare_forge_lint!(
 impl<'gcx> LateLintPass<'gcx> for MsgValueLoop {
     fn check_function(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, func: &'gcx Function<'gcx>) {
         for_each_payable_loop_expr(gcx, func, |expr| {
-            if let ExprKind::Member(base, member) = &expr.peel_parens().kind
-                && member.name == sym::value
-                && is_builtin(base, sym::msg)
-            {
+            if gcx.resolved_builtin(expr) == Some(Builtin::MsgValue) {
                 ctx.emit(&MSG_VALUE_LOOP, expr.span);
             }
         });

--- a/crates/lint/src/sol/low/payable_loop.rs
+++ b/crates/lint/src/sol/low/payable_loop.rs
@@ -7,7 +7,7 @@
 use crate::sol::analysis::{is_builtin, is_contract_cast, loop_stmts};
 use solar::{
     ast::{StateMutability, Visibility},
-    interface::{Symbol, sym},
+    interface::sym,
     sema::{
         Gcx,
         hir::{
@@ -95,8 +95,10 @@ impl<'gcx, F: FnMut(LoopItem<'gcx>)> LoopWalker<'gcx, F> {
             return self.visit_scoped(body, None, contract);
         };
         let _ = self.visit_call_args(&modifier.args);
-        if let Some(id) = modifier.id.as_function()
-            && let Some(modifier_body) = self.gcx.hir.function(id).body
+        if let Some(id) = self.dispatch.map_or_else(
+            || modifier.id.as_function(),
+            |contract| self.gcx.resolve_modifier_target(contract, modifier),
+        ) && let Some(modifier_body) = self.gcx.hir.function(id).body
             && !self.stack.contains(&id)
         {
             self.stack.push(id);
@@ -138,25 +140,19 @@ impl<'gcx, F: FnMut(LoopItem<'gcx>)> LoopWalker<'gcx, F> {
     /// Calls on a contract-typed value (`this` included) are external and are not followed.
     fn callee(&self, callee: &'gcx Expr<'gcx>) -> Option<FunctionId> {
         let callee = callee.peel_parens();
-        let func_id = self.gcx.resolved_expr(callee)?.as_function()?;
-        let ExprKind::Member(base, member) = &callee.kind else { return Some(func_id) };
+        let func_id = self.gcx.resolved_function(callee)?;
+        let ExprKind::Member(base, _) = &callee.kind else {
+            return Some(
+                self.dispatch.map_or(func_id, |contract| {
+                    self.gcx.resolve_virtual_function(contract, func_id)
+                }),
+            );
+        };
         if is_builtin(base, sym::super_) {
-            return self.super_target(func_id, member.name);
+            return Some(self.gcx.resolve_super_function(self.dispatch?, self.current?, func_id));
         }
         let attached = self.gcx.resolved_callee(callee.id).is_some_and(|c| c.attached);
         (attached || is_contract_cast(base)).then_some(func_id)
-    }
-
-    /// `super.<name>(..)` resolved against the dispatching contract: the first base after the
-    /// current one (in its linearization) defining `name` with the resolved signature.
-    fn super_target(&self, resolved: FunctionId, name: Symbol) -> Option<FunctionId> {
-        let bases = self.gcx.hir.contract(self.dispatch?).linearized_bases;
-        let start = bases.iter().position(|&c| Some(c) == self.current)? + 1;
-        let params = self.gcx.item_parameter_types(resolved);
-        bases[start..].iter().flat_map(|&c| self.gcx.hir.contract(c).functions()).find(|&id| {
-            let func = self.gcx.hir.function(id);
-            func.name.is_some_and(|n| n.name == name) && self.gcx.item_parameter_types(id) == params
-        })
     }
 }
 

--- a/crates/lint/src/sol/low/payable_loop.rs
+++ b/crates/lint/src/sol/low/payable_loop.rs
@@ -4,7 +4,7 @@
 //! its modifier chain through `_` and inlining the internal helpers it calls (including `super`
 //! dispatch, resolved against the contract the entry point belongs to).
 
-use crate::sol::analysis::{is_builtin, is_contract_cast, loop_stmts};
+use crate::sol::analysis::{is_builtin, loop_stmts};
 use solar::{
     ast::{StateMutability, Visibility},
     interface::sym,
@@ -14,6 +14,7 @@ use solar::{
             Block, ContractId, Expr, ExprKind, Function, FunctionId, FunctionKind, Hir, Modifier,
             Stmt, StmtKind, Visit,
         },
+        ty::TyKind,
     },
 };
 use std::{convert::Infallible, ops::ControlFlow};
@@ -140,6 +141,10 @@ impl<'gcx, F: FnMut(LoopItem<'gcx>)> LoopWalker<'gcx, F> {
     /// Calls on a contract-typed value (`this` included) are external and are not followed.
     fn callee(&self, callee: &'gcx Expr<'gcx>) -> Option<FunctionId> {
         let callee = callee.peel_parens();
+        let TyKind::Fn(function) = self.gcx.type_of_expr(callee.id)?.kind else { return None };
+        if !function.is_internal() && !function.is_delegate_call() {
+            return None;
+        }
         let func_id = self.gcx.resolved_function(callee)?;
         let ExprKind::Member(base, _) = &callee.kind else {
             return Some(
@@ -148,11 +153,10 @@ impl<'gcx, F: FnMut(LoopItem<'gcx>)> LoopWalker<'gcx, F> {
                 }),
             );
         };
-        if is_builtin(base, sym::super_) {
+        if is_builtin(self.gcx, base, sym::super_) {
             return Some(self.gcx.resolve_super_function(self.dispatch?, self.current?, func_id));
         }
-        let attached = self.gcx.resolved_callee(callee.id).is_some_and(|c| c.attached);
-        (attached || is_contract_cast(base)).then_some(func_id)
+        Some(func_id)
     }
 }
 

--- a/crates/lint/src/sol/low/reentrancy_events.rs
+++ b/crates/lint/src/sol/low/reentrancy_events.rs
@@ -227,7 +227,7 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
             }
             StmtKind::DeclMulti(_, expr) | StmtKind::Expr(expr) => {
                 self.analyze_expr(expr, &mut entry);
-                if is_exit_call(expr) {
+                if is_exit_call(self.gcx, expr) {
                     return Exits::default();
                 }
                 self.unless_aborted(Exits::fallthrough(entry))

--- a/crates/lint/src/sol/low/reentrancy_events.rs
+++ b/crates/lint/src/sol/low/reentrancy_events.rs
@@ -1,14 +1,11 @@
-use super::{
-    ReentrancyEvents,
-    calls_loop::{is_state_mutating_external_call, resolved_super_function_ids},
-};
+use super::{ReentrancyEvents, calls_loop::is_state_mutating_external_call};
 use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
         analysis::{
-            DEFAULT_HELPER_ANALYSIS_CACHE_LIMIT, HelperAnalysisCache, for_each_child, is_exit_call,
-            loop_stmts, loop_update, resolved_internal_function_ids,
+            DEFAULT_HELPER_ANALYSIS_CACHE_LIMIT, HelperAnalysisCache, dispatched_function,
+            for_each_child, is_exit_call, loop_stmts, loop_update,
         },
     },
 };
@@ -165,8 +162,13 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         // A modifier may legitimately appear several times in the chain (`m(false) m(true)`),
         // so duplicates are not skipped; `index` strictly increases, and recursion through
         // internal calls is handled by `analyze_internal_call`.
-        let Some((modifier_id, modifier_body)) =
-            modifier.id.as_function().and_then(|id| Some((id, self.gcx.hir.function(id).body?)))
+        let Some((modifier_id, modifier_body)) = self
+            .enclosing_contract
+            .map_or_else(
+                || modifier.id.as_function(),
+                |contract| self.gcx.resolve_modifier_target(contract, modifier),
+            )
+            .and_then(|id| Some((id, self.gcx.hir.function(id).body?)))
         else {
             return self.analyze_modifier_chain(modifiers, index + 1, body, entry);
         };
@@ -318,14 +320,14 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
 
     fn analyze_expr(&mut self, expr: &'gcx Expr<'gcx>, tainted: &mut bool) {
         match &expr.kind {
-            ExprKind::Call(callee, args, _) => {
+            ExprKind::Call(callee, ..) => {
                 for_each_child(expr, &mut |child| self.analyze_expr(child, tainted));
                 if is_state_mutating_external_call(self.gcx, callee) {
                     *tainted = true;
                 }
                 // Follow internal helpers and `super` dispatch so their external calls taint the
                 // caller too.
-                for func_id in self.callees(callee, args.len()) {
+                for func_id in self.callees(callee) {
                     self.analyze_internal_call(func_id, tainted);
                 }
             }
@@ -364,14 +366,13 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
     }
 
     /// Internal functions and `super` targets a call through `callee` dispatches to.
-    fn callees(&self, callee: &'gcx Expr<'gcx>, arg_count: usize) -> Vec<FunctionId> {
-        resolved_internal_function_ids(&self.gcx.hir, callee)
-            .chain(resolved_super_function_ids(
-                self.gcx,
-                self.enclosing_contract,
-                callee,
-                arg_count,
-            ))
+    fn callees(&self, callee: &'gcx Expr<'gcx>) -> Vec<FunctionId> {
+        self.enclosing_contract
+            .map_or_else(
+                || self.gcx.resolved_function(callee),
+                |contract| dispatched_function(self.gcx, contract, callee),
+            )
+            .into_iter()
             .collect()
     }
 
@@ -509,10 +510,10 @@ impl<'ctx, 's, 'c, 'gcx> Analyzer<'ctx, 's, 'c, 'gcx> {
         if reached {
             return true;
         }
-        let ExprKind::Call(callee, args, _) = &expr.kind else { return false };
+        let ExprKind::Call(callee, ..) = &expr.kind else { return false };
         is_state_mutating_external_call(self.gcx, callee)
             || self
-                .callees(callee, args.len())
+                .callees(callee)
                 .into_iter()
                 .any(|id| self.helper_may_reach_external_call(id, seen))
     }

--- a/crates/lint/src/sol/low/require_revert_in_loop.rs
+++ b/crates/lint/src/sol/low/require_revert_in_loop.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{Severity, SolLint, analysis::builtins},
+    sol::{Severity, SolLint},
 };
 use solar::sema::{
     Gcx,
@@ -27,7 +27,7 @@ impl<'gcx> LateLintPass<'gcx> for RequireRevertInLoop {
                     StmtKind::Revert(expr) => Some(expr),
                     _ => None,
                 },
-                LoopItem::Expr(expr) => is_require_or_revert_call(expr).then_some(expr),
+                LoopItem::Expr(expr) => is_require_or_revert_call(gcx, expr).then_some(expr),
             };
             if let Some(expr) = reported {
                 ctx.emit(&REQUIRE_REVERT_IN_LOOP, expr.span);
@@ -37,9 +37,10 @@ impl<'gcx> LateLintPass<'gcx> for RequireRevertInLoop {
 }
 
 /// `require(..)`, `revert(..)` or the Yul `revert(..)` builtin.
-fn is_require_or_revert_call(expr: &Expr<'_>) -> bool {
+fn is_require_or_revert_call(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let ExprKind::Call(callee, ..) = &expr.peel_parens().kind else { return false };
-    builtins(callee).any(|b| {
-        matches!(b, Builtin::Require | Builtin::Revert | Builtin::RevertMsg | Builtin::YulRevert)
-    })
+    matches!(
+        gcx.resolved_builtin(callee),
+        Some(Builtin::Require | Builtin::Revert | Builtin::RevertMsg | Builtin::YulRevert)
+    )
 }

--- a/crates/lint/src/sol/low/return_bomb.rs
+++ b/crates/lint/src/sol/low/return_bomb.rs
@@ -1,18 +1,13 @@
 use super::ReturnBomb;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        analysis::{is_address_like, is_call_with_gas_limit},
-    },
+    sol::{Severity, SolLint, analysis::is_call_with_gas_limit},
 };
-use solar::{
-    interface::kw,
-    sema::{
-        Gcx, Ty,
-        hir::{self, ExprKind},
-        ty::TyKind,
-    },
+use solar::sema::{
+    Gcx, Ty,
+    builtins::Builtin,
+    hir::{self, ExprKind},
+    ty::TyKind,
 };
 
 declare_forge_lint!(
@@ -31,9 +26,10 @@ impl<'gcx> LateLintPass<'gcx> for ReturnBomb {
             return;
         }
         let ExprKind::Call(callee, ..) = &expr.kind else { return };
-        let low_level = matches!(&callee.peel_parens().kind, ExprKind::Member(receiver, member)
-            if matches!(member.name, kw::Call | kw::Delegatecall | kw::Staticcall)
-                && is_address_like(gcx, receiver));
+        let low_level = matches!(
+            gcx.resolved_builtin(callee),
+            Some(Builtin::AddressCall | Builtin::AddressDelegatecall | Builtin::AddressStaticcall)
+        );
         if low_level || gcx.type_of_expr(expr.id).is_some_and(|ty| is_dynamic_ty(gcx, ty)) {
             ctx.emit(&RETURN_BOMB, expr.span);
         }
@@ -43,10 +39,6 @@ impl<'gcx> LateLintPass<'gcx> for ReturnBomb {
 fn is_dynamic_ty<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> bool {
     let ty = ty.peel_refs();
     match ty.kind {
-        TyKind::Struct(id) => {
-            ty.is_dynamically_encoded(gcx)
-                || gcx.struct_field_types(id).iter().any(|ty| is_dynamic_ty(gcx, *ty))
-        }
         TyKind::Tuple(elements) => elements.iter().any(|ty| is_dynamic_ty(gcx, *ty)),
         _ => ty.is_dynamically_encoded(gcx),
     }

--- a/crates/lint/src/sol/low/solmate_safe_transfer_lib.rs
+++ b/crates/lint/src/sol/low/solmate_safe_transfer_lib.rs
@@ -1,10 +1,7 @@
 use super::SolmateSafeTransferLib;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        analysis::{resolved_function, source_in_package},
-    },
+    sol::{Severity, SolLint, analysis::source_in_package},
 };
 use solar::sema::{
     Gcx,
@@ -24,7 +21,7 @@ impl<'gcx> LateLintPass<'gcx> for SolmateSafeTransferLib {
         // used as a value: judge the single declaration the type checker selected (overloads,
         // overrides, `using for` and import aliases already accounted for).
         if matches!(expr.kind, ExprKind::Ident(..) | ExprKind::Member(..))
-            && let Some(function_id) = resolved_function(gcx, expr)
+            && let Some(function_id) = gcx.resolved_function(expr)
             && is_unchecked_token_op(gcx, function_id)
         {
             ctx.emit(&SOLMATE_SAFE_TRANSFER_LIB, expr.span);

--- a/crates/lint/src/sol/med/assert_state_change.rs
+++ b/crates/lint/src/sol/med/assert_state_change.rs
@@ -1,21 +1,14 @@
 use super::AssertStateChange;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        analysis::{
-            for_each_lhs_var, function_ids, is_address_like, is_builtin, receiver_contract_id,
-            resolved_function, ty_contract_id,
-        },
-    },
+    sol::{Severity, SolLint, analysis::for_each_lhs_var},
 };
 use solar::{
-    ast::{DataLocation, ElementaryType},
-    interface::{kw, sym},
+    ast::{DataLocation, StateMutability},
     sema::{
         Gcx,
-        hir::{CallArgs, ContractId, Expr, ExprKind},
-        ty::TyKind,
+        builtins::Builtin,
+        hir::{Expr, ExprKind},
     },
 };
 use std::ops::ControlFlow;
@@ -30,7 +23,7 @@ declare_forge_lint!(
 impl<'gcx> LateLintPass<'gcx> for AssertStateChange {
     fn check_expr(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) {
         let ExprKind::Call(callee, args, _) = &expr.kind else { return };
-        if !is_builtin(callee, sym::assert) {
+        if gcx.resolved_builtin(callee) != Some(Builtin::Assert) {
             return;
         }
         for arg in args.exprs() {
@@ -58,7 +51,7 @@ fn is_state_change<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
     match &expr.kind {
         ExprKind::Assign(lhs, ..) | ExprKind::Delete(lhs) => is_storage_lvalue(gcx, lhs),
         ExprKind::Unary(op, lhs) => op.kind.has_side_effects() && is_storage_lvalue(gcx, lhs),
-        ExprKind::Call(callee, args, _) => is_mutating_call(gcx, callee, args),
+        ExprKind::Call(callee, ..) => is_mutating_call(gcx, callee),
         _ => false,
     }
 }
@@ -67,62 +60,39 @@ fn is_state_change<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
 /// `storage`, which aliases contract storage.
 fn is_storage_lvalue(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let mut found = false;
-    for_each_lhs_var(expr, &mut |v| {
+    for_each_lhs_var(gcx, expr, &mut |v| {
         let v = gcx.hir.variable(v);
         found |= v.is_state_variable() || v.data_location == Some(DataLocation::Storage);
     });
     found
 }
 
-fn is_mutating_call<'gcx>(gcx: Gcx<'gcx>, callee: &Expr<'gcx>, args: &CallArgs<'gcx>) -> bool {
-    let mutates = |fid| gcx.hir.function(fid).mutates_state();
-    if let ExprKind::Member(base, method) = &callee.kind {
+fn is_mutating_call<'gcx>(gcx: Gcx<'gcx>, callee: &Expr<'gcx>) -> bool {
+    if let ExprKind::Member(base, _) = &callee.kind {
         // `arr.push(..)` / `arr.pop()` on a storage array or `bytes`. The type check keeps
         // contract methods that happen to be named push/pop out of this heuristic.
-        if matches!(method.name, sym::push | kw::Pop)
-            && gcx.type_of_expr(base.peel_parens().id).is_some_and(|ty| {
-                matches!(
-                    ty.peel_refs().kind,
-                    TyKind::DynArray(_)
-                        | TyKind::Array(..)
-                        | TyKind::Elementary(ElementaryType::Bytes)
-                )
-            })
-            && is_storage_lvalue(gcx, base)
+        if matches!(
+            gcx.resolved_builtin(callee),
+            Some(Builtin::ArrayPush0 | Builtin::ArrayPush | Builtin::ArrayPop)
+        ) && is_storage_lvalue(gcx, base)
         {
             return true;
         }
         // Low-level address calls always transfer value or execute foreign code. The receiver
         // must be address-like so contract methods named send/call/transfer are not caught.
-        if matches!(method.name, kw::Call | kw::Delegatecall | sym::send | sym::transfer)
-            && is_address_like(gcx, base)
-        {
-            return true;
-        }
-        // Member calls on a contract: flag when any overload with this name and arity mutates,
-        // so a mutating overload is not hidden behind a view one of the same arity.
-        if let Some(cid) = contract_id_of(gcx, base)
-            && gcx.hir.contract_item_ids(cid).filter_map(|item| item.as_function()).any(|fid| {
-                let f = gcx.hir.function(fid);
-                f.name.is_some_and(|n| n.name == method.name)
-                    && f.parameters.len() == args.len()
-                    && mutates(fid)
-            })
-        {
+        if matches!(
+            gcx.resolved_builtin(callee),
+            Some(
+                Builtin::AddressCall
+                    | Builtin::AddressDelegatecall
+                    | Builtin::AddressPayableSend
+                    | Builtin::AddressPayableTransfer
+            )
+        ) {
             return true;
         }
     }
-    // Whatever the type checker resolved (including `using for` extensions), then the same
-    // any-overload-mutates policy for bare internal calls.
-    resolved_function(gcx, callee).is_some_and(mutates)
-        || function_ids(callee)
-            .filter(|&fid| gcx.hir.function(fid).parameters.len() == args.len())
-            .any(mutates)
-}
-
-/// The contract a method-call receiver denotes, including `this`.
-fn contract_id_of<'gcx>(gcx: Gcx<'gcx>, recv: &Expr<'gcx>) -> Option<ContractId> {
-    gcx.type_of_expr(recv.peel_parens().id)
-        .and_then(ty_contract_id)
-        .or_else(|| receiver_contract_id(gcx, recv))
+    gcx.type_of_expr(callee.peel_parens().id)
+        .and_then(|ty| ty.state_mutability())
+        .is_some_and(|mutability| mutability > StateMutability::View)
 }

--- a/crates/lint/src/sol/med/cheatcode_environment.rs
+++ b/crates/lint/src/sol/med/cheatcode_environment.rs
@@ -21,10 +21,7 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{
-            arg_for_param, dispatched_function, for_each_child, is_exit_call, is_inc_dec,
-            loop_update,
-        },
+        analysis::{arg_for_param, dispatched_function, for_each_child, is_exit_call, loop_update},
     },
 };
 use alloy_primitives::{U256, keccak256, uint};
@@ -279,7 +276,7 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
                 .parameters
                 .iter()
                 .map(|&param| {
-                    let value = arg_for_param(&self.gcx.hir, definition, param, &modifier.args)
+                    let value = arg_for_param(self.gcx, id, param, &modifier.args)
                         .map(|arg| self.expr(arg, &mut state))
                         .unwrap_or_default();
                     (param, value)
@@ -508,7 +505,7 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
                 }
             }
             _ => {
-                if let Some(var) = lhs.as_variable()
+                if let Some(var) = self.gcx.resolved_variable(lhs)
                     && !self.gcx.hir.variable(var).is_state_variable()
                 {
                     state.locals.insert(var, value);
@@ -524,7 +521,7 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
             for part in parts.iter().flatten() {
                 self.destination(part, state);
             }
-        } else if expr.as_variable().is_none() {
+        } else if self.gcx.resolved_variable(expr).is_none() {
             for_each_child(expr, &mut |child| {
                 self.expr(child, state);
             });
@@ -588,7 +585,7 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
             state.seen.merge(&value);
             return value;
         }
-        if let Some(var) = expr.as_variable()
+        if let Some(var) = self.gcx.resolved_variable(expr)
             && let Some(value) = state.locals.get(&var)
         {
             self.use_value(value);
@@ -616,12 +613,15 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
             }
             ExprKind::Delete(lhs) => {
                 self.destination(lhs, state);
-                let value =
-                    lhs.as_variable().map(|var| self.default_value(var)).unwrap_or_default();
+                let value = self
+                    .gcx
+                    .resolved_variable(lhs)
+                    .map(|var| self.default_value(var))
+                    .unwrap_or_default();
                 self.bind(lhs, value, state);
                 Value::default()
             }
-            ExprKind::Unary(op, inner) if is_inc_dec(op.kind) => {
+            ExprKind::Unary(op, inner) if op.kind.has_side_effects() => {
                 let before = self.expr(inner, state);
                 let mut value = before.clone();
                 let binary = if matches!(op.kind, UnOpKind::PreInc | UnOpKind::PostInc) {

--- a/crates/lint/src/sol/med/cheatcode_environment.rs
+++ b/crates/lint/src/sol/med/cheatcode_environment.rs
@@ -452,7 +452,7 @@ impl<'gcx> Checker<'_, '_, '_, 'gcx> {
             }
             StmtKind::Expr(expr) | StmtKind::Emit(expr) => {
                 self.expr(expr, &mut state);
-                if is_exit_call(expr) {
+                if is_exit_call(self.gcx, expr) {
                     state.flow = Flow::Halt;
                 }
             }

--- a/crates/lint/src/sol/med/div_mul.rs
+++ b/crates/lint/src/sol/med/div_mul.rs
@@ -7,9 +7,9 @@ use crate::{
     },
 };
 use solar::sema::{
-    Gcx, Hir,
+    Gcx,
     builtins::Builtin,
-    hir::{BinOpKind, Block, Expr, ExprKind, Function, Res, Stmt, StmtKind, VariableId},
+    hir::{BinOpKind, Block, Expr, ExprKind, Function, Stmt, StmtKind, VariableId},
 };
 use std::collections::HashSet;
 
@@ -26,7 +26,7 @@ type Tainted = HashSet<VariableId>;
 impl<'gcx> LateLintPass<'gcx> for DivideBeforeMultiply {
     fn check_function(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, func: &'gcx Function<'gcx>) {
         if let Some(body) = func.body {
-            check_block(ctx, &gcx.hir, body, &mut Tainted::new());
+            check_block(ctx, gcx, body, &mut Tainted::new());
         }
     }
 }
@@ -34,25 +34,25 @@ impl<'gcx> LateLintPass<'gcx> for DivideBeforeMultiply {
 /// Checks `block`, returning `false` once control cannot continue past a statement.
 fn check_block<'gcx>(
     ctx: &LintContext,
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     block: Block<'gcx>,
     tainted: &mut Tainted,
 ) -> bool {
-    block.stmts.iter().all(|stmt| check_stmt(ctx, hir, stmt, tainted))
+    block.stmts.iter().all(|stmt| check_stmt(ctx, gcx, stmt, tainted))
 }
 
 /// Checks the bodies of mutually exclusive branches and keeps the taint of every branch that
 /// falls through, on top of the taint before the branch.
 fn check_branches<'gcx>(
     ctx: &LintContext,
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     blocks: impl Iterator<Item = Block<'gcx>>,
     tainted: &mut Tainted,
 ) {
     let mut merged = Tainted::new();
     for block in blocks {
         let mut branch_tainted = tainted.clone();
-        if check_block(ctx, hir, block, &mut branch_tainted) {
+        if check_block(ctx, gcx, block, &mut branch_tainted) {
             merged.extend(branch_tainted);
         }
     }
@@ -61,47 +61,48 @@ fn check_branches<'gcx>(
 
 fn check_stmt<'gcx>(
     ctx: &LintContext,
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     stmt: &'gcx Stmt<'gcx>,
     tainted: &mut Tainted,
 ) -> bool {
     match &stmt.kind {
         StmtKind::DeclSingle(var_id) => {
-            if let Some(init) = hir.variable(*var_id).initializer {
-                check_expr(ctx, hir, init, tainted);
-                set_taint(hir, *var_id, is_division_or_tainted(init, tainted), tainted);
+            if let Some(init) = gcx.hir.variable(*var_id).initializer {
+                check_expr(ctx, gcx, init, tainted);
+                set_taint(gcx, *var_id, is_division_or_tainted(gcx, init, tainted), tainted);
             }
             true
         }
         StmtKind::DeclMulti(vars, expr) => {
-            check_expr(ctx, hir, expr, tainted);
-            for (var_id, is_tainted) in vars.iter().zip(rhs_taints(expr, vars.len(), tainted)) {
+            check_expr(ctx, gcx, expr, tainted);
+            for (var_id, is_tainted) in vars.iter().zip(rhs_taints(gcx, expr, vars.len(), tainted))
+            {
                 if let Some(var_id) = var_id {
-                    set_taint(hir, *var_id, is_tainted, tainted);
+                    set_taint(gcx, *var_id, is_tainted, tainted);
                 }
             }
             true
         }
         StmtKind::Expr(expr) => {
-            check_expr(ctx, hir, expr, tainted);
+            check_expr(ctx, gcx, expr, tainted);
             !is_revert_call(expr)
         }
         StmtKind::Emit(expr) => {
-            check_expr(ctx, hir, expr, tainted);
+            check_expr(ctx, gcx, expr, tainted);
             true
         }
         StmtKind::Revert(expr) | StmtKind::Return(Some(expr)) => {
-            check_expr(ctx, hir, expr, tainted);
+            check_expr(ctx, gcx, expr, tainted);
             false
         }
         StmtKind::Return(None) => false,
         StmtKind::If(cond, then_stmt, else_stmt) => {
-            check_expr(ctx, hir, cond, tainted);
+            check_expr(ctx, gcx, cond, tainted);
             let mut merged = Tainted::new();
             let mut falls_through = false;
             for branch in [Some(*then_stmt), *else_stmt] {
                 let mut branch_tainted = tainted.clone();
-                if branch.is_none_or(|stmt| check_stmt(ctx, hir, stmt, &mut branch_tainted)) {
+                if branch.is_none_or(|stmt| check_stmt(ctx, gcx, stmt, &mut branch_tainted)) {
                     merged.extend(branch_tainted);
                     falls_through = true;
                 }
@@ -113,119 +114,122 @@ fn check_stmt<'gcx>(
         }
         StmtKind::Loop(block, source) => {
             let mut branch = tainted.clone();
-            if check_block(ctx, hir, *block, &mut branch)
+            if check_block(ctx, gcx, *block, &mut branch)
                 && loop_update(*source)
-                    .is_none_or(|update| check_stmt(ctx, hir, update, &mut branch))
+                    .is_none_or(|update| check_stmt(ctx, gcx, update, &mut branch))
             {
                 tainted.extend(branch);
             }
             true
         }
         StmtKind::Try(try_stmt) => {
-            check_expr(ctx, hir, &try_stmt.expr, tainted);
-            check_branches(ctx, hir, try_stmt.clauses.iter().map(|c| c.block), tainted);
+            check_expr(ctx, gcx, &try_stmt.expr, tainted);
+            check_branches(ctx, gcx, try_stmt.clauses.iter().map(|c| c.block), tainted);
             true
         }
         StmtKind::Switch(switch) => {
-            check_expr(ctx, hir, switch.selector, tainted);
-            check_branches(ctx, hir, switch.cases.iter().map(|c| c.body), tainted);
+            check_expr(ctx, gcx, switch.selector, tainted);
+            check_branches(ctx, gcx, switch.cases.iter().map(|c| c.body), tainted);
             true
         }
         StmtKind::Block(block)
         | StmtKind::UncheckedBlock(block)
-        | StmtKind::AssemblyBlock(block) => check_block(ctx, hir, *block, tainted),
+        | StmtKind::AssemblyBlock(block) => check_block(ctx, gcx, *block, tainted),
         StmtKind::Break | StmtKind::Continue | StmtKind::Placeholder | StmtKind::Err(_) => true,
     }
 }
 
 fn check_expr<'gcx>(
     ctx: &LintContext,
-    hir: &'gcx Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     expr: &'gcx Expr<'gcx>,
     tainted: &mut Tainted,
 ) {
     match &expr.peel_parens().kind {
         ExprKind::Assign(lhs, op, rhs) => {
-            check_expr(ctx, hir, rhs, tainted);
-            check_expr(ctx, hir, lhs, tainted);
+            check_expr(ctx, gcx, rhs, tainted);
+            check_expr(ctx, gcx, lhs, tainted);
             match op.map(|op| op.kind) {
                 None => match tuple_elems(lhs) {
                     Some(elems) => {
                         for (lhs, is_tainted) in
-                            elems.iter().zip(rhs_taints(rhs, elems.len(), tainted))
+                            elems.iter().zip(rhs_taints(gcx, rhs, elems.len(), tainted))
                         {
                             if let Some(lhs) = lhs {
-                                set_lhs_taint(hir, lhs, is_tainted, tainted);
+                                set_lhs_taint(gcx, lhs, is_tainted, tainted);
                             }
                         }
                     }
-                    None => set_lhs_taint(hir, lhs, is_division_or_tainted(rhs, tainted), tainted),
+                    None => {
+                        set_lhs_taint(gcx, lhs, is_division_or_tainted(gcx, rhs, tainted), tainted)
+                    }
                 },
                 Some(BinOpKind::Mul) => {
-                    let is_tainted = is_division_or_tainted(lhs, tainted)
-                        || is_division_or_tainted(rhs, tainted);
+                    let is_tainted = is_division_or_tainted(gcx, lhs, tainted)
+                        || is_division_or_tainted(gcx, rhs, tainted);
                     if is_tainted {
                         ctx.emit(&DIVIDE_BEFORE_MULTIPLY, expr.span);
                     }
-                    set_lhs_taint(hir, lhs, is_tainted, tainted);
+                    set_lhs_taint(gcx, lhs, is_tainted, tainted);
                 }
-                Some(op) => set_lhs_taint(hir, lhs, op == BinOpKind::Div, tainted),
+                Some(op) => set_lhs_taint(gcx, lhs, op == BinOpKind::Div, tainted),
             }
         }
         ExprKind::Binary(left, op, right) => {
-            check_expr(ctx, hir, left, tainted);
-            check_expr(ctx, hir, right, tainted);
+            check_expr(ctx, gcx, left, tainted);
+            check_expr(ctx, gcx, right, tainted);
             if op.kind == BinOpKind::Mul
-                && (is_division_or_tainted(left, tainted) || is_division_or_tainted(right, tainted))
+                && (is_division_or_tainted(gcx, left, tainted)
+                    || is_division_or_tainted(gcx, right, tainted))
             {
                 ctx.emit(&DIVIDE_BEFORE_MULTIPLY, expr.span);
             }
         }
         ExprKind::Call(callee, args, named_args) => {
-            check_expr(ctx, hir, callee, tainted);
+            check_expr(ctx, gcx, callee, tainted);
             for arg in args.exprs() {
-                check_expr(ctx, hir, arg, tainted);
+                check_expr(ctx, gcx, arg, tainted);
             }
             for arg in named_args.iter().flat_map(|opts| opts.args) {
-                check_expr(ctx, hir, &arg.value, tainted);
+                check_expr(ctx, gcx, &arg.value, tainted);
             }
             if is_yul_call(expr, &[Builtin::YulMul])
-                && args.exprs().any(|arg| is_division_or_tainted(arg, tainted))
+                && args.exprs().any(|arg| is_division_or_tainted(gcx, arg, tainted))
             {
                 ctx.emit(&DIVIDE_BEFORE_MULTIPLY, expr.span);
             }
         }
         ExprKind::Ternary(cond, then_expr, else_expr) => {
-            check_expr(ctx, hir, cond, tainted);
+            check_expr(ctx, gcx, cond, tainted);
             let mut then_tainted = tainted.clone();
-            check_expr(ctx, hir, then_expr, &mut then_tainted);
-            check_expr(ctx, hir, else_expr, tainted);
+            check_expr(ctx, gcx, then_expr, &mut then_tainted);
+            check_expr(ctx, gcx, else_expr, tainted);
             tainted.extend(then_tainted);
         }
         ExprKind::Unary(op, inner) => {
-            check_expr(ctx, hir, inner, tainted);
+            check_expr(ctx, gcx, inner, tainted);
             if op.kind.has_side_effects() {
-                set_lhs_taint(hir, inner, false, tainted);
+                set_lhs_taint(gcx, inner, false, tainted);
             }
         }
-        ExprKind::Array(exprs) => exprs.iter().for_each(|e| check_expr(ctx, hir, e, tainted)),
+        ExprKind::Array(exprs) => exprs.iter().for_each(|e| check_expr(ctx, gcx, e, tainted)),
         ExprKind::Tuple(exprs) => {
-            exprs.iter().flatten().for_each(|e| check_expr(ctx, hir, e, tainted))
+            exprs.iter().flatten().for_each(|e| check_expr(ctx, gcx, e, tainted))
         }
         ExprKind::Index(base, index) => {
-            check_expr(ctx, hir, base, tainted);
+            check_expr(ctx, gcx, base, tainted);
             if let Some(index) = index {
-                check_expr(ctx, hir, index, tainted);
+                check_expr(ctx, gcx, index, tainted);
             }
         }
         ExprKind::Slice(base, start, end) => {
-            check_expr(ctx, hir, base, tainted);
-            start.iter().chain(end).for_each(|e| check_expr(ctx, hir, e, tainted));
+            check_expr(ctx, gcx, base, tainted);
+            start.iter().chain(end).for_each(|e| check_expr(ctx, gcx, e, tainted));
         }
         ExprKind::Delete(inner)
         | ExprKind::Member(inner, _)
         | ExprKind::YulMember(inner, _)
-        | ExprKind::Payable(inner) => check_expr(ctx, hir, inner, tainted),
+        | ExprKind::Payable(inner) => check_expr(ctx, gcx, inner, tainted),
         ExprKind::Ident(_)
         | ExprKind::Lit(_)
         | ExprKind::New(_)
@@ -237,31 +241,32 @@ fn check_expr<'gcx>(
 
 /// Taint of each of the `n` slots assigned from `rhs`: elementwise for a tuple of matching arity,
 /// otherwise the taint of the whole expression.
-fn rhs_taints(rhs: &Expr<'_>, n: usize, tainted: &Tainted) -> Vec<bool> {
+fn rhs_taints(gcx: Gcx<'_>, rhs: &Expr<'_>, n: usize, tainted: &Tainted) -> Vec<bool> {
     match tuple_elems(rhs) {
-        Some(elems) if elems.len() == n => {
-            elems.iter().map(|e| e.is_some_and(|e| is_division_or_tainted(e, tainted))).collect()
-        }
-        _ => vec![is_division_or_tainted(rhs, tainted); n],
+        Some(elems) if elems.len() == n => elems
+            .iter()
+            .map(|e| e.is_some_and(|e| is_division_or_tainted(gcx, e, tainted)))
+            .collect(),
+        _ => vec![is_division_or_tainted(gcx, rhs, tainted); n],
     }
 }
 
-fn set_lhs_taint(hir: &Hir<'_>, lhs: &Expr<'_>, is_tainted: bool, tainted: &mut Tainted) {
+fn set_lhs_taint(gcx: Gcx<'_>, lhs: &Expr<'_>, is_tainted: bool, tainted: &mut Tainted) {
     match &lhs.peel_parens().kind {
-        ExprKind::Ident(reses) => {
-            for var_id in reses.iter().filter_map(Res::as_variable) {
-                set_taint(hir, var_id, is_tainted, tainted);
+        ExprKind::Ident(_) => {
+            if let Some(var_id) = gcx.resolved_variable(lhs) {
+                set_taint(gcx, var_id, is_tainted, tainted);
             }
         }
         ExprKind::Tuple(exprs) => {
-            exprs.iter().flatten().for_each(|e| set_lhs_taint(hir, e, is_tainted, tainted))
+            exprs.iter().flatten().for_each(|e| set_lhs_taint(gcx, e, is_tainted, tainted))
         }
         _ => {}
     }
 }
 
-fn set_taint(hir: &Hir<'_>, var_id: VariableId, is_tainted: bool, tainted: &mut Tainted) {
-    if hir.variable(var_id).is_local_or_return() {
+fn set_taint(gcx: Gcx<'_>, var_id: VariableId, is_tainted: bool, tainted: &mut Tainted) {
+    if gcx.hir.variable(var_id).is_local_or_return() {
         if is_tainted {
             tainted.insert(var_id);
         } else {
@@ -271,14 +276,12 @@ fn set_taint(hir: &Hir<'_>, var_id: VariableId, is_tainted: bool, tainted: &mut 
 }
 
 /// The value of `expr` is a division result, directly or through a tainted local.
-fn is_division_or_tainted(expr: &Expr<'_>, tainted: &Tainted) -> bool {
+fn is_division_or_tainted(gcx: Gcx<'_>, expr: &Expr<'_>, tainted: &Tainted) -> bool {
     match &expr.peel_parens().kind {
         ExprKind::Binary(_, op, _) => op.kind == BinOpKind::Div,
-        ExprKind::Ident(reses) => {
-            reses.iter().filter_map(Res::as_variable).any(|v| tainted.contains(&v))
-        }
+        ExprKind::Ident(_) => gcx.resolved_variable(expr).is_some_and(|v| tainted.contains(&v)),
         ExprKind::Call(..) => is_yul_call(expr, &[Builtin::YulDiv, Builtin::YulSdiv]),
-        ExprKind::YulMember(inner, _) => is_division_or_tainted(inner, tainted),
+        ExprKind::YulMember(inner, _) => is_division_or_tainted(gcx, inner, tainted),
         _ => false,
     }
 }

--- a/crates/lint/src/sol/med/div_mul.rs
+++ b/crates/lint/src/sol/med/div_mul.rs
@@ -3,7 +3,7 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{builtins, is_revert_call, loop_update, tuple_elems},
+        analysis::{is_revert_call, loop_update, tuple_elems},
     },
 };
 use solar::sema::{
@@ -85,7 +85,7 @@ fn check_stmt<'gcx>(
         }
         StmtKind::Expr(expr) => {
             check_expr(ctx, gcx, expr, tainted);
-            !is_revert_call(expr)
+            !is_revert_call(gcx, expr)
         }
         StmtKind::Emit(expr) => {
             check_expr(ctx, gcx, expr, tainted);
@@ -193,7 +193,7 @@ fn check_expr<'gcx>(
             for arg in named_args.iter().flat_map(|opts| opts.args) {
                 check_expr(ctx, gcx, &arg.value, tainted);
             }
-            if is_yul_call(expr, &[Builtin::YulMul])
+            if is_yul_call(gcx, expr, &[Builtin::YulMul])
                 && args.exprs().any(|arg| is_division_or_tainted(gcx, arg, tainted))
             {
                 ctx.emit(&DIVIDE_BEFORE_MULTIPLY, expr.span);
@@ -280,14 +280,14 @@ fn is_division_or_tainted(gcx: Gcx<'_>, expr: &Expr<'_>, tainted: &Tainted) -> b
     match &expr.peel_parens().kind {
         ExprKind::Binary(_, op, _) => op.kind == BinOpKind::Div,
         ExprKind::Ident(_) => gcx.resolved_variable(expr).is_some_and(|v| tainted.contains(&v)),
-        ExprKind::Call(..) => is_yul_call(expr, &[Builtin::YulDiv, Builtin::YulSdiv]),
+        ExprKind::Call(..) => is_yul_call(gcx, expr, &[Builtin::YulDiv, Builtin::YulSdiv]),
         ExprKind::YulMember(inner, _) => is_division_or_tainted(gcx, inner, tainted),
         _ => false,
     }
 }
 
 /// A two-argument call to one of the given Yul builtins.
-fn is_yul_call(expr: &Expr<'_>, candidates: &[Builtin]) -> bool {
+fn is_yul_call(gcx: Gcx<'_>, expr: &Expr<'_>, candidates: &[Builtin]) -> bool {
     matches!(&expr.peel_parens().kind, ExprKind::Call(callee, args, _)
-        if args.len() == 2 && builtins(callee).any(|b| candidates.contains(&b)))
+        if args.len() == 2 && gcx.resolved_builtin(callee).is_some_and(|b| candidates.contains(&b)))
 }

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -3,7 +3,7 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{is_exit_call, is_inc_dec, is_require_or_assert, loop_update, tuple_elems},
+        analysis::{is_exit_call, is_require_or_assert, loop_update, tuple_elems},
     },
 };
 use alloy_primitives::{U256, uint};
@@ -15,8 +15,8 @@ use solar::{
         builtins::Builtin,
         eval::ConstValue,
         hir::{
-            self, Expr, ExprId, ExprKind, ItemId, LoopSource, Res, StateMutability, Stmt, StmtKind,
-            TypeKind, VariableId, Visit,
+            self, Expr, ExprId, ExprKind, LoopSource, StateMutability, Stmt, StmtKind, TypeKind,
+            VariableId, Visit,
         },
         ty::TyKind,
     },
@@ -268,9 +268,9 @@ impl<'gcx> Analyzer<'gcx> {
                 self.place_key(args.exprs().next()?)
             }
             ExprKind::Member(base, field) => {
-                var_of(base).map(|var| self.state.field_key(var, field.name))
+                var_of(self.gcx, base).map(|var| self.state.field_key(var, field.name))
             }
-            _ => var_of(expr).map(ValueKey::Var),
+            _ => var_of(self.gcx, expr).map(ValueKey::Var),
         }
     }
 
@@ -299,7 +299,7 @@ impl<'gcx> Analyzer<'gcx> {
         receiver
             .into_iter()
             .chain(args.exprs())
-            .filter_map(var_of)
+            .filter_map(|expr| var_of(self.gcx, expr))
             .filter(|&var| {
                 matches!(
                     self.gcx.hir.variable(var).data_location,
@@ -821,7 +821,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
                     self.assign(key, (None, true));
                 }
             }
-            ExprKind::Unary(op, target) if is_inc_dec(op.kind) => {
+            ExprKind::Unary(op, target) if op.kind.has_side_effects() => {
                 let _ = self.walk_expr(expr);
                 if let Some(key) = self.place_key(target) {
                     self.assign(key, (None, false));
@@ -863,7 +863,7 @@ impl<'gcx> Visit<'gcx> for SideEffects<'_, 'gcx> {
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<()> {
         match &expr.kind {
             ExprKind::Assign(..) | ExprKind::Delete(_) => ControlFlow::Break(()),
-            ExprKind::Unary(op, _) if is_inc_dec(op.kind) => ControlFlow::Break(()),
+            ExprKind::Unary(op, _) if op.kind.has_side_effects() => ControlFlow::Break(()),
             ExprKind::Call(callee, ..) if call_may_mutate_state(self.0.gcx, callee) => {
                 ControlFlow::Break(())
             }
@@ -889,11 +889,11 @@ impl<'gcx> Visit<'gcx> for SideEffects<'_, 'gcx> {
 }
 
 /// The variable an expression denotes, through parens and `uint256(..)`/`bytes32(..)` casts.
-fn var_of(expr: &Expr<'_>) -> Option<VariableId> {
+fn var_of(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<VariableId> {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().find_map(Res::as_variable),
+        ExprKind::Ident(_) => gcx.resolved_variable(expr),
         ExprKind::Call(callee, args, _) if is_transparent_cast(callee) && args.len() == 1 => {
-            args.exprs().next().and_then(var_of)
+            args.exprs().next().and_then(|expr| var_of(gcx, expr))
         }
         _ => None,
     }
@@ -943,14 +943,5 @@ fn call_may_mutate_state(gcx: Gcx<'_>, callee: &Expr<'_>) -> bool {
     {
         return function.state_mutability > StateMutability::View;
     }
-    match &callee.kind {
-        ExprKind::Ident(reses) => !reses.iter().all(|res| match res {
-            Res::Builtin(_) => true,
-            Res::Item(ItemId::Function(id)) => {
-                gcx.hir.function(*id).state_mutability <= StateMutability::View
-            }
-            _ => false,
-        }),
-        _ => true,
-    }
+    gcx.resolved_builtin(callee).is_none()
 }

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -703,7 +703,7 @@ impl<'gcx> Analyzer<'gcx> {
                         let _ = self.visit_expr(expr);
                     }
                 }
-                !is_exit_call(expr)
+                !is_exit_call(self.gcx, expr)
             }
             StmtKind::AssemblyBlock(_) | StmtKind::Err(_) => {
                 // Inline assembly is opaque and may observe any local before changing it. Flush
@@ -800,7 +800,7 @@ impl<'gcx> Visit<'gcx> for Analyzer<'gcx> {
                     },
                 );
             }
-            ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
+            ExprKind::Call(callee, args, _) if is_require_or_assert(self.gcx, callee) => {
                 let _ = self.walk_expr(expr);
                 if let Some(cond) = args.exprs().next() {
                     self.assume(cond, false);

--- a/crates/lint/src/sol/med/incorrect_strict_equality.rs
+++ b/crates/lint/src/sol/med/incorrect_strict_equality.rs
@@ -1,16 +1,13 @@
 use super::IncorrectStrictEquality;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{
-        Severity, SolLint,
-        analysis::{expr_is_address, referenced_item},
-    },
+    sol::{Severity, SolLint, analysis::referenced_item},
 };
 use solar::{
     ast::BinOpKind,
-    interface::kw,
     sema::{
         Gcx,
+        builtins::Builtin,
         hir::{Expr, ExprKind, ItemId},
     },
 };
@@ -50,7 +47,7 @@ impl<'gcx> LateLintPass<'gcx> for IncorrectStrictEquality {
 /// method), skipping static library calls to avoid internal helpers of the same name.
 fn is_externally_influenced<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
     match &expr.peel_parens().kind {
-        ExprKind::Member(base, member) => member.name == kw::Balance && expr_is_address(gcx, base),
+        ExprKind::Member(..) => gcx.resolved_builtin(expr) == Some(Builtin::AddressBalance),
         ExprKind::Call(callee, ..) => {
             matches!(&callee.peel_parens().kind, ExprKind::Member(base, m)
                 if m.as_str() == "balanceOf"

--- a/crates/lint/src/sol/med/incorrect_strict_equality.rs
+++ b/crates/lint/src/sol/med/incorrect_strict_equality.rs
@@ -3,7 +3,7 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{is_address_like, referenced_item},
+        analysis::{expr_is_address, referenced_item},
     },
 };
 use solar::{
@@ -50,11 +50,11 @@ impl<'gcx> LateLintPass<'gcx> for IncorrectStrictEquality {
 /// method), skipping static library calls to avoid internal helpers of the same name.
 fn is_externally_influenced<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
     match &expr.peel_parens().kind {
-        ExprKind::Member(base, member) => member.name == kw::Balance && is_address_like(gcx, base),
+        ExprKind::Member(base, member) => member.name == kw::Balance && expr_is_address(gcx, base),
         ExprKind::Call(callee, ..) => {
             matches!(&callee.peel_parens().kind, ExprKind::Member(base, m)
                 if m.as_str() == "balanceOf"
-                    && !matches!(referenced_item(base), Some(ItemId::Contract(cid))
+                    && !matches!(referenced_item(gcx, base), Some(ItemId::Contract(cid))
                         if gcx.hir.contract(cid).kind.is_library()))
         }
         _ => false,

--- a/crates/lint/src/sol/med/locked_ether.rs
+++ b/crates/lint/src/sol/med/locked_ether.rs
@@ -5,19 +5,18 @@ use crate::{
         Severity, SolLint,
         analysis::{
             block_outcome, expr_is_address, is_address_self, is_builtin, is_contract_cast,
-            is_literal_zero,
+            is_literal_zero, runtime_entry_points,
         },
     },
 };
 use solar::{
-    ast::{ContractKind, StateMutability, Visibility},
+    ast::{ContractKind, StateMutability},
     interface::{Span, kw, sym},
     sema::{
         Gcx,
         builtins::Builtin,
         hir::{
-            self, Block, ContractId, ExprKind, FunctionId, FunctionKind, ItemId, Res, StmtKind,
-            TypeKind, Visit,
+            self, Block, ContractId, ExprKind, FunctionId, ItemId, Res, StmtKind, TypeKind, Visit,
         },
     },
 };
@@ -48,11 +47,12 @@ impl<'gcx> LateLintPass<'gcx> for LockedEther {
 
         let receives = |fid: FunctionId| {
             let func = gcx.hir.function(fid);
-            func.state_mutability == StateMutability::Payable && !always_reverts(gcx, func)
+            func.state_mutability == StateMutability::Payable
+                && !always_reverts(gcx, contract_id, func)
         };
         // Runtime entries and the constructor are separate inflow channels: only the leaf's own
         // constructor receives deployment value, and it has no runtime exit path.
-        let entries = runtime_dispatch_surface(gcx, contract.linearized_bases);
+        let entries = runtime_entry_points(gcx, contract_id);
         if !entries.iter().any(|&fid| receives(fid)) && !contract.ctor.is_some_and(receives) {
             return;
         }
@@ -60,18 +60,18 @@ impl<'gcx> LateLintPass<'gcx> for LockedEther {
         // Explore the runtime entries and, transitively, the helpers and modifiers they reach.
         // Constructor bodies are excluded so their exits don't count.
         let mut visited = HashSet::new();
-        let mut checker = SendChecker { gcx, bases: contract.linearized_bases, worklist: entries };
+        let mut checker = SendChecker { gcx, contract_id, worklist: entries };
         while let Some(fid) = checker.worklist.pop() {
             let func = gcx.hir.function(fid);
             // Any ETH movement inside an always-reverting function rolls back.
-            if !visited.insert(fid) || always_reverts(gcx, func) {
+            if !visited.insert(fid) || always_reverts(gcx, contract_id, func) {
                 continue;
             }
             for modifier in func.modifiers {
                 if checker.visit_call_args(&modifier.args).is_break() {
                     return;
                 }
-                checker.worklist.extend(modifier.id.as_function());
+                checker.worklist.extend(gcx.resolve_modifier_target(contract_id, modifier));
             }
             if let Some(body) = func.body
                 && body.stmts.iter().any(|stmt| checker.visit_stmt(stmt).is_break())
@@ -86,13 +86,15 @@ impl<'gcx> LateLintPass<'gcx> for LockedEther {
 
 /// True if invoking `func` always reverts, through its body or an attached modifier (one that
 /// reverts before its first `_` or after its last one).
-fn always_reverts(gcx: Gcx<'_>, func: &hir::Function<'_>) -> bool {
+fn always_reverts(gcx: Gcx<'_>, contract: ContractId, func: &hir::Function<'_>) -> bool {
     let reverts = |stmts: &[hir::Stmt<'_>]| {
         !block_outcome(Block { span: Span::DUMMY, stmts }).can_skip_placeholder()
     };
     func.body.is_some_and(|body| reverts(body.stmts))
         || func.modifiers.iter().any(|m| {
-            let Some(body) = m.id.as_function().and_then(|id| gcx.hir.function(id).body) else {
+            let Some(body) =
+                gcx.resolve_modifier_target(contract, m).and_then(|id| gcx.hir.function(id).body)
+            else {
                 return false;
             };
             let is_placeholder = |s: &hir::Stmt<'_>| matches!(s.kind, StmtKind::Placeholder);
@@ -104,63 +106,13 @@ fn always_reverts(gcx: Gcx<'_>, func: &hir::Function<'_>) -> bool {
         })
 }
 
-/// Runtime entry points reachable on the deployed contract: the most-derived implementation of
-/// each `(name, parameter types)` plus the most-derived `receive` / `fallback`. `bases` must be
-/// the C3 linearization (leaf first). Constructors and modifiers are excluded.
-fn runtime_dispatch_surface<'gcx>(gcx: Gcx<'gcx>, bases: &[ContractId]) -> Vec<FunctionId> {
-    let mut seen = HashSet::new();
-    let mut out = Vec::new();
-    for fid in bases.iter().flat_map(|&cid| gcx.hir.contract(cid).all_functions()) {
-        let func = gcx.hir.function(fid);
-        let params = match func.kind {
-            FunctionKind::Function
-                if matches!(func.visibility, Visibility::Public | Visibility::External) =>
-            {
-                gcx.item_parameter_types(fid)
-            }
-            FunctionKind::Receive | FunctionKind::Fallback => &[],
-            _ => continue,
-        };
-        if seen.insert((func.kind, func.name.map(|n| n.name), params)) {
-            out.push(fid);
-        }
-    }
-    out
-}
-
 /// HIR visitor that short-circuits on the first ETH-sending expression and queues statically
 /// resolved callees for transitive exploration by the outer worklist loop.
 struct SendChecker<'gcx> {
     gcx: Gcx<'gcx>,
-    /// Linearization of the linted contract, which resolves virtual dispatch.
-    bases: &'gcx [ContractId],
+    /// The linted contract, which resolves virtual dispatch.
+    contract_id: ContractId,
     worklist: Vec<FunctionId>,
-}
-
-impl SendChecker<'_> {
-    /// Redirects `fid` to the linted contract's most-derived override of the same `(name,
-    /// parameter types)`. Functions not inheritable from it (free functions, library helpers,
-    /// private functions, constructors and modifiers) are returned as-is.
-    fn resolve_virtual(&self, fid: FunctionId) -> FunctionId {
-        let func = self.gcx.hir.function(fid);
-        if !func.contract.is_some_and(|origin| self.bases.contains(&origin))
-            || func.visibility == Visibility::Private
-            || func.kind != FunctionKind::Function
-        {
-            return fid;
-        }
-        let Some(name) = func.name else { return fid };
-        let params = self.gcx.item_parameter_types(fid);
-        self.bases
-            .iter()
-            .flat_map(|&cid| self.gcx.hir.contract(cid).functions())
-            .find(|&candidate| {
-                let c = self.gcx.hir.function(candidate);
-                c.name.is_some_and(|n| n.name == name.name)
-                    && self.gcx.item_parameter_types(candidate) == params
-            })
-            .unwrap_or(fid)
-    }
 }
 
 impl<'gcx> Visit<'gcx> for SendChecker<'gcx> {
@@ -191,7 +143,11 @@ impl<'gcx> Visit<'gcx> for SendChecker<'gcx> {
                     // call dispatches through the leaf's linearization.
                     let direct = matches!(&callee.peel_parens().kind, ExprKind::Member(base, _)
                         if is_builtin(base, sym::super_) || is_contract_cast(base));
-                    self.worklist.push(if direct { fid } else { self.resolve_virtual(fid) });
+                    self.worklist.push(if direct {
+                        fid
+                    } else {
+                        self.gcx.resolve_virtual_function(self.contract_id, fid)
+                    });
                 }
                 // Function-typed variable: the bound target is unknown, treat the call as opaque.
                 Some(Res::Item(ItemId::Variable(id)))

--- a/crates/lint/src/sol/med/locked_ether.rs
+++ b/crates/lint/src/sol/med/locked_ether.rs
@@ -88,7 +88,7 @@ impl<'gcx> LateLintPass<'gcx> for LockedEther {
 /// reverts before its first `_` or after its last one).
 fn always_reverts(gcx: Gcx<'_>, contract: ContractId, func: &hir::Function<'_>) -> bool {
     let reverts = |stmts: &[hir::Stmt<'_>]| {
-        !block_outcome(Block { span: Span::DUMMY, stmts }).can_skip_placeholder()
+        !block_outcome(gcx, Block { span: Span::DUMMY, stmts }).can_skip_placeholder()
     };
     func.body.is_some_and(|body| reverts(body.stmts))
         || func.modifiers.iter().any(|m| {
@@ -142,7 +142,7 @@ impl<'gcx> Visit<'gcx> for SendChecker<'gcx> {
                     // `super.f()`, `Base.f()` and `Lib.f()` name one implementation; every other
                     // call dispatches through the leaf's linearization.
                     let direct = matches!(&callee.peel_parens().kind, ExprKind::Member(base, _)
-                        if is_builtin(base, sym::super_) || is_contract_cast(base));
+                        if is_builtin(self.gcx, base, sym::super_) || is_contract_cast(self.gcx, base));
                     self.worklist.push(if direct {
                         fid
                     } else {
@@ -175,7 +175,7 @@ fn expr_sends_ether<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx hir::Expr<'gcx>) -> bool {
     };
     if opts.is_some_and(|opts| {
         opts.args.iter().any(|arg| arg.name.name == sym::value && !is_literal_zero(&arg.value))
-    }) && !receiver.is_some_and(|r| is_address_self(r))
+    }) && !receiver.is_some_and(|r| is_address_self(gcx, r))
     {
         return true;
     }
@@ -183,7 +183,7 @@ fn expr_sends_ether<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx hir::Expr<'gcx>) -> bool {
         // Only address-typed receivers can move ETH out: `.transfer`/`.send` on a contract type
         // dispatch to a user-defined member.
         ExprKind::Member(receiver, member)
-            if expr_is_address(gcx, receiver) && !is_address_self(receiver) =>
+            if expr_is_address(gcx, receiver) && !is_address_self(gcx, receiver) =>
         {
             match member.name {
                 // Single-arg form, to tell it apart from ERC20's 2-arg `transfer`.
@@ -197,11 +197,9 @@ fn expr_sends_ether<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx hir::Expr<'gcx>) -> bool {
                 _ => true,
             }
         }
-        ExprKind::Ident(reses)
-            if reses.iter().any(|r| matches!(r, Res::Builtin(Builtin::Selfdestruct))) =>
-        {
+        ExprKind::Ident(_) if gcx.resolved_builtin(callee) == Some(Builtin::Selfdestruct) => {
             // `selfdestruct(self)` burns the balance in place.
-            !args.exprs().next().is_some_and(is_address_self)
+            !args.exprs().next().is_some_and(|expr| is_address_self(gcx, expr))
         }
         _ => false,
     }

--- a/crates/lint/src/sol/med/mapping_deletion.rs
+++ b/crates/lint/src/sol/med/mapping_deletion.rs
@@ -6,7 +6,6 @@ use crate::{
 use solar::sema::{
     Gcx,
     hir::{self, ExprKind},
-    ty::{Ty, TyKind},
 };
 
 declare_forge_lint!(
@@ -20,29 +19,9 @@ impl<'gcx> LateLintPass<'gcx> for MappingDeletion {
     fn check_expr(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, expr: &'gcx hir::Expr<'gcx>) {
         if let ExprKind::Delete(operand) = &expr.kind
             && let Some(ty) = gcx.type_of_expr(operand.peel_parens().id)
-            && ty_contains_mapping(gcx, ty, &mut Vec::new())
+            && ty.has_mapping(gcx)
         {
             ctx.emit(&MAPPING_DELETION, expr.span);
         }
-    }
-}
-
-/// True if `ty` is, or transitively contains, a `mapping`. `delete` cannot enumerate a mapping's
-/// keys, so the entries survive. `seen` guards against recursive struct definitions.
-fn ty_contains_mapping<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>, seen: &mut Vec<hir::StructId>) -> bool {
-    match ty.peel_refs().kind {
-        TyKind::Mapping(..) => true,
-        TyKind::Array(elem, _) | TyKind::DynArray(elem) | TyKind::Slice(elem) => {
-            ty_contains_mapping(gcx, elem, seen)
-        }
-        TyKind::Struct(id) if !seen.contains(&id) => {
-            seen.push(id);
-            gcx.hir
-                .strukt(id)
-                .fields
-                .iter()
-                .any(|&field| ty_contains_mapping(gcx, gcx.type_of_item(field.into()), seen))
-        }
-        _ => false,
     }
 }

--- a/crates/lint/src/sol/med/mod.rs
+++ b/crates/lint/src/sol/med/mod.rs
@@ -41,6 +41,6 @@ register_lints!(
     locked_ether: (LockedEther, late, (LOCKED_ETHER));
     mapping_deletion: (MappingDeletion, late, (MAPPING_DELETION));
     non_reentrant_not_first: (NonReentrantNotFirst, late, (NON_REENTRANT_NOT_FIRST));
-    weak_prng: (WeakPrng, early, (WEAK_PRNG));
+    weak_prng: (WeakPrng, late, (WEAK_PRNG));
     tautological_compare: (TautologicalCompare, late, (TAUTOLOGICAL_COMPARE));
 );

--- a/crates/lint/src/sol/med/tautology.rs
+++ b/crates/lint/src/sol/med/tautology.rs
@@ -8,7 +8,8 @@ use solar::{
     ast::{BinOpKind, LitKind, UnOpKind},
     sema::{
         Gcx,
-        hir::{self, ElementaryType, Expr, ExprKind, TypeKind, VariableId},
+        hir::{ElementaryType, Expr, ExprKind, VariableId},
+        ty::TyKind,
     },
 };
 use std::cmp::Ordering;
@@ -27,11 +28,11 @@ impl<'gcx> LateLintPass<'gcx> for TypeBasedTautology {
         // A pair of comparisons can cover the complete type range even when neither is
         // tautological on its own, e.g. `x > 0 || x == 0` for `uint`.
         let is_tautology = if op.kind == BinOpKind::Or {
-            matches!((comparison_of(&gcx.hir, left), comparison_of(&gcx.hir, right)),
+            matches!((comparison_of(gcx, left), comparison_of(gcx, right)),
                 (Some(l), Some(r)) if is_boundary_composition(&l, &r))
         } else {
             split_comparison(expr).is_some_and(|(operand, val, op)| {
-                elem_type_of(&gcx.hir, operand)
+                elem_type_of(gcx, operand)
                     .and_then(integer_bounds)
                     .is_some_and(|range| is_tautology(range, val, op))
             })
@@ -114,9 +115,9 @@ struct Comparison {
 }
 
 /// A comparison of one resolved integer variable (possibly cast) against a constant.
-fn comparison_of<'gcx>(hir: &hir::Hir<'gcx>, expr: &'gcx Expr<'gcx>) -> Option<Comparison> {
+fn comparison_of<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> Option<Comparison> {
     let (operand, val, op) = split_comparison(expr)?;
-    let (variable, cast_path, range) = comparison_operand_of(hir, operand)?;
+    let (variable, cast_path, range) = comparison_operand_of(gcx, operand)?;
     Some(Comparison { variable, cast_path, range, op, val })
 }
 
@@ -141,20 +142,20 @@ fn is_boundary_composition(l: &Comparison, r: &Comparison) -> bool {
 /// distinguishes the operand from the uncast expression; any other cast resets the range to the
 /// target type's and becomes part of the operand's identity.
 fn comparison_operand_of<'gcx>(
-    hir: &hir::Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     expr: &'gcx Expr<'gcx>,
 ) -> Option<(VariableId, Vec<ElementaryType>, Range)> {
     match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => {
-            let variable = reses.first()?.as_variable()?;
-            let TypeKind::Elementary(ty) = hir.variable(variable).ty.kind else { return None };
+        ExprKind::Ident(_) => {
+            let variable = gcx.resolved_variable(expr)?;
+            let ty = elem_type_of(gcx, expr)?;
             Some((variable, Vec::new(), integer_bounds(ty)?))
         }
         ExprKind::Call(callee, args, _) if args.len() == 1 => {
             let ty = cast_type(callee)?;
             let inner = args.exprs().next()?;
-            let (variable, mut cast_path, range) = comparison_operand_of(hir, inner)?;
-            let source = elem_type_of(hir, inner)?;
+            let (variable, mut cast_path, range) = comparison_operand_of(gcx, inner)?;
+            let source = elem_type_of(gcx, inner)?;
             let widening = match (source, ty) {
                 (ElementaryType::UInt(from), ElementaryType::UInt(to))
                 | (ElementaryType::Int(from), ElementaryType::Int(to)) => from.bits() <= to.bits(),
@@ -170,14 +171,10 @@ fn comparison_operand_of<'gcx>(
     }
 }
 
-/// The elementary type of a variable reference or of an explicit cast's target.
-fn elem_type_of(hir: &hir::Hir<'_>, expr: &Expr<'_>) -> Option<ElementaryType> {
-    match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => match hir.variable(reses.first()?.as_variable()?).ty.kind {
-            TypeKind::Elementary(ty) => Some(ty),
-            _ => None,
-        },
-        ExprKind::Call(callee, ..) => cast_type(callee),
+/// The elementary type selected by the type checker.
+fn elem_type_of(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<ElementaryType> {
+    match gcx.type_of_expr(expr.peel_parens().id)?.peel_refs().kind {
+        TyKind::Elementary(ty) => Some(ty),
         _ => None,
     }
 }

--- a/crates/lint/src/sol/med/uninitialized_local.rs
+++ b/crates/lint/src/sol/med/uninitialized_local.rs
@@ -12,7 +12,7 @@ use solar::{
     sema::{
         Gcx, Hir,
         hir::{
-            BinOpKind, Block, Expr, ExprKind, Function, LoopSource, Res, Stmt, StmtKind, TypeKind,
+            BinOpKind, Block, Expr, ExprKind, Function, LoopSource, Stmt, StmtKind, TypeKind,
             UnOpKind, VarKind, VariableId, Visit,
         },
     },
@@ -33,7 +33,7 @@ impl<'gcx> LateLintPass<'gcx> for UninitializedLocal {
     fn check_function(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, func: &'gcx Function<'gcx>) {
         let Some(body) = func.body else { return };
         let mut checker =
-            Checker { hir: &gcx.hir, uninitialized: HashSet::new(), findings: HashMap::new() };
+            Checker { gcx, hir: &gcx.hir, uninitialized: HashSet::new(), findings: HashMap::new() };
         for stmt in body.stmts {
             let _ = checker.visit_stmt(stmt);
         }
@@ -44,6 +44,7 @@ impl<'gcx> LateLintPass<'gcx> for UninitializedLocal {
 }
 
 struct Checker<'gcx> {
+    gcx: Gcx<'gcx>,
     hir: &'gcx Hir<'gcx>,
     /// Value-type locals declared without an initializer that have not yet been written on
     /// every path.
@@ -54,7 +55,7 @@ struct Checker<'gcx> {
 
 impl Checker<'_> {
     fn mark_written(&mut self, lhs: &Expr<'_>) {
-        for_each_lhs_var(lhs, &mut |v| {
+        for_each_lhs_var(self.gcx, lhs, &mut |v| {
             self.uninitialized.remove(&v);
         });
     }
@@ -65,25 +66,26 @@ impl Checker<'_> {
 /// the update on the loop source; matching the wrapper's span keeps declarations outside the
 /// header distinct.
 fn defaulted_counter_loop<'gcx>(
-    hir: &Hir<'gcx>,
+    gcx: Gcx<'gcx>,
     block: &'gcx Block<'gcx>,
 ) -> Option<&'gcx Stmt<'gcx>> {
     if let [Stmt { kind: StmtKind::DeclSingle(vid), .. }, loop_stmt] = block.stmts
         && block.span == loop_stmt.span
         && let StmtKind::Loop(body, LoopSource::For { update: Some(update) }) = &loop_stmt.kind
-        && let var = hir.variable(*vid)
+        && let var = gcx.hir.variable(*vid)
         && var.initializer.is_none()
         && matches!(var.ty.kind, TypeKind::Elementary(ElementaryType::UInt(_)))
         && let [Stmt { kind: StmtKind::If(cond, _, Some(else_)), .. }] = body.stmts
         && matches!(else_.kind, StmtKind::Break)
         && let ExprKind::Binary(left, op, right) = &cond.peel_parens().kind
-        && ((matches!(op.kind, BinOpKind::Lt | BinOpKind::Le) && left.as_variable() == Some(*vid))
+        && ((matches!(op.kind, BinOpKind::Lt | BinOpKind::Le)
+            && gcx.resolved_variable(left) == Some(*vid))
             || (matches!(op.kind, BinOpKind::Gt | BinOpKind::Ge)
-                && right.as_variable() == Some(*vid)))
+                && gcx.resolved_variable(right) == Some(*vid)))
         && let StmtKind::Expr(update) = &update.kind
         && let ExprKind::Unary(op, target) = &update.peel_parens().kind
         && matches!(op.kind, UnOpKind::PreInc | UnOpKind::PostInc)
-        && target.as_variable() == Some(*vid)
+        && gcx.resolved_variable(target) == Some(*vid)
     {
         Some(loop_stmt)
     } else {
@@ -101,7 +103,7 @@ impl<'gcx> Visit<'gcx> for Checker<'gcx> {
     fn visit_stmt(&mut self, stmt: &'gcx Stmt<'gcx>) -> ControlFlow<Never> {
         match &stmt.kind {
             StmtKind::Block(block) => {
-                if let Some(loop_stmt) = defaulted_counter_loop(self.hir, block) {
+                if let Some(loop_stmt) = defaulted_counter_loop(self.gcx, block) {
                     // Skip only the counter's declaration; all reads in the loop still run
                     // through the ordinary checker, including reads of other locals.
                     return self.visit_stmt(loop_stmt);
@@ -186,11 +188,9 @@ impl<'gcx> Visit<'gcx> for Checker<'gcx> {
                 self.mark_written(target);
                 self.visit_expr(target)
             }
-            ExprKind::Ident(reses) => {
-                if let Some(vid) = reses
-                    .iter()
-                    .filter_map(Res::as_variable)
-                    .find(|v| self.uninitialized.contains(v))
+            ExprKind::Ident(_) => {
+                if let Some(vid) =
+                    self.gcx.resolved_variable(expr).filter(|v| self.uninitialized.contains(v))
                 {
                     self.findings.entry(vid).or_insert(expr.span);
                 }

--- a/crates/lint/src/sol/med/uninitialized_local.rs
+++ b/crates/lint/src/sol/med/uninitialized_local.rs
@@ -113,7 +113,7 @@ impl<'gcx> Visit<'gcx> for Checker<'gcx> {
                 let v = self.hir.variable(*vid);
                 if v.kind == VarKind::Statement
                     && v.initializer.is_none()
-                    && matches!(v.ty.kind, TypeKind::Elementary(ty) if ty.is_value_type())
+                    && self.gcx.type_of_item((*vid).into()).is_value_type()
                 {
                     self.uninitialized.insert(*vid);
                 }
@@ -127,9 +127,9 @@ impl<'gcx> Visit<'gcx> for Checker<'gcx> {
                 if let Some(else_) = else_ {
                     self.visit_stmt(else_)?;
                 }
-                if branch_always_exits(then) {
+                if branch_always_exits(self.gcx, then) {
                     // Only the else path continues; keep its state.
-                } else if else_.is_some_and(branch_always_exits) {
+                } else if else_.is_some_and(|expr| branch_always_exits(self.gcx, expr)) {
                     self.uninitialized = after_then;
                 } else {
                     self.uninitialized.extend(after_then);

--- a/crates/lint/src/sol/med/uninitialized_state_variables.rs
+++ b/crates/lint/src/sol/med/uninitialized_state_variables.rs
@@ -3,17 +3,17 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{is_builtin, referenced_item, tuple_elems},
+        analysis::{referenced_item, tuple_elems},
     },
 };
 use solar::{
     ast::ContractKind,
-    interface::{data_structures::Never, sym},
+    interface::data_structures::Never,
     sema::{
         Gcx, Hir,
         hir::{
-            CallArgs, CallArgsKind, Contract, ContractId, DataLocation, Expr, ExprKind, Function,
-            ItemId, Res, Stmt, StmtKind, TypeKind, VariableId, Visit,
+            Contract, ContractId, DataLocation, Expr, ExprKind, Function, Stmt, StmtKind, TypeKind,
+            VariableId, Visit,
         },
     },
 };
@@ -50,7 +50,7 @@ impl<'gcx> LateLintPass<'gcx> for UninitializedStateVariables {
         let bases = contract.linearized_bases;
         let mut collector = Collector {
             hir: &gcx.hir,
-            bases,
+            gcx,
             read: HashSet::new(),
             written: HashSet::new(),
             aliases: HashMap::new(),
@@ -78,7 +78,7 @@ impl<'gcx> LateLintPass<'gcx> for UninitializedStateVariables {
 
 struct Collector<'gcx> {
     hir: &'gcx Hir<'gcx>,
-    bases: &'gcx [ContractId],
+    gcx: Gcx<'gcx>,
     read: HashSet<VariableId>,
     written: HashSet<VariableId>,
     /// State variables each local `storage` pointer of the current function may reference.
@@ -99,8 +99,8 @@ impl<'gcx> Collector<'gcx> {
     /// destructuring) as written; a write through a `storage` pointer writes its targets.
     fn mark_written(&mut self, expr: &Expr<'_>) {
         match &expr.peel_parens().kind {
-            ExprKind::Ident([Res::Item(id), ..]) => {
-                if let Some(id) = id.as_variable() {
+            ExprKind::Ident(_) => {
+                if let Some(id) = self.gcx.resolved_variable(expr) {
                     self.written.insert(id);
                     if let Some(targets) = self.aliases.get(&id) {
                         self.written.extend(targets);
@@ -115,66 +115,19 @@ impl<'gcx> Collector<'gcx> {
         }
     }
 
-    /// Internal functions that take a `storage` parameter mutate the corresponding argument in
-    /// place. Overloads are not resolved, so an argument counts as written when *any* candidate
-    /// of the callee's name has a `storage` parameter in that position (or of that name).
-    fn mark_storage_args(&mut self, callee: &'gcx Expr<'gcx>, args: &'gcx CallArgs<'gcx>) {
-        let funcs = self.callee_candidates(callee);
-        let is_storage =
-            |pid: &VariableId| self.hir.variable(*pid).data_location == Some(DataLocation::Storage);
-        match args.kind {
-            CallArgsKind::Unnamed(exprs) => {
-                for (i, arg) in exprs.iter().enumerate() {
-                    if funcs.iter().any(|f| f.parameters.get(i).is_some_and(is_storage)) {
-                        self.mark_written(arg);
-                    }
+    /// A call taking a `storage` parameter may write through its corresponding argument.
+    fn mark_storage_args(&mut self, call: &'gcx Expr<'gcx>) {
+        if let ExprKind::Call(callee, ..) = &call.kind
+            && let Some(parameters) =
+                self.gcx.type_of_expr(callee.id).and_then(|ty| ty.parameters())
+        {
+            for (index, ty) in parameters.iter().enumerate() {
+                if ty.is_ref_at(DataLocation::Storage)
+                    && let Some(arg) = self.gcx.call_arg(call, index)
+                {
+                    self.mark_written(arg);
                 }
             }
-            CallArgsKind::Named(named) => {
-                for arg in named {
-                    if funcs.iter().any(|f| {
-                        f.parameters.iter().any(|pid| {
-                            self.hir.variable(*pid).name.is_some_and(|n| n.name == arg.name.name)
-                                && is_storage(pid)
-                        })
-                    }) {
-                        self.mark_written(&arg.value);
-                    }
-                }
-            }
-        }
-    }
-
-    /// Functions a call may dispatch to: `f(..)`, `Contract.f(..)`, or `super.f(..)`, which
-    /// resolves through the parent MRO entries only (never the current contract).
-    fn callee_candidates(&self, callee: &'gcx Expr<'gcx>) -> Vec<&'gcx Function<'gcx>> {
-        match &callee.kind {
-            ExprKind::Ident(reses) => {
-                reses.iter().filter_map(Res::as_function).map(|f| self.hir.function(f)).collect()
-            }
-            ExprKind::Member(base, method) => {
-                let contracts = if is_builtin(base, sym::super_) {
-                    self.bases.get(1..).unwrap_or_default().to_vec()
-                } else {
-                    match &base.peel_parens().kind {
-                        ExprKind::Ident(reses) => reses
-                            .iter()
-                            .filter_map(|r| match r {
-                                Res::Item(ItemId::Contract(cid)) => Some(*cid),
-                                _ => None,
-                            })
-                            .collect(),
-                        _ => Vec::new(),
-                    }
-                };
-                contracts
-                    .iter()
-                    .flat_map(|&cid| self.hir.contract(cid).all_functions())
-                    .map(|fid| self.hir.function(fid))
-                    .filter(|f| f.name.is_some_and(|n| n.name == method.name))
-                    .collect()
-            }
-            _ => Vec::new(),
         }
     }
 }
@@ -187,7 +140,7 @@ impl<'gcx> Visit<'gcx> for Collector<'gcx> {
     }
 
     fn visit_function(&mut self, func: &'gcx Function<'gcx>) -> ControlFlow<()> {
-        self.aliases = storage_aliases(self.hir, func);
+        self.aliases = storage_aliases(self.gcx, func);
         func.modifiers.iter().try_for_each(|m| self.visit_modifier(m))?;
         func.body.iter().flat_map(|body| body.stmts).try_for_each(|stmt| self.visit_stmt(stmt))
     }
@@ -203,20 +156,20 @@ impl<'gcx> Visit<'gcx> for Collector<'gcx> {
 
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<()> {
         match &expr.kind {
-            ExprKind::Ident(reses) => self.read.extend(reses.iter().filter_map(Res::as_variable)),
+            ExprKind::Ident(_) => self.read.extend(self.gcx.resolved_variable(expr)),
             // Reassigning a bare storage pointer repoints it rather than writing its target.
-            ExprKind::Assign(lhs, ..) if !is_storage_pointer(self.hir, lhs) => {
+            ExprKind::Assign(lhs, ..) if !is_storage_pointer(self.gcx, lhs) => {
                 self.mark_written(lhs)
             }
             ExprKind::Delete(lhs) => self.mark_written(lhs),
             ExprKind::Unary(op, lhs) if op.kind.has_side_effects() => self.mark_written(lhs),
-            ExprKind::Call(callee, args, _) => {
+            ExprKind::Call(callee, ..) => {
                 // The receiver of a member call covers `push`/`pop` and `using for` library
                 // dispatch with a `T storage self` parameter.
                 if let ExprKind::Member(base, _) = &callee.kind {
                     self.mark_written(base);
                 }
-                self.mark_storage_args(callee, args);
+                self.mark_storage_args(expr);
             }
             _ => {}
         }
@@ -227,8 +180,10 @@ impl<'gcx> Visit<'gcx> for Collector<'gcx> {
 /// Collects, flow-insensitively, the state variables each local `storage` pointer declared in
 /// `func` may reference: every assignment contributes to the pointer's target set, and pointers
 /// assigned from other pointers are resolved transitively.
-fn storage_aliases<'gcx>(hir: &'gcx Hir<'gcx>, func: &'gcx Function<'gcx>) -> Aliases {
+fn storage_aliases<'gcx>(gcx: Gcx<'gcx>, func: &'gcx Function<'gcx>) -> Aliases {
+    let hir = &gcx.hir;
     struct Edges<'gcx> {
+        gcx: Gcx<'gcx>,
         hir: &'gcx Hir<'gcx>,
         edges: HashMap<VariableId, HashSet<VariableId>>,
     }
@@ -245,7 +200,9 @@ fn storage_aliases<'gcx>(hir: &'gcx Hir<'gcx>, func: &'gcx Function<'gcx>) -> Al
                     }
                 }
                 _ => {
-                    if let Some(var) = referenced_item(lhs).and_then(|id| id.as_variable()) {
+                    if let Some(var) =
+                        referenced_item(self.gcx, lhs).and_then(|id| id.as_variable())
+                    {
                         self.record_var(var, rhs);
                     }
                 }
@@ -254,7 +211,7 @@ fn storage_aliases<'gcx>(hir: &'gcx Hir<'gcx>, func: &'gcx Function<'gcx>) -> Al
 
         fn record_var(&mut self, var: VariableId, rhs: &Expr<'_>) {
             if is_local_storage_var(self.hir, var) {
-                root_vars(rhs, self.edges.entry(var).or_default());
+                root_vars(self.gcx, rhs, self.edges.entry(var).or_default());
             }
         }
     }
@@ -293,7 +250,7 @@ fn storage_aliases<'gcx>(hir: &'gcx Hir<'gcx>, func: &'gcx Function<'gcx>) -> Al
         }
     }
 
-    let mut edges = Edges { hir, edges: HashMap::new() };
+    let mut edges = Edges { gcx, hir, edges: HashMap::new() };
     let _ = edges.visit_function(func);
     let edges = edges.edges;
     let mut aliases = Aliases::new();
@@ -317,25 +274,25 @@ fn storage_aliases<'gcx>(hir: &'gcx Hir<'gcx>, func: &'gcx Function<'gcx>) -> Al
 }
 
 /// The variables an expression is rooted in, through indexing, member access and ternaries.
-fn root_vars(expr: &Expr<'_>, roots: &mut HashSet<VariableId>) {
+fn root_vars(gcx: Gcx<'_>, expr: &Expr<'_>, roots: &mut HashSet<VariableId>) {
     match &expr.peel_parens().kind {
-        ExprKind::Ident([Res::Item(id), ..]) => roots.extend(id.as_variable()),
+        ExprKind::Ident(_) => roots.extend(gcx.resolved_variable(expr)),
         ExprKind::Index(base, _) | ExprKind::Slice(base, ..) | ExprKind::Member(base, _) => {
-            root_vars(base, roots)
+            root_vars(gcx, base, roots)
         }
         ExprKind::Ternary(_, then, otherwise) => {
-            root_vars(then, roots);
-            root_vars(otherwise, roots);
+            root_vars(gcx, then, roots);
+            root_vars(gcx, otherwise, roots);
         }
         _ => {}
     }
 }
 
 /// A bare local `storage` pointer.
-fn is_storage_pointer(hir: &Hir<'_>, expr: &Expr<'_>) -> bool {
-    referenced_item(expr)
+fn is_storage_pointer(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
+    referenced_item(gcx, expr)
         .and_then(|id| id.as_variable())
-        .is_some_and(|var| is_local_storage_var(hir, var))
+        .is_some_and(|var| is_local_storage_var(&gcx.hir, var))
 }
 
 fn is_local_storage_var(hir: &Hir<'_>, var: VariableId) -> bool {

--- a/crates/lint/src/sol/med/unsafe_oz_erc721_mint.rs
+++ b/crates/lint/src/sol/med/unsafe_oz_erc721_mint.rs
@@ -471,7 +471,7 @@ impl<'gcx> Cx<'gcx> {
     fn branch_always_reverts(self, stmt: &'gcx Stmt<'gcx>) -> bool {
         match &stmt.kind {
             StmtKind::Revert(_) => !self.may_return(stmt),
-            StmtKind::Expr(expr) => is_revert_call(expr) && !self.may_return(stmt),
+            StmtKind::Expr(expr) => is_revert_call(self.gcx, expr) && !self.may_return(stmt),
             // Read in order: a `revert` further down is only reached when nothing before it can
             // leave the function on its own.
             StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => block
@@ -1164,7 +1164,7 @@ impl<'gcx> GuardWalker<'_, 'gcx> {
     fn guard_expr_coverage(&mut self, expr: &'gcx Expr<'gcx>) -> GuardCoverage {
         let expr = expr.peel_parens();
         let ExprKind::Call(callee, args, _) = &expr.kind else { return GuardCoverage::None };
-        if is_require_or_assert(callee) {
+        if is_require_or_assert(self.cx.gcx, callee) {
             return args
                 .exprs()
                 .next()
@@ -1187,7 +1187,7 @@ impl<'gcx> GuardWalker<'_, 'gcx> {
     /// before the condition's code-length snapshot.
     fn guard_extra_args_may_change_account_code(&self, expr: &'gcx Expr<'gcx>) -> bool {
         let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
-        is_require_or_assert(callee)
+        is_require_or_assert(self.cx.gcx, callee)
             && args.exprs().skip(1).any(|arg| self.may_change_account_code(&[], Some(arg)))
     }
 
@@ -1340,10 +1340,10 @@ fn assigns_to(gcx: Gcx<'_>, expr: &Expr<'_>, var: VariableId) -> bool {
 }
 
 /// `revert(...)`, `require(false, ...)` and `assert(false)`.
-fn is_revert_call(expr: &Expr<'_>) -> bool {
+fn is_revert_call(gcx: Gcx<'_>, expr: &Expr<'_>) -> bool {
     let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
-    is_builtin(callee, kw::Revert)
-        || (is_require_or_assert(callee) && args.exprs().next().is_some_and(is_literal_false))
+    is_builtin(gcx, callee, kw::Revert)
+        || (is_require_or_assert(gcx, callee) && args.exprs().next().is_some_and(is_literal_false))
 }
 
 /// The statements before and after a modifier's single top-level placeholder. More complicated

--- a/crates/lint/src/sol/med/unsafe_oz_erc721_mint.rs
+++ b/crates/lint/src/sol/med/unsafe_oz_erc721_mint.rs
@@ -5,8 +5,8 @@ use crate::{
         Severity, SolLint,
         analysis::{
             OPENZEPPELIN_ROOTS, arg_for_param, for_each_lhs_var, is_address_type, is_builtin,
-            is_literal_false, is_require_or_assert, loop_stmts, resolved_function,
-            source_in_package, underlying_var, unique, write_target,
+            is_literal_false, is_require_or_assert, loop_stmts, source_in_package, underlying_var,
+            unique, write_target,
         },
     },
 };
@@ -17,8 +17,8 @@ use solar::{
     sema::{
         Gcx,
         hir::{
-            self, BinOpKind, CallArgs, Expr, ExprKind, FunctionId, Hir, ItemId, Res, Stmt,
-            StmtKind, TypeKind, VariableId, Visit,
+            self, BinOpKind, CallArgs, Expr, ExprKind, FunctionId, Hir, ItemId, Stmt, StmtKind,
+            TypeKind, VariableId, Visit,
         },
         ty::{TyFn, TyKind},
     },
@@ -221,7 +221,8 @@ impl<'gcx> Cx<'gcx> {
         let forwards = |index: usize, var: Option<VariableId>| {
             var.is_some_and(|var| {
                 delegations.iter().all(|&&(callee, args, _)| {
-                    self.arg(callee, args, index).and_then(underlying_var) == Some(var)
+                    self.arg(callee, args, index).and_then(|expr| underlying_var(self.gcx, expr))
+                        == Some(var)
                 })
             })
         };
@@ -233,7 +234,7 @@ impl<'gcx> Cx<'gcx> {
         let mut token = None;
         let mut token_consistent = true;
         for &&(callee, args, _) in &delegations {
-            let minted = self.arg(callee, args, 1).and_then(underlying_var);
+            let minted = self.arg(callee, args, 1).and_then(|expr| underlying_var(self.gcx, expr));
             match minted.filter(|&minted| keeps_its_value(self.gcx, minted)) {
                 Some(minted) => {
                     token_consistent &= token.is_none_or(|token| token == minted);
@@ -343,7 +344,7 @@ impl<'gcx> Cx<'gcx> {
     /// The function a call expression dispatches to, as the type checker resolved it.
     fn resolved_callee(self, expr: &Expr<'_>) -> Option<FunctionId> {
         let ExprKind::Call(callee, ..) = &expr.kind else { return None };
-        resolved_function(self.gcx, callee)
+        self.gcx.resolved_function(callee)
     }
 
     fn callee_fn(self, expr: &Expr<'_>) -> Option<&'gcx TyFn<'gcx>> {
@@ -368,8 +369,8 @@ impl<'gcx> Cx<'gcx> {
     fn is_unresolved_internal_pointer_call(self, expr: &Expr<'_>) -> bool {
         let ExprKind::Call(callee, ..) = &expr.kind else { return false };
         self.callee_fn(expr).is_some_and(|f| f.is_internal() && f.function_id.is_none())
-            && matches!(&callee.peel_parens().kind, ExprKind::Ident(reses)
-                if reses.iter().any(|res| res.as_variable().is_some()))
+            && matches!(callee.peel_parens().kind, ExprKind::Ident(_))
+            && self.gcx.resolved_variable(callee).is_some()
     }
 
     /// The argument a call binds to the callee's parameter at `index`, positional or named.
@@ -380,7 +381,7 @@ impl<'gcx> Cx<'gcx> {
         index: usize,
     ) -> Option<&'gcx Expr<'gcx>> {
         let function = self.gcx.hir.function(function_id);
-        arg_for_param(&self.gcx.hir, function, *function.parameters.get(index)?, args)
+        arg_for_param(self.gcx, function_id, *function.parameters.get(index)?, args)
     }
 
     /// Whether a resolved declaration is the ERC721 receiver hook: the exact name, the exact
@@ -424,10 +425,10 @@ impl<'gcx> Cx<'gcx> {
             }
             ExprKind::Member(base, member) => {
                 member.as_str() == "selector"
-                    && resolved_function(self.gcx, base).is_some_and(|id| self.is_receiver_hook(id))
+                    && self.gcx.resolved_function(base).is_some_and(|id| self.is_receiver_hook(id))
             }
             // A constant is worth what it holds.
-            ExprKind::Ident(reses) => reses.iter().filter_map(Res::as_variable).any(|vid| {
+            ExprKind::Ident(_) => self.gcx.resolved_variable(expr).is_some_and(|vid| {
                 let variable = self.gcx.hir.variable(vid);
                 variable.is_constant()
                     && variable.initializer.is_some_and(|init| self.is_received_selector(init))
@@ -568,11 +569,13 @@ impl<'gcx> Cx<'gcx> {
     /// Identity is by variable, not by value, so a guard that checked `var` says nothing once
     /// `var` is reassigned.
     fn mutates_var(self, stmt: &'gcx Stmt<'gcx>, var: VariableId) -> bool {
-        self.any_in_stmts(slice::from_ref(stmt), is_assembly, |expr| assigns_to(expr, var))
+        self.any_in_stmts(slice::from_ref(stmt), is_assembly, |expr| {
+            assigns_to(self.gcx, expr, var)
+        })
     }
 
     fn expr_mutates_var(self, expr: &'gcx Expr<'gcx>, var: VariableId) -> bool {
-        self.any_in_expr(expr, |expr| assigns_to(expr, var))
+        self.any_in_expr(expr, |expr| assigns_to(self.gcx, expr, var))
     }
 
     /// Whether a subtree may change the code installed at an account. Inline assembly is opaque
@@ -675,7 +678,9 @@ impl<'gcx> Cx<'gcx> {
                 .iter()
                 .enumerate()
                 .find(|&(index, _)| {
-                    self.arg(function_id, args, index).and_then(underlying_var) == Some(var)
+                    self.arg(function_id, args, index)
+                        .and_then(|expr| underlying_var(self.gcx, expr))
+                        == Some(var)
                 })
                 .map(|(_, &parameter)| parameter)
         };
@@ -1217,8 +1222,9 @@ impl<'gcx> GuardWalker<'_, 'gcx> {
         let ExprKind::Member(receiver, _) = &callee.peel_parens().kind else { return false };
         let Some(function_id) = self.cx.resolved_callee(expr) else { return false };
         self.cx.is_receiver_hook(function_id)
-            && underlying_var(receiver) == Some(self.recipient)
-            && self.cx.arg(function_id, args, 2).and_then(underlying_var) == Some(self.token)
+            && underlying_var(self.cx.gcx, receiver) == Some(self.recipient)
+            && self.cx.arg(function_id, args, 2).and_then(|expr| underlying_var(self.cx.gcx, expr))
+                == Some(self.token)
     }
 
     /// `recipient.onERC721Received(...) <op> x`, and nothing else. The comparison must be the
@@ -1245,7 +1251,7 @@ impl<'gcx> GuardWalker<'_, 'gcx> {
             let ExprKind::Member(base, member) = &code.peel_parens().kind else { return false };
             length.as_str() == "length"
                 && member.as_str() == "code"
-                && underlying_var(base) == Some(self.recipient)
+                && underlying_var(self.cx.gcx, base) == Some(self.recipient)
         };
         let literal = |expr: &Expr<'_>| match &expr.peel_parens().kind {
             ExprKind::Lit(lit) => match &lit.kind {
@@ -1326,10 +1332,10 @@ fn keeps_its_value(gcx: Gcx<'_>, variable: VariableId) -> bool {
 
 /// Whether an expression writes `var`: `var = x`, `var += x`, `var++` or `delete var`, directly
 /// or as one component of a tuple.
-fn assigns_to(expr: &Expr<'_>, var: VariableId) -> bool {
+fn assigns_to(gcx: Gcx<'_>, expr: &Expr<'_>, var: VariableId) -> bool {
     let Some(target) = write_target(expr) else { return false };
     let mut hit = false;
-    for_each_lhs_var(target, &mut |vid| hit |= vid == var);
+    for_each_lhs_var(gcx, target, &mut |vid| hit |= vid == var);
     hit
 }
 

--- a/crates/lint/src/sol/med/unused_return.rs
+++ b/crates/lint/src/sol/med/unused_return.rs
@@ -41,37 +41,27 @@ impl<'gcx> LateLintPass<'gcx> for UnusedReturn {
     }
 }
 
-/// True if `expr` is a member call on a contract whose every candidate function (same name and
-/// arity) has return values, excluding ERC20 `transfer`/`transferFrom` (covered by
+/// True if `expr` is a member call on a contract whose selected function has return values,
+/// excluding ERC20 `transfer`/`transferFrom` (covered by
 /// `erc20-unchecked-transfer`).
 fn is_unused_return_call<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
-    let ExprKind::Call(callee, args, ..) = &expr.peel_parens().kind else { return false };
+    let ExprKind::Call(callee, ..) = &expr.peel_parens().kind else { return false };
     let ExprKind::Member(receiver, name) = &callee.peel_parens().kind else { return false };
-    let Some(cid) = receiver_contract_id(gcx, receiver) else { return false };
+    if receiver_contract_id(gcx, receiver).is_none() {
+        return false;
+    }
+    let Some(fid) = gcx.resolved_function(callee) else { return false };
+    let f = gcx.hir.function(fid);
 
     let sig = |vars: &[_], expected: &[&str]| {
         vars.len() == expected.len()
             && vars.iter().zip(expected).all(|(&id, &ty)| is_elementary(&gcx.hir, id, ty))
     };
-    let mut candidates = gcx
-        .hir
-        .contract_item_ids(cid)
-        .filter_map(|item| item.as_function())
-        .map(|fid| gcx.hir.function(fid))
-        .filter(|f| {
-            f.kind.is_function()
-                && f.name.is_some_and(|n| n.name == name.name)
-                && f.parameters.len() == args.kind.len()
-        })
-        .peekable();
-    candidates.peek().is_some()
-        && candidates.all(|f| {
-            let is_erc20_transfer = sig(f.returns, &["bool"])
-                && match name.as_str() {
-                    "transfer" => sig(f.parameters, &["address", "uint256"]),
-                    "transferFrom" => sig(f.parameters, &["address", "address", "uint256"]),
-                    _ => false,
-                };
-            !f.returns.is_empty() && !is_erc20_transfer
-        })
+    let is_erc20_transfer = sig(f.returns, &["bool"])
+        && match name.as_str() {
+            "transfer" => sig(f.parameters, &["address", "uint256"]),
+            "transferFrom" => sig(f.parameters, &["address", "address", "uint256"]),
+            _ => false,
+        };
+    !f.returns.is_empty() && !is_erc20_transfer
 }

--- a/crates/lint/src/sol/med/weak_prng.rs
+++ b/crates/lint/src/sol/med/weak_prng.rs
@@ -1,11 +1,16 @@
 use super::WeakPrng;
 use crate::{
-    linter::{EarlyLintPass, LintContext},
+    linter::{LateLintPass, LintContext},
     sol::{Severity, SolLint},
 };
+use alloy_primitives::U256;
 use solar::{
-    ast::{BinOp, BinOpKind, Expr, ExprKind, LitKind, SourceUnit, visit::Visit},
-    interface::{kw, sym},
+    ast::{BinOp, BinOpKind},
+    sema::{
+        Gcx,
+        builtins::Builtin,
+        hir::{Expr, ExprKind, Hir, SourceId, Visit},
+    },
 };
 use std::ops::ControlFlow;
 
@@ -16,30 +21,37 @@ declare_forge_lint!(
     "weak randomness derived from a predictable on-chain value"
 );
 
-impl<'ast> EarlyLintPass<'ast> for WeakPrng {
-    fn check_full_source_unit(&mut self, ctx: &LintContext<'ast, '_>, ast: &'ast SourceUnit<'ast>) {
+impl<'gcx> LateLintPass<'gcx> for WeakPrng {
+    fn check_nested_source(&mut self, ctx: &LintContext, gcx: Gcx<'gcx>, id: SourceId) {
         if ctx.is_lint_enabled(WEAK_PRNG.id) {
-            let _ = WeakPrngChecker { ctx }.visit_source_unit(ast);
+            let _ = WeakPrngChecker { ctx, gcx }.visit_nested_source(id);
         }
     }
 }
 
-struct WeakPrngChecker<'a, 's> {
+struct WeakPrngChecker<'a, 's, 'gcx> {
     ctx: &'a LintContext<'s, 'a>,
+    gcx: Gcx<'gcx>,
 }
 
-impl<'ast> Visit<'ast> for WeakPrngChecker<'_, '_> {
+impl<'gcx> Visit<'gcx> for WeakPrngChecker<'_, '_, 'gcx> {
     type BreakValue = ();
 
+    fn hir(&self) -> &'gcx Hir<'gcx> {
+        &self.gcx.hir
+    }
+
     /// Emits once per outermost `<..> % <..>` or `keccak256(..)` fed by a predictable source.
-    fn visit_expr(&mut self, expr: &'ast Expr<'ast>) -> ControlFlow<()> {
+    fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<()> {
         let is_randomness = match &expr.peel_parens().kind {
             ExprKind::Binary(lhs, BinOp { kind: BinOpKind::Rem, .. }, rhs) => {
-                !is_timestamp_time_bucket(lhs, rhs)
-                    && (contains_predictable_source(lhs) || contains_predictable_source(rhs))
+                !is_timestamp_time_bucket(self.gcx, lhs, rhs)
+                    && (contains_predictable_source(self.gcx, lhs)
+                        || contains_predictable_source(self.gcx, rhs))
             }
-            ExprKind::Call(callee, args) => {
-                is_ident(callee, kw::Keccak256) && args.exprs().any(contains_predictable_source)
+            ExprKind::Call(callee, args, _) => {
+                self.gcx.resolved_builtin(callee) == Some(Builtin::Keccak256)
+                    && args.exprs().any(|arg| contains_predictable_source(self.gcx, arg))
             }
             _ => false,
         };
@@ -51,66 +63,59 @@ impl<'ast> Visit<'ast> for WeakPrngChecker<'_, '_> {
     }
 }
 
-fn contains_predictable_source<'ast>(expr: &'ast Expr<'ast>) -> bool {
-    PredictableSourceFinder.visit_expr(expr).is_break()
+fn contains_predictable_source<'gcx>(gcx: Gcx<'gcx>, expr: &'gcx Expr<'gcx>) -> bool {
+    PredictableSourceFinder { gcx }.visit_expr(expr).is_break()
 }
 
-struct PredictableSourceFinder;
+struct PredictableSourceFinder<'gcx> {
+    gcx: Gcx<'gcx>,
+}
 
-impl<'ast> Visit<'ast> for PredictableSourceFinder {
+impl<'gcx> Visit<'gcx> for PredictableSourceFinder<'gcx> {
     type BreakValue = ();
 
-    fn visit_expr(&mut self, expr: &'ast Expr<'ast>) -> ControlFlow<()> {
+    fn hir(&self) -> &'gcx Hir<'gcx> {
+        &self.gcx.hir
+    }
+
+    fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<()> {
         match &expr.peel_parens().kind {
             // `block.timestamp % 1 days` is a time bucket, not a random draw.
             ExprKind::Binary(lhs, BinOp { kind: BinOpKind::Rem, .. }, rhs)
-                if is_timestamp_time_bucket(lhs, rhs) =>
+                if is_timestamp_time_bucket(self.gcx, lhs, rhs) =>
             {
                 ControlFlow::Continue(())
             }
-            ExprKind::Member(base, member)
-                if is_ident(base, sym::block)
-                    && matches!(
-                        member.name,
-                        kw::Timestamp | kw::Number | kw::Coinbase | kw::Prevrandao | kw::Difficulty
-                    ) =>
+            _ if matches!(
+                self.gcx.resolved_builtin(expr),
+                Some(
+                    Builtin::BlockTimestamp
+                        | Builtin::BlockNumber
+                        | Builtin::BlockCoinbase
+                        | Builtin::BlockPrevrandao
+                        | Builtin::BlockDifficulty
+                )
+            ) =>
             {
                 ControlFlow::Break(())
             }
-            ExprKind::Call(callee, _) if is_ident(callee, kw::Blockhash) => ControlFlow::Break(()),
+            ExprKind::Call(callee, ..)
+                if self.gcx.resolved_builtin(callee) == Some(Builtin::Blockhash) =>
+            {
+                ControlFlow::Break(())
+            }
             _ => self.walk_expr(expr),
         }
     }
 }
 
 /// `block.timestamp % <multiple of one day>`.
-fn is_timestamp_time_bucket(lhs: &Expr<'_>, rhs: &Expr<'_>) -> bool {
-    const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
-    matches!(&lhs.peel_parens().kind, ExprKind::Member(base, member)
-        if is_ident(base, sym::block) && member.name == kw::Timestamp)
-        && const_eval_u64(rhs).is_some_and(|v| v >= SECONDS_PER_DAY && v % SECONDS_PER_DAY == 0)
-}
-
-fn const_eval_u64(expr: &Expr<'_>) -> Option<u64> {
-    match &expr.peel_parens().kind {
-        ExprKind::Lit(lit, sub) => {
-            let LitKind::Number(value) = &lit.kind else { return None };
-            u64::try_from(value).ok()?.checked_mul(sub.map_or(1, |s| s.value()))
-        }
-        ExprKind::Binary(lhs, op, rhs) => {
-            let (lhs, rhs) = (const_eval_u64(lhs)?, const_eval_u64(rhs)?);
-            match op.kind {
-                BinOpKind::Add => lhs.checked_add(rhs),
-                BinOpKind::Sub => lhs.checked_sub(rhs),
-                BinOpKind::Mul => lhs.checked_mul(rhs),
-                BinOpKind::Div => lhs.checked_div(rhs),
-                _ => None,
-            }
-        }
-        _ => None,
-    }
-}
-
-fn is_ident(expr: &Expr<'_>, name: solar::interface::Symbol) -> bool {
-    matches!(&expr.peel_parens().kind, ExprKind::Ident(ident) if ident.name == name)
+fn is_timestamp_time_bucket(gcx: Gcx<'_>, lhs: &Expr<'_>, rhs: &Expr<'_>) -> bool {
+    const SECONDS_PER_DAY: U256 = U256::from_limbs([24 * 60 * 60, 0, 0, 0]);
+    gcx.resolved_builtin(lhs) == Some(Builtin::BlockTimestamp)
+        && gcx
+            .try_eval_const(rhs)
+            .ok()
+            .and_then(|v| v.as_u256())
+            .is_some_and(|v| v >= SECONDS_PER_DAY && v % SECONDS_PER_DAY == U256::ZERO)
 }

--- a/crates/lint/testdata/ArbitrarySendErc20.sol
+++ b/crates/lint/testdata/ArbitrarySendErc20.sol
@@ -961,3 +961,23 @@ contract PullModifierDerived is PullModifierBase {
 
     function depositFrom(address from, uint256 a) external pullFromAnyone(from, a) {}
 }
+
+interface InheritedERC20 is IERC20 {}
+
+interface InheritedFlashBorrower is IERC3156FlashBorrower {}
+
+contract InheritedERC20CallSites {
+    function arbitraryFrom(InheritedERC20 token, address from, address to, uint256 amount) external {
+        token.transferFrom(from, to, amount); //~WARN: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+    }
+
+    function callerFrom(InheritedERC20 token, address to, uint256 amount) external {
+        token.transferFrom(msg.sender, to, amount);
+    }
+
+    function flashRepayment(InheritedERC20 token, InheritedFlashBorrower receiver, uint256 amount, uint256 fee, bytes calldata data) external {
+        token.transfer(address(receiver), amount);
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        token.transferFrom(address(receiver), address(this), amount + fee);
+    }
+}

--- a/crates/lint/testdata/ArbitrarySendErc20.stderr
+++ b/crates/lint/testdata/ArbitrarySendErc20.stderr
@@ -446,3 +446,11 @@ LL │ …     token.transferFrom(from, address(this), a);
    │
    ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
 
+warning[arbitrary-send-erc20]: `transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`
+   ╭▸ ROOT/testdata/ArbitrarySendErc20.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, amount);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20
+

--- a/crates/lint/testdata/ArbitrarySendEth.sol
+++ b/crates/lint/testdata/ArbitrarySendEth.sol
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
+import "./ArbitrarySendEth.sol" as Self;
+
 interface IERC20 {
     function transfer(address to, uint256 amount) external returns (bool);
 }
@@ -805,6 +807,12 @@ library SelfRetLib {
 
 contract NumericCastSafeOk {
     function payZeroViaUint160Ok(uint256 amt) external { payable(address(uint160(0))).transfer(amt); }
+}
+
+contract QualifiedSelfCastOk {
+    function paySelf(uint256 amount) external {
+        Self.IThing(address(this)).ping{value: amount}();
+    }
 }
 
 contract FnPtrFromSelf {

--- a/crates/lint/testdata/AssertStateChange.sol
+++ b/crates/lint/testdata/AssertStateChange.sol
@@ -89,6 +89,7 @@ interface IToken {
     // narrowing can correctly distinguish them.
     function update(address target, uint256 amount) external returns (bool);
     function update(uint256 n) external view returns (bool);
+    function update(address target) external returns (bool);
 }
 
 // Interface with view functions that share names with low-level address builtins.
@@ -124,6 +125,10 @@ contract AssertStateChangeExternal {
     // the 2-arg mutating overload, so no false positive.
     function goodOverloadView(uint256 n) external view {
         assert(token.update(n));
+    }
+
+    function badSameArityOverload(address target) external {
+        assert(token.update(target)); //~WARN: `assert()` argument contains a state-modifying expression
     }
 
     // Bad: calling the 2-arg mutating overload `update(address,uint256)` — only
@@ -210,9 +215,7 @@ contract AssertStateChangeUsingFor {
     }
 }
 
-// ---- same-arity overloads: any-mutates policy ----
-// Both overloads have arity 1 but different param types. Since Solar does not resolve
-// which overload was selected, we flag whenever any candidate mutates state.
+// Same-arity overloads use the selected function's mutability.
 interface IOverloaded {
     function check(uint256 n) external returns (bool);   // mutating
     function check(address a) external view returns (bool); // view
@@ -221,14 +224,14 @@ interface IOverloaded {
 contract AssertStateChangeSameArityOverload {
     IOverloaded public o;
 
-    // Bad: `check(uint256)` mutates state; any-mutates policy must flag this.
+    // Bad: the selected `check(uint256)` overload mutates state.
     function badSameArityMutating(uint256 n) external {
         assert(o.check(n)); //~WARN: `assert()` argument contains a state-modifying expression
     }
 
-    // Bad: `check(address)` is view but `check(uint256)` mutates; still flagged.
-    function badSameArityView(address a) external {
-        assert(o.check(a)); //~WARN: `assert()` argument contains a state-modifying expression
+    // Good: the selected `check(address)` overload only reads state.
+    function goodSameArityView(address a) external {
+        assert(o.check(a));
     }
 }
 

--- a/crates/lint/testdata/AssertStateChange.stderr
+++ b/crates/lint/testdata/AssertStateChange.stderr
@@ -65,6 +65,14 @@ LL │         assert(token.transfer(to, amt));
 warning[assert-state-change]: `assert()` argument contains a state-modifying expression; `assert()` is for invariants, hoist the mutation before the `assert`, or use `require()` for validation
    ╭▸ ROOT/testdata/AssertStateChange.sol:LL:CC
    │
+LL │         assert(token.update(target));
+   │                ━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/assert-state-change
+
+warning[assert-state-change]: `assert()` argument contains a state-modifying expression; `assert()` is for invariants, hoist the mutation before the `assert`, or use `require()` for validation
+   ╭▸ ROOT/testdata/AssertStateChange.sol:LL:CC
+   │
 LL │         assert(token.update(target, amt));
    │                ━━━━━━━━━━━━━━━━━━━━━━━━━
    │
@@ -90,14 +98,6 @@ warning[assert-state-change]: `assert()` argument contains a state-modifying exp
    ╭▸ ROOT/testdata/AssertStateChange.sol:LL:CC
    │
 LL │         assert(o.check(n));
-   │                ━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/assert-state-change
-
-warning[assert-state-change]: `assert()` argument contains a state-modifying expression; `assert()` is for invariants, hoist the mutation before the `assert`, or use `require()` for validation
-   ╭▸ ROOT/testdata/AssertStateChange.sol:LL:CC
-   │
-LL │         assert(o.check(a));
    │                ━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/assert-state-change

--- a/crates/lint/testdata/CacheArrayLength.sol
+++ b/crates/lint/testdata/CacheArrayLength.sol
@@ -186,6 +186,18 @@ contract CacheArrayLength {
         }
     }
 
+    function viewPointer(function(uint256) external view check) external view {
+        for (uint256 i = 0; i < items.length; ++i) { //~NOTE: array length is read on every loop iteration
+            check(i);
+        }
+    }
+
+    function mutatingPointer(function(uint256) external check) external {
+        for (uint256 i = 0; i < items.length; ++i) {
+            check(i);
+        }
+    }
+
     function generatedValues() internal pure returns (uint256[] memory values) {
         values = new uint256[](3);
     }

--- a/crates/lint/testdata/CacheArrayLength.stderr
+++ b/crates/lint/testdata/CacheArrayLength.stderr
@@ -22,3 +22,11 @@ LL │         for (uint256 i = 0; i < cap && items.length > i; ++i) {
    │
    ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
 
+note[cache-array-length]: array length is read on every loop iteration; cache it outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < items.length; ++i) {
+   │                                 ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+

--- a/crates/lint/testdata/CallsLoop.sol
+++ b/crates/lint/testdata/CallsLoop.sol
@@ -43,6 +43,10 @@ library ReceiverLib {
         self;
         return value;
     }
+
+    function notify(IReceiver self, uint256 value) public {
+        self.ping(value);
+    }
 }
 
 struct Target {
@@ -169,6 +173,25 @@ contract CallsLoop {
 
     function noLoopCall() external {
         receiver.ping(0);
+    }
+
+    function externalFunctionPointer(function(uint256) external returns (bool) callback) external {
+        for (uint256 i; i < 1; ++i) {
+            callback(i);
+        }
+    }
+
+    function externalViewFunctionPointer(function(uint256) external view returns (bool) callback) external view {
+        for (uint256 i; i < 1; ++i) {
+            callback(i);
+        }
+    }
+
+    function publicLibraryCalls() external {
+        for (uint256 i; i < 1; ++i) {
+            receiver.notify(i);
+            ReceiverLib.notify(receiver, i);
+        }
     }
 
     function internalLibraryCallsAreIgnored() external {

--- a/crates/lint/testdata/CallsLoop.stderr
+++ b/crates/lint/testdata/CallsLoop.stderr
@@ -118,3 +118,43 @@ LL │         receiver.ping(0);
    │
    ╰ help: https://getfoundry.sh/forge/linting/calls-loop
 
+warning[calls-loop]: external call inside a loop
+   ╭▸ ROOT/testdata/CallsLoop.sol:LL:CC
+   │
+LL │             callback(i);
+   │             ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/calls-loop
+
+warning[calls-loop]: external call inside a loop
+   ╭▸ ROOT/testdata/CallsLoop.sol:LL:CC
+   │
+LL │             callback(i);
+   │             ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/calls-loop
+
+warning[calls-loop]: external call inside a loop
+   ╭▸ ROOT/testdata/CallsLoop.sol:LL:CC
+   │
+LL │             receiver.notify(i);
+   │             ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/calls-loop
+
+warning[calls-loop]: external call inside a loop
+   ╭▸ ROOT/testdata/CallsLoop.sol:LL:CC
+   │
+LL │         self.ping(value);
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/calls-loop
+
+warning[calls-loop]: external call inside a loop
+   ╭▸ ROOT/testdata/CallsLoop.sol:LL:CC
+   │
+LL │             ReceiverLib.notify(receiver, i);
+   │             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/calls-loop
+

--- a/crates/lint/testdata/ExternalFunction.sol
+++ b/crates/lint/testdata/ExternalFunction.sol
@@ -140,7 +140,7 @@ abstract contract Base {
     // Abstract — must stay ≥ public for derived contracts to override.
     function virtualWithoutBody(bytes memory data) public virtual;
 
-    // Reached via `super.calledViaSuper(...)` in `Derived`; matched by name.
+    // Reached via `super.calledViaSuper(...)` in `Derived`.
     function calledViaSuper(bytes memory data) public virtual {
         _bytes = data;
     }
@@ -258,5 +258,47 @@ contract EscapingParams is WithGuard {
 
     function returnsParam(bytes memory data) public returns (bytes memory) { //~NOTE: `public` function can be declared `external`
         return data;
+    }
+}
+
+contract OverloadedReferences {
+    function consume(bytes memory data) public pure returns (uint256) { //~NOTE: `public` function can be declared `external`
+        return data.length;
+    }
+
+    function consume(uint256[] memory data) public pure returns (uint256) {
+        return data.length;
+    }
+
+    function callArray(uint256[] memory data) external pure returns (uint256) {
+        return consume(data);
+    }
+}
+
+contract OverloadedSuperBase {
+    function consume(bytes memory data) public pure virtual returns (uint256) { //~NOTE: `public` function can be declared `external`
+        return data.length;
+    }
+
+    function consume(uint256[] memory data) public pure virtual returns (uint256) {
+        return data.length;
+    }
+}
+
+contract OverloadedSuperDerived is OverloadedSuperBase {
+    function callArray(uint256[] memory data) external pure returns (uint256) {
+        return super.consume(data);
+    }
+}
+
+contract QualifiedReferenceBase {
+    function consume(bytes memory data) public pure returns (uint256) {
+        return data.length;
+    }
+}
+
+contract QualifiedReferenceDerived is QualifiedReferenceBase {
+    function callBase(bytes memory data) external pure returns (uint256) {
+        return QualifiedReferenceBase.consume(data);
     }
 }

--- a/crates/lint/testdata/ExternalFunction.stderr
+++ b/crates/lint/testdata/ExternalFunction.stderr
@@ -78,3 +78,19 @@ LL │     function returnsParam(bytes memory data) public returns (bytes memory
    │
    ╰ help: https://getfoundry.sh/forge/linting/external-function
 
+note[external-function]: `public` function can be declared `external`
+   ╭▸ ROOT/testdata/ExternalFunction.sol:LL:CC
+   │
+LL │     function consume(bytes memory data) public pure returns (uint256) {
+   │              ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/external-function
+
+note[external-function]: `public` function can be declared `external`
+   ╭▸ ROOT/testdata/ExternalFunction.sol:LL:CC
+   │
+LL │     function consume(bytes memory data) public pure virtual returns (uint256) {
+   │              ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/external-function
+

--- a/crates/lint/testdata/MissingEventsAccessControl.sol
+++ b/crates/lint/testdata/MissingEventsAccessControl.sol
@@ -378,6 +378,19 @@ abstract contract MissingEventsAccessControlAssertionHelpers {
     }
 }
 
+contract NamedArgumentAccessControl {
+    address public owner = msg.sender;
+
+    function setOwner(address next) external {
+        require(msg.sender == owner);
+        _setOwner({next: next, ignored: address(1)});
+    }
+
+    function _setOwner(address ignored, address next) internal {
+        owner = next; //~WARN: `owner` is changed without an event but is used for access control
+    }
+}
+
 contract MissingEventsAccessControlForgeStdLikeTest is MissingEventsAccessControlAssertionHelpers {
     function testFuzz_SendMail(uint128 mintAmount, uint128 sendAmount) public view {
         assertEq(uint256(mintAmount), uint256(sendAmount));

--- a/crates/lint/testdata/MissingEventsAccessControl.stderr
+++ b/crates/lint/testdata/MissingEventsAccessControl.stderr
@@ -174,3 +174,11 @@ LL │         admin = newAdmin;
    │
    ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
 
+warning[missing-events-access-control]: `owner` is changed without an event but is used for access control
+   ╭▸ ROOT/testdata/MissingEventsAccessControl.sol:LL:CC
+   │
+LL │         owner = next;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-access-control
+

--- a/crates/lint/testdata/MissingEventsArithmetic.sol
+++ b/crates/lint/testdata/MissingEventsArithmetic.sol
@@ -661,6 +661,28 @@ contract EventsArithmeticConcreteBase {
 
 contract EventsArithmeticConcreteDerived is EventsArithmeticConcreteBase {}
 
+contract NamedArgumentArithmetic {
+    address public owner = msg.sender;
+    uint256 public fee;
+
+    function setFee(uint256 next) external {
+        require(msg.sender == owner);
+        _setFee({next: next, ignored: 0});
+    }
+
+    function _setFee(uint256 ignored, uint256 next) internal {
+        fee = next; //~WARN: `fee` is changed without an event but is used in arithmetic
+    }
+
+    function quote() external view returns (uint256) {
+        return _scale({value: fee, ignored: 0});
+    }
+
+    function _scale(uint256 ignored, uint256 value) internal pure returns (uint256) {
+        return value * 2;
+    }
+}
+
 contract ReproAccessNameCalleeResultIgnored {
     address public owner = msg.sender;
     uint256 public price;

--- a/crates/lint/testdata/MissingEventsArithmetic.stderr
+++ b/crates/lint/testdata/MissingEventsArithmetic.stderr
@@ -182,3 +182,11 @@ LL │         concreteFee = newFee;
    │
    ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
 
+warning[missing-events-arithmetic]: `fee` is changed without an event but is used in arithmetic
+   ╭▸ ROOT/testdata/MissingEventsArithmetic.sol:LL:CC
+   │
+LL │         fee = next;
+   │         ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/missing-events-arithmetic
+

--- a/crates/lint/testdata/ReentrancyEvents.sol
+++ b/crates/lint/testdata/ReentrancyEvents.sol
@@ -274,12 +274,10 @@ contract ReentrancyEvents {
         emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
     }
 
-    // Known limitation: member-form internal calls (`Lib.f(...)`, `using for`)
-    // are not yet followed because Solar's `members_of` for `TyKind::Type(Contract)` is a
-    // TODO. The external call inside `staticHelper` is therefore missed and no warning fires.
+    // A resolved static library call runs in this frame and can make an external call.
     function emitAfterLibraryStaticCall() external {
         NotifyLib.staticHelper(ext);
-        emit Tick();
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
     }
 
     function emitAfterUsingForCall() external {

--- a/crates/lint/testdata/ReentrancyEvents.sol
+++ b/crates/lint/testdata/ReentrancyEvents.sol
@@ -21,6 +21,36 @@ interface ICall {
     function poke() external;
 }
 
+library ReadOnlyEventLibrary {
+    function read(uint256 value) public pure returns (uint256) {
+        return value;
+    }
+}
+
+contract FunctionPointerEvents {
+    event Tick();
+
+    function mutableCallback(function() external callback) external {
+        callback();
+        emit Tick(); //~WARN: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+    }
+
+    function viewCallback(function() external view callback) external {
+        callback();
+        emit Tick();
+    }
+
+    function viewLibrary() external {
+        ReadOnlyEventLibrary.read(1);
+        emit Tick();
+    }
+
+    function internalCallback(function() internal callback) internal {
+        callback();
+        emit Tick();
+    }
+}
+
 contract Other {
     function action(uint256) external returns (bool) {
         return true;

--- a/crates/lint/testdata/ReentrancyEvents.stderr
+++ b/crates/lint/testdata/ReentrancyEvents.stderr
@@ -25,6 +25,14 @@ LL │ …     emit Tick();
 warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
    ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
    │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
 LL │ …     emit Counter(counter);
    │       ━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/ReentrancyEvents.stderr
+++ b/crates/lint/testdata/ReentrancyEvents.stderr
@@ -177,6 +177,14 @@ LL │ …     emit Tick();
 warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
    ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
    │
+LL │ …     emit Tick();
+   │       ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/reentrancy-events
+
+warning[reentrancy-events]: event emitted after an external call; reentrancy can reorder or fabricate logs that off-chain consumers rely on
+   ╭▸ ROOT/testdata/ReentrancyEvents.sol:LL:CC
+   │
 LL │ …     emit Counter(x);
    │       ━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/TypeBasedTautology.sol
+++ b/crates/lint/testdata/TypeBasedTautology.sol
@@ -190,4 +190,24 @@ contract TypeBasedTautology {
     function uintNegativeZeroLowerBoundaryOr(uint256 x) public pure returns (bool) {
         return x > -0 || x == -0; //~WARN: condition is always true or false based on the variable's type
     }
+
+    struct Amount {
+        uint256 value;
+    }
+
+    function structField(Amount memory amount) public pure returns (bool) {
+        return amount.value >= 0; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function arrayElement(uint256[] memory amounts) public pure returns (bool) {
+        return amounts[0] < 0; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function returnedValue() public pure returns (bool) {
+        return integerValue() >= 0; //~WARN: condition is always true or false based on the variable's type
+    }
+
+    function integerValue() internal pure returns (uint256) {
+        return 1;
+    }
 }

--- a/crates/lint/testdata/TypeBasedTautology.stderr
+++ b/crates/lint/testdata/TypeBasedTautology.stderr
@@ -230,3 +230,27 @@ LL │         return x > -0 || x == -0;
    │
    ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
 
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return amount.value >= 0;
+   │                ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return amounts[0] < 0;
+   │                ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+
+warning[type-based-tautology]: condition is always true or false based on the variable's type
+   ╭▸ ROOT/testdata/TypeBasedTautology.sol:LL:CC
+   │
+LL │         return integerValue() >= 0;
+   │                ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/type-based-tautology
+

--- a/crates/lint/testdata/UncheckedTransferERC20.sol
+++ b/crates/lint/testdata/UncheckedTransferERC20.sol
@@ -131,3 +131,14 @@ contract UncheckedTransferUsingCurrencyLib {
         token.transferFrom(from, to, amount);
     }
 }
+
+interface IOverloadedTransfer {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transfer(address to, bytes32 referenceId) external returns (uint256);
+}
+
+contract SelectedTransferOverload {
+    function transferReference(IOverloadedTransfer token, address to, bytes32 referenceId) external {
+        token.transfer(to, referenceId);
+    }
+}

--- a/crates/lint/testdata/UninitializedLocal.sol
+++ b/crates/lint/testdata/UninitializedLocal.sol
@@ -3,7 +3,41 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+type LocalAmount is uint256;
+
 contract UninitializedLocal {
+    enum Status { Pending, Done }
+
+    function enumValue() public pure returns (Status) {
+        Status status;
+        return status; //~WARN: local variable is read before being initialized
+    }
+
+    function contractValue() public pure returns (IFoo) {
+        IFoo target;
+        return target; //~WARN: local variable is read before being initialized
+    }
+
+    function userDefinedValue() public pure returns (uint256) {
+        LocalAmount amount;
+        return LocalAmount.unwrap(amount); //~WARN: local variable is read before being initialized
+    }
+
+    function functionValue() public pure returns (uint256) {
+        function() internal pure returns (uint256) callback;
+        return callback(); //~WARN: local variable is read before being initialized
+    }
+
+    function initializedValues() public pure returns (Status, IFoo, LocalAmount) {
+        Status status;
+        IFoo target;
+        LocalAmount amount;
+        status = Status.Done;
+        target = IFoo(address(1));
+        amount = LocalAmount.wrap(1);
+        return (status, target, amount);
+    }
+
     struct Point {
         uint256 x;
         uint256 y;

--- a/crates/lint/testdata/UninitializedLocal.stderr
+++ b/crates/lint/testdata/UninitializedLocal.stderr
@@ -1,6 +1,38 @@
 warning[uninitialized-local]: local variable is read before being initialized
    ╭▸ ROOT/testdata/UninitializedLocal.sol:LL:CC
    │
+LL │         return status;
+   │                ━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-local
+
+warning[uninitialized-local]: local variable is read before being initialized
+   ╭▸ ROOT/testdata/UninitializedLocal.sol:LL:CC
+   │
+LL │         return target;
+   │                ━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-local
+
+warning[uninitialized-local]: local variable is read before being initialized
+   ╭▸ ROOT/testdata/UninitializedLocal.sol:LL:CC
+   │
+LL │         return LocalAmount.unwrap(amount);
+   │                                   ━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-local
+
+warning[uninitialized-local]: local variable is read before being initialized
+   ╭▸ ROOT/testdata/UninitializedLocal.sol:LL:CC
+   │
+LL │         return callback();
+   │                ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-local
+
+warning[uninitialized-local]: local variable is read before being initialized
+   ╭▸ ROOT/testdata/UninitializedLocal.sol:LL:CC
+   │
 LL │         to.transfer(address(this).balance);
    │         ━━
    │

--- a/crates/lint/testdata/UninitializedStateVariables.sol
+++ b/crates/lint/testdata/UninitializedStateVariables.sol
@@ -285,13 +285,11 @@ contract DerivedFromBaseDeployable is BaseDeployable {
 }
 
 // ── Overloaded internal function ──────────────────────────────────────────────
-// When overloads exist and any of them takes `storage` at that position, the
-// argument is conservatively treated as written to avoid false positives.
-// The write is only suppressed when NO overload has a storage parameter.
+// Only the selected overload determines whether an argument can be written.
 
 contract OverloadUnion {
     struct S { uint256 v; }
-    uint256 public x; // any-overload: f(S storage) has storage at pos 0 → x treated as written
+    uint256 public x; //~WARN: state variable is read but never written
     S internal data;
 
     function f(uint256) internal {}

--- a/crates/lint/testdata/UninitializedStateVariables.stderr
+++ b/crates/lint/testdata/UninitializedStateVariables.stderr
@@ -73,6 +73,14 @@ LL │     uint256 public x;
 warning[uninitialized-state]: state variable is read but never written
    ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
    │
+LL │     uint256 public x;
+   │     ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/uninitialized-state
+
+warning[uninitialized-state]: state variable is read but never written
+   ╭▸ ROOT/testdata/UninitializedStateVariables.sol:LL:CC
+   │
 LL │     address public owner;
    │     ━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/UnprotectedInitializer.sol
+++ b/crates/lint/testdata/UnprotectedInitializer.sol
@@ -347,3 +347,17 @@ contract RepeatedInitializerCalls is Initializable, DangerousBase {
         _left(owner_);
     }
 }
+
+contract SelectedInitializerOverload is Initializable, DangerousBase {
+    uint256 public value;
+
+    function initialize(address account) external initializer {
+        _initialize(account);
+    }
+
+    function _initialize(address) internal pure {}
+
+    function _initialize(uint256 next) internal {
+        value = next;
+    }
+}

--- a/crates/lint/testdata/UnprotectedInitializer.sol
+++ b/crates/lint/testdata/UnprotectedInitializer.sol
@@ -361,3 +361,39 @@ contract SelectedInitializerOverload is Initializable, DangerousBase {
         value = next;
     }
 }
+
+contract ExternalLockBase {
+    bool private initialized;
+
+    modifier initializer() {
+        _;
+    }
+
+    function _disableInitializers() public {
+        initialized = true;
+    }
+}
+
+contract ExternalLockInitializer is ExternalLockBase, DangerousBase {
+    address public owner;
+
+    constructor(ExternalLockBase other) {
+        other._disableInitializers();
+    }
+
+    function initialize(address next) external initializer { //~WARN: upgradeable initializer is not protected against direct implementation calls
+        owner = next;
+    }
+}
+
+contract InternalPublicLockInitializer is ExternalLockBase, DangerousBase {
+    address public owner;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address next) external initializer {
+        owner = next;
+    }
+}

--- a/crates/lint/testdata/UnprotectedInitializer.stderr
+++ b/crates/lint/testdata/UnprotectedInitializer.stderr
@@ -94,3 +94,11 @@ LL │     function initialize(address owner_) public initializer {
    │
    ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
 
+warning[unprotected-initializer]: upgradeable initializer is not protected against direct implementation calls
+   ╭▸ ROOT/testdata/UnprotectedInitializer.sol:LL:CC
+   │
+LL │     function initialize(address next) external initializer {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unprotected-initializer
+

--- a/crates/lint/testdata/UnusedReturn.sol
+++ b/crates/lint/testdata/UnusedReturn.sol
@@ -13,7 +13,7 @@ interface IOracle {
 // Same name+arity as IOracle.getPrice but one overload has no return value.
 interface IOracleOverloaded {
     function getPrice(address token) external returns (uint256);
-    function getPrice(uint256 id) external; // no return, makes getPrice ambiguous
+    function getPrice(uint256 id) external;
 }
 
 interface IERC20 {
@@ -73,10 +73,13 @@ contract UnusedReturn {
         token.transferFrom(from, to, amt);
     }
 
-    // SHOULD PASS: ambiguous overload set, getPrice(address) returns uint256 but
-    // getPrice(uint256) returns nothing; conservatively skip to avoid false positives
-    function good6(address t) external {
-        oracleOverloaded.getPrice(t);
+    // The selected address overload returns a value.
+    function badOverload(address t) external {
+        oracleOverloaded.getPrice(t); //~WARN: return value of an external call is not used
+    }
+
+    function goodOverload(uint256 id) external {
+        oracleOverloaded.getPrice(id);
     }
 
     // SHOULD FAIL: named-arg call, arity should still be 1

--- a/crates/lint/testdata/UnusedReturn.stderr
+++ b/crates/lint/testdata/UnusedReturn.stderr
@@ -25,6 +25,14 @@ LL │         IOracle(oracleAddr).getPrice(t);
 warning[unused-return]: return value of an external call is not used
    ╭▸ ROOT/testdata/UnusedReturn.sol:LL:CC
    │
+LL │         oracleOverloaded.getPrice(t);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-return
+
+warning[unused-return]: return value of an external call is not used
+   ╭▸ ROOT/testdata/UnusedReturn.sol:LL:CC
+   │
 LL │         oracle.getPrice({token: t});
    │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/VarReadUsingThis.sol
+++ b/crates/lint/testdata/VarReadUsingThis.sol
@@ -262,9 +262,7 @@ contract VarReadUsingThis is Base {
         return this.counter();
     }
 
-    // Edge case: same-arity overloads with mixed mutability — solar's HIR doesn't
-    // carry the resolved overload, so we conservatively skip flagging to avoid a
-    // false positive on the mutating overload below.
+    // Same-arity overloads use the selected function's mutability.
     function ambiguous(uint256 x) public view returns (uint256) {
         return x;
     }
@@ -272,7 +270,10 @@ contract VarReadUsingThis is Base {
         counter += 1;
     }
     function callAmbiguous() external view returns (uint256) {
-        return this.ambiguous(0);
+        return this.ambiguous(0); //~NOTE: call through `this` to a `view` or `pure` function
+    }
+    function callMutatingOverload() external {
+        this.ambiguous(address(0));
     }
 }
 

--- a/crates/lint/testdata/VarReadUsingThis.stderr
+++ b/crates/lint/testdata/VarReadUsingThis.stderr
@@ -268,6 +268,19 @@ LL │             return v + this.counter();
 note[var-read-using-this]: call through `this` to a `view` or `pure` function incurs a `STATICCALL`
    ╭▸ ROOT/testdata/VarReadUsingThis.sol:LL:CC
    │
+LL │         return this.ambiguous(0);
+   │                ━━━━━━━━━━━━━━━━━
+   │
+   ├ note: avoid the `STATICCALL` by invoking the function directly
+   │       
+   │       call directly without `this.`: `ambiguous(...)`
+   │       
+   │       
+   ╰ help: https://getfoundry.sh/forge/linting/var-read-using-this
+
+note[var-read-using-this]: call through `this` to a `view` or `pure` function incurs a `STATICCALL`
+   ╭▸ ROOT/testdata/VarReadUsingThis.sol:LL:CC
+   │
 LL │         return this.abstractVar();
    │                ━━━━━━━━━━━━━━━━━━ help: consider reading the state variable directly: `abstractVar`
    │

--- a/crates/lint/testdata/WeakPrng.sol
+++ b/crates/lint/testdata/WeakPrng.sol
@@ -11,6 +11,8 @@ contract WeakPrngBase {
 }
 
 contract WeakPrng is WeakPrngBase(block.timestamp % 10) { //~WARN: weak randomness derived from a predictable on-chain value
+    uint256 constant DAY = 1 days;
+    uint256 constant MINUTE = 1 minutes;
     uint256 public deadline;
     uint256 public initializedSeed = block.timestamp % 10; //~WARN: weak randomness derived from a predictable on-chain value
 
@@ -70,6 +72,10 @@ contract WeakPrng is WeakPrngBase(block.timestamp % 10) { //~WARN: weak randomne
         return block.timestamp % 60; //~WARN: weak randomness derived from a predictable on-chain value
     }
 
+    function timestampConstantMinute() external view returns (uint256) {
+        return block.timestamp % MINUTE; //~WARN: weak randomness derived from a predictable on-chain value
+    }
+
     function timestampTenMinuteBound() external view returns (uint256) {
         return block.timestamp % 600; //~WARN: weak randomness derived from a predictable on-chain value
     }
@@ -102,6 +108,14 @@ contract WeakPrng is WeakPrngBase(block.timestamp % 10) { //~WARN: weak randomne
 
     function timestampTimeBucket() external view returns (uint256) {
         return block.timestamp % 1 days;
+    }
+
+    function timestampConstantTimeBucket() external view returns (uint256) {
+        return block.timestamp % DAY;
+    }
+
+    function timestampShiftedTimeBucket() external view returns (uint256) {
+        return block.timestamp % (DAY << 1);
     }
 
     function timestampNumericTimeBucket() external view returns (uint256) {
@@ -151,5 +165,16 @@ contract WeakPrng is WeakPrngBase(block.timestamp % 10) { //~WARN: weak randomne
     function localValueNotTracked(uint256 upper) external view returns (uint256) {
         uint256 seed = block.timestamp;
         return seed % upper;
+    }
+}
+
+contract UserDefinedBlock {
+    struct BlockData {
+        uint256 timestamp;
+        uint256 number;
+    }
+
+    function modulo(BlockData memory block) external pure returns (uint256) {
+        return block.timestamp % block.number;
     }
 }

--- a/crates/lint/testdata/WeakPrng.stderr
+++ b/crates/lint/testdata/WeakPrng.stderr
@@ -121,6 +121,14 @@ LL │         return block.timestamp % 60;
 warning[weak-prng]: weak randomness derived from a predictable on-chain value
    ╭▸ ROOT/testdata/WeakPrng.sol:LL:CC
    │
+LL │         return block.timestamp % MINUTE;
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/weak-prng
+
+warning[weak-prng]: weak randomness derived from a predictable on-chain value
+   ╭▸ ROOT/testdata/WeakPrng.sol:LL:CC
+   │
 LL │         return block.timestamp % 600;
    │                ━━━━━━━━━━━━━━━━━━━━━
    │

--- a/docs/dev/lintrules.md
+++ b/docs/dev/lintrules.md
@@ -65,6 +65,9 @@ Next, choose whether you want an [early or late lint pass](#choosing-between-ear
   ```
 
 - Reuse the shared HIR probes in `crates/lint/src/sol/analysis/` (expression, statement, type and access-control helpers) instead of reimplementing them in the lint.
+- Use Solar's `Gcx` queries for inferred expression types, resolved calls and arguments, and
+  inheritance. Do not reconstruct type-checker results or choose overloads by name or arity.
+  Keep lint-specific data-flow and control-flow analysis in the lint or shared probes.
 
 - Implement the appropriate trait logic (`EarlyLintPass` or `LateLintPass`) for your lint. Do it in a new file within the relevant severity module (e.g., `src/sol/med/my_new_lint.rs`).
 


### PR DESCRIPTION
Solidity lints reconstruct types and guess overloads, call arguments, and inherited targets that Solar already resolves. Use Solar's semantic queries for those results, builtin resolution, and constant evaluation, while retaining lint-specific control-flow and data-flow analysis.

This fixes missed warnings and false positives involving overloads, inherited functions, named arguments, and function pointers. Add regression cases to existing fixtures and update diagnostic snapshots, lint documentation, and the changelog.

Code, tests, documentation, and this PR description were written with Codex assistance.
