### PR TITLE
fix(fmt): stabilize multiline comment indentation

### DIFF
--- a/.changelog/fmt-multiline-comment-indent.md
+++ b/.changelog/fmt-multiline-comment-indent.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+forge-fmt: patch
+foundry-common: patch
+---
+
+Fixed multiline block comments in expressions gaining indentation on repeated formatting runs.

--- a/crates/common/src/comments/mod.rs
+++ b/crates/common/src/comments/mod.rs
@@ -230,11 +230,13 @@ impl<'ast> CommentGatherer<'ast> {
                 };
                 let kind = CommentKind::Block;
 
-                // Count the number of chars since the start of the line by rescanning.
+                // Measure the opening column, expanding tabs for non-doc comments.
                 let pos_in_file = self.start_bpos + BytePos(self.pos as u32);
                 let line_begin_in_file = line_begin_pos(self.sf, pos_in_file);
                 let line_begin_pos = (line_begin_in_file - self.start_bpos).to_usize();
-                let mut col = CharPos(self.text[line_begin_pos..self.pos].chars().count());
+                let tab_width = if is_doc { 1 } else { self.tab_width.unwrap_or(1) };
+                let mut col =
+                    CharPos(estimate_line_width(&self.text[line_begin_pos..self.pos], tab_width));
 
                 // To preserve alignment in multi-line non-doc comments, normalize the block based
                 // on its least-indented line.
@@ -244,7 +246,10 @@ impl<'ast> CommentGatherer<'ast> {
                             return min;
                         }
                         std::cmp::min(
-                            CharPos(line.chars().count() - line.trim_start().chars().count()),
+                            CharPos(estimate_line_width(
+                                &line[..line.len() - line.trim_start().len()],
+                                tab_width,
+                            )),
                             min,
                         )
                     })
@@ -312,6 +317,22 @@ impl<'ast> CommentGatherer<'ast> {
         }
 
         for (pos, line) in lines.delimited() {
+            let indent_end = line.len() - line.trim_start().len();
+            let mut expanded = String::new();
+            let line = if !is_doc
+                && let Some(tab_width) = self.tab_width
+                && line[..indent_end].contains('\t')
+            {
+                // Trim tab indentation in the same display columns used by the printer.
+                expanded.extend(std::iter::repeat_n(
+                    ' ',
+                    estimate_line_width(&line[..indent_end], tab_width),
+                ));
+                expanded.push_str(&line[indent_end..]);
+                expanded.as_str()
+            } else {
+                line
+            };
             let line = normalize_block_comment_ws(line, col).trim_end().to_string();
             if !is_doc {
                 res.push(line);

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -820,13 +820,17 @@ impl<'sess> State<'sess, '_> {
                         }
                     }
                 } else {
-                    // No wrapping, print as-is
+                    // Match the opening-column normalization of continuation lines.
+                    self.visual_align();
                     for (pos, line) in cmnt.lines.into_iter().delimited() {
-                        self.word(line);
+                        if !line.is_empty() {
+                            self.word(line);
+                        }
                         if !pos.is_last {
                             self.hardbreak();
                         }
                     }
+                    self.end();
                 }
                 if config.mixed_post_nbsp {
                     if config.mixed_post_glued {

--- a/crates/fmt/testdata/MixedBlockComments/fmt.sol
+++ b/crates/fmt/testdata/MixedBlockComments/fmt.sol
@@ -1,0 +1,24 @@
+contract MixedBlockComments {
+    function condition(uint256 x) external pure returns (uint256) {
+        if (
+            x /* First line.
+              more text. */ > 0
+        ) {
+            return 1;
+        }
+        return 0;
+    }
+
+    function expression(uint256 x) external pure returns (uint256) {
+        return x /* Explanation.
+                 Indented detail.
+
+                 More detail. */ + 1;
+    }
+
+    function aligned(uint256 x) external pure returns (uint256) {
+        return x /* Column A.
+                    Column B.
+                  Column C. */ + 1;
+    }
+}

--- a/crates/fmt/testdata/MixedBlockComments/original.sol
+++ b/crates/fmt/testdata/MixedBlockComments/original.sol
@@ -1,0 +1,20 @@
+contract MixedBlockComments {
+    function condition(uint256 x) external pure returns (uint256) {
+        if (x /* First line.
+more text. */ > 0) { return 1; }
+        return 0;
+    }
+
+    function expression(uint256 x) external pure returns (uint256) {
+        return x /* Explanation.
+   Indented detail.
+
+   More detail. */ + 1;
+    }
+
+    function aligned(uint256 x) external pure returns (uint256) {
+        return x /* Column A.
+                    Column B.
+                  Column C. */ + 1;
+    }
+}

--- a/crates/fmt/testdata/MixedBlockComments/tab.fmt.sol
+++ b/crates/fmt/testdata/MixedBlockComments/tab.fmt.sol
@@ -1,0 +1,25 @@
+// config: style = "tab"
+contract MixedBlockComments {
+	function condition(uint256 x) external pure returns (uint256) {
+		if (
+			x /* First line.
+			  more text. */ > 0
+		) {
+			return 1;
+		}
+		return 0;
+	}
+
+	function expression(uint256 x) external pure returns (uint256) {
+		return x /* Explanation.
+				 Indented detail.
+
+				 More detail. */ + 1;
+	}
+
+	function aligned(uint256 x) external pure returns (uint256) {
+		return x /* Column A.
+				    Column B.
+				  Column C. */ + 1;
+	}
+}

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -263,6 +263,7 @@ fmt_tests! {
     MappingType,
     MethodChain,
     MethodChainCallOptions,
+    MixedBlockComments,
     ModifierDefinition,
     NamedCallArgsInChain,
     NestedNamedCallArgumentChain,


### PR DESCRIPTION
Multiline block comments inside expressions drift on repeated `forge fmt` runs because continuation lines are printed relative to the expression while normalization uses the comment's opening column. Align those lines with the opening comment and measure tab indentation consistently, preserving internal alignment and blank lines. Written with Codex assistance for implementation and regression tests.
