### PR TITLE
refactor: replace direct U256 limb construction

### DIFF
--- a/crates/cheatcodes/src/test/assert.rs
+++ b/crates/cheatcodes/src/test/assert.rs
@@ -1,5 +1,5 @@
 use crate::{CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
-use alloy_primitives::{I256, U256, U512};
+use alloy_primitives::{I256, U256, U512, uint};
 use foundry_evm_core::{
     abi::console::{format_units_int, format_units_uint},
     backend::GLOBAL_FAIL_SLOT,
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use revm::context::{ContextTr, JournalTr};
 use std::{borrow::Cow, fmt};
 
-const EQ_REL_DELTA_RESOLUTION: U256 = U256::from_limbs([18, 0, 0, 0]);
+const EQ_REL_DELTA_RESOLUTION: U256 = uint!(18_U256);
 
 struct ComparisonAssertionError<'a, T> {
     kind: AssertionKind,

--- a/crates/evm/fuzz/src/strategies/int.rs
+++ b/crates/evm/fuzz/src/strategies/int.rs
@@ -183,16 +183,12 @@ impl IntStrategy {
         };
 
         // init I256 from 2 randoms
-        let mut inner: [u64; 4] = [0; 4];
-        inner[0] = lower as u64;
-        inner[1] = (lower >> 64) as u64;
-        inner[2] = higher as u64;
-        inner[3] = (higher >> 64) as u64;
+        let magnitude = (U256::from(higher) << 128) | U256::from(lower);
 
         // we have a small bias here, i.e. intN::min will never be generated
         // but it's ok since it's generated in `fn generate_edge_tree(...)`
         let sign = if rng.random::<bool>() { Sign::Positive } else { Sign::Negative };
-        let (start, _) = I256::overflowing_from_sign_and_abs(sign, U256::from_limbs(inner));
+        let (start, _) = I256::overflowing_from_sign_and_abs(sign, magnitude);
 
         Ok(IntValueTree::new(start, false))
     }

--- a/crates/evm/fuzz/src/strategies/uint.rs
+++ b/crates/evm/fuzz/src/strategies/uint.rs
@@ -157,12 +157,7 @@ impl UintStrategy {
         };
 
         // init U256 from 2 randoms
-        let mut inner: [u64; 4] = [0; 4];
-        inner[0] = lower as u64;
-        inner[1] = (lower >> 64) as u64;
-        inner[2] = higher as u64;
-        inner[3] = (higher >> 64) as u64;
-        let start: U256 = U256::from_limbs(inner);
+        let start = (U256::from(higher) << 128) | U256::from(lower);
 
         Ok(UintValueTree::new(start, false))
     }

--- a/crates/evm/symbolic/src/consts.rs
+++ b/crates/evm/symbolic/src/consts.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, U256, address};
+use alloy_primitives::{Address, U256, address, uint};
 use std::time::Duration;
 
 // HD wallet key derivation
@@ -18,7 +18,7 @@ pub(crate) const CONCRETE_BASE_SYMBOLIC_EXPONENT_LIMIT: u64 = 256;
 // Revert selectors and assertion constants
 pub(crate) const PANIC_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71];
 pub(crate) const ERROR_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
-pub(crate) const ASSERT_PANIC_CODE: U256 = U256::from_limbs([1, 0, 0, 0]);
+pub(crate) const ASSERT_PANIC_CODE: U256 = uint!(1_U256);
 pub(crate) const ASSERTION_FAILED_PREFIX: &str = "assertion failed";
 
 // ABI encoding lengths

--- a/crates/lint/src/sol/med/weak_prng.rs
+++ b/crates/lint/src/sol/med/weak_prng.rs
@@ -3,7 +3,7 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{Severity, SolLint},
 };
-use alloy_primitives::U256;
+use alloy_primitives::{U256, uint};
 use solar::{
     ast::{BinOp, BinOpKind},
     sema::{
@@ -111,7 +111,7 @@ impl<'gcx> Visit<'gcx> for PredictableSourceFinder<'gcx> {
 
 /// `block.timestamp % <multiple of one day>`.
 fn is_timestamp_time_bucket(gcx: Gcx<'_>, lhs: &Expr<'_>, rhs: &Expr<'_>) -> bool {
-    const SECONDS_PER_DAY: U256 = U256::from_limbs([24 * 60 * 60, 0, 0, 0]);
+    const SECONDS_PER_DAY: U256 = uint!(86400_U256);
     gcx.resolved_builtin(lhs) == Some(Builtin::BlockTimestamp)
         && gcx
             .try_eval_const(rhs)


### PR DESCRIPTION
Use `uint!` for `U256` constants and combine runtime halves directly in the fuzz strategies, removing manual limb construction without changing values.

The Clippy ban is deferred because `uint!` itself expands to `from_limbs` and triggers it. This internal cleanup needs a maintainer to apply `L-ignore`.

Code and this PR description were written with Codex assistance.
