### PR TITLE
fix(cast,script): resolve transaction networks more consistently

### DIFF
--- a/.changelog/cast-network-dispatch.md
+++ b/.changelog/cast-network-dispatch.md
@@ -1,0 +1,7 @@
+---
+cast: patch
+forge: patch
+forge-script: patch
+---
+
+Resolved Cast transaction networks consistently from configuration and RPC discovery, and rejected Tempo transaction options that conflict with an explicitly selected network in Cast and Forge scripts.

--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -11,6 +11,7 @@ use foundry_cli::{
     utils::LoadConfig,
 };
 use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder, shell};
+use foundry_config::Config;
 use foundry_wallets::{BrowserWalletOpts, WalletOpts};
 use std::str::FromStr;
 use tempo_alloy::TempoNetwork;
@@ -65,22 +66,28 @@ pub struct AccessListArgs {
 
 impl AccessListArgs {
     pub async fn run(self) -> Result<()> {
-        if self.tx.tempo.is_tempo() {
-            self.run_with_network::<TempoNetwork>().await
+        let config = self.rpc.load_config()?;
+        let requires_tempo = self.tx.tempo.is_tempo() || self.tx.tempo.session_id()?.is_some();
+        let network = super::resolve_transaction_network(&config, requires_tempo).await?;
+        if network.is_tempo() {
+            self.run_with_network::<TempoNetwork>(config).await
         } else {
-            self.run_with_network::<Ethereum>().await
+            self.run_with_network::<Ethereum>(config).await
         }
     }
 
-    async fn run_with_network<N: Network + Unpin>(self) -> Result<()>
+    async fn run_with_network<N: Network + Unpin>(self, config: Config) -> Result<()>
     where
         N::TransactionRequest: FoundryTransactionBuilder<N>,
     {
-        let Self { to, sig, args, data, tx, force, rpc, wallet, browser, block } = self;
+        let Self { to, sig, args, data, tx, force, rpc: _, wallet, browser, block } = self;
 
-        let config = rpc.load_config()?;
         let provider = ProviderBuilder::<N>::from_config(&config)?.build()?;
-        let (sender, _) = read_only_sender::<N>(&browser, wallet).await?;
+        let chain_id = match config.chain {
+            Some(chain) => chain.id(),
+            None => provider.get_chain_id().await?,
+        };
+        let (sender, _) = read_only_sender::<N>(&browser, wallet, &tx.tempo, chain_id).await?;
 
         let builder = CastTxBuilder::new(&provider, tx, &config)
             .await?

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -32,7 +32,7 @@ use clap::Parser;
 use eyre::{Result, WrapErr};
 use foundry_cli::{
     opts::{ChainValueParser, RpcOpts, TracingArgs, TransactionOpts},
-    utils::{LoadConfig, TraceResult, parse_ether_value},
+    utils::{TraceResult, load_config_from_provider, parse_ether_value},
 };
 use foundry_common::{
     FoundryTransactionBuilder,
@@ -261,11 +261,19 @@ impl CallArgs {
         let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
         let (mut config, mut evm_opts) = super::load_cast_config_and_evm_opts(figment)?;
         evm_opts.fork_url = Some(config.get_rpc_url_or_localhost_http()?.into_owned());
-        if self.tx.tempo.is_tempo() {
+        let has_tempo_session = self.tx.tempo.session_id()?.is_some();
+        let requires_tempo = self.tx.tempo.is_tempo() || has_tempo_session;
+        super::validate_tempo_network(&config, requires_tempo)?;
+        if requires_tempo {
             evm_opts.networks = NetworkConfigs::with_tempo();
-        } else if let Some(chain) = self.chain {
+        } else if !evm_opts.networks.has_network_selection()
+            && let Some(chain) = config.chain
+        {
             evm_opts.networks =
                 evm_opts.networks.try_with_chain_id(chain.id()).map_err(eyre::Report::msg)?;
+        }
+        if has_tempo_session && self.will_disclose_auth() {
+            eyre::bail!("Tempo sessions cannot be combined with EIP-7702 authorizations");
         }
         let Some(auth_preflight) = self.preflight_auth_disclosure().await? else {
             return Ok(());
@@ -418,7 +426,13 @@ impl CallArgs {
             if debug_trace_call { Some(evm_opts.discover_fork_endpoint().await?) } else { None };
         let sender = match auth_sender {
             Some(sender) => sender,
-            None => read_only_sender::<FEN::Network>(&browser, wallet).await?.0,
+            None => {
+                let chain_id = match config.chain {
+                    Some(chain) => chain.id(),
+                    None => provider.get_chain_id().await?,
+                };
+                read_only_sender::<FEN::Network>(&browser, wallet, &tx.tempo, chain_id).await?.0
+            }
         };
         let from = sender.address();
 
@@ -766,7 +780,13 @@ impl CallArgs {
 
     /// Handle --curl mode by generating curl command without any RPC interaction.
     async fn run_curl(self) -> Result<()> {
-        let config = self.rpc.load_config()?;
+        let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
+        let config = load_config_from_provider(figment)?;
+        let has_tempo_session = self.tx.tempo.session_id()?.is_some();
+        super::validate_tempo_network(&config, self.tx.tempo.is_tempo() || has_tempo_session)?;
+        if has_tempo_session {
+            eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --curl");
+        }
         let url = config.get_rpc_url_or_localhost_http()?;
         let jwt = config.get_rpc_jwt_secret()?;
 

--- a/crates/cast/src/cmd/erc20/permit.rs
+++ b/crates/cast/src/cmd/erc20/permit.rs
@@ -1,7 +1,5 @@
 //! ERC-2612 signed approvals.
 
-use std::str::FromStr;
-
 use crate::{
     cmd::send::SendTxArgs,
     tempo,
@@ -19,7 +17,7 @@ use clap::Args;
 use eyre::{Result, WrapErr, ensure};
 use foundry_cli::{
     json::{print_json_success, print_scalar},
-    utils::{LoadConfig, get_chain, get_provider},
+    utils::{LoadConfig, get_provider},
 };
 use foundry_common::{
     FoundryTransactionBuilder,
@@ -31,6 +29,7 @@ use foundry_config::Config;
 use foundry_wallets::WalletSigner;
 use serde::Serialize;
 use serde_json::json;
+use std::str::FromStr;
 use tempo_alloy::TempoNetwork;
 
 sol! {
@@ -101,16 +100,14 @@ impl PermitArgs {
             config.chain.is_none_or(|chain| chain.id() == rpc_chain_id),
             "Configured chain does not match the RPC chain"
         );
-        let rpc_is_tempo = get_chain(config.chain, &provider).await?.is_tempo();
-        let (resolved_tempo, signer, access_key) =
+        let (network, signer, access_key) =
             tempo::resolve_transaction_network_and_signer(&self.tx.tempo, &self.send_tx.eth)
                 .await?;
         ensure!(
             access_key.is_none(),
             "Tempo access keys cannot sign ERC-2612 permits; use a root account signer"
         );
-        let is_tempo = resolved_tempo || (self.send_tx.browser.browser && rpc_is_tempo);
-        if is_tempo {
+        if network.is_tempo() {
             self.run_generic::<TempoNetwork>(signer, config, rpc_chain_id).await
         } else {
             self.run_generic::<Ethereum>(signer, config, rpc_chain_id).await

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -12,6 +12,7 @@ use foundry_cli::{
     utils::{LoadConfig, parse_ether_value},
 };
 use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder};
+use foundry_config::Config;
 use foundry_wallets::{BrowserWalletOpts, WalletOpts};
 use std::str::FromStr;
 use tempo_alloy::TempoNetwork;
@@ -89,14 +90,17 @@ pub enum EstimateSubcommands {
 
 impl EstimateArgs {
     pub async fn run(self) -> Result<()> {
-        if self.tx.tempo.is_tempo() {
-            self.run_with_network::<TempoNetwork>().await
+        let config = self.rpc.load_config()?;
+        let requires_tempo = self.tx.tempo.is_tempo() || self.tx.tempo.session_id()?.is_some();
+        let network = super::resolve_transaction_network(&config, requires_tempo).await?;
+        if network.is_tempo() {
+            self.run_with_network::<TempoNetwork>(config).await
         } else {
-            self.run_with_network::<Ethereum>().await
+            self.run_with_network::<Ethereum>(config).await
         }
     }
 
-    async fn run_with_network<N: Network>(self) -> Result<()>
+    async fn run_with_network<N: Network>(self, config: Config) -> Result<()>
     where
         N::TransactionRequest: FoundryTransactionBuilder<N>,
     {
@@ -110,13 +114,17 @@ impl EstimateArgs {
             wallet,
             browser,
             force,
-            rpc,
+            rpc: _,
             command,
         } = self;
 
-        let config = rpc.load_config()?;
         let provider = ProviderBuilder::<N>::from_config(&config)?.build()?;
-        let (sender, is_browser) = read_only_sender::<N>(&browser, wallet).await?;
+        let chain_id = match config.chain {
+            Some(chain) => chain.id(),
+            None => provider.get_chain_id().await?,
+        };
+        let (sender, is_browser) =
+            read_only_sender::<N>(&browser, wallet, &tx.tempo, chain_id).await?;
 
         let code = if let Some(EstimateSubcommands::Create {
             code,

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -107,13 +107,9 @@ impl MakeTxArgs {
             );
         }
 
-        if self.tx.tempo.session_id()?.is_some() {
-            return self.run_generic::<TempoNetwork>(None, None).await;
-        }
-
-        let (is_tempo, signer, access_key) =
+        let (network, signer, access_key) =
             tempo::resolve_transaction_network_and_signer(&self.tx.tempo, &self.eth).await?;
-        if is_tempo {
+        if network.is_tempo() {
             self.run_generic::<TempoNetwork>(signer, access_key).await
         } else {
             self.run_generic::<Ethereum>(signer, None).await

--- a/crates/cast/src/cmd/mod.rs
+++ b/crates/cast/src/cmd/mod.rs
@@ -5,7 +5,7 @@
 //! implement `figment::Provider` which allows the subcommand to override the config's defaults, see
 //! [`foundry_config::Config`].
 
-use alloy_network::Network;
+use alloy_network::{AnyNetwork, Network};
 use alloy_primitives::{Address, Bytes, map::AddressHashMap};
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockId;
@@ -15,9 +15,13 @@ use foundry_cli::{
     opts::RpcOpts,
     utils::{LoadConfig, get_provider, load_config_from_provider},
 };
-use foundry_common::{provider::RetryProvider, shell};
+use foundry_common::{
+    provider::{ProviderBuilder, RetryProvider},
+    shell,
+};
 use foundry_config::{Config, figment::Figment};
 use foundry_evm::{core::bytecode::InstIter, opts::EvmOpts};
+use foundry_evm_networks::NetworkVariant;
 use futures::StreamExt;
 use serde::Serialize;
 use serde_json::Value;
@@ -144,18 +148,40 @@ pub mod txpool;
 pub mod vaddr;
 pub mod wallet;
 
-#[cfg(all(test, feature = "monad"))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn normalized_hardfork_network_is_applied_to_evm_opts() {
-        let figment = Config::figment().merge(("hardfork", "monad:MonadNine"));
-        let (config, evm_opts) = load_cast_config_and_evm_opts(figment).unwrap();
-
-        assert!(config.networks.is_monad());
-        assert!(evm_opts.networks.is_monad());
+/// Validates a Tempo transaction requirement against an explicit execution family.
+pub(crate) fn validate_tempo_network(config: &Config, requires_tempo: bool) -> Result<()> {
+    if requires_tempo && config.networks.has_network_selection() {
+        let network = config.networks.execution_network();
+        eyre::ensure!(
+            network.is_tempo(),
+            "Tempo transaction options conflict with configured network `{}`",
+            config.networks.execution_profile_name()
+        );
     }
+    Ok(())
+}
+
+/// Resolves the RPC request family before typed transaction construction.
+pub(crate) async fn resolve_transaction_network(
+    config: &Config,
+    requires_tempo: bool,
+) -> Result<NetworkVariant> {
+    validate_tempo_network(config, requires_tempo)?;
+    if requires_tempo {
+        return Ok(NetworkVariant::Tempo);
+    }
+    if config.networks.has_network_selection() {
+        return Ok(config.networks.execution_network());
+    }
+    if let Some(chain) = config.chain {
+        return Ok(chain.id().into());
+    }
+    if config.eth_rpc_curl {
+        return Ok(NetworkVariant::Ethereum);
+    }
+
+    let provider = ProviderBuilder::<AnyNetwork>::from_config(config)?.build()?;
+    Ok(provider.get_chain_id().await?.into())
 }
 
 pub(crate) fn disassemble(code: &[u8]) -> Result<String> {
@@ -164,4 +190,55 @@ pub(crate) fn disassemble(code: &[u8]) -> Result<String> {
         writeln!(output, "{pc:08x}: {inst}")?;
     }
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn transaction_network_respects_explicit_selection() {
+        for network in [NetworkVariant::Ethereum, NetworkVariant::Tempo] {
+            let config =
+                Config { networks: network.into(), eth_rpc_curl: true, ..Default::default() };
+            assert_eq!(resolve_transaction_network(&config, false).await.unwrap(), network);
+            assert_eq!(
+                resolve_transaction_network(&config, true).await.is_ok(),
+                network.is_tempo()
+            );
+        }
+        let config = Config { eth_rpc_curl: true, ..Default::default() };
+        assert_eq!(
+            resolve_transaction_network(&config, true).await.unwrap(),
+            NetworkVariant::Tempo
+        );
+        assert_eq!(
+            resolve_transaction_network(&config, false).await.unwrap(),
+            NetworkVariant::Ethereum
+        );
+
+        let config = Config {
+            networks: foundry_evm_networks::NetworkConfigs::with_celo(),
+            eth_rpc_curl: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_transaction_network(&config, false).await.unwrap(),
+            NetworkVariant::Ethereum
+        );
+        assert_eq!(
+            resolve_transaction_network(&config, true).await.unwrap_err().to_string(),
+            "Tempo transaction options conflict with configured network `celo`"
+        );
+    }
+
+    #[cfg(feature = "monad")]
+    #[test]
+    fn normalized_hardfork_network_is_applied_to_evm_opts() {
+        let figment = Config::figment().merge(("hardfork", "monad:MonadNine"));
+        let (config, evm_opts) = load_cast_config_and_evm_opts(figment).unwrap();
+
+        assert!(config.networks.is_monad());
+        assert!(evm_opts.networks.is_monad());
+    }
 }

--- a/crates/cast/src/cmd/safe/transaction.rs
+++ b/crates/cast/src/cmd/safe/transaction.rs
@@ -50,14 +50,14 @@ impl SafeSendOpts {
     ) -> Result<SafeSendResult> {
         let Self { rpc, wallet, tx } = self;
         let eth = EthereumOpts { rpc: *rpc, wallet: *wallet, ..Default::default() };
-        let (is_tempo, signer, access_key) =
+        let (network, signer, access_key) =
             tempo::resolve_transaction_network_and_signer(&tx.tempo, &eth).await?;
         ensure!(
             access_key.is_none(),
             "Tempo Accounts sessions are not yet supported by `cast safe create` or `cast safe execute`"
         );
         let call = SafeCall { to, data, confirmations, timeout, poll_interval };
-        if is_tempo {
+        if network.is_tempo() {
             call.send::<TempoNetwork>(eth, *tx, signer).await
         } else {
             call.send::<Ethereum>(eth, *tx, signer).await

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -128,15 +128,24 @@ impl SendTxArgs {
     }
 
     pub async fn run(self) -> Result<()> {
-        if self.tx.tempo.session_id()?.is_some() {
-            return self.run_generic::<TempoNetwork>(None, None).await;
+        if self.to.is_none() && matches!(self.command, Some(SendTxSubcommands::Create { .. })) {
+            if !self.tx.auth.is_empty() {
+                eyre::bail!(
+                    "EIP-7702 transactions can't be CREATE transactions and require a destination address"
+                );
+            }
+            if self.path.is_some() {
+                eyre::bail!(
+                    "EIP-4844 transactions can't be CREATE transactions and require a destination address"
+                );
+            }
         }
 
-        let (is_tempo, signer, tempo_access_key) =
+        let (network, signer, tempo_access_key) =
             tempo::resolve_transaction_network_and_signer(&self.tx.tempo, &self.send_tx.eth)
                 .await?;
 
-        if is_tempo {
+        if network.is_tempo() {
             self.run_generic::<TempoNetwork>(signer, tempo_access_key).await
         } else {
             self.run_generic::<Ethereum>(signer, None).await
@@ -225,18 +234,6 @@ impl SendTxArgs {
             args: constructor_args,
         }) = command
         {
-            // 7702 and 4844 transactions require a target, so they can't be CREATE transactions.
-            if to.is_none() && !tx.auth.is_empty() {
-                return Err(eyre!(
-                    "EIP-7702 transactions can't be CREATE transactions and require a destination address"
-                ));
-            }
-            if to.is_none() && blob_data.is_some() {
-                return Err(eyre!(
-                    "EIP-4844 transactions can't be CREATE transactions and require a destination address"
-                ));
-            }
-
             sig = constructor_sig;
             args = constructor_args;
             Some(code)

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -20,6 +20,7 @@ use foundry_common::{
 };
 use foundry_config::{Chain, Config, Eip1559FeeEstimatePreset};
 use foundry_evm::hardfork::TempoHardfork;
+use foundry_evm_networks::NetworkVariant;
 use foundry_wallets::{TempoAccountsWallet, WalletOpts, WalletSigner};
 use serde::Deserialize;
 use serde_json::Value;
@@ -55,6 +56,14 @@ where
     N::TransactionRequest: Default + FoundryTransactionBuilder<N>,
     P: Provider<N>,
 {
+    if tx.gas_price().is_some() {
+        eyre::ensure!(
+            sponsor.is_none() && !tx.is_tempo_aa(),
+            "Tempo transaction options cannot be combined with a legacy transaction"
+        );
+        return Ok(());
+    }
+
     if sponsor.is_some() {
         maybe_attach_sponsor(sponsor, provider, chain, tx, payer).await
     } else {
@@ -271,41 +280,51 @@ pub(crate) fn sponsor_relay_connector<N: Network>(
 /// Accounts store change ordinary Ethereum commands.
 ///
 /// Explicit signer options are resolved with `from` cleared so the store fallback is not consulted.
-/// The fallback is only enabled when a Tempo transaction option is present or the RPC chain is a
-/// known Tempo chain.
+/// The fallback is only enabled after selecting Tempo from transaction options, configuration,
+/// or the RPC chain.
 pub(crate) async fn resolve_transaction_network_and_signer(
     tempo: &TempoOpts,
     eth: &EthereumOpts,
-) -> Result<(bool, Option<WalletSigner>, Option<TempoAccountsWallet>)> {
+) -> Result<(NetworkVariant, Option<WalletSigner>, Option<TempoAccountsWallet>)> {
+    let config = eth.load_config()?;
+    let has_session = tempo.session_id()?.is_some();
+    let requires_tempo = tempo.is_tempo() || has_session;
+    crate::cmd::validate_tempo_network(&config, requires_tempo)?;
+    if has_session {
+        return Ok((NetworkVariant::Tempo, None, None));
+    }
+
     let mut explicit_wallet = eth.wallet.clone();
     explicit_wallet.from = None;
     let (signer, access_key) = explicit_wallet.maybe_signer().await?;
-
-    if access_key.is_some() {
-        return Ok((true, signer, access_key));
+    let network =
+        crate::cmd::resolve_transaction_network(&config, requires_tempo || access_key.is_some())
+            .await?;
+    if let (Some(from), Some(access_key)) = (eth.wallet.from, &access_key) {
+        eyre::ensure!(
+            access_key.account() == from,
+            "sender {from} does not match Tempo account {}",
+            access_key.account()
+        );
+    }
+    if !network.is_tempo() || signer.is_some() || access_key.is_some() || eth.wallet.from.is_none()
+    {
+        return Ok((network, signer, access_key));
     }
 
-    if tempo.is_tempo() {
-        if signer.is_some() || eth.wallet.from.is_none() {
-            return Ok((true, signer, None));
-        }
-        let (signer, access_key) = eth.wallet.maybe_signer().await?;
-        return Ok((true, signer, access_key));
-    }
-
-    if signer.is_some() || eth.wallet.from.is_none() {
-        return Ok((false, signer, None));
-    }
-
-    let config = eth.load_config()?;
+    // Only consult the Accounts store after selecting Tempo.
     let provider = ProviderBuilder::<Ethereum>::from_config(&config)?.build()?;
     let chain = get_chain(config.chain, &provider).await?;
-    if !chain.is_tempo() {
-        return Ok((false, None, None));
-    }
-
     let (signer, access_key) = eth.wallet.maybe_signer_for_chain(chain.id()).await?;
-    Ok((true, signer, access_key))
+    if let Some(access_key) = &access_key {
+        let from = eth.wallet.from.expect("checked above");
+        eyre::ensure!(
+            access_key.account() == from,
+            "sender {from} does not match active Tempo account {}",
+            access_key.account()
+        );
+    }
+    Ok((network, signer, access_key))
 }
 
 /// Fills a Tempo transaction request that was built outside [`crate::tx::CastTxBuilder`] before
@@ -364,6 +383,29 @@ mod tests {
             Some(true)
         );
         assert_eq!(active_from_anvil_node_info(&info("ethereum", "T3"), TempoHardfork::T3), None);
+    }
+
+    #[tokio::test]
+    async fn legacy_fee_payment_skips_stored_token_and_rejects_tempo_fields() {
+        let asserter = Asserter::new();
+        let provider =
+            AlloyProviderBuilder::new().network::<TempoNetwork>().connect_mocked_client(asserter);
+        let payer = Address::repeat_byte(0x11);
+        let chain = Chain::from_id(4217);
+        let mut tx = <TempoNetwork as Network>::TransactionRequest::default();
+        tx.set_gas_price(1);
+
+        apply_fee_payment(None, Some(&provider), chain, &mut tx, payer).await.unwrap();
+        assert!(tx.fee_token().is_none());
+
+        tx.set_fee_token(Address::repeat_byte(0x22));
+        assert_eq!(
+            apply_fee_payment(None, Some(&provider), chain, &mut tx, payer)
+                .await
+                .unwrap_err()
+                .to_string(),
+            "Tempo transaction options cannot be combined with a legacy transaction"
+        );
     }
 
     #[tokio::test]

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -188,7 +188,14 @@ impl From<WalletSigner> for SenderKind<'_> {
 pub(crate) async fn read_only_sender<N: Network>(
     browser: &BrowserWalletOpts,
     wallet: WalletOpts,
+    tempo: &TempoOpts,
+    chain_id: u64,
 ) -> Result<(SenderKind<'static>, bool)> {
+    crate::tempo::ensure_session_not_browser(tempo, browser.browser)?;
+    if let Some(session) = tempo.session_signer_for_wallet(&wallet, chain_id)? {
+        return Ok((session.access_key.account().into(), false));
+    }
+
     Ok(match browser.run::<N>().await? {
         Some(browser) => (browser.address().into(), true),
         None => (SenderKind::from_wallet_opts(wallet).await?, false),

--- a/crates/cast/tests/cli/call.rs
+++ b/crates/cast/tests/cli/call.rs
@@ -998,6 +998,16 @@ casttest!(curl_call, |_prj, cmd| {
     assert!(output.contains(rpc));
 });
 
+casttest!(curl_call_accepts_named_chain_config, |prj, cmd| {
+    let rpc = "https://eth.example.com";
+    prj.create_file("foundry.toml", "[profile.default]\nchain_id = \"sepolia\"\n");
+
+    cmd.current_dir(prj.root())
+        .args(["call", "0xdead000000000000000000000000000000000000", "--rpc-url", rpc, "--curl"])
+        .assert_success()
+        .stderr_eq(str![""]);
+});
+
 // https://github.com/foundry-rs/foundry/issues/11584
 // Tests that invalid hex with uppercase 0X prefix also produces clear error
 casttest!(cast_call_invalid_hex_uppercase_prefix, |_prj, cmd| {

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -1149,3 +1149,86 @@ casttest!(channel_id_defaults, async |_prj, cmd| {
     .assert_success()
     .stdout_eq(format!("{expected:#x}\n"));
 });
+
+casttest!(tempo_options_reject_conflicting_network, |prj, cmd| {
+    prj.update_config(|config| {
+        config.networks = foundry_evm_networks::NetworkVariant::Ethereum.into();
+    });
+    for command in ["access-list", "estimate", "send", "mktx", "call"] {
+        cmd.cast_fuse()
+            .current_dir(prj.root())
+            .args([
+                command,
+                "0x0000000000000000000000000000000000000001",
+                "--tempo.fee-token",
+                "0x20c0000000000000000000000000000000000000",
+                "--rpc-url",
+                "http://127.0.0.1:1",
+            ])
+            .assert_failure()
+            .stderr_eq(str![[r#"
+Error: Tempo transaction options conflict with configured network `ethereum`
+
+"#]]);
+    }
+});
+
+casttest!(tempo_sessions_reject_conflicting_network, |prj, cmd| {
+    prj.update_config(|config| {
+        config.networks = foundry_evm_networks::NetworkVariant::Ethereum.into();
+    });
+    for command in ["access-list", "estimate", "send", "mktx", "call"] {
+        cmd.cast_fuse()
+            .current_dir(prj.root())
+            .args([
+                command,
+                "0x0000000000000000000000000000000000000001",
+                "--tempo.session",
+                "0x4444444444444444444444444444444444444444444444444444444444444444",
+                "--rpc-url",
+                "http://127.0.0.1:1",
+            ])
+            .assert_failure()
+            .stderr_eq(str![[r#"
+Error: Tempo transaction options conflict with configured network `ethereum`
+
+"#]]);
+    }
+});
+
+casttest!(tempo_mktx_selects_network_without_tempo_options, async |prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo().with_chain_id(Some(4217u64))).await;
+    let rpc = handle.http_endpoint();
+    for network in [
+        None,
+        Some(foundry_evm_networks::NetworkVariant::Tempo),
+        Some(foundry_evm_networks::NetworkVariant::Ethereum),
+    ] {
+        prj.update_config(|config| {
+            config.networks = network.map(Into::into).unwrap_or_default();
+        });
+        let expected = if network == Some(foundry_evm_networks::NetworkVariant::Ethereum) {
+            str![[r#"
+0x02[..]
+
+"#]]
+        } else {
+            str![[r#"
+0x76[..]
+
+"#]]
+        };
+        cmd.cast_fuse()
+            .current_dir(prj.root())
+            .args([
+                "mktx",
+                "0x0000000000000000000000000000000000000001",
+                "--private-key",
+                "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+                "--rpc-url",
+                &rpc,
+            ])
+            .assert_success()
+            .stdout_eq(expected);
+    }
+});

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -309,6 +309,14 @@ impl ScriptArgs {
         mut evm_opts: EvmOpts,
     ) -> Result<(Config, EvmOpts)> {
         if self.tempo.is_tempo() || self.has_tempo_session()? {
+            if evm_opts.networks.has_network_selection() {
+                let network = evm_opts.networks.execution_network();
+                eyre::ensure!(
+                    network.is_tempo(),
+                    "Tempo transaction options conflict with configured network `{}`",
+                    evm_opts.networks.execution_profile_name()
+                );
+            }
             // If Tempo tx options or a session are set, select the Tempo network.
             evm_opts.networks = NetworkConfigs::with_tempo();
         }
@@ -2308,6 +2316,33 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(state.script_config.evm_opts.sender, root);
+    }
+
+    #[tokio::test]
+    async fn tempo_options_preserve_explicit_script_network() {
+        let temp = tempdir().unwrap();
+        let _guard = TempoHomeGuard::set(temp.path()).await;
+        for options in [
+            vec!["--tempo.fee-token", "0x20c0000000000000000000000000000000000000"],
+            vec![
+                "--tempo.session",
+                "0x4444444444444444444444444444444444444444444444444444444444444444",
+            ],
+        ] {
+            let args =
+                ScriptArgs::parse_from(["foundry-cli", "Contract.sol"].into_iter().chain(options));
+            for (networks, name) in [
+                (NetworkConfigs::with_ethereum(), "ethereum"),
+                (NetworkConfigs::with_celo(), "celo"),
+            ] {
+                let evm_opts = EvmOpts { networks, ..Default::default() };
+                let err = args.resolved_evm_opts(Config::default(), evm_opts).await.unwrap_err();
+                assert_eq!(
+                    err.to_string(),
+                    format!("Tempo transaction options conflict with configured network `{name}`")
+                );
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Transaction commands previously resolved network-specific behavior at different stages and from different sources. This could produce inconsistent handling of explicit network flags, configured chains, RPC-discovered chains, and Tempo sessions, including selecting the wrong signing account or applying incompatible fee settings.

Centralize Cast network resolution with explicit configuration taking precedence over the configured chain and RPC discovery. Reject conflicting Tempo, Ethereum, and Celo selections; resolve Tempo session senders safely; and preserve legacy transaction and named-chain curl behavior.

Apply the same network conflict validation to Forge scripts so transaction execution follows consistent rules across both tools.

This change was developed with AI assistance.