### PR TITLE
fix(tempo): use issuer role accessor

### DIFF
--- a/.changelog/tempo-issuer-role-accessor.md
+++ b/.changelog/tempo-issuer-role-accessor.md
@@ -1,0 +1,5 @@
+---
+foundry-evm-core: patch
+---
+
+Fixed compilation against Tempo revisions that compute the TIP-20 issuer role hash at compile time.

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -16,7 +16,7 @@ use tempo_hardfork::TempoHardfork;
 use tempo_precompiles::{
     error::TempoPrecompileError,
     storage::{PrecompileStorageProvider, StorageCtx},
-    tip20::{ISSUER_ROLE, ITIP20, TIP20Token},
+    tip20::{ITIP20, TIP20Token},
     tip20_factory::TIP20Factory,
     validator_config,
 };
@@ -229,7 +229,7 @@ fn create_and_mint_token(
     )?;
 
     let mut token = TIP20Token::from_address(token_address)?;
-    token.grant_role_internal(admin, *ISSUER_ROLE)?;
+    token.grant_role_internal(admin, TIP20Token::issuer_role())?;
     token.mint(admin, ITIP20::mintCall { to: recipient, amount: mint_amount })?;
     if admin != recipient {
         token.mint(admin, ITIP20::mintCall { to: admin, amount: mint_amount })?;


### PR DESCRIPTION
Tempo's invariant workflow fails to compile Foundry after https://github.com/tempoxyz/tempo/pull/7590 changes `ISSUER_ROLE` from `LazyLock<B256>` to a `B256` constant: dereferencing it now passes `[u8; 32]` to `grant_role_internal`. Use `TIP20Token::issuer_role()`, which returns `B256` with both Foundry's pinned Tempo revision and the failing `731535b9808eda12e81ab6459703602554eaee5a` revision.

This PR was written by Centaur with AI assistance for investigation and code generation.

Prompted by: @grandizzy
