### PR TITLE
test: remove redundant cases and setup

### DIFF
--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -297,31 +297,6 @@ fmt_tests! {
 }
 
 #[test]
-fn test_comment_empty_line_bug() {
-    init_tracing();
-    let source = r#"pragma solidity ^0.8.0;
-
-contract ProofOfConcept {
-    // some comment
-
-}
-"#;
-
-    let expected = r#"pragma solidity ^0.8.0;
-
-contract ProofOfConcept {
-    // some comment
-}
-"#;
-
-    let fmt_config = Arc::new(FormatterConfig::default());
-    let path = Path::new("test.sol");
-    let formatted = format(source, path, fmt_config);
-
-    assert_eq!(formatted, expected, "Formatting mismatch");
-}
-
-#[test]
 fn test_override_state_variable_without_initializer_does_not_leak_indent() {
     init_tracing();
 
@@ -464,6 +439,5 @@ struct AfterInitializer {
     for (case, source, expected) in cases {
         let formatted = format(source, path, fmt_config.clone());
         assert_eq!(formatted, expected, "{case}");
-        assert_eq!(format(&formatted, path, fmt_config.clone()), expected, "{case} idempotency");
     }
 }

--- a/crates/forge/src/mutation/mutators/assembly_mutator.rs
+++ b/crates/forge/src/mutation/mutators/assembly_mutator.rs
@@ -155,6 +155,7 @@ fn replace_at_span(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use solar::{ast::Span, interface::BytePos};
 
     #[test]
     fn test_opcode_mutations_exist() {
@@ -196,47 +197,21 @@ mod tests {
     }
 
     #[test]
-    fn test_replace_at_span_valid() {
-        use solar::interface::BytePos;
-        let original = "add(a, b)";
-        let outer = solar::ast::Span::new(BytePos(10), BytePos(19));
-        let target = solar::ast::Span::new(BytePos(10), BytePos(13));
-        let result = replace_at_span(original, outer, target, "add", "sub");
-        assert_eq!(result, Some("sub(a, b)".to_string()));
-    }
-
-    #[test]
-    fn test_replace_at_span_target_outside_outer() {
-        use solar::interface::BytePos;
-        let original = "add(a, b)";
-        let outer = solar::ast::Span::new(BytePos(20), BytePos(29));
-        let target = solar::ast::Span::new(BytePos(10), BytePos(13));
-        assert!(replace_at_span(original, outer, target, "add", "sub").is_none());
-    }
-
-    #[test]
-    fn test_replace_at_span_target_exceeds_length() {
-        use solar::interface::BytePos;
-        let original = "add(a, b)";
-        let outer = solar::ast::Span::new(BytePos(10), BytePos(19));
-        let target = solar::ast::Span::new(BytePos(10), BytePos(30));
-        assert!(replace_at_span(original, outer, target, "add", "sub").is_none());
-    }
-
-    #[test]
-    fn test_replace_at_span_opcode_mismatch() {
-        use solar::interface::BytePos;
-        let original = "mul(a, b)";
-        let outer = solar::ast::Span::new(BytePos(10), BytePos(19));
-        let target = solar::ast::Span::new(BytePos(10), BytePos(13));
-        assert!(replace_at_span(original, outer, target, "add", "sub").is_none());
-    }
-
-    #[test]
-    fn test_replace_at_span_empty_original() {
-        use solar::interface::BytePos;
-        let outer = solar::ast::Span::new(BytePos(10), BytePos(19));
-        let target = solar::ast::Span::new(BytePos(10), BytePos(13));
-        assert!(replace_at_span("", outer, target, "add", "sub").is_none());
+    fn test_replace_at_span() {
+        for (case, original, outer, target, expected) in [
+            ("valid", "add(a, b)", (10, 19), (10, 13), Some("sub(a, b)")),
+            ("target outside outer", "add(a, b)", (20, 29), (10, 13), None),
+            ("target exceeds length", "add(a, b)", (10, 19), (10, 30), None),
+            ("opcode mismatch", "mul(a, b)", (10, 19), (10, 13), None),
+            ("empty original", "", (10, 19), (10, 13), None),
+        ] {
+            let outer = Span::new(BytePos(outer.0), BytePos(outer.1));
+            let target = Span::new(BytePos(target.0), BytePos(target.1));
+            assert_eq!(
+                replace_at_span(original, outer, target, "add", "sub").as_deref(),
+                expected,
+                "{case}",
+            );
+        }
     }
 }

--- a/crates/forge/tests/cli/fmt.rs
+++ b/crates/forge/tests/cli/fmt.rs
@@ -1,6 +1,6 @@
 //! Integration tests for `forge fmt` command
 
-use foundry_test_utils::{forgetest, forgetest_init};
+use foundry_test_utils::forgetest;
 
 const UNFORMATTED: &str = r#"// SPDX-License-Identifier: MIT
 pragma         solidity  =0.8.33    ;
@@ -24,7 +24,7 @@ contract Test {
 }
 "#;
 
-forgetest_init!(fmt_exclude_libs_in_recursion, |prj, cmd| {
+forgetest!(fmt_exclude_libs_in_recursion, |prj, cmd| {
     prj.update_config(|config| config.fmt.ignore = vec!["src/ignore/".to_string()]);
 
     prj.add_lib("SomeLib.sol", UNFORMATTED);
@@ -37,7 +37,7 @@ forgetest_init!(fmt_exclude_libs_in_recursion, |prj, cmd| {
 });
 
 // Test that fmt can format a simple contract file
-forgetest_init!(fmt_file, |prj, cmd| {
+forgetest!(fmt_file, |prj, cmd| {
     prj.add_raw_source("FmtTest.sol", UNFORMATTED);
     cmd.arg("fmt").arg("src/FmtTest.sol");
     cmd.assert_success().stdout_eq(str![""]).stderr_eq(str![[r#"
@@ -56,16 +56,17 @@ forgetest!(fmt_stdin, |_prj, cmd| {
     cmd.stdin(UNFORMATTED.as_bytes());
     cmd.assert_success().stdout_eq(FORMATTED);
 
-    // stdin with `--raw` returns formatted code
+    // Already formatted stdin is returned unchanged.
+    // <https://github.com/foundry-rs/foundry/issues/11871>
     cmd.stdin(FORMATTED.as_bytes());
-    cmd.assert_success().stdout_eq(FORMATTED);
+    cmd.assert_success().stdout_eq(FORMATTED.as_bytes());
 
     // stdin with `--check` and without `--raw`returns diff
     cmd.forge_fuse().args(["fmt", "-", "--check"]);
     cmd.assert_success().stdout_eq("");
 });
 
-forgetest_init!(fmt_check_mode, |prj, cmd| {
+forgetest!(fmt_check_mode, |prj, cmd| {
     // Run fmt --check on a well-formatted file
     prj.add_raw_source("Test.sol", FORMATTED);
     cmd.arg("fmt").arg("--check").arg("src/Test.sol");
@@ -107,17 +108,8 @@ Diff in stdin:
 "#]]);
 });
 
-// Test that original is returned if read from stdin and no diff.
-// <https://github.com/foundry-rs/foundry/issues/11871>
-forgetest!(fmt_stdin_original, |_prj, cmd| {
-    cmd.args(["fmt", "-", "--raw"]);
-
-    cmd.stdin(FORMATTED.as_bytes());
-    cmd.assert_success().stdout_eq(FORMATTED.as_bytes());
-});
-
 // Test that fmt can format a simple contract file
-forgetest_init!(fmt_file_config_parms_first, |prj, cmd| {
+forgetest!(fmt_file_config_parms_first, |prj, cmd| {
     prj.create_file(
         "foundry.toml",
         r#"
@@ -245,7 +237,7 @@ Error: `--nearest` cannot be used when `FOUNDRY_CONFIG` is set
 });
 
 // https://github.com/foundry-rs/foundry/issues/12000
-forgetest_init!(fmt_only_cmnts_file, |prj, cmd| {
+forgetest!(fmt_only_cmnts_file, |prj, cmd| {
     // Only line breaks
     prj.add_raw_source("FmtTest.sol", "\n\n");
 
@@ -269,7 +261,7 @@ forgetest_init!(fmt_only_cmnts_file, |prj, cmd| {
 });
 
 // <https://github.com/foundry-rs/foundry/issues/16268>
-forgetest_init!(fmt_keeps_disable_directive_in_every_file, |prj, cmd| {
+forgetest!(fmt_keeps_disable_directive_in_every_file, |prj, cmd| {
     const NAMES: [&str; 4] = ["A", "B", "C", "D"];
     const SOURCE: &str = "// forgefmt: disable-next-line\ncontract  Disabled {}\n";
 

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -474,51 +474,7 @@ exclude_operators = [
     assert_eq!(summary["mutation_score"], 100.0);
 });
 
-forgetest_init!(mutation_testing_rejects_list_mode, |prj, cmd| {
-    prj.add_source(
-        "Counter.sol",
-        r#"
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
-
-contract Counter {
-    uint256 public number;
-
-    function increment() public {
-        number++;
-    }
-}
-"#,
-    );
-
-    prj.add_test(
-        "Counter.t.sol",
-        r#"
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
-
-import "../src/Counter.sol";
-
-contract CounterTest {
-    function test_Increment() public {
-        Counter counter = new Counter();
-        counter.increment();
-        assert(counter.number() == 1);
-    }
-}
-"#,
-    );
-
-    let output = cmd.args(["test", "--mutate", "src/Counter.sol", "--list"]).assert_failure();
-    let stderr = output.get_output().stderr_lossy();
-
-    assert!(
-        stderr.contains("`--mutate` cannot be combined with: --list"),
-        "unexpected stderr:\n{stderr}"
-    );
-});
-
-forgetest_init!(mutation_testing_rejects_list_mode_before_compile, |prj, cmd| {
+forgetest!(mutation_testing_rejects_list_mode_before_compile, |prj, cmd| {
     prj.add_source(
         "Broken.sol",
         r#"
@@ -533,17 +489,13 @@ contract Broken {
 "#,
     );
 
-    let output = cmd.args(["test", "--mutate", "src/Broken.sol", "--list"]).assert_failure();
-    let stderr = output.get_output().stderr_lossy();
+    cmd.args(["test", "--mutate", "src/Broken.sol", "--list"])
+        .assert_failure()
+        .stdout_eq("")
+        .stderr_eq(str![[r#"
+Error: `--mutate` cannot be combined with: --list. Re-run without those flags to use mutation testing.
 
-    assert!(
-        stderr.contains("`--mutate` cannot be combined with: --list"),
-        "unexpected stderr:\n{stderr}"
-    );
-    assert!(
-        !stderr.contains("Compiler run failed"),
-        "mutation/list conflict should be reported before compile errors:\n{stderr}"
-    );
+"#]]);
 });
 
 forgetest_init!(mutation_testing_rejects_all_skipped_baseline, |prj, cmd| {


### PR DESCRIPTION
Remove duplicate formatter and mutation CLI regressions, retain the stronger conflict-before-compilation check, and consolidate five span-replacement cases into a named table. Formatter CLI tests use empty projects instead of copying the initialized template, and the override-indentation test relies on the formatter’s existing idempotency guard. All formatter fixtures and configuration variants are preserved.

This test-only cleanup removes 107 lines and eight template initializations; it makes no measured build-time claim. Motivated by the test-footprint discussion around #16648. `L-ignore` exempts this maintenance change from release notes.

AI assistance: Codex implemented and validated the cleanup, with Omp/Astra consulted to identify redundant coverage.
