### PR TITLE
feat(anvil): add --no-fork-node-info to skip fork identity probes

### DIFF
--- a/.changelog/anvil-no-fork-node-info.md
+++ b/.changelog/anvil-no-fork-node-info.md
@@ -1,0 +1,6 @@
+---
+anvil: minor
+---
+
+Added `--no-fork-node-info` to skip `anvil_nodeInfo` / `anvil_metadata` probes
+on the fork URL.

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -309,6 +309,7 @@ impl NodeArgs {
             })
             .with_fork_headers(self.evm.fork_headers)
             .with_fork_chain_id(self.evm.fork_chain_id.map(u64::from).map(U256::from))
+            .with_no_fork_node_info(self.evm.no_fork_node_info)
             .fork_request_timeout(self.evm.fork_request_timeout.map(Duration::from_millis))
             .fork_request_retries(self.evm.fork_request_retries)
             .fork_retry_backoff(self.evm.fork_retry_backoff.map(Duration::from_millis))
@@ -571,6 +572,14 @@ pub struct AnvilEvmArgs {
         requires = "fork_block_number"
     )]
     pub fork_chain_id: Option<Chain>,
+
+    /// Do not probe the fork endpoint with `anvil_nodeInfo` / `anvil_metadata`.
+    ///
+    /// Those calls detect a nested Anvil. Some public RPCs retry unknown methods for tens of
+    /// seconds instead of returning method-not-found, which delays listen until the probe
+    /// finishes.
+    #[arg(long, requires = "fork_url", help_heading = "Fork config")]
+    pub no_fork_node_info: bool,
 
     /// Sets the number of assumed available compute units per second for this provider
     ///
@@ -1320,6 +1329,19 @@ mod tests {
     }
 
     #[test]
+    fn can_parse_no_fork_node_info() {
+        let args = NodeArgs::parse_from([
+            "anvil",
+            "--fork-url",
+            "http://localhost:8545",
+            "--no-fork-node-info",
+        ]);
+        assert!(args.evm.no_fork_node_info);
+        let config = args.into_node_config().unwrap();
+        assert!(config.no_fork_node_info);
+    }
+
+    #[test]
     fn can_parse_multiple_fork_urls() {
         let args: NodeArgs = NodeArgs::parse_from([
             "anvil",
@@ -1373,6 +1395,7 @@ mod tests {
             vec!["anvil", "--retries", "3"],
             vec!["anvil", "--fork-block-number", "100"],
             vec!["anvil", "--fork-retry-backoff", "500"],
+            vec!["anvil", "--no-fork-node-info"],
         ];
         for args in &cases {
             let result = NodeArgs::try_parse_from(args);

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -113,14 +113,18 @@ struct StableForkSnapshot {
 #[derive(Clone, Copy, Debug, Default)]
 struct AnvilNodeInfoProbe {
     identified: bool,
+    skip: bool,
 }
 
 impl AnvilNodeInfoProbe {
-    const fn new(identified: bool) -> Self {
-        Self { identified }
+    const fn new(identified: bool, skip: bool) -> Self {
+        Self { identified, skip }
     }
 
     async fn request(&mut self, provider: &RetryProvider) -> Result<Option<NodeInfo>> {
+        if self.skip {
+            return Ok(None);
+        }
         match provider.raw_request::<_, NodeInfo>("anvil_nodeInfo".into(), ()).await {
             Ok(node_info) => {
                 self.identified = true;
@@ -217,6 +221,8 @@ pub struct NodeConfig {
     pub fork_headers: Vec<String>,
     /// specifies chain id for cache to skip fetching from remote in offline-start mode
     pub fork_chain_id: Option<U256>,
+    /// Skip `anvil_nodeInfo` / `anvil_metadata` probes against the fork URL.
+    pub no_fork_node_info: bool,
     /// Chain ID discovered from the active fork source.
     pub fork_source_chain_id: Option<u64>,
     /// Chain ID exposed by the active fork endpoint.
@@ -611,6 +617,7 @@ impl Default for NodeConfig {
             fork_request_retries: 5,
             fork_retry_backoff: Duration::from_millis(1_000),
             fork_chain_id: None,
+            no_fork_node_info: false,
             fork_source_chain_id: None,
             fork_execution_chain_id: None,
             fork_endpoint_is_anvil: false,
@@ -1064,6 +1071,17 @@ impl NodeConfig {
     pub const fn with_fork_chain_id(mut self, fork_chain_id: Option<U256>) -> Self {
         self.fork_chain_id = fork_chain_id;
         self
+    }
+
+    /// Skip `anvil_nodeInfo` / `anvil_metadata` probes against the fork URL.
+    #[must_use]
+    pub const fn with_no_fork_node_info(mut self, no_fork_node_info: bool) -> Self {
+        self.no_fork_node_info = no_fork_node_info;
+        self
+    }
+
+    const fn node_info_probe(&self, identified: bool) -> AnvilNodeInfoProbe {
+        AnvilNodeInfoProbe::new(identified, self.no_fork_node_info)
     }
 
     /// Sets the `fork_headers` to use with fork RPC endpoints
@@ -1653,7 +1671,7 @@ impl NodeConfig {
         serving_instance_id: B256,
     ) -> Result<(Arc<RetryProvider>, ForkEndpointIdentity)> {
         let provider = Arc::new(self.fork_provider(eth_rpc_url)?);
-        let mut node_info_probe = AnvilNodeInfoProbe::default();
+        let mut node_info_probe = self.node_info_probe(false);
         for _ in 0..3 {
             let before =
                 self.resolved_fork_endpoint_identity(&provider, &mut node_info_probe).await?;
@@ -1691,7 +1709,7 @@ impl NodeConfig {
         provider: &Arc<RetryProvider>,
         fork_overrides: ForkOverrides,
     ) -> Result<StableForkSnapshot> {
-        let mut node_info_probe = AnvilNodeInfoProbe::new(self.fork_endpoint_is_anvil);
+        let mut node_info_probe = self.node_info_probe(self.fork_endpoint_is_anvil);
         for _ in 0..3 {
             let before =
                 self.resolved_fork_endpoint_identity(provider, &mut node_info_probe).await?;
@@ -1741,7 +1759,7 @@ impl NodeConfig {
         block_hash: B256,
     ) -> Result<bool> {
         let provider = self.fork_provider(eth_rpc_url)?;
-        let mut node_info_probe = AnvilNodeInfoProbe::new(expected.is_authoritative());
+        let mut node_info_probe = self.node_info_probe(expected.is_authoritative());
         for _ in 0..3 {
             let before =
                 self.resolved_fork_endpoint_identity(&provider, &mut node_info_probe).await?;

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -45,9 +45,9 @@ use foundry_evm::hardfork::OpHardfork;
 use foundry_evm_networks::{NetworkConfigs, arbitrum};
 use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope};
 use foundry_test_utils::rpc::{
-    self, next_http_rpc_endpoint, next_rpc_endpoint, spawn_rpc_proxy_internal_error_after,
-    spawn_rpc_proxy_method_not_found_before, spawn_rpc_proxy_rejecting_method_after,
-    spawn_rpc_proxy_rejecting_method_when_enabled,
+    self, next_http_rpc_endpoint, next_rpc_endpoint, spawn_rpc_proxy_canned_method,
+    spawn_rpc_proxy_internal_error_after, spawn_rpc_proxy_method_not_found_before,
+    spawn_rpc_proxy_rejecting_method_after, spawn_rpc_proxy_rejecting_method_when_enabled,
     spawn_rpc_proxy_retyping_first_block_transaction,
 };
 use futures::StreamExt;
@@ -55,7 +55,7 @@ use revm::{
     context::BlockEnv, context_interface::block::BlobExcessGasAndPrice,
     precompile::PrecompileStatus, primitives::hardfork::SpecId,
 };
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::{Arc, atomic::Ordering},
@@ -109,6 +109,22 @@ async fn test_fork_ignores_initial_anvil_node_info_rpc_error() {
     let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(fork_url))).await;
 
     assert_eq!(api.chain_id(), NamedChain::Mainnet as u64);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_skips_anvil_node_info_when_disabled() {
+    let (_api, origin) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
+    let (fork_url, node_info_calls) =
+        spawn_rpc_proxy_canned_method(origin.http_endpoint(), "anvil_nodeInfo", json!({})).await;
+
+    let (api, _handle) = spawn(
+        NodeConfig::test().with_eth_rpc_url(Some(fork_url)).with_no_fork_node_info(true),
+    )
+    .await;
+
+    assert_eq!(api.chain_id(), NamedChain::Mainnet as u64);
+    assert_eq!(node_info_calls.load(Ordering::Relaxed), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Motivation

Anvil probes the fork URL with `anvil_nodeInfo` (and `anvil_metadata` if that succeeds) before it binds the listen port. That is how nested Anvil is detected.

Some public RPCs do not fail-fast on unknown methods. They retry/hedge at the gateway for ~18s, then return `-32601`. For those endpoints, Anvil can take ~30s to listen even though `eth_chainId` / `eth_getBlockByNumber` are fast.

Callers that wait on localhost RPC (and then SIGINT) hit a start timeout even though the chain itself is healthy.

## Solution

Add `--no-fork-node-info` (requires `--fork-url`). When set, Anvil skips `anvil_nodeInfo` / `anvil_metadata` and treats the endpoint as a regular chain: `eth_chainId`, `eth_getBlockByNumber`, `eth_gasPrice` still run.

Example:

```sh
anvil --fork-url https://rpc.example --no-fork-node-info
```

This PR was written with Cursor (Grok). I specified the flag and the skip-probe behavior; the implementation and tests were generated in that session.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation (clap help on the flag)
- [ ] Breaking changes

Made with [Cursor](https://cursor.com)