### PR TITLE
fix(fmt): preserve tuple and mapping comments

### DIFF
--- a/.changelog/fmt-tuple-mapping-comments.md
+++ b/.changelog/fmt-tuple-mapping-comments.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-fmt: patch
+---
+
+Fixed line comments in tuple assignments and mapping keys consuming subsequent Solidity code during formatting.

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1280,12 +1280,11 @@ impl<'ast> State<'_, 'ast> {
                 // consumes "comment6" of which should be printed after the `=>`
                 self.print_comments(
                     value.span.lo(),
-                    CommentConfig::skip_ws()
-                        .trailing_no_break()
-                        .mixed_no_break()
-                        .mixed_prev_space(),
+                    CommentConfig::skip_ws().mixed_no_break().mixed_prev_space(),
                 );
-                self.space();
+                if !self.is_bol_or_only_ind() {
+                    self.space();
+                }
                 self.s.offset(self.ind);
                 self.word("=> ");
                 self.s.ibox(self.ind);
@@ -1517,7 +1516,10 @@ impl<'ast> State<'_, 'ast> {
                 |this, expr| match expr.as_ref() {
                     SpannedOption::Some(expr) => this.print_expr(expr),
                     SpannedOption::None(span) => {
-                        this.print_comments(span.hi(), CommentConfig::skip_ws().no_breaks());
+                        this.print_comments(
+                            span.hi(),
+                            CommentConfig::skip_ws().mixed_no_break_post(),
+                        );
                     }
                 },
                 |expr| match expr.as_ref() {

--- a/crates/fmt/testdata/LineComments/fmt.sol
+++ b/crates/fmt/testdata/LineComments/fmt.sol
@@ -1,0 +1,47 @@
+contract LineComments {
+    mapping(
+        address account // Account key.
+            => uint256 balance
+    ) named;
+    mapping(
+        address // Unnamed key.
+            => uint256
+    ) unnamed;
+    mapping(
+        address // Value type.
+            => uint256
+    ) afterArrow;
+    mapping(
+        address
+            => mapping(
+            uint256 id // Nested key.
+                => uint256
+        )
+    ) nested;
+    mapping(address /* Block key. */ => uint256) blockComment;
+
+    function tuples() external pure returns (uint256 x, uint256 y) {
+        (
+            // Omitted first result.
+            ,
+            x
+        ) = (1, 2);
+        (
+            x,
+            // Omitted middle result.
+            ,
+            y
+        ) = (1, 2, 3);
+        (
+            x,
+            // Consecutive omissions.
+            ,,
+            y
+        ) = (1, 2, 3, 4);
+        (
+            x,
+            // Omitted last result.
+        ) = (1, 2);
+        (/* Block omission. */, x) = (1, 2);
+    }
+}

--- a/crates/fmt/testdata/LineComments/original.sol
+++ b/crates/fmt/testdata/LineComments/original.sol
@@ -1,0 +1,30 @@
+contract LineComments {
+    mapping(address account // Account key.
+        => uint256 balance) named;
+    mapping(address // Unnamed key.
+        => uint256) unnamed;
+    mapping(address => // Value type.
+        uint256) afterArrow;
+    mapping(address => mapping(uint256 id // Nested key.
+        => uint256)) nested;
+    mapping(address /* Block key. */ => uint256) blockComment;
+
+    function tuples() external pure returns (uint256 x, uint256 y) {
+        (
+            // Omitted first result.
+            , x
+        ) = (1, 2);
+        (x,
+            // Omitted middle result.
+            , y
+        ) = (1, 2, 3);
+        (x,
+            // Consecutive omissions.
+            , , y
+        ) = (1, 2, 3, 4);
+        (x,
+            // Omitted last result.
+        ) = (1, 2);
+        (/* Block omission. */, x) = (1, 2);
+    }
+}

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -259,6 +259,7 @@ fmt_tests! {
     ImportDirective,
     InlineDisable,
     IntTypes,
+    LineComments,
     LiteralExpression,
     MappingType,
     MethodChain,


### PR DESCRIPTION
Line comments in omitted tuple elements and mapping keys can absorb the following Solidity tokens, leaving `forge fmt` output unparsable. Preserve their terminating line breaks while retaining inline block-comment handling, with regression fixtures for tuple omissions and named, unnamed, and nested mappings. Related to #16649. Written with Codex assistance for implementation and regression tests.
