### PR TITLE
fix(fmt): retain modifier and constructor comments

### DIFF
--- a/.changelog/fmt-modifier-header-comments.md
+++ b/.changelog/fmt-modifier-header-comments.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-fmt: patch
+---
+
+Preserved comments before modifier and constructor bodies when their headers have no attributes.

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -3072,7 +3072,9 @@ impl<'ast> AttributeCommentMapper<'ast> {
         header: &'ast ast::FunctionHeader<'ast>,
     ) -> (AttributeCommentMap, Vec<AttributeInfo<'ast>>, BytePos) {
         let first_attr = self.collect_attributes(header);
-        self.cache_comments(state);
+        if !self.attributes.is_empty() {
+            self.cache_comments(state);
+        }
         (self.map(), self.attributes, first_attr)
     }
 

--- a/crates/fmt/testdata/ModifierDefinition/fmt.sol
+++ b/crates/fmt/testdata/ModifierDefinition/fmt.sol
@@ -11,4 +11,32 @@ contract ModifierDefinitions {
         uint256 d
     ) {}
     modifier overridden() override(Base1, Base2) {}
+    modifier inlineBlock()/* Inline explanation. */  {
+        _;
+    }
+    modifier trailingLine(uint256 a) // Trailing explanation.
+         {
+        require(a > 0);
+        _;
+    }
+    modifier isolatedLine()
+        // Isolated explanation.
+         {
+        _;
+    }
+    modifier isolatedBlock()
+        /* Block explanation. */
+         {
+        _;
+    }
+    modifier multiline()
+        /* First line.
+        Second line. */
+         {
+        _;
+    }
+    modifier attributed() virtual /* Virtual. */  {
+        _;
+    }
+    constructor()/* Constructor explanation. */  {}
 }

--- a/crates/fmt/testdata/ModifierDefinition/original.sol
+++ b/crates/fmt/testdata/ModifierDefinition/original.sol
@@ -6,4 +6,17 @@ contract ModifierDefinitions {
     modifier fourParams(uint a,uint b   ,uint c, uint d) {}
     modifier overridden (
     ) override ( Base1 , Base2) {}
+    modifier inlineBlock() /* Inline explanation. */ { _; }
+    modifier trailingLine(uint a) // Trailing explanation.
+    { require(a > 0); _; }
+    modifier isolatedLine()
+    // Isolated explanation.
+    { _; }
+    modifier isolatedBlock()
+    /* Block explanation. */
+    { _; }
+    modifier multiline() /* First line.
+    Second line. */ { _; }
+    modifier attributed() virtual /* Virtual. */ { _; }
+    constructor() /* Constructor explanation. */ {}
 }

--- a/crates/fmt/testdata/ModifierDefinition/override-spacing.fmt.sol
+++ b/crates/fmt/testdata/ModifierDefinition/override-spacing.fmt.sol
@@ -12,4 +12,32 @@ contract ModifierDefinitions {
         uint256 d
     ) {}
     modifier overridden() override (Base1, Base2) {}
+    modifier inlineBlock()/* Inline explanation. */  {
+        _;
+    }
+    modifier trailingLine(uint256 a) // Trailing explanation.
+         {
+        require(a > 0);
+        _;
+    }
+    modifier isolatedLine()
+        // Isolated explanation.
+         {
+        _;
+    }
+    modifier isolatedBlock()
+        /* Block explanation. */
+         {
+        _;
+    }
+    modifier multiline()
+        /* First line.
+        Second line. */
+         {
+        _;
+    }
+    modifier attributed() virtual /* Virtual. */  {
+        _;
+    }
+    constructor()/* Constructor explanation. */  {}
 }


### PR DESCRIPTION
`forge fmt` drops comments before modifier and constructor bodies because the attribute mapper consumes them even when the header has no attributes. Leave those comments for the body printer, with regression coverage for line and block comments and a control case with an attributed modifier. Written with Codex assistance for implementation and regression tests.
