### PR TITLE
fix(tempo): update dependencies and halt reasons

### DIFF
--- a/.changelog/tempo-standard-halt-reason.md
+++ b/.changelog/tempo-standard-halt-reason.md
@@ -1,0 +1,9 @@
+---
+foundry-evm-core: patch
+forge: patch
+cast: patch
+anvil: patch
+chisel: patch
+---
+
+Updated Tempo dependencies and execution integration for Tempo's standard EVM halt reasons.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -73,11 +73,6 @@ jobs:
             git worktree add --detach ../foundry-baseline "$base_sha"
             echo "versions=master=../foundry-baseline,local" >> "$GITHUB_OUTPUT"
             echo "is_source_comparison=true" >> "$GITHUB_OUTPUT"
-            if [[ -f ../foundry-baseline/cooldown.toml ]]; then
-              echo "baseline_strict_project_config=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "baseline_strict_project_config=false" >> "$GITHUB_OUTPUT"
-            fi
             printf '%s' "$base_sha" > benches/baseline-ref.txt
             printf '%s' "$candidate_sha" > benches/candidate-ref.txt
             git rev-list --count "${candidate_sha}..${base_sha}" > benches/behind-count.txt
@@ -99,7 +94,8 @@ jobs:
         env:
           RUSTC_WRAPPER: ""
         with:
-          strict-project-config: ${{ steps.prep.outputs.baseline_strict_project_config }}
+          # Baselines may contain the same named package exceptions as the candidate.
+          strict-project-config: false
           working-directory: ../foundry-baseline
 
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1

--- a/.github/workflows/cargo-cooldown.yml
+++ b/.github/workflows/cargo-cooldown.yml
@@ -25,4 +25,5 @@ jobs:
       - name: Enforce Cargo dependency cooldown
         uses: tempoxyz/gh-actions/actions/cargo-cooldown@0aa93238d85fd085d7901320b670cc6adb7a02f3
         with:
-          strict-project-config: true
+          # Match foundry-core: permit named package exceptions in cooldown.toml.
+          strict-project-config: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9867f85f660948ddbef071ae484027654c04b62c7decd5b61464a7ed1f8931a0"
+checksum = "63c01387073b598705167c9dd88447d39b99306a1f7572b3b7a20ea107ecbb90"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
+checksum = "fdd59d7221d384c46771ffbf6f18f70aa7753326351277857016bed5127b888f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10148,7 +10148,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10200,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10214,7 +10214,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10227,9 +10227,10 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "arrayvec",
@@ -10253,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10268,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10284,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10297,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10311,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10335,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10355,7 +10356,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10368,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10387,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10432,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10448,7 +10449,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10476,7 +10477,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10490,7 +10491,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10504,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10529,7 +10530,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10546,7 +10547,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10556,7 +10557,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10591,9 +10592,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d1681d52ee61171b838db4924827f63d659d4c3ad559aa3a57003f3dda3f7c"
+checksum = "55f2322f5ea197fac72c2cdc88cb501b2a7db0b0009911133fd3dda45bfceedd"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10623,9 +10624,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85bce65cc8969955309d5c4c37a63612209c720d040f1982dda6b59e39ab059"
+checksum = "c16835bc2ead203219a18fcc84c2c71879ad6b890e8a71150cf7f10e4e355dc4"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10640,9 +10641,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97d0c7f8bdf65601d35ed27cf6b0f0bd436087f0a97a52aa767a49bbcea8373"
+checksum = "e3b4109bdceaca5ee6e27bf41f6b156f2b15892dc5bb47d3530bc4d3b3060077"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10686,9 +10687,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b5923be8784704d119be5381d76a602f65e4a9991650bb87291565bd0d8ec"
+checksum = "73a7409031d87ec281b74efff65d7a4dbea9d80727a55dbc7e4b3fd77b5e03fb"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10705,9 +10706,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a988ad0879bd81b269cad53c235a8ce87cd44a7c1de7d21a6ff3dd9e9f3e70a9"
+checksum = "7a56f37224afd628f7244aa6965609ada04b440ed8ab7a19f55e4291df5a0112"
 dependencies = [
  "auto_impl",
  "either",
@@ -10743,9 +10744,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddc442e3c5006ebb65f479e9e8fded7fc10f300c040276e825eee81e00c94cc"
+checksum = "932f7fe05a2cdeb08195dd7e88a09a4da7c3660cdc6e62720839c77ba77f65aa"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10756,9 +10757,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e22eb3326b44ec0bc47a874966a562390e1613f1f0ba4dc4a1056e525e0f628"
+checksum = "ac4dc0279f2a44770faa8c93d008df684440cf573c91b8e0e39d0d581abf7b3d"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12574,7 +12575,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12614,7 +12615,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12637,7 +12638,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12648,8 +12649,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+version = "1.14.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12660,8 +12661,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+version = "1.14.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12669,7 +12670,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-sol-types",
  "commonware-codec",
- "commonware-cryptography",
  "derive_more",
  "reth-chainspec",
  "reth-consensus",
@@ -12692,7 +12692,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12703,8 +12703,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+version = "1.14.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12730,8 +12730,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+version = "1.14.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12742,7 +12742,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12769,8 +12769,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.13.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=db87590363feee42ef424e481e6a974927f591a2#db87590363feee42ef424e481e6a974927f591a2"
+version = "1.14.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec#ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,7 +401,7 @@ alloy-evm = "0.39.0"
 alloy-op-evm = "0.32.0"
 
 # revm
-revm = { version = "43.0.0", default-features = false }
+revm = { version = "43.0.2", default-features = false }
 revm-inspectors = { version = "0.43.0", features = ["serde"] }
 op-revm = { git = "https://github.com/foundry-rs/optimism", rev = "206d26cedb9d861b983d89fc71e1122187dfa877", default-features = false }
 
@@ -519,20 +519,20 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "965692a8a5457896b2269
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec" }
 
 # Monad
 alloy-monad-evm = { version = "0.8.0", default-features = false, features = [
@@ -623,9 +623,9 @@ op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "20
 alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "206d26cedb9d861b983d89fc71e1122187dfa877" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "db87590363feee42ef424e481e6a974927f591a2" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -1,5 +1,5 @@
 [allow]
-# Match foundry-core: allow revm releases without per-version exceptions.
+# Match foundry-core's revm pattern for revm and Alloy releases.
 package = [
     { crate = "revm", min-publish-age = "0" },
     { crate = "revm-bytecode", min-publish-age = "0" },
@@ -13,48 +13,65 @@ package = [
     { crate = "revm-precompile", min-publish-age = "0" },
     { crate = "revm-primitives", min-publish-age = "0" },
     { crate = "revm-state", min-publish-age = "0" },
+    # Alloy and alloy-core packages used by this workspace.
+    { crate = "alloy", min-publish-age = "0" },
+    { crate = "alloy-chains", min-publish-age = "0" },
+    { crate = "alloy-consensus", min-publish-age = "0" },
+    { crate = "alloy-consensus-any", min-publish-age = "0" },
+    { crate = "alloy-contract", min-publish-age = "0" },
+    { crate = "alloy-core", min-publish-age = "0" },
+    { crate = "alloy-dyn-abi", min-publish-age = "0" },
+    { crate = "alloy-eip2124", min-publish-age = "0" },
+    { crate = "alloy-eip2930", min-publish-age = "0" },
+    { crate = "alloy-eip5792", min-publish-age = "0" },
+    { crate = "alloy-eip7702", min-publish-age = "0" },
+    { crate = "alloy-eip7928", min-publish-age = "0" },
+    { crate = "alloy-eips", min-publish-age = "0" },
+    { crate = "alloy-ens", min-publish-age = "0" },
+    { crate = "alloy-evm", min-publish-age = "0" },
+    { crate = "alloy-genesis", min-publish-age = "0" },
+    { crate = "alloy-hardforks", min-publish-age = "0" },
+    { crate = "alloy-json-abi", min-publish-age = "0" },
+    { crate = "alloy-json-rpc", min-publish-age = "0" },
+    { crate = "alloy-network", min-publish-age = "0" },
+    { crate = "alloy-network-primitives", min-publish-age = "0" },
+    { crate = "alloy-primitives", min-publish-age = "0" },
+    { crate = "alloy-provider", min-publish-age = "0" },
+    { crate = "alloy-pubsub", min-publish-age = "0" },
+    { crate = "alloy-rlp", min-publish-age = "0" },
+    { crate = "alloy-rlp-derive", min-publish-age = "0" },
+    { crate = "alloy-rpc-client", min-publish-age = "0" },
+    { crate = "alloy-rpc-types", min-publish-age = "0" },
+    { crate = "alloy-rpc-types-anvil", min-publish-age = "0" },
+    { crate = "alloy-rpc-types-any", min-publish-age = "0" },
+    { crate = "alloy-rpc-types-beacon", min-publish-age = "0" },
+    { crate = "alloy-rpc-types-debug", min-publish-age = "0" },
+    { crate = "alloy-rpc-types-engine", min-publish-age = "0" },
+    { crate = "alloy-rpc-types-eth", min-publish-age = "0" },
+    { crate = "alloy-rpc-types-mev", min-publish-age = "0" },
+    { crate = "alloy-rpc-types-trace", min-publish-age = "0" },
+    { crate = "alloy-rpc-types-txpool", min-publish-age = "0" },
+    { crate = "alloy-serde", min-publish-age = "0" },
+    { crate = "alloy-signer", min-publish-age = "0" },
+    { crate = "alloy-signer-aws", min-publish-age = "0" },
+    { crate = "alloy-signer-gcp", min-publish-age = "0" },
+    { crate = "alloy-signer-ledger", min-publish-age = "0" },
+    { crate = "alloy-signer-local", min-publish-age = "0" },
+    { crate = "alloy-signer-trezor", min-publish-age = "0" },
+    { crate = "alloy-signer-turnkey", min-publish-age = "0" },
+    { crate = "alloy-sol-macro", min-publish-age = "0" },
+    { crate = "alloy-sol-macro-expander", min-publish-age = "0" },
+    { crate = "alloy-sol-macro-input", min-publish-age = "0" },
+    { crate = "alloy-sol-type-parser", min-publish-age = "0" },
+    { crate = "alloy-sol-types", min-publish-age = "0" },
+    { crate = "alloy-transport", min-publish-age = "0" },
+    { crate = "alloy-transport-http", min-publish-age = "0" },
+    { crate = "alloy-transport-ipc", min-publish-age = "0" },
+    { crate = "alloy-transport-ws", min-publish-age = "0" },
+    { crate = "alloy-trie", min-publish-age = "0" },
+    { crate = "alloy-tx-macros", min-publish-age = "0" },
+    { crate = "syn-solidity", min-publish-age = "0" },
 ]
-
-# Exact-version exceptions for the coordinated Tempo Alloy 1.7.2 release.
-[[allow.exact]]
-crate = "alloy-core"
-version = "1.7.2"
-
-[[allow.exact]]
-crate = "alloy-dyn-abi"
-version = "1.7.2"
-
-[[allow.exact]]
-crate = "alloy-json-abi"
-version = "1.7.2"
-
-[[allow.exact]]
-crate = "alloy-primitives"
-version = "1.7.2"
-
-[[allow.exact]]
-crate = "alloy-sol-macro"
-version = "1.7.2"
-
-[[allow.exact]]
-crate = "alloy-sol-macro-expander"
-version = "1.7.2"
-
-[[allow.exact]]
-crate = "alloy-sol-macro-input"
-version = "1.7.2"
-
-[[allow.exact]]
-crate = "alloy-sol-type-parser"
-version = "1.7.2"
-
-[[allow.exact]]
-crate = "alloy-sol-types"
-version = "1.7.2"
-
-[[allow.exact]]
-crate = "syn-solidity"
-version = "1.7.2"
 
 # Exact-version exception for the RustCrypto release required by the updated dependency graph.
 [[allow.exact]]
@@ -79,140 +96,6 @@ version = "0.12.0"
 [[allow.exact]]
 crate = "soldeer-core"
 version = "0.12.0"
-
-# Temporary exact-version exceptions for the Alloy 2.4.2 update.
-# Remove after 2026-09-15 07:36 UTC, when these releases clear the 7-day cooldown.
-[[allow.exact]]
-crate = "alloy"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-eip7928"
-version = "0.4.9"
-
-[[allow.exact]]
-crate = "alloy-consensus"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-consensus-any"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-contract"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-eip5792"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-eips"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-ens"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-genesis"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-json-rpc"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-network"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-network-primitives"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-provider"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-pubsub"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-client"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types-anvil"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types-any"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types-beacon"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types-debug"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types-engine"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types-eth"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types-mev"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types-trace"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-rpc-types-txpool"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-serde"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-signer"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-signer-local"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-transport"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-transport-http"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-transport-ipc"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-transport-ws"
-version = "2.4.2"
-
-[[allow.exact]]
-crate = "alloy-tx-macros"
-version = "2.4.2"
 
 # Exact-version exceptions for the maintained Monad releases required by revm 43.
 # Remove after 2026-09-16 17:29 UTC, when both releases clear the 7-day cooldown.

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -1,3 +1,20 @@
+[allow]
+# Match foundry-core: allow revm releases without per-version exceptions.
+package = [
+    { crate = "revm", min-publish-age = "0" },
+    { crate = "revm-bytecode", min-publish-age = "0" },
+    { crate = "revm-context", min-publish-age = "0" },
+    { crate = "revm-context-interface", min-publish-age = "0" },
+    { crate = "revm-database", min-publish-age = "0" },
+    { crate = "revm-database-interface", min-publish-age = "0" },
+    { crate = "revm-handler", min-publish-age = "0" },
+    { crate = "revm-inspector", min-publish-age = "0" },
+    { crate = "revm-interpreter", min-publish-age = "0" },
+    { crate = "revm-precompile", min-publish-age = "0" },
+    { crate = "revm-primitives", min-publish-age = "0" },
+    { crate = "revm-state", min-publish-age = "0" },
+]
+
 # Exact-version exceptions for the coordinated Tempo Alloy 1.7.2 release.
 [[allow.exact]]
 crate = "alloy-core"
@@ -65,6 +82,14 @@ version = "0.12.0"
 
 # Temporary exact-version exceptions for the Alloy 2.4.2 update.
 # Remove after 2026-09-15 07:36 UTC, when these releases clear the 7-day cooldown.
+[[allow.exact]]
+crate = "alloy"
+version = "2.4.2"
+
+[[allow.exact]]
+crate = "alloy-eip7928"
+version = "0.4.9"
+
 [[allow.exact]]
 crate = "alloy-consensus"
 version = "2.4.2"

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -201,8 +201,8 @@ use tempo_primitives::{
     },
 };
 use tempo_revm::{
-    ExecutionContext, TempoBatchCallEnv, TempoBlockEnv, TempoHaltReason, TempoTxEnv,
-    evm::TempoContext, gas_params::tempo_gas_params,
+    ExecutionContext, TempoBatchCallEnv, TempoBlockEnv, TempoTxEnv, evm::TempoContext,
+    gas_params::tempo_gas_params,
 };
 use tokio::{sync::RwLock as AsyncRwLock, task::JoinSet};
 
@@ -2623,14 +2623,7 @@ impl<N: Network> Backend<N> {
             inspector,
         );
         self.inject_tempo_precompiles(&mut evm, evm_env);
-        let result = evm.transact(tx_env)?;
-        Ok(ResultAndState {
-            result: result.result.map_haltreason(|h| match h {
-                TempoHaltReason::Ethereum(eth) => eth,
-                _ => HaltReason::PrecompileError,
-            }),
-            state: result.state,
-        })
+        Ok(evm.transact(tx_env)?)
     }
 
     /// Creates a concrete EVM + [`AnvilBlockExecutor`], runs pre-execution changes, and
@@ -3080,7 +3073,6 @@ impl<N: Network> Backend<N> {
                 tx_hash: B256::ZERO,
                 valid_before: request.valid_before.map(|value| value.get()),
                 valid_after: request.valid_after.map(|value| value.get()),
-                subblock_transaction: false,
                 override_key_id: key_id,
                 expiring_nonce_idx: None,
             })),

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -5,15 +5,15 @@ use foundry_fork_db::DatabaseError;
 use revm::{
     context::{
         Journal,
-        result::{EVMError, HaltReason, ResultAndState},
+        result::{EVMError, ResultAndState},
     },
     handler::{EvmTr, FrameResult},
     inspector::InspectorHandler,
-    interpreter::{FrameInput, InstructionResult},
+    interpreter::FrameInput,
     state::Bytecode,
 };
 use tempo_alloy::TempoNetwork;
-use tempo_evm::{TempoBlockEnv, TempoEvmFactory, TempoHaltReason, evm::TempoEvm};
+use tempo_evm::{TempoBlockEnv, TempoEvmFactory, evm::TempoEvm};
 use tempo_precompiles::{
     extend_tempo_precompiles,
     storage::{StorageActions, StorageCtx},
@@ -27,10 +27,7 @@ use crate::{
     FoundryContextExt, FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
     constants::{CALLER, SYSTEM_PRECOMPILE_STUB, TEST_CONTRACT_ADDRESS},
-    evm::{
-        FoundryEvmFactory, FoundryEvmNetwork, IntoInstructionResult, NestedEvm, NestedEvmFor,
-        run_inspected_frame,
-    },
+    evm::{FoundryEvmFactory, FoundryEvmNetwork, NestedEvm, NestedEvmFor, run_inspected_frame},
     tempo::{TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, initialize_tempo_test_genesis_inner},
 };
 
@@ -43,15 +40,6 @@ impl FoundryEvmNetwork for TempoEvmNetwork {
 
 // Will be removed when the next revm release includes bluealloy/revm#3518.
 pub type TempoRevmEvm<'db, I> = tempo_revm::TempoEvm<&'db mut dyn DatabaseExt<TempoEvmFactory>, I>;
-
-impl IntoInstructionResult for TempoHaltReason {
-    fn into_instruction_result(self) -> InstructionResult {
-        match self {
-            Self::Ethereum(eth) => eth.into(),
-            _ => InstructionResult::PrecompileError,
-        }
-    }
-}
 
 impl FoundryEvmFactory for TempoEvmFactory {
     type Chain = ();
@@ -140,11 +128,6 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
 
         let mut handler = TempoEvmHandler::new();
         let result = handler.inspect_run(self).map_err(map_tempo_error)?;
-
-        let result = result.map_haltreason(|h| match h {
-            TempoHaltReason::Ethereum(eth) => eth,
-            _ => HaltReason::PrecompileError,
-        });
 
         Ok(ResultAndState::new(result, self.ctx.journaled_state.inner.state.clone()))
     }

--- a/crates/evm/core/tests/tempo.rs
+++ b/crates/evm/core/tests/tempo.rs
@@ -1,5 +1,5 @@
 use alloy_evm::{Evm, EvmEnv, FromRecoveredTx};
-use alloy_primitives::{Address, TxKind, U256};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_signer::Signer;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolCall;
@@ -8,7 +8,12 @@ use foundry_evm_core::{
     evm::{FoundryEvmFactory, TempoEvmNetwork},
     fork::MultiFork,
 };
-use revm::{Inspector, inspector::NoOpInspector, state::AccountInfo};
+use revm::{
+    Inspector,
+    context::result::{ExecutionResult, HaltReason},
+    inspector::NoOpInspector,
+    state::{AccountInfo, Bytecode},
+};
 use tempo_alloy::primitives::TempoTxEnvelope;
 use tempo_evm::{TempoBlockEnv, TempoEvmFactory};
 use tempo_hardfork::TempoHardfork;
@@ -31,6 +36,49 @@ use tempo_revm::{TempoTxEnv, gas_params::tempo_gas_params};
 const GAS_LIMIT: u64 = 500_000;
 const GAS_PRICE: u128 = 1_000_000_000_000;
 const TRANSFER_AMOUNT: u64 = 1_234;
+
+#[tokio::test]
+async fn nested_tempo_execution_preserves_halt_reason() {
+    let account = PrivateKeySigner::random();
+    let target = Address::repeat_byte(0xee);
+
+    for (opcode, expected) in
+        [(0x0c, HaltReason::OpcodeNotFound), (0x50, HaltReason::StackUnderflow)]
+    {
+        let mut db = in_memory_tempo_backend();
+        seed_fee_token_balances(&mut db, account.address(), target);
+        db.insert_account_info(
+            target,
+            AccountInfo::default().with_code(Bytecode::new_raw(Bytes::from(vec![opcode]))),
+        );
+        let evm_env = EvmEnv::new(
+            revm::context::CfgEnv::<TempoHardfork>::default()
+                .with_spec_and_gas_params(TempoHardfork::T11, tempo_gas_params(TempoHardfork::T11)),
+            TempoBlockEnv::default(),
+        );
+        let mut evm = TempoEvmFactory::default().create_nested_evm(&mut db, evm_env);
+        let tx = primitive_tx(
+            &account,
+            TempoTransaction {
+                chain_id: 1,
+                fee_token: Some(DEFAULT_FEE_TOKEN),
+                gas_limit: GAS_LIMIT,
+                calls: vec![Call {
+                    to: TxKind::Call(target),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                }],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let result = evm.transact_raw(tx).expect("nested transaction executes");
+        assert!(
+            matches!(result.result, ExecutionResult::Halt { reason, .. } if reason == expected)
+        );
+    }
+}
 
 fn in_memory_tempo_backend() -> Backend<TempoEvmNetwork> {
     let (forks, _fork_handler) = MultiFork::new();


### PR DESCRIPTION
Bumps Tempo to [ff8aa978](https://github.com/tempoxyz/tempo/commit/ff8aa9784723d6abbe019a7a9dc62b3bae3ff3ec) and revm to 43.0.2. Tempo removed `TempoHaltReason` in https://github.com/tempoxyz/tempo/pull/7449, which breaks the Forge build used by Tempo's invariant workflows. Use the shared `HaltReason` implementation and preserve nested execution results directly, with regression coverage for opcode and stack-underflow halts.

Updates Anvil's execution path and call environment for the same Tempo API change. Applies [foundry-core's cooldown pattern](https://github.com/foundry-rs/foundry-core/blob/main/cooldown.toml) to the named revm and Alloy packages, replacing Alloy's version-specific exceptions with `min-publish-age = "0"` package rules. CI and benchmark baseline checks accept these package rules while retaining the seven-day default cooldown.

AI assistance was used to diagnose the failure and write the code, regression test, cooldown configuration, and PR description.

Prompted by: @grandizzy
