### PR TITLE
chore(deps): bump svm to 0.5.28

### DIFF
--- a/.changelog/svm-solc-0-8-37.md
+++ b/.changelog/svm-solc-0-8-37.md
@@ -1,0 +1,8 @@
+---
+forge: patch
+cast: patch
+chisel: patch
+foundry-config: patch
+---
+
+Updated svm dependencies to 0.5.28 for Solidity 0.8.37 support.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12418,9 +12418,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs"
-version = "0.5.27"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c237a2fa75db3754792aae93571a0e172c0b60f52cfe20fb96632d96fdf37fa"
+checksum = "497544d5ea6d62d7a382868d244081710a89358e7329d624ea2bf655d908b936"
 dependencies = [
  "const-hex",
  "dirs",
@@ -12437,9 +12437,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.5.27"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9535b2e1700ef60c8036dee0ead4e0dd36f5e6c7120d616ca4171aaa37c506"
+checksum = "83f9fd6ebd5373360678e6abc9a89e1a60f005ebfe88ed33a5f8aa8d7047904a"
 dependencies = [
  "const-hex",
  "semver 1.0.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,7 +343,7 @@ solar = { package = "solar-compiler", version = "=0.2.0", default-features = fal
 solar-cli = { version = "=0.2.0", default-features = false }
 solar-lsp = { version = "=0.2.0", default-features = false }
 solar-lint = { version = "=0.2.0", default-features = false }
-svm = { package = "svm-rs", version = "0.5.27", default-features = false, features = [
+svm = { package = "svm-rs", version = "0.5.28", default-features = false, features = [
     "rustls",
 ] }
 

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -78,14 +78,14 @@ package = [
 crate = "wnaf"
 version = "0.14.1"
 
-# Exact-version exceptions for the solc installation race fixes.
+# Exact-version exceptions for the Solidity 0.8.37 release update.
 [[allow.exact]]
 crate = "svm-rs"
-version = "0.5.27"
+version = "0.5.28"
 
 [[allow.exact]]
 crate = "svm-rs-builds"
-version = "0.5.27"
+version = "0.5.28"
 
 # Temporary exact-version exceptions for Soldeer's validated archive extraction fixes.
 # Remove once the 0.12.0 releases published on 2026-09-07 clear the cooldown.


### PR DESCRIPTION
Bumps `svm-rs` and `svm-rs-builds` to 0.5.28 for Solidity 0.8.37 support, following [alloy-rs/svm-rs#243](https://github.com/alloy-rs/svm-rs/pull/243). Updates the workspace dependency and lockfile, replaces both svm cooldown exceptions with exact-version allowances for 0.5.28, and adds a changelog entry.

This PR was authored by Centaur using AI assistance for the dependency, cooldown, and changelog updates.

Prompted by: @mattsse
