### PR TITLE
fix(evm): align trace hardfork metadata

### DIFF
--- a/.changelog/tracing-spec-authority.md
+++ b/.changelog/tracing-spec-authority.md
@@ -1,0 +1,14 @@
+---
+cast: patch
+forge: patch
+chisel: patch
+forge-script: patch
+forge-verify: patch
+foundry-evm: patch
+foundry-evm-core: patch
+foundry-evm-hardforks: patch
+foundry-evm-traces: patch
+foundry-evm-networks: patch
+---
+
+Keep execution hardfork resolution and trace metadata consistent with the selected EVM family, including explicit version overrides and historical forks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6053,6 +6053,7 @@ dependencies = [
  "eyre",
  "foundry-cheatcodes-spec",
  "foundry-common",
+ "foundry-compilers",
  "foundry-config",
  "foundry-evm-abi",
  "foundry-evm-hardforks",

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -582,7 +582,14 @@ impl CallArgs {
             return handle_traces(
                 result,
                 &config,
-                TraceContext::new(chain, endpoint_identity.network_profile, resolved_hardfork),
+                {
+                    let context = TraceContext::new(
+                        chain,
+                        endpoint_identity.network_profile,
+                        resolved_hardfork,
+                    );
+                    context.with_hardfork(context.decoding_hardfork(&config))
+                },
                 &contracts_bytecode,
                 &tracing,
                 with_local_artifacts,

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -399,7 +399,11 @@ impl RunArgs {
         handle_traces(
             result,
             &config,
-            TraceContext::new(chain, endpoint_identity.network_profile, resolved_hardfork),
+            {
+                let context =
+                    TraceContext::new(chain, endpoint_identity.network_profile, resolved_hardfork);
+                context.with_hardfork(context.decoding_hardfork(&config))
+            },
             &contracts_bytecode,
             &tracing,
             with_local_artifacts,

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -94,7 +94,7 @@ pub(crate) async fn handle_traces(
         .with_signature_identifier(SignaturesIdentifier::from_config(config)?)
         .with_networks(context.networks())
         .with_chain_id(Some(context.chain().id()))
-        .with_hardfork(context.decoding_hardfork(config));
+        .with_hardfork(context.hardfork());
     let mut identifier = TraceIdentifiers::new().with_external(config, Some(context.chain()))?;
     if let Some(contracts) = &known_contracts {
         builder = builder.with_known_contracts(contracts);

--- a/crates/cast/tests/cli/monad.rs
+++ b/crates/cast/tests/cli/monad.rs
@@ -503,3 +503,86 @@ casttest!(monad_run_replays_current_sender_context, async |_prj, cmd| {
     assert!(output.contains("ReserveBalance::dippedIntoReserve()"), "{output}");
     assert!(output.contains("[Return] true"), "{output}");
 });
+
+// An explicit EVM version selects the concrete Monad spec even when configuration and
+// endpoint metadata request MonadEight. Execution and labels must both use the override.
+casttest!(monad_fork_trace_evm_version_override, async |prj, cmd| {
+    prj.update_config(|config| {
+        config.networks = foundry_evm_networks::NetworkConfigs::with_monad();
+        config.hardfork = Some("monad:MonadEight".parse().unwrap());
+    });
+    let (_api, handle) = anvil::spawn(
+        NodeConfig::test_monad()
+            .with_hardfork(Some("monad:MonadEight".parse().unwrap()))
+            .with_chain_id(Some(MONAD_TESTNET_CHAIN_ID)),
+    )
+    .await;
+    let endpoint = handle.http_endpoint();
+    let from = handle.dev_accounts().next().unwrap();
+    let target = MONAD_RESERVE_BALANCE_ADDRESS.to_string();
+    let input = format!("0x{}", hex::encode(MONAD_DIPPED_INTO_RESERVE_SELECTOR));
+    cmd.args([
+        "call",
+        &target,
+        "--data",
+        &input,
+        "--rpc-url",
+        &endpoint,
+        "--trace",
+        "--from",
+        &from.to_string(),
+        "--evm-version",
+        "cancun",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+Traces:
+  [..] ReserveBalance::dippedIntoReserve()
+    └─ ← [Return] false
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]])
+    .stderr_eq(str![""]);
+
+    let receipt = handle
+        .http_provider()
+        .send_transaction(
+            TransactionRequest::default()
+                .with_from(from)
+                .with_to(MONAD_RESERVE_BALANCE_ADDRESS)
+                .with_gas_limit(100_000)
+                .with_input(MONAD_DIPPED_INTO_RESERVE_SELECTOR)
+                .into(),
+        )
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(receipt.status());
+    cmd.cast_fuse()
+        .args([
+            "run",
+            &receipt.transaction_hash.to_string(),
+            "--rpc-url",
+            &endpoint,
+            "--quick",
+            "--evm-version",
+            "cancun",
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [..] ReserveBalance::dippedIntoReserve()
+    └─ ← [Return] false
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]])
+        .stderr_eq(str![""]);
+});

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -319,11 +319,10 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
         let fork_hardfork = fork_context.and_then(|context| context.hardfork);
         self.config.source_chain_id = fork_chain_id;
         self.config.resolved_hardfork = resolve_execution_spec(
-            &self.config.foundry_config,
-            self.config.evm_opts.networks,
+            self.config.foundry_config.evm_version,
+            self.config.foundry_config.hardfork,
             &mut evm_env,
             ExecutionSpecContext::local_or_fork(fork_chain_id, fork_hardfork),
-            None,
             None,
         );
 

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 foundry-cheatcodes-spec.workspace = true
 foundry-common.workspace = true
+foundry-compilers.workspace = true
 foundry-config.workspace = true
 foundry-evm-abi.workspace = true
 foundry-evm-hardforks.workspace = true

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -18,8 +18,8 @@ use foundry_common::{
     ALCHEMY_FREE_TIER_CUPS, NON_ARCHIVE_NODE_WARNING,
     provider::{ProviderBuilder, is_rpc_method_not_found},
 };
+use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::{Chain, Config, ExecutionSpec, FoundryHardfork, GasLimit};
-use foundry_evm_hardforks::TempoHardfork;
 use foundry_evm_networks::{NetworkConfigs, NetworkVariant};
 use revm::{context::CfgEnv, primitives::hardfork::SpecId};
 use serde::{Deserialize, Serialize};
@@ -1457,23 +1457,15 @@ impl ExecutionSpecContext {
         Self::Historical { source_chain_id, endpoint_hardfork }
     }
 
-    fn endpoint_hardfork(self, networks: NetworkConfigs) -> Option<FoundryHardfork> {
+    fn hardfork<SPEC: ExecutionSpec>(self, timestamp: u64) -> Option<FoundryHardfork> {
         match self {
-            Self::Historical { endpoint_hardfork, .. } => endpoint_hardfork,
-            Self::Fork { endpoint_hardfork, .. } if networks.active_network_name().is_some() => {
-                endpoint_hardfork
+            Self::Local => None,
+            Self::Fork { source_chain_id, endpoint_hardfork } => {
+                SPEC::fork_hardfork(source_chain_id, timestamp, endpoint_hardfork)
             }
-            Self::Local | Self::Fork { .. } => None,
-        }
-    }
-
-    fn schedule_chain_id(self, networks: NetworkConfigs) -> Option<ChainId> {
-        match self {
-            Self::Historical { source_chain_id, .. } => Some(source_chain_id),
-            Self::Fork { source_chain_id, .. } if networks.active_network_name().is_some() => {
-                Some(source_chain_id)
-            }
-            Self::Local | Self::Fork { .. } => None,
+            Self::Historical { source_chain_id, endpoint_hardfork } => endpoint_hardfork
+                .filter(|&hardfork| SPEC::from_foundry_hardfork(hardfork).is_some())
+                .or_else(|| SPEC::historical_hardfork(source_chain_id, timestamp)),
         }
     }
 }
@@ -1488,53 +1480,30 @@ impl ExecutionSpecContext {
 /// Returns the exact namespaced hardfork, when applicable, so execution and trace decoding can use
 /// the same hardfork.
 pub fn resolve_execution_spec<SPEC, BLOCK>(
-    config: &Config,
-    networks: NetworkConfigs,
+    evm_version: EvmVersion,
+    configured_hardfork: Option<FoundryHardfork>,
     evm_env: &mut EvmEnv<SPEC, BLOCK>,
     context: ExecutionSpecContext,
     explicit_spec: Option<SPEC>,
-    explicit_hardfork: Option<FoundryHardfork>,
 ) -> Option<FoundryHardfork>
 where
     SPEC: ExecutionSpec + Into<SpecId> + Copy,
     BLOCK: FoundryBlock,
 {
-    let supports = |hardfork| SPEC::from_foundry_hardfork(hardfork).is_some();
-    let configured_hardfork = config.hardfork.filter(|&hardfork| supports(hardfork));
-    let endpoint_hardfork =
-        context.endpoint_hardfork(networks).filter(|&hardfork| supports(hardfork));
-    let timestamp_hardfork = context
-        .schedule_chain_id(networks)
-        .and_then(|chain_id| {
-            FoundryHardfork::from_chain_and_timestamp(
-                chain_id,
-                evm_env.block_env.timestamp().saturating_to(),
-            )
-        })
-        .filter(|&hardfork| supports(hardfork));
-    let fallback_hardfork = if networks.is_tempo() {
-        Some(FoundryHardfork::Tempo(config.evm_spec_id::<TempoHardfork>()))
+    let (spec, hardfork) = if let Some(spec) = explicit_spec {
+        (spec, spec.reported_hardfork())
+    } else if let Some((hardfork, spec)) = configured_hardfork
+        .filter(|&hardfork| SPEC::from_foundry_hardfork(hardfork).is_some())
+        .or_else(|| context.hardfork::<SPEC>(evm_env.block_env.timestamp().saturating_to()))
+        .and_then(|hardfork| SPEC::from_foundry_hardfork(hardfork).map(|spec| (hardfork, spec)))
+    {
+        (spec, Some(hardfork))
     } else {
-        #[cfg(feature = "monad")]
-        let hardfork = networks.is_monad().then(|| {
-            FoundryHardfork::Monad(config.evm_spec_id::<foundry_evm_hardforks::MonadHardfork>())
-        });
-        #[cfg(not(feature = "monad"))]
-        let hardfork = None;
-        hardfork
+        let spec = SPEC::from_evm_version(evm_version);
+        (spec, spec.reported_hardfork())
     };
-
-    let resolved_hardfork = if explicit_spec.is_some() {
-        explicit_hardfork
-    } else {
-        configured_hardfork.or(endpoint_hardfork).or(timestamp_hardfork).or(fallback_hardfork)
-    };
-    let spec = explicit_spec
-        .or_else(|| resolved_hardfork.and_then(SPEC::from_foundry_hardfork))
-        .unwrap_or_else(|| config.evm_spec_id());
     evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec);
-
-    resolved_hardfork
+    hardfork
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -1944,18 +1913,16 @@ mod tests {
     #[cfg(feature = "monad")]
     fn resolve_execution_spec_uses_monad_ten_activation_timestamp() {
         let config = Config::default();
-        let networks = NetworkConfigs::with_monad();
         let activation =
             foundry_evm_hardforks::MonadHardfork::MonadTen.mainnet_activation_timestamp().unwrap();
 
         let mut before = monad_env(activation - 1);
         assert_eq!(
             resolve_execution_spec(
-                &config,
-                networks,
+                config.evm_version,
+                config.hardfork,
                 &mut before,
                 ExecutionSpecContext::fork(NamedChain::Monad as u64, None),
-                None,
                 None,
             ),
             Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadNine))
@@ -1965,11 +1932,10 @@ mod tests {
         let mut after = monad_env(activation);
         assert_eq!(
             resolve_execution_spec(
-                &config,
-                networks,
+                config.evm_version,
+                config.hardfork,
                 &mut after,
                 ExecutionSpecContext::fork(NamedChain::Monad as u64, None),
-                None,
                 None,
             ),
             Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadTen))
@@ -1989,11 +1955,10 @@ mod tests {
 
         assert_eq!(
             resolve_execution_spec(
-                &config,
-                NetworkConfigs::with_monad(),
+                config.evm_version,
+                config.hardfork,
                 &mut env,
                 ExecutionSpecContext::fork(NamedChain::Monad as u64, Some(endpoint_hardfork),),
-                None,
                 None,
             ),
             Some(endpoint_hardfork)
@@ -2005,18 +1970,16 @@ mod tests {
     #[cfg(feature = "monad")]
     fn resolve_execution_spec_ignores_schedule_for_local_env() {
         let config = Config::default();
-        let networks = NetworkConfigs::with_monad();
         let activation =
             foundry_evm_hardforks::MonadHardfork::MonadTen.mainnet_activation_timestamp().unwrap();
         let mut env = monad_env(activation - 1);
 
         assert_eq!(
             resolve_execution_spec(
-                &config,
-                networks,
+                config.evm_version,
+                config.hardfork,
                 &mut env,
                 ExecutionSpecContext::Local,
-                None,
                 None,
             ),
             Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadTen))
@@ -2033,11 +1996,10 @@ mod tests {
 
         assert_eq!(
             resolve_execution_spec(
-                &config,
-                NetworkConfigs::default(),
+                config.evm_version,
+                config.hardfork,
                 &mut env,
                 ExecutionSpecContext::fork(NamedChain::Mainnet as u64, None),
-                None,
                 None,
             ),
             None
@@ -2048,11 +2010,10 @@ mod tests {
             FoundryHardfork::Ethereum(foundry_evm_hardforks::EthereumHardfork::Frontier);
         assert_eq!(
             resolve_execution_spec(
-                &config,
-                NetworkConfigs::default(),
+                config.evm_version,
+                config.hardfork,
                 &mut env,
                 ExecutionSpecContext::fork(NamedChain::Mainnet as u64, Some(endpoint_hardfork),),
-                None,
                 None,
             ),
             None
@@ -2073,11 +2034,10 @@ mod tests {
 
         assert_eq!(
             resolve_execution_spec(
-                &config,
-                NetworkConfigs::default(),
+                config.evm_version,
+                config.hardfork,
                 &mut env,
                 ExecutionSpecContext::historical(NamedChain::Mainnet as u64, None),
-                None,
                 None,
             ),
             Some(expected)
@@ -2088,7 +2048,8 @@ mod tests {
     #[test]
     #[cfg(feature = "optimism")]
     fn resolve_execution_spec_uses_optimism_schedule_for_local_forks() {
-        let config = Config::default();
+        let config =
+            Config { hardfork: Some("ethereum:london".parse().unwrap()), ..Default::default() };
         let chain_id = NamedChain::Optimism as u64;
         let timestamp = u64::MAX;
         let expected = FoundryHardfork::from_chain_and_timestamp(chain_id, timestamp).unwrap();
@@ -2098,11 +2059,10 @@ mod tests {
 
         assert_eq!(
             resolve_execution_spec(
-                &config,
-                NetworkConfigs::with_optimism(),
+                config.evm_version,
+                config.hardfork,
                 &mut env,
-                ExecutionSpecContext::fork(chain_id, None),
-                None,
+                ExecutionSpecContext::fork(chain_id, Some("tempo:T3".parse().unwrap())),
                 None,
             ),
             Some(expected)
@@ -2113,7 +2073,6 @@ mod tests {
     #[test]
     #[cfg(feature = "monad")]
     fn resolve_execution_spec_honors_explicit_precedence() {
-        let networks = NetworkConfigs::with_monad();
         let activation =
             foundry_evm_hardforks::MonadHardfork::MonadNine.mainnet_activation_timestamp().unwrap();
         let mut configured = Config {
@@ -2124,11 +2083,10 @@ mod tests {
 
         assert_eq!(
             resolve_execution_spec(
-                &configured,
-                networks,
+                configured.evm_version,
+                configured.hardfork,
                 &mut env,
                 ExecutionSpecContext::fork(NamedChain::Monad as u64, None),
-                None,
                 None,
             ),
             configured.hardfork
@@ -2138,12 +2096,11 @@ mod tests {
         configured.hardfork = None;
         assert_eq!(
             resolve_execution_spec(
-                &configured,
-                networks,
+                configured.evm_version,
+                configured.hardfork,
                 &mut env,
                 ExecutionSpecContext::fork(NamedChain::Monad as u64, None),
                 Some(foundry_evm_hardforks::MonadHardfork::MonadEight),
-                Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight)),
             ),
             Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight))
         );
@@ -2183,11 +2140,10 @@ mod tests {
         assert_eq!(tx_env.chain_id, Some(NamedChain::Mainnet as u64));
         assert_eq!(
             resolve_execution_spec(
-                &Config::default(),
-                NetworkConfigs::with_monad(),
+                Config::default().evm_version,
+                Config::default().hardfork,
                 &mut evm_env,
                 ExecutionSpecContext::fork(fork_context.source_chain_id, fork_context.hardfork,),
-                None,
                 None,
             ),
             Some(FoundryHardfork::Monad(foundry_evm_hardforks::MonadHardfork::MonadEight))
@@ -2581,11 +2537,10 @@ mod tests {
         );
         assert_eq!(
             resolve_execution_spec(
-                &Config::default(),
-                evm_opts.networks,
+                Config::default().evm_version,
+                Config::default().hardfork,
                 &mut evm_env,
                 ExecutionSpecContext::fork(context.source_chain_id, context.hardfork),
-                None,
                 None,
             ),
             context.hardfork

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -10,8 +10,12 @@ use foundry_evm_core::{
     fork::CreateFork,
     opts::{EvmOpts, ExecutionSpecContext, resolve_execution_spec},
 };
-use foundry_evm_hardforks::{FoundryHardfork, TempoHardfork};
-use foundry_evm_networks::NetworkConfigs;
+use foundry_evm_hardforks::FoundryHardfork;
+use foundry_evm_networks::{
+    NetworkConfigs,
+    celo::transfer::{CELO_TRANSFER_ADDRESS, CELO_TRANSFER_LABEL},
+    resolved_precompile_labels,
+};
 use foundry_evm_traces::{TraceContext, TraceRequirements};
 use revm::state::Bytecode;
 use std::ops::{Deref, DerefMut};
@@ -38,7 +42,6 @@ impl<FEN: FoundryEvmNetwork> TracingFork<FEN> {
     pub fn resolve_spec(&mut self, config: &Config, evm_version: Option<EvmVersion>) {
         let hardfork = TracingExecutor::<FEN>::resolve_spec_for_chain(
             config,
-            self.context.networks(),
             self.context.chain().id(),
             self.context.hardfork(),
             &mut self.evm_env,
@@ -126,41 +129,20 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         self.executor.spec_id()
     }
 
-    /// Resolves and applies the execution spec for the effective block environment.
-    pub fn resolve_spec(
-        config: &Config,
-        networks: NetworkConfigs,
-        evm_env: &mut EvmEnvFor<FEN>,
-        evm_version: Option<EvmVersion>,
-    ) -> Option<FoundryHardfork> {
-        Self::resolve_spec_for_chain(
-            config,
-            networks,
-            evm_env.cfg_env.chain_id,
-            None,
-            evm_env,
-            evm_version,
-        )
-    }
-
     /// Resolves and applies the execution spec using the source chain's hardfork schedule.
     pub fn resolve_spec_for_chain(
         config: &Config,
-        networks: NetworkConfigs,
         source_chain_id: ChainId,
         endpoint_hardfork: Option<FoundryHardfork>,
         evm_env: &mut EvmEnvFor<FEN>,
         evm_version: Option<EvmVersion>,
     ) -> Option<FoundryHardfork> {
-        let explicit_hardfork =
-            evm_version.and_then(|version| network_hardfork_from_evm_version(networks, version));
         resolve_execution_spec(
-            config,
-            networks,
+            config.evm_version,
+            config.hardfork,
             evm_env,
             ExecutionSpecContext::historical(source_chain_id, endpoint_hardfork),
             evm_version.map(evm_spec_id::<SpecFor<FEN>>),
-            explicit_hardfork,
         )
     }
 
@@ -170,7 +152,11 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         networks: NetworkConfigs,
         resolved_hardfork: Option<FoundryHardfork>,
     ) {
-        config.labels.extend(networks.precompiles_label(resolved_hardfork));
+        config.labels.extend(resolved_precompile_labels(resolved_hardfork));
+        // Celo shares the Ethereum spec and remains a separate inspector configuration.
+        if networks.is_celo() {
+            config.labels.insert(CELO_TRANSFER_ADDRESS, CELO_TRANSFER_LABEL.to_string());
+        }
     }
 
     /// Resolves the fork state and trace context using the fork block number from the config.
@@ -245,22 +231,6 @@ fn apply_state_overrides<FEN: FoundryEvmNetwork>(
     Ok(())
 }
 
-fn network_hardfork_from_evm_version(
-    networks: NetworkConfigs,
-    evm_version: EvmVersion,
-) -> Option<FoundryHardfork> {
-    if networks.is_tempo() {
-        return Some(FoundryHardfork::Tempo(evm_spec_id::<TempoHardfork>(evm_version)));
-    }
-    #[cfg(feature = "monad")]
-    if networks.is_monad() {
-        return Some(FoundryHardfork::Monad(evm_spec_id::<foundry_evm_hardforks::MonadHardfork>(
-            evm_version,
-        )));
-    }
-    None
-}
-
 impl<FEN: FoundryEvmNetwork> Deref for TracingExecutor<FEN> {
     type Target = Executor<FEN>;
 
@@ -281,6 +251,63 @@ mod tests {
     use alloy_rpc_types::state::AccountOverride;
     use foundry_evm_core::{FoundryTransaction, evm::EthEvmNetwork};
     use revm::context::Transaction;
+
+    fn assert_trace_spec_authority<FEN>(
+        networks: NetworkConfigs,
+        configured: FoundryHardfork,
+        evm_version: EvmVersion,
+        expected_spec: SpecFor<FEN>,
+        expected_hardfork: Option<FoundryHardfork>,
+    ) where
+        FEN: FoundryEvmNetwork,
+        SpecFor<FEN>: std::fmt::Debug + PartialEq,
+    {
+        let mut config = Config { networks, hardfork: Some(configured), ..Default::default() };
+        let mut env = EvmEnvFor::<FEN>::default();
+        env.cfg_env.chain_id = 999_999;
+        let hardfork = TracingExecutor::<FEN>::resolve_spec_for_chain(
+            &config,
+            1,
+            Some(configured),
+            &mut env,
+            Some(evm_version),
+        );
+        assert_eq!(env.cfg_env.spec, expected_spec);
+        assert_eq!(hardfork, expected_hardfork);
+        assert_eq!(env.cfg_env.chain_id, 999_999);
+
+        TracingExecutor::<FEN>::extend_precompile_labels(&mut config, networks, hardfork);
+        assert_eq!(config.labels, resolved_precompile_labels(expected_hardfork));
+        let context = TraceContext::new(Chain::from_id(1), networks, hardfork);
+        let decoder = foundry_evm_traces::CallTraceDecoderBuilder::new()
+            .with_networks(context.networks())
+            .with_hardfork(context.hardfork())
+            .build();
+        assert_eq!(decoder.hardfork(), expected_hardfork);
+    }
+
+    #[test]
+    fn trace_spec_ethereum_override_preserves_absent_metadata() {
+        assert_trace_spec_authority::<EthEvmNetwork>(
+            NetworkConfigs::default(),
+            "ethereum:shanghai".parse().unwrap(),
+            EvmVersion::Cancun,
+            revm::primitives::hardfork::SpecId::CANCUN,
+            None,
+        );
+    }
+
+    #[test]
+    fn trace_spec_tempo_override_reports_executed_hardfork() {
+        let spec = evm_spec_id::<foundry_evm_hardforks::TempoHardfork>(EvmVersion::Cancun);
+        assert_trace_spec_authority::<foundry_evm_core::evm::TempoEvmNetwork>(
+            NetworkConfigs::with_tempo(),
+            "tempo:T3".parse().unwrap(),
+            EvmVersion::Cancun,
+            spec,
+            Some(spec.into()),
+        );
+    }
 
     #[test]
     fn state_override_nonce_does_not_modify_transaction_nonce() {

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -329,7 +329,7 @@ pub trait FromEvmVersion: From<FoundryHardfork> {
     fn from_evm_version(version: EvmVersion) -> Self;
 }
 
-/// Trait for parsing and displaying a network-specific execution spec.
+/// Conversion, hardfork scheduling, and trace metadata for a concrete execution spec.
 pub trait ExecutionSpec: FromEvmVersion {
     // Returns the user-facing name for the active execution spec.
     fn evm_version_name(&self) -> String;
@@ -341,6 +341,31 @@ pub trait ExecutionSpec: FromEvmVersion {
 
     // Converts a namespaced Foundry hardfork if it belongs to this spec family.
     fn from_foundry_hardfork(hardfork: FoundryHardfork) -> Option<Self>;
+
+    /// Returns this family's hardfork at a historical source-chain timestamp.
+    /// Unknown source chains return `None`; this never discovers another execution family.
+    fn historical_hardfork(chain_id: u64, timestamp: u64) -> Option<FoundryHardfork> {
+        FoundryHardfork::from_chain_and_timestamp(chain_id, timestamp)
+            .filter(|&hardfork| Self::from_foundry_hardfork(hardfork).is_some())
+    }
+
+    /// Resolves a local fork's hardfork from compatible endpoint metadata or its source schedule.
+    /// Ethereum overrides this to retain the configured EVM version for local forks.
+    fn fork_hardfork(
+        chain_id: u64,
+        timestamp: u64,
+        endpoint_hardfork: Option<FoundryHardfork>,
+    ) -> Option<FoundryHardfork> {
+        endpoint_hardfork
+            .filter(|&hardfork| Self::from_foundry_hardfork(hardfork).is_some())
+            .or_else(|| Self::historical_hardfork(chain_id, timestamp))
+    }
+
+    /// Returns exact metadata for a directly selected spec, when the family requires it.
+    /// Ethereum and Optimism retain their existing absence of metadata for direct spec overrides.
+    fn reported_hardfork(self) -> Option<FoundryHardfork> {
+        None
+    }
 }
 
 impl FromEvmVersion for SpecId {
@@ -382,6 +407,14 @@ impl ExecutionSpec for SpecId {
             FoundryHardfork::Ethereum(hardfork) => Some(spec_id_from_ethereum_hardfork(hardfork)),
             _ => None,
         }
+    }
+
+    fn fork_hardfork(
+        _chain_id: u64,
+        _timestamp: u64,
+        _endpoint_hardfork: Option<FoundryHardfork>,
+    ) -> Option<FoundryHardfork> {
+        None
     }
 }
 
@@ -453,6 +486,10 @@ impl ExecutionSpec for TempoHardfork {
             _ => None,
         }
     }
+
+    fn reported_hardfork(self) -> Option<FoundryHardfork> {
+        Some(self.into())
+    }
 }
 
 #[cfg(feature = "monad")]
@@ -481,6 +518,10 @@ impl ExecutionSpec for MonadHardfork {
             FoundryHardfork::Monad(hardfork) => Some(hardfork),
             _ => None,
         }
+    }
+
+    fn reported_hardfork(self) -> Option<FoundryHardfork> {
+        Some(self.into())
     }
 }
 

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -924,6 +924,25 @@ const fn bsc_p256_precompile(chain_id: ChainId, timestamp: u64) -> Option<Option
     }
 }
 
+/// Returns custom precompile labels for an already resolved execution hardfork.
+/// This metadata lookup does not discover or select an execution network.
+pub fn resolved_precompile_labels(hardfork: Option<FoundryHardfork>) -> AddressHashMap<String> {
+    match hardfork {
+        Some(FoundryHardfork::Tempo(hardfork)) => TEMPO_PRECOMPILES
+            .iter()
+            .filter(|(_, address)| is_tempo_precompile_active_at(*address, hardfork))
+            .map(|(label, address)| (*address, (*label).to_string()))
+            .collect(),
+        #[cfg(feature = "monad")]
+        Some(FoundryHardfork::Monad(hardfork)) => MONAD_PRECOMPILE_LABELS
+            .iter()
+            .filter(|(_, address)| is_monad_precompile_active_at(*address, hardfork))
+            .map(|(label, address)| (*address, (*label).to_string()))
+            .collect(),
+        _ => AddressHashMap::default(),
+    }
+}
+
 /// Returns whether a well-known Tempo precompile address is active at `hardfork`.
 pub fn is_tempo_precompile_active_at(address: Address, hardfork: TempoHardfork) -> bool {
     if address == CURRENT_COMMITTEE_ADDRESS {

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -65,7 +65,9 @@ impl TraceContext {
         self
     }
 
-    /// Returns the hardfork to use while decoding this context's traces.
+    /// Completes metadata for a remotely executed trace before decoding.
+    /// Locally executed traces must use [`Self::hardfork`] directly, including `None`, so a
+    /// configured hardfork cannot replace an explicit execution-spec override.
     pub fn decoding_hardfork(self, config: &Config) -> Option<FoundryHardfork> {
         let execution_network = self.networks.execution_network();
         let mut hardfork = self

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -495,11 +495,10 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
         self.sender = config.sender;
         self.evm_opts.networks = config.networks;
         self.hardfork = resolve_execution_spec(
-            &config,
-            self.evm_opts.networks,
+            config.evm_version,
+            config.hardfork,
             &mut self.evm_env,
             ExecutionSpecContext::local_or_fork(self.fork_chain_id, self.fork_hardfork),
-            None,
             None,
         );
         self.spec_id = self.evm_env.cfg_env.spec;
@@ -906,11 +905,10 @@ impl MultiContractRunnerBuilder {
             (self.fork.is_some() || evm_opts.fork_url.is_some()).then_some(evm_env.cfg_env.chain_id)
         });
         let hardfork = resolve_execution_spec(
-            &self.config,
-            evm_opts.networks,
+            self.config.evm_version,
+            self.config.hardfork,
             &mut evm_env,
             ExecutionSpecContext::local_or_fork(fork_chain_id, self.fork_hardfork),
-            None,
             None,
         );
         let spec_id = evm_env.cfg_env.spec;

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -1206,11 +1206,10 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         let fork_hardfork = fork_context.and_then(|context| context.hardfork);
         self.source_chain_id = fork_chain_id;
         self.hardfork = resolve_execution_spec(
-            &self.config,
-            self.evm_opts.networks,
+            self.config.evm_version,
+            self.config.hardfork,
             &mut evm_env,
             ExecutionSpecContext::local_or_fork(fork_chain_id, fork_hardfork),
-            None,
             None,
         );
         Ok((resolved, evm_env, tx_env))

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -397,7 +397,6 @@ where
 #[cfg(all(test, feature = "monad"))]
 fn resolve_runtime_spec<FEN>(
     config: &Config,
-    networks: NetworkConfigs,
     source_chain_id: ChainId,
     endpoint_hardfork: Option<FoundryHardfork>,
     evm_env: &mut EvmEnvFor<FEN>,
@@ -407,7 +406,6 @@ where
 {
     TracingExecutor::<FEN>::resolve_spec_for_chain(
         config,
-        networks,
         source_chain_id,
         endpoint_hardfork,
         evm_env,
@@ -768,7 +766,6 @@ contract Broken {
         before_env.cfg_env.chain_id = NamedChain::Mainnet as u64;
         let before = resolve_runtime_spec::<foundry_evm::core::evm::MonadEvmNetwork>(
             &before_config,
-            NetworkConfigs::with_monad(),
             NamedChain::Monad as u64,
             None,
             &mut before_env,
@@ -788,7 +785,6 @@ contract Broken {
         let mut after_env = monad_env(monad_nine_timestamp);
         let after = resolve_runtime_spec::<foundry_evm::core::evm::MonadEvmNetwork>(
             &after_config,
-            NetworkConfigs::with_monad(),
             NamedChain::Monad as u64,
             None,
             &mut after_env,
@@ -817,7 +813,6 @@ contract Broken {
 
         let resolved = resolve_runtime_spec::<foundry_evm::core::evm::MonadEvmNetwork>(
             &config,
-            networks,
             NamedChain::Monad as u64,
             Some(foundry_evm::hardforks::MonadHardfork::MonadNine.into()),
             &mut env,

--- a/docs/dev/networks.md
+++ b/docs/dev/networks.md
@@ -77,6 +77,13 @@ network's execution semantics.
 | `NetworkConfigs` and hardfork types | Pre-dispatch selection, chain and endpoint inference, feature configuration, and hardfork validation |
 | Foundry tools | CLI/config plumbing, one authoritative dispatch per execution entry point, and tool-specific workflows and user-visible behavior |
 
+After dispatch, `SpecFor<FEN>` owns hardfork resolution through `ExecutionSpec`: checked
+namespaced conversion, native source-chain schedules, local-fork behavior, and metadata for direct
+spec overrides. The shared resolver accepts one typed explicit spec and derives its reported
+hardfork from that same value. Tracing carries the result, including absent metadata for an
+Ethereum or Optimism version override, directly into decoding. Keep the source chain ID separate
+from an overridden execution chain ID when supplying historical context.
+
 Do not encode protocol behavior only as a chain-ID branch in a tool. Put execution semantics in the
 network factory or context, selection in the network configuration layer, and tool-specific workflow
 behavior in the relevant tool.


### PR DESCRIPTION
This makes the concrete execution spec authoritative for hardfork resolution and trace metadata after network dispatch. Explicit EVM-version overrides, configured hardforks, endpoint metadata, and source-chain schedules are now resolved within the selected execution family, preventing execution and trace decoding from reporting different hardforks.

Remote traces continue completing metadata from their endpoint context, while locally executed traces carry the exact resolved result, including intentionally absent Ethereum and Optimism override metadata. Custom Tempo and Monad precompile labels now follow that resolved hardfork, with Celo’s separate inspector configuration preserved.

Improved coverage.

This PR was developed with AI assistance.