### PR TITLE
test(verify): cover HyperEVM testnet

### DIFF
--- a/.github/workflows/test-deploy-verify.yml
+++ b/.github/workflows/test-deploy-verify.yml
@@ -80,6 +80,7 @@ jobs:
           SEPOLIA_RPC_URL: ${{ secrets.ETH_SEPOLIA_RPC || 'https://ethereum-sepolia-rpc.publicnode.com' }}
           BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL || 'https://sepolia.base.org' }}
           ARBITRUM_SEPOLIA_RPC_URL: ${{ secrets.ARBITRUM_SEPOLIA_RPC_URL || 'https://sepolia-rollup.arbitrum.io/rpc' }}
+          HYPEREVM_TESTNET_RPC_URL: ${{ secrets.HYPEREVM_TESTNET_RPC_URL || 'https://rpc.hyperliquid-testnet.xyz/evm' }}
           MONAD_TESTNET_RPC_URL: ${{ secrets.MONAD_TESTNET_RPC_URL || 'https://testnet-rpc.monad.xyz' }}
           ROBINHOOD_TESTNET_RPC_URL: ${{ secrets.ROBINHOOD_TESTNET_RPC_URL || 'https://rpc.testnet.chain.robinhood.com' }}
           TESTNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.FUNDED_TESTNET_PKEY }}
@@ -93,8 +94,9 @@ jobs:
 
           # Thresholds are roughly 20 more runs at the measured per-run burn. Monad testnet is the
           # expensive one at ~0.08 MON per run; the L2s are effectively free.
+          # HyperEVM starts with a conservative 0.1 HYPE refill threshold.
           low=""
-          for spec in HOODI:0.05 SEPOLIA:0.05 BASE_SEPOLIA:0.01 ARBITRUM_SEPOLIA:0.01 MONAD_TESTNET:2.0 ROBINHOOD_TESTNET:0.01; do
+          for spec in HOODI:0.05 SEPOLIA:0.05 BASE_SEPOLIA:0.01 ARBITRUM_SEPOLIA:0.01 MONAD_TESTNET:2.0 ROBINHOOD_TESTNET:0.01 HYPEREVM_TESTNET:0.1; do
             net="${spec%%:*}"
             min="${spec##*:}"
             url_var="${net}_RPC_URL"
@@ -121,6 +123,7 @@ jobs:
           SEPOLIA_RPC_URL: ${{ secrets.ETH_SEPOLIA_RPC || 'https://ethereum-sepolia-rpc.publicnode.com' }}
           BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL || 'https://sepolia.base.org' }}
           ARBITRUM_SEPOLIA_RPC_URL: ${{ secrets.ARBITRUM_SEPOLIA_RPC_URL || 'https://sepolia-rollup.arbitrum.io/rpc' }}
+          HYPEREVM_TESTNET_RPC_URL: ${{ secrets.HYPEREVM_TESTNET_RPC_URL || 'https://rpc.hyperliquid-testnet.xyz/evm' }}
           MONAD_TESTNET_RPC_URL: ${{ secrets.MONAD_TESTNET_RPC_URL || 'https://testnet-rpc.monad.xyz' }}
           ROBINHOOD_TESTNET_RPC_URL: ${{ secrets.ROBINHOOD_TESTNET_RPC_URL || 'https://rpc.testnet.chain.robinhood.com' }}
           # Funded throwaway deployer, shared by every network. Holds testnet funds only, and is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,8 +110,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.37"
-source = "git+https://github.com/alloy-rs/chains?rev=1ed86765a836a117eda91d49b2985ff658742726#1ed86765a836a117eda91d49b2985ff658742726"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e8b1ebba2b80691b880da6d6add754b740252352959948e50c9d6a93c64f01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,8 +102,7 @@ dependencies = [
 [[package]]
 name = "alloy-chains"
 version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fdcfed8f106be3df944054aaa42bc13ae103a3ac8a9f4b08d4f053e3a743f8"
+source = "git+https://github.com/alloy-rs/chains?rev=1ed86765a836a117eda91d49b2985ff658742726#1ed86765a836a117eda91d49b2985ff658742726"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -556,6 +556,8 @@ snapbox = { version = "1.2", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
+# HyperliquidTestnet is not yet available in a crates.io release.
+alloy-chains = { git = "https://github.com/alloy-rs/chains", rev = "1ed86765a836a117eda91d49b2985ff658742726" }
 solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }
 solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }
 solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,7 +386,7 @@ alloy-sol-macro-expander = "1.7.0"
 alloy-sol-macro-input = "1.7.0"
 alloy-sol-types = "1.7.0"
 
-alloy-chains = "0.2"
+alloy-chains = "0.2.38"
 alloy-rlp = "0.3"
 alloy-trie = "0.9"
 
@@ -556,8 +556,6 @@ snapbox = { version = "1.2", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-# HyperliquidTestnet is not yet available in a crates.io release.
-alloy-chains = { git = "https://github.com/alloy-rs/chains", rev = "1ed86765a836a117eda91d49b2985ff658742726" }
 solar-compiler = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }
 solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }
 solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }

--- a/crates/forge/tests/cli/utils.rs
+++ b/crates/forge/tests/cli/utils.rs
@@ -1,6 +1,6 @@
 //! Various helper functions
 
-use alloy_chains::NamedChain;
+use alloy_chains::{Chain, NamedChain};
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use std::path::Path;
@@ -48,7 +48,7 @@ pub fn network_private_key(chain: &str) -> Option<String> {
 
 /// Represents external input required for executing verification requests
 pub struct EnvExternalities {
-    pub chain: NamedChain,
+    pub chain: Chain,
     pub rpc: String,
     pub pk: String,
     pub etherscan: String,
@@ -65,23 +65,28 @@ impl EnvExternalities {
     /// Externalities for a deploy + verify run of `chain` against `verifier`.
     ///
     /// `network` is the name used to look up `<NETWORK>_RPC_URL` and `<NETWORK>_PRIVATE_KEY`, and
-    /// matches the canonical `NamedChain::as_str` spelling. Blockscout instances have no shared
-    /// registry, so they must be given an explicit `verifier_url`.
+    /// uses a stable network name, including for numeric chains. Blockscout instances have no
+    /// shared registry, so they must be given an explicit `verifier_url`.
     ///
     /// Returns `None` when the network is not configured, which is how these tests stay inert
     /// outside of the nightly workflow that supplies the funded deployer key.
     pub fn deploy_verify(
-        chain: NamedChain,
+        chain: impl Into<Chain>,
         network: &str,
         verifier: &str,
         verifier_url: Option<&str>,
     ) -> Option<Self> {
+        let chain = chain.into();
         Some(Self {
             chain,
             rpc: network_rpc_key(network)?,
             pk: network_private_key(network)?,
             // Only Etherscan authenticates; Sourcify and Blockscout take no key.
-            etherscan: if verifier == "etherscan" { etherscan_key(chain)? } else { String::new() },
+            etherscan: if verifier == "etherscan" {
+                chain.named().and_then(etherscan_key)?
+            } else {
+                String::new()
+            },
             verifier: verifier.to_string(),
             verifier_url: verifier_url.map(str::to_string),
         })
@@ -89,7 +94,7 @@ impl EnvExternalities {
 
     pub fn goerli() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Goerli,
+            chain: NamedChain::Goerli.into(),
             rpc: network_rpc_key("goerli")?,
             pk: network_private_key("goerli")?,
             etherscan: etherscan_key(NamedChain::Goerli)?,
@@ -100,7 +105,7 @@ impl EnvExternalities {
 
     pub fn ftm_testnet() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::FantomTestnet,
+            chain: NamedChain::FantomTestnet.into(),
             rpc: network_rpc_key("ftm_testnet")?,
             pk: network_private_key("ftm_testnet")?,
             etherscan: etherscan_key(NamedChain::FantomTestnet)?,
@@ -111,7 +116,7 @@ impl EnvExternalities {
 
     pub fn optimism_kovan() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::OptimismKovan,
+            chain: NamedChain::OptimismKovan.into(),
             rpc: network_rpc_key("op_kovan")?,
             pk: network_private_key("op_kovan")?,
             etherscan: etherscan_key(NamedChain::OptimismKovan)?,
@@ -122,7 +127,7 @@ impl EnvExternalities {
 
     pub fn arbitrum_goerli() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::ArbitrumGoerli,
+            chain: NamedChain::ArbitrumGoerli.into(),
             rpc: network_rpc_key("arbitrum-goerli")?,
             pk: network_private_key("arbitrum-goerli")?,
             etherscan: etherscan_key(NamedChain::ArbitrumGoerli)?,
@@ -133,7 +138,7 @@ impl EnvExternalities {
 
     pub fn amoy() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::PolygonAmoy,
+            chain: NamedChain::PolygonAmoy.into(),
             rpc: network_rpc_key("amoy")?,
             pk: network_private_key("amoy")?,
             etherscan: etherscan_key(NamedChain::PolygonAmoy)?,
@@ -144,7 +149,7 @@ impl EnvExternalities {
 
     pub fn sepolia_etherscan() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia,
+            chain: NamedChain::Sepolia.into(),
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: etherscan_key(NamedChain::Sepolia)?,
@@ -155,7 +160,7 @@ impl EnvExternalities {
 
     pub fn sepolia_sourcify() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia,
+            chain: NamedChain::Sepolia.into(),
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: String::new(),
@@ -166,7 +171,7 @@ impl EnvExternalities {
 
     pub fn sepolia_sourcify_with_etherscan_api_key_set() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia,
+            chain: NamedChain::Sepolia.into(),
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: etherscan_key(NamedChain::Sepolia)?,
@@ -177,7 +182,7 @@ impl EnvExternalities {
 
     pub fn sepolia_blockscout() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia,
+            chain: NamedChain::Sepolia.into(),
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: String::new(),
@@ -188,7 +193,7 @@ impl EnvExternalities {
 
     pub fn sepolia_blockscout_with_etherscan_api_key_set() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia,
+            chain: NamedChain::Sepolia.into(),
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: etherscan_key(NamedChain::Sepolia)?,
@@ -199,7 +204,7 @@ impl EnvExternalities {
 
     pub fn sepolia_empty_verifier() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia,
+            chain: NamedChain::Sepolia.into(),
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: String::new(),

--- a/crates/forge/tests/cli/utils.rs
+++ b/crates/forge/tests/cli/utils.rs
@@ -1,6 +1,6 @@
 //! Various helper functions
 
-use alloy_chains::{Chain, NamedChain};
+use alloy_chains::NamedChain;
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use std::path::Path;
@@ -48,7 +48,7 @@ pub fn network_private_key(chain: &str) -> Option<String> {
 
 /// Represents external input required for executing verification requests
 pub struct EnvExternalities {
-    pub chain: Chain,
+    pub chain: NamedChain,
     pub rpc: String,
     pub pk: String,
     pub etherscan: String,
@@ -65,28 +65,23 @@ impl EnvExternalities {
     /// Externalities for a deploy + verify run of `chain` against `verifier`.
     ///
     /// `network` is the name used to look up `<NETWORK>_RPC_URL` and `<NETWORK>_PRIVATE_KEY`, and
-    /// uses a stable network name, including for numeric chains. Blockscout instances have no
+    /// can differ from the canonical `NamedChain::as_str` spelling. Blockscout instances have no
     /// shared registry, so they must be given an explicit `verifier_url`.
     ///
     /// Returns `None` when the network is not configured, which is how these tests stay inert
     /// outside of the nightly workflow that supplies the funded deployer key.
     pub fn deploy_verify(
-        chain: impl Into<Chain>,
+        chain: NamedChain,
         network: &str,
         verifier: &str,
         verifier_url: Option<&str>,
     ) -> Option<Self> {
-        let chain = chain.into();
         Some(Self {
             chain,
             rpc: network_rpc_key(network)?,
             pk: network_private_key(network)?,
             // Only Etherscan authenticates; Sourcify and Blockscout take no key.
-            etherscan: if verifier == "etherscan" {
-                chain.named().and_then(etherscan_key)?
-            } else {
-                String::new()
-            },
+            etherscan: if verifier == "etherscan" { etherscan_key(chain)? } else { String::new() },
             verifier: verifier.to_string(),
             verifier_url: verifier_url.map(str::to_string),
         })
@@ -94,7 +89,7 @@ impl EnvExternalities {
 
     pub fn goerli() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Goerli.into(),
+            chain: NamedChain::Goerli,
             rpc: network_rpc_key("goerli")?,
             pk: network_private_key("goerli")?,
             etherscan: etherscan_key(NamedChain::Goerli)?,
@@ -105,7 +100,7 @@ impl EnvExternalities {
 
     pub fn ftm_testnet() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::FantomTestnet.into(),
+            chain: NamedChain::FantomTestnet,
             rpc: network_rpc_key("ftm_testnet")?,
             pk: network_private_key("ftm_testnet")?,
             etherscan: etherscan_key(NamedChain::FantomTestnet)?,
@@ -116,7 +111,7 @@ impl EnvExternalities {
 
     pub fn optimism_kovan() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::OptimismKovan.into(),
+            chain: NamedChain::OptimismKovan,
             rpc: network_rpc_key("op_kovan")?,
             pk: network_private_key("op_kovan")?,
             etherscan: etherscan_key(NamedChain::OptimismKovan)?,
@@ -127,7 +122,7 @@ impl EnvExternalities {
 
     pub fn arbitrum_goerli() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::ArbitrumGoerli.into(),
+            chain: NamedChain::ArbitrumGoerli,
             rpc: network_rpc_key("arbitrum-goerli")?,
             pk: network_private_key("arbitrum-goerli")?,
             etherscan: etherscan_key(NamedChain::ArbitrumGoerli)?,
@@ -138,7 +133,7 @@ impl EnvExternalities {
 
     pub fn amoy() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::PolygonAmoy.into(),
+            chain: NamedChain::PolygonAmoy,
             rpc: network_rpc_key("amoy")?,
             pk: network_private_key("amoy")?,
             etherscan: etherscan_key(NamedChain::PolygonAmoy)?,
@@ -149,7 +144,7 @@ impl EnvExternalities {
 
     pub fn sepolia_etherscan() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia.into(),
+            chain: NamedChain::Sepolia,
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: etherscan_key(NamedChain::Sepolia)?,
@@ -160,7 +155,7 @@ impl EnvExternalities {
 
     pub fn sepolia_sourcify() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia.into(),
+            chain: NamedChain::Sepolia,
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: String::new(),
@@ -171,7 +166,7 @@ impl EnvExternalities {
 
     pub fn sepolia_sourcify_with_etherscan_api_key_set() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia.into(),
+            chain: NamedChain::Sepolia,
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: etherscan_key(NamedChain::Sepolia)?,
@@ -182,7 +177,7 @@ impl EnvExternalities {
 
     pub fn sepolia_blockscout() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia.into(),
+            chain: NamedChain::Sepolia,
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: String::new(),
@@ -193,7 +188,7 @@ impl EnvExternalities {
 
     pub fn sepolia_blockscout_with_etherscan_api_key_set() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia.into(),
+            chain: NamedChain::Sepolia,
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: etherscan_key(NamedChain::Sepolia)?,
@@ -204,7 +199,7 @@ impl EnvExternalities {
 
     pub fn sepolia_empty_verifier() -> Option<Self> {
         Some(Self {
-            chain: NamedChain::Sepolia.into(),
+            chain: NamedChain::Sepolia,
             rpc: network_rpc_key("sepolia")?,
             pk: network_private_key("sepolia")?,
             etherscan: String::new(),

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -291,7 +291,7 @@ fn deploy_and_verify_on_chain(
 
     let mut args = vec![
         "--chain-id".to_string(),
-        info.chain.id().to_string(),
+        (info.chain as u64).to_string(),
         address,
         contract_path.to_string(),
         "--watch".to_string(),
@@ -360,7 +360,7 @@ forgetest!(can_verify_contract_sepolia_etherscan_also_runs_sourcify, |prj, cmd| 
             .root_arg()
             .args([
                 "--chain-id",
-                &info.chain.to_string(),
+                info.chain.as_ref(),
                 &address,
                 contract_path,
                 "--etherscan-api-key",
@@ -497,7 +497,7 @@ macro_rules! deploy_verify_tests {
 }
 
 deploy_verify_tests! {
-    deploy_verify_hyperevm_testnet_sourcify: 998u64, "hyperevm-testnet", "sourcify", None;
+    deploy_verify_hyperevm_testnet_sourcify: NamedChain::HyperliquidTestnet, "hyperevm-testnet", "sourcify", None;
 
     deploy_verify_hoodi_etherscan: NamedChain::Hoodi, "hoodi", "etherscan", None;
     deploy_verify_hoodi_sourcify: NamedChain::Hoodi, "hoodi", "sourcify", None;

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -291,7 +291,7 @@ fn deploy_and_verify_on_chain(
 
     let mut args = vec![
         "--chain-id".to_string(),
-        (info.chain as u64).to_string(),
+        info.chain.id().to_string(),
         address,
         contract_path.to_string(),
         "--watch".to_string(),
@@ -360,7 +360,7 @@ forgetest!(can_verify_contract_sepolia_etherscan_also_runs_sourcify, |prj, cmd| 
             .root_arg()
             .args([
                 "--chain-id",
-                info.chain.as_ref(),
+                &info.chain.to_string(),
                 &address,
                 contract_path,
                 "--etherscan-api-key",
@@ -483,7 +483,7 @@ const ROBINHOOD_TESTNET_BLOCKSCOUT_URL: &str = "https://explorer.testnet.chain.r
 ///
 /// Etherscan v2 covers Hoodi, Sepolia, Base Sepolia, Arbitrum Sepolia and Monad testnet. Robinhood
 /// testnet is not on the v2 chainlist, so it is covered by Sourcify and its own Blockscout instance
-/// instead.
+/// instead. HyperEVM testnet (998) is covered by Sourcify.
 macro_rules! deploy_verify_tests {
     ($($name:ident: $chain:expr, $network:literal, $verifier:literal, $url:expr;)*) => {$(
         forgetest!($name, |prj, cmd| {
@@ -497,6 +497,8 @@ macro_rules! deploy_verify_tests {
 }
 
 deploy_verify_tests! {
+    deploy_verify_hyperevm_testnet_sourcify: 998u64, "hyperevm-testnet", "sourcify", None;
+
     deploy_verify_hoodi_etherscan: NamedChain::Hoodi, "hoodi", "etherscan", None;
     deploy_verify_hoodi_sourcify: NamedChain::Hoodi, "hoodi", "sourcify", None;
 

--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,8 @@ unknown-registry = "warn"
 # in the allow list is encountered
 unknown-git = "deny"
 allow-git = [
+    # Temporary: alloy-chains until HyperliquidTestnet is released.
+    "https://github.com/alloy-rs/chains",
     "https://github.com/foundry-rs/foundry-core",
     "https://github.com/paradigmxyz/solar",
     # Only for tests.


### PR DESCRIPTION
Extends #16469 with a deploy-and-verify test for HyperEVM testnet (chain 998) using Sourcify. The shared test helper now accepts numeric chain IDs, and the nightly workflow supplies the HyperEVM RPC endpoint and checks the deployer's HYPE balance with a 0.1 HYPE refill threshold.

The CI deployer is funded with testnet HYPE. Local runs use `HYPEREVM_TESTNET_RPC_URL` and `HYPEREVM_TESTNET_PRIVATE_KEY` (or the existing shared deployer key).

CI-only change; uses the maintainer `L-ignore` changelog exemption. Code and PR text were generated with Codex assistance.

