### PR TITLE
test(svm): bump integration tests to solc 0.8.37

### DIFF
--- a/crates/forge/tests/cli/svm.rs
+++ b/crates/forge/tests/cli/svm.rs
@@ -11,7 +11,7 @@ use svm::Platform;
 /// 3. svm bumped in foundry-compilers
 /// 4. foundry-compilers update with any breaking changes
 /// 5. upgrade the `LATEST_SOLC`
-const LATEST_SOLC: Version = Version::new(0, 8, 36);
+const LATEST_SOLC: Version = Version::new(0, 8, 37);
 
 macro_rules! ensure_svm_releases {
     ($($test:ident => $platform:ident),* $(,)?) => {$(
@@ -82,12 +82,12 @@ Ran 2 test suites [ELAPSED]: 3 tests passed, 0 failed, 0 skipped (3 total tests)
 "#]]);
 });
 
-forgetest_init!(can_test_with_solc_0_8_36_amsterdam, |prj, cmd| {
+forgetest_init!(can_test_with_solc_0_8_37_amsterdam, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.add_test(
         "StateGas.t.sol",
         r#"
-pragma solidity =0.8.36;
+pragma solidity =0.8.37;
 
 import "forge-std/Test.sol";
 
@@ -212,8 +212,8 @@ contract StateGasTest is Test {
 "#,
     );
 
-    // Amsterdam is an experimental EVM version in solc 0.8.36.
-    let args = ["test", "--use", "0.8.36", "--evm-version", "amsterdam", "--experimental"];
+    // Amsterdam is an experimental EVM version in solc 0.8.37.
+    let args = ["test", "--use", "0.8.37", "--evm-version", "amsterdam", "--experimental"];
     cmd.args(args).assert_success();
     // Exercise the individual and combined CLI flags.
     cmd.forge_fuse().args(args).arg("--enable-tx-gas-limit").assert_success();


### PR DESCRIPTION
Follow-up to #16783: bump `LATEST_SOLC` to 0.8.37 so the SVM release checks cover all five platforms and the latest-compiler integration test runs against the new release. Update the Amsterdam integration test's compiler pin, name, and comment to 0.8.37 as well.

This is a test-only change; `L-ignore` exempts it from release notes.

AI assistance: Codex updated the tests and prepared this PR.
