### PR TITLE
fix(symbolic): retry deferred call branches

### DIFF
--- a/.changelog/symbolic-external-deferred-arithmetic.md
+++ b/.changelog/symbolic-external-deferred-arithmetic.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Resolved deferred hard-arithmetic branches inside deterministic symbolic external calls and contract creation after cheaper root paths complete.

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -174,6 +174,7 @@ impl SymbolicExecutor {
             return Ok(StepOutcome::Revert);
         }
 
+        self.stateless_retry_safe = false;
         let mut initcode = artifact_code(&artifact, false)?;
         initcode.extend_from_slice(&constructor_args);
         let initcode = SymCode::concrete(&mut self.cx, initcode);
@@ -1931,6 +1932,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.getCode",
                 )?;
+                self.stateless_retry_safe = false;
                 let code = artifact_code(&artifact, selector == getDeployedCodeCall::SELECTOR)?;
                 return Ok(CheatcodeOutcome::ContinueData(abi_concrete_bytes_return(
                     &mut self.cx,
@@ -2359,6 +2361,7 @@ impl SymbolicExecutor {
                 )));
             }
             projectRootCall::SELECTOR => {
+                self.stateless_retry_safe = false;
                 let root = std::env::current_dir()
                     .map_err(|_| SymbolicError::Unsupported("symbolic vm.projectRoot"))?;
                 return Ok(CheatcodeOutcome::ContinueData(abi_concrete_bytes_return(
@@ -2367,6 +2370,7 @@ impl SymbolicExecutor {
                 )));
             }
             unixTimeCall::SELECTOR => {
+                self.stateless_retry_safe = false;
                 let milliseconds = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .map_err(|_| SymbolicError::Unsupported("symbolic vm.unixTime"))?
@@ -2684,6 +2688,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.envExists",
                 )?;
+                self.stateless_retry_safe = false;
                 return Ok(CheatcodeOutcome::Continue(vec![SymExpr::constant(
                     &mut self.cx,
                     U256::from(std::env::var_os(name).is_some()),
@@ -2697,6 +2702,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.envBool",
                 )?;
+                self.stateless_retry_safe = false;
                 let value = std::env::var(name)
                     .map_err(|_| SymbolicError::Unsupported("symbolic env var missing"))?;
                 return Ok(CheatcodeOutcome::Continue(vec![SymExpr::constant(
@@ -2712,6 +2718,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.envUint",
                 )?;
+                self.stateless_retry_safe = false;
                 let value = std::env::var(name)
                     .map_err(|_| SymbolicError::Unsupported("symbolic env var missing"))?;
                 return Ok(CheatcodeOutcome::Continue(vec![SymExpr::constant(
@@ -2727,6 +2734,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.envInt",
                 )?;
+                self.stateless_retry_safe = false;
                 let value = std::env::var(name)
                     .map_err(|_| SymbolicError::Unsupported("symbolic env var missing"))?;
                 return Ok(CheatcodeOutcome::Continue(vec![SymExpr::constant(
@@ -2742,6 +2750,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.envAddress",
                 )?;
+                self.stateless_retry_safe = false;
                 let value = std::env::var(name)
                     .map_err(|_| SymbolicError::Unsupported("symbolic env var missing"))?;
                 let address = parse_env_address(&value)?;
@@ -2758,6 +2767,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.envBytes32",
                 )?;
+                self.stateless_retry_safe = false;
                 let value = std::env::var(name)
                     .map_err(|_| SymbolicError::Unsupported("symbolic env var missing"))?;
                 return Ok(CheatcodeOutcome::Continue(vec![SymExpr::constant(
@@ -2773,6 +2783,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.envString",
                 )?;
+                self.stateless_retry_safe = false;
                 let value = std::env::var(name)
                     .map_err(|_| SymbolicError::Unsupported("symbolic env var missing"))?;
                 return Ok(CheatcodeOutcome::ContinueData(abi_concrete_bytes_return(
@@ -2788,6 +2799,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.envBytes",
                 )?;
+                self.stateless_retry_safe = false;
                 let value = std::env::var(name)
                     .map_err(|_| SymbolicError::Unsupported("symbolic env var missing"))?;
                 let bytes = parse_env_bytes(&value)?;
@@ -2812,6 +2824,7 @@ impl SymbolicExecutor {
                 )?;
                 let name = dyn_string(&values[0])?;
                 let delimiter = dyn_string(&values[1])?;
+                self.stateless_retry_safe = false;
                 let value = std::env::var(name)
                     .map_err(|_| SymbolicError::Unsupported("symbolic env var missing"))?;
                 let value = if selector == envBool_1Call::SELECTOR {
@@ -2842,6 +2855,7 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.envOr",
                 )?;
+                self.stateless_retry_safe = false;
                 let value = match std::env::var(name) {
                     Ok(value) => U256::from(parse_env_bool(&value)?),
                     Err(_) => read_abi_concrete_word_arg(
@@ -2875,6 +2889,7 @@ impl SymbolicExecutor {
                     1,
                     "symbolic vm.envOr",
                 )?;
+                self.stateless_retry_safe = false;
                 let value = match std::env::var(name) {
                     Ok(value) if selector == envOr_1Call::SELECTOR => parse_env_uint(&value)?,
                     Ok(value) if selector == envOr_2Call::SELECTOR => parse_env_int(&value)?,
@@ -2898,6 +2913,7 @@ impl SymbolicExecutor {
                     vec![DynSolType::String, DynSolType::String],
                 )?;
                 let name = dyn_string(&values[0])?;
+                self.stateless_retry_safe = false;
                 let value = std::env::var(name).unwrap_or(dyn_string(&values[1])?);
                 return Ok(CheatcodeOutcome::ContinueData(abi_concrete_bytes_return(
                     &mut self.cx,
@@ -2913,6 +2929,7 @@ impl SymbolicExecutor {
                     vec![DynSolType::String, DynSolType::Bytes],
                 )?;
                 let name = dyn_string(&values[0])?;
+                self.stateless_retry_safe = false;
                 let value = match std::env::var(name) {
                     Ok(value) => parse_env_bytes(&value)?,
                     Err(_) => dyn_bytes(&values[1])?,
@@ -2957,6 +2974,7 @@ impl SymbolicExecutor {
                 )?;
                 let name = dyn_string(&values[0])?;
                 let delimiter = dyn_string(&values[1])?;
+                self.stateless_retry_safe = false;
                 let value = match std::env::var(name) {
                     Ok(value) if selector == envOr_7Call::SELECTOR => {
                         parse_env_array(&value, &delimiter, parse_env_bool_value)?
@@ -2999,6 +3017,7 @@ impl SymbolicExecutor {
                 if args.is_empty() || args[0].is_empty() {
                     return Err(SymbolicError::Unsupported("symbolic ffi empty command"));
                 }
+                self.stateless_retry_safe = false;
                 let output = Command::new(&args[0])
                     .args(&args[1..])
                     .output()

--- a/crates/evm/symbolic/src/executor/mod.rs
+++ b/crates/evm/symbolic/src/executor/mod.rs
@@ -41,6 +41,11 @@ enum CallPathOpcode {
     Discard,
 }
 
+pub(super) struct FeasiblePath {
+    state: PathState,
+    from_deferred: bool,
+}
+
 #[derive(Debug)]
 struct SequencePath {
     state: PathState,
@@ -81,8 +86,8 @@ impl SymbolicExecutor {
         &mut self,
         paths: &mut VecDeque<PathState>,
         deferred_paths: &mut VecDeque<PathState>,
-        escalate_deferred: bool,
-    ) -> Result<Option<PathState>, SymbolicError> {
+        deferred_mode: DeferredPathMode,
+    ) -> Result<Option<FeasiblePath>, SymbolicError> {
         loop {
             while let Some(mut state) = self.pop_next_path(paths) {
                 if state.take_deferred_feasibility_check() {
@@ -95,7 +100,7 @@ impl SymbolicExecutor {
                         Ok(BranchFeasibility::Sat) => {}
                         Ok(BranchFeasibility::Unsat) => continue,
                         Ok(BranchFeasibility::NeedsSolver) => {
-                            if !escalate_deferred {
+                            if matches!(deferred_mode, DeferredPathMode::Skip) {
                                 self.defer_hard_arithmetic();
                                 continue;
                             }
@@ -110,7 +115,7 @@ impl SymbolicExecutor {
                         Err(err) => return Err(err),
                     }
                 }
-                return Ok(Some(state));
+                return Ok(Some(FeasiblePath { state, from_deferred: false }));
             }
 
             let Some(state) = self.pop_next_path(deferred_paths) else {
@@ -126,7 +131,7 @@ impl SymbolicExecutor {
             self.check_timeout()?;
             trace!("escalating deferred hard arithmetic branch to SMT solver");
             match self.is_sat_with_state(&state, &state.constraints) {
-                Ok(true) => return Ok(Some(state)),
+                Ok(true) => return Ok(Some(FeasiblePath { state, from_deferred: true })),
                 Ok(false) => {}
                 Err(SymbolicError::SolverUnknown) => self.defer_solver_unknown(),
                 Err(err) => return Err(err),
@@ -208,24 +213,41 @@ impl SymbolicExecutor {
         kind: CallPathKind,
     ) -> Result<Vec<CallOutcome>, SymbolicError> {
         let mut outcomes = Vec::new();
+        let mut outcomes_before_deferred = None;
         let path_limit = self.config.path_width() as usize;
         let depth_limit = self.config.execution_depth() as usize;
 
         loop {
-            // Let invariant execution inspect each completed sequence outcome before escalating a
-            // deferred hard-arithmetic sibling. External calls still return all outcomes together
-            // because their parent frame must join them before it can continue.
+            // Let callers inspect a completed outcome before spending the remaining budget on a
+            // deferred sibling. A later proof pass reconstructs and drains all nested paths.
             if matches!(kind, CallPathKind::Sequence) && !outcomes.is_empty() {
                 break;
             }
-            let Some(mut state) = self.pop_next_feasible_path(
-                worklist,
-                deferred_worklist,
-                matches!(kind, CallPathKind::Sequence) || self.escalate_nested_deferred,
-            )?
+            if matches!(kind, CallPathKind::External)
+                && matches!(self.nested_deferred_mode, DeferredPathMode::Yield)
+                && outcomes_before_deferred.is_some_and(|count| outcomes.len() > count)
+            {
+                if !worklist.is_empty() || !deferred_worklist.is_empty() {
+                    self.defer_hard_arithmetic();
+                }
+                break;
+            }
+            let deferred_mode = match kind {
+                CallPathKind::Sequence => DeferredPathMode::Drain,
+                CallPathKind::External => self.nested_deferred_mode,
+            };
+            let Some(next) =
+                self.pop_next_feasible_path(worklist, deferred_worklist, deferred_mode)?
             else {
                 break;
             };
+            if next.from_deferred
+                && matches!(kind, CallPathKind::External)
+                && matches!(deferred_mode, DeferredPathMode::Yield)
+            {
+                outcomes_before_deferred = Some(outcomes.len());
+            }
+            let mut state = next.state;
             if *completed_paths >= path_limit {
                 return Err(SymbolicError::Unsupported("symbolic path limit exceeded"));
             }

--- a/crates/evm/symbolic/src/executor/mod.rs
+++ b/crates/evm/symbolic/src/executor/mod.rs
@@ -221,7 +221,7 @@ impl SymbolicExecutor {
             let Some(mut state) = self.pop_next_feasible_path(
                 worklist,
                 deferred_worklist,
-                matches!(kind, CallPathKind::Sequence),
+                matches!(kind, CallPathKind::Sequence) || self.escalate_nested_deferred,
             )?
             else {
                 break;

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -17,14 +17,14 @@ impl SymbolicExecutor {
             solver,
             deferred_incomplete: None,
             deadline: None,
-            escalate_nested_deferred: false,
+            nested_deferred_mode: DeferredPathMode::Skip,
             stateless_retry_safe: true,
         }
     }
 
     fn reset_run_state(&mut self, use_wall_clock_deadline: bool) {
         self.deferred_incomplete = None;
-        self.escalate_nested_deferred = false;
+        self.nested_deferred_mode = DeferredPathMode::Skip;
         self.stateless_retry_safe = true;
         self.deadline = if use_wall_clock_deadline {
             self.config
@@ -214,7 +214,7 @@ impl SymbolicExecutor {
             };
 
         // Preserve the cheap-path priority of the first pass. Only a deterministic stateless
-        // proof retries once after nested hard arithmetic was its remaining limitation.
+        // proof retries after nested hard arithmetic was its remaining limitation.
         let retry_nested_deferred = branch_candidates.is_none()
             && self.stateless_retry_safe
             && matches!(self.deferred_incomplete, Some(DeferredIncomplete::HardArithmetic))
@@ -238,7 +238,40 @@ impl SymbolicExecutor {
         }
 
         self.deferred_incomplete = None;
-        self.escalate_nested_deferred = true;
+        self.nested_deferred_mode = DeferredPathMode::Yield;
+        let prioritized = match self.run_inner(&input, None, &mut completed_paths) {
+            Ok(result) => result,
+            Err(err) => {
+                return SymbolicRunResult::Incomplete {
+                    kind: err.stop_reason(),
+                    reason: err.to_string(),
+                    stats: self.stats_with_paths(completed_paths),
+                };
+            }
+        };
+        let drain_nested_deferred = self.stateless_retry_safe
+            && matches!(self.deferred_incomplete, Some(DeferredIncomplete::HardArithmetic))
+            && matches!(
+                &prioritized,
+                SymbolicRunResult::Incomplete {
+                    kind: SymbolicStopReason::RevertAll | SymbolicStopReason::Timeout,
+                    ..
+                }
+            );
+        if !drain_nested_deferred {
+            return prioritized;
+        }
+
+        if let Err(err) = self.check_timeout() {
+            return SymbolicRunResult::Incomplete {
+                kind: err.stop_reason(),
+                reason: err.to_string(),
+                stats: self.stats_with_paths(completed_paths),
+            };
+        }
+
+        self.deferred_incomplete = None;
+        self.nested_deferred_mode = DeferredPathMode::Drain;
         match self.run_inner(&input, None, &mut completed_paths) {
             Ok(result) => result,
             Err(err) => SymbolicRunResult::Incomplete {
@@ -388,9 +421,12 @@ impl SymbolicExecutor {
         let path_limit = self.config.path_width() as usize;
         let depth_limit = self.config.execution_depth() as usize;
 
-        while let Some(mut state) =
-            self.pop_next_feasible_path(&mut worklist, &mut deferred_worklist, true)?
-        {
+        while let Some(next) = self.pop_next_feasible_path(
+            &mut worklist,
+            &mut deferred_worklist,
+            DeferredPathMode::Drain,
+        )? {
+            let mut state = next.state;
             if *completed_paths >= path_limit {
                 debug!(
                     completed_paths = *completed_paths,

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -11,11 +11,21 @@ impl SymbolicExecutor {
     /// a fresh executor when a caller needs independent solver query accounting.
     pub fn new(config: SymbolicConfig) -> Self {
         let solver = SmtLibSubprocessSolver::from_config(&config);
-        Self { config, cx: SymCx::new(), solver, deferred_incomplete: None, deadline: None }
+        Self {
+            config,
+            cx: SymCx::new(),
+            solver,
+            deferred_incomplete: None,
+            deadline: None,
+            escalate_nested_deferred: false,
+            stateless_retry_safe: true,
+        }
     }
 
     fn reset_run_state(&mut self, use_wall_clock_deadline: bool) {
         self.deferred_incomplete = None;
+        self.escalate_nested_deferred = false;
+        self.stateless_retry_safe = true;
         self.deadline = if use_wall_clock_deadline {
             self.config
                 .timeout
@@ -37,12 +47,22 @@ impl SymbolicExecutor {
 
     /// Defers an incomplete result until all counterexample-producing modeled paths are explored.
     pub(super) fn defer_incomplete(&mut self, reason: &'static str) {
-        self.deferred_incomplete.get_or_insert(DeferredIncomplete::Unsupported(reason));
+        if self
+            .deferred_incomplete
+            .is_none_or(|reason| reason == DeferredIncomplete::HardArithmetic)
+        {
+            self.deferred_incomplete = Some(DeferredIncomplete::Unsupported(reason));
+        }
     }
 
     /// Defers a solver-unknown result while continuing with decidable sibling paths.
     pub(super) fn defer_solver_unknown(&mut self) {
-        self.deferred_incomplete.get_or_insert(DeferredIncomplete::SolverUnknown);
+        if self
+            .deferred_incomplete
+            .is_none_or(|reason| reason == DeferredIncomplete::HardArithmetic)
+        {
+            self.deferred_incomplete = Some(DeferredIncomplete::SolverUnknown);
+        }
     }
 
     /// Defers an incomplete result for a hard-arithmetic branch skipped by nested execution.
@@ -75,9 +95,9 @@ impl SymbolicExecutor {
         }
     }
 
-    /// Returns and clears any deferred incomplete reason.
-    fn take_deferred_incomplete(&mut self) -> Option<(SymbolicStopReason, String)> {
-        match self.deferred_incomplete.take()? {
+    /// Returns any deferred incomplete reason.
+    fn deferred_incomplete(&self) -> Option<(SymbolicStopReason, String)> {
+        match self.deferred_incomplete? {
             DeferredIncomplete::Unsupported(reason) => Some((
                 SymbolicStopReason::Stuck,
                 format!("unsupported symbolic execution feature: {reason}"),
@@ -167,7 +187,7 @@ impl SymbolicExecutor {
     fn execute_run<FEN: FoundryEvmNetwork>(
         &mut self,
         input: SymbolicRunInput<'_, FEN>,
-        branch_candidates: Option<&mut Vec<SymbolicConcreteInput>>,
+        mut branch_candidates: Option<&mut Vec<SymbolicConcreteInput>>,
     ) -> SymbolicRunResult {
         self.reset_run_state(false);
         self.solver.clear_context_caches();
@@ -180,12 +200,51 @@ impl SymbolicExecutor {
             };
         }
 
-        match self.run_inner(input, branch_candidates) {
+        let mut completed_paths = 0;
+        let first =
+            match self.run_inner(&input, branch_candidates.as_deref_mut(), &mut completed_paths) {
+                Ok(result) => result,
+                Err(err) => {
+                    return SymbolicRunResult::Incomplete {
+                        kind: err.stop_reason(),
+                        reason: err.to_string(),
+                        stats: self.stats_with_paths(completed_paths),
+                    };
+                }
+            };
+
+        // Preserve the cheap-path priority of the first pass. Only a deterministic stateless
+        // proof retries once after nested hard arithmetic was its remaining limitation.
+        let retry_nested_deferred = branch_candidates.is_none()
+            && self.stateless_retry_safe
+            && matches!(self.deferred_incomplete, Some(DeferredIncomplete::HardArithmetic))
+            && matches!(
+                &first,
+                SymbolicRunResult::Incomplete {
+                    kind: SymbolicStopReason::RevertAll | SymbolicStopReason::Timeout,
+                    ..
+                }
+            );
+        if !retry_nested_deferred {
+            return first;
+        }
+
+        if let Err(err) = self.check_timeout() {
+            return SymbolicRunResult::Incomplete {
+                kind: err.stop_reason(),
+                reason: err.to_string(),
+                stats: self.stats_with_paths(completed_paths),
+            };
+        }
+
+        self.deferred_incomplete = None;
+        self.escalate_nested_deferred = true;
+        match self.run_inner(&input, None, &mut completed_paths) {
             Ok(result) => result,
             Err(err) => SymbolicRunResult::Incomplete {
                 kind: err.stop_reason(),
                 reason: err.to_string(),
-                stats: self.solver.stats(),
+                stats: self.stats_with_paths(completed_paths),
             },
         }
     }
@@ -276,7 +335,7 @@ impl SymbolicExecutor {
         // Deferred hard-arithmetic branches are now sent to SMT before candidate search finishes.
         // Only branches that nested execution could not escalate remain incomplete.
         if limitation.is_none()
-            && let Some((kind, reason)) = self.take_deferred_incomplete()
+            && let Some((kind, reason)) = self.deferred_incomplete()
         {
             limitation = Some(SymbolicInvariantSearchLimitation { kind, reason });
         }
@@ -286,8 +345,9 @@ impl SymbolicExecutor {
 
     pub(super) fn run_inner<FEN: FoundryEvmNetwork>(
         &mut self,
-        input: SymbolicRunInput<'_, FEN>,
+        input: &SymbolicRunInput<'_, FEN>,
         mut branch_candidates: Option<&mut Vec<SymbolicConcreteInput>>,
+        completed_paths: &mut usize,
     ) -> Result<SymbolicRunResult, SymbolicError> {
         let account = input
             .executor
@@ -322,7 +382,6 @@ impl SymbolicExecutor {
         order_roots_by_corpus_seed_count(&mut roots, self.config.exploration_order);
         let mut worklist = roots.into_iter().collect::<VecDeque<_>>();
         let mut deferred_worklist = VecDeque::new();
-        let mut completed_paths = 0usize;
         let mut reverted_paths = 0usize;
         let mut normal_paths = 0usize;
         let mut success_input = None;
@@ -332,12 +391,15 @@ impl SymbolicExecutor {
         while let Some(mut state) =
             self.pop_next_feasible_path(&mut worklist, &mut deferred_worklist, true)?
         {
-            if completed_paths >= path_limit {
-                debug!(completed_paths, path_limit, "symbolic path limit reached");
+            if *completed_paths >= path_limit {
+                debug!(
+                    completed_paths = *completed_paths,
+                    path_limit, "symbolic path limit reached"
+                );
                 return Ok(SymbolicRunResult::Incomplete {
                     kind: SymbolicStopReason::Stuck,
                     reason: format!("symbolic path limit exceeded ({path_limit})"),
-                    stats: self.stats_with_paths(completed_paths),
+                    stats: self.stats_with_paths(*completed_paths),
                 });
             }
             if std::mem::take(&mut state.pending_storage_hook_revert) {
@@ -346,14 +408,21 @@ impl SymbolicExecutor {
                     input.function,
                     &state,
                 )?;
-                completed_paths += 1;
+                *completed_paths += 1;
                 reverted_paths += 1;
                 continue;
             }
-            let _path_span =
-                trace_span!("symbolic_path", completed_paths, worklist_size = worklist.len())
-                    .entered();
-            trace!(completed_paths, worklist_size = worklist.len(), "exploring symbolic path");
+            let _path_span = trace_span!(
+                "symbolic_path",
+                completed_paths = *completed_paths,
+                worklist_size = worklist.len()
+            )
+            .entered();
+            trace!(
+                completed_paths = *completed_paths,
+                worklist_size = worklist.len(),
+                "exploring symbolic path"
+            );
 
             loop {
                 self.check_timeout()?;
@@ -362,7 +431,7 @@ impl SymbolicExecutor {
                     return Ok(SymbolicRunResult::Incomplete {
                         kind: SymbolicStopReason::Stuck,
                         reason: format!("symbolic depth limit exceeded ({depth_limit})"),
-                        stats: self.stats_with_paths(completed_paths),
+                        stats: self.stats_with_paths(*completed_paths),
                     });
                 }
                 state.depth += 1;
@@ -378,13 +447,13 @@ impl SymbolicExecutor {
                                 &state,
                             )?
                         else {
-                            completed_paths += 1;
+                            *completed_paths += 1;
                             break;
                         };
                         return Ok(SymbolicRunResult::Counterexample {
                             args,
                             calldata: calldata_bytes,
-                            stats: self.stats_with_paths(completed_paths + 1),
+                            stats: self.stats_with_paths(*completed_paths + 1),
                         });
                     }
                     let candidate = self.collect_branch_candidate(
@@ -409,7 +478,7 @@ impl SymbolicExecutor {
                         };
                         success_input = Some((state.depth, input));
                     }
-                    completed_paths += 1;
+                    *completed_paths += 1;
                     break;
                 };
 
@@ -420,7 +489,7 @@ impl SymbolicExecutor {
                     code.jump_table(),
                     &mut state,
                     &mut worklist,
-                    &mut completed_paths,
+                    completed_paths,
                     op,
                 )? {
                     StepOutcome::Continue => {}
@@ -435,13 +504,13 @@ impl SymbolicExecutor {
                                     &state,
                                 )?
                             else {
-                                completed_paths += 1;
+                                *completed_paths += 1;
                                 break;
                             };
                             return Ok(SymbolicRunResult::Counterexample {
                                 args,
                                 calldata: calldata_bytes,
-                                stats: self.stats_with_paths(completed_paths + 1),
+                                stats: self.stats_with_paths(*completed_paths + 1),
                             });
                         }
                         let candidate = self.collect_branch_candidate(
@@ -466,7 +535,7 @@ impl SymbolicExecutor {
                             };
                             success_input = Some((state.depth, input));
                         }
-                        completed_paths += 1;
+                        *completed_paths += 1;
                         normal_paths += 1;
                         break;
                     }
@@ -476,7 +545,7 @@ impl SymbolicExecutor {
                             input.function,
                             &state,
                         )?;
-                        completed_paths += 1;
+                        *completed_paths += 1;
                         reverted_paths += 1;
                         break;
                     }
@@ -492,13 +561,13 @@ impl SymbolicExecutor {
                                 &state,
                             )?
                         else {
-                            completed_paths += 1;
+                            *completed_paths += 1;
                             break;
                         };
                         return Ok(SymbolicRunResult::Counterexample {
                             args,
                             calldata: calldata_bytes,
-                            stats: self.stats_with_paths(completed_paths + 1),
+                            stats: self.stats_with_paths(*completed_paths + 1),
                         });
                     }
                 }
@@ -506,25 +575,25 @@ impl SymbolicExecutor {
         }
 
         if normal_paths == 0 && reverted_paths > 0 {
-            debug!(completed_paths, "all symbolic paths reverted");
+            debug!(completed_paths = *completed_paths, "all symbolic paths reverted");
             return Ok(SymbolicRunResult::Incomplete {
                 kind: SymbolicStopReason::RevertAll,
                 reason: "all symbolic paths reverted".to_string(),
-                stats: self.stats_with_paths(completed_paths),
+                stats: self.stats_with_paths(*completed_paths),
             });
         }
 
-        if let Some((kind, reason)) = self.take_deferred_incomplete() {
+        if let Some((kind, reason)) = self.deferred_incomplete() {
             return Ok(SymbolicRunResult::Incomplete {
                 kind,
                 reason,
-                stats: self.stats_with_paths(completed_paths),
+                stats: self.stats_with_paths(*completed_paths),
             });
         }
 
-        debug!(completed_paths, "symbolic execution safe");
+        debug!(completed_paths = *completed_paths, "symbolic execution safe");
         Ok(SymbolicRunResult::Safe {
-            stats: self.stats_with_paths(completed_paths),
+            stats: self.stats_with_paths(*completed_paths),
             success_input: success_input.map(|(_, input)| input),
         })
     }
@@ -847,7 +916,7 @@ impl SymbolicExecutor {
             frontier = next_frontier;
         }
 
-        if let Some((kind, reason)) = self.take_deferred_incomplete() {
+        if let Some((kind, reason)) = self.deferred_incomplete() {
             return Ok(SymbolicInvariantRunResult::Incomplete {
                 kind,
                 reason,
@@ -908,5 +977,27 @@ mod tests {
 
         executor.reset_run_state(true);
         assert!(executor.deadline.is_some());
+    }
+
+    #[test]
+    fn hard_arithmetic_never_masks_a_specific_incomplete_reason() {
+        let mut executor = SymbolicExecutor::new(SymbolicConfig::default());
+
+        executor.defer_hard_arithmetic();
+        executor.defer_solver_unknown();
+        assert_eq!(executor.deferred_incomplete, Some(DeferredIncomplete::SolverUnknown));
+
+        executor.reset_run_state(false);
+        executor.defer_hard_arithmetic();
+        executor.defer_incomplete("unsupported after hard arithmetic");
+        assert_eq!(
+            executor.deferred_incomplete,
+            Some(DeferredIncomplete::Unsupported("unsupported after hard arithmetic"))
+        );
+
+        executor.reset_run_state(false);
+        executor.defer_solver_unknown();
+        executor.defer_hard_arithmetic();
+        assert_eq!(executor.deferred_incomplete, Some(DeferredIncomplete::SolverUnknown));
     }
 }

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -415,8 +415,15 @@ pub struct SymbolicExecutor {
     solver: runtime::SmtLibSubprocessSolver,
     deferred_incomplete: Option<DeferredIncomplete>,
     deadline: Option<Instant>,
-    escalate_nested_deferred: bool,
+    nested_deferred_mode: DeferredPathMode,
     stateless_retry_safe: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeferredPathMode {
+    Skip,
+    Yield,
+    Drain,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -415,9 +415,11 @@ pub struct SymbolicExecutor {
     solver: runtime::SmtLibSubprocessSolver,
     deferred_incomplete: Option<DeferredIncomplete>,
     deadline: Option<Instant>,
+    escalate_nested_deferred: bool,
+    stateless_retry_safe: bool,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DeferredIncomplete {
     Unsupported(&'static str),
     SolverUnknown,

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -5627,13 +5627,19 @@ fn feasible_path_selection_drains_easy_paths_before_deferred_hard_arithmetic() {
     let mut deferred_paths = VecDeque::new();
 
     assert!(
-        executor.pop_next_feasible_path(&mut paths, &mut deferred_paths, true).unwrap().is_some()
+        executor
+            .pop_next_feasible_path(&mut paths, &mut deferred_paths, DeferredPathMode::Drain)
+            .unwrap()
+            .is_some()
     );
     assert_eq!(deferred_paths.len(), 1);
     assert!(executor.deadline.is_none());
     assert_eq!(counted_solver_invocations(&marker), 0);
     assert!(
-        executor.pop_next_feasible_path(&mut paths, &mut deferred_paths, true).unwrap().is_none()
+        executor
+            .pop_next_feasible_path(&mut paths, &mut deferred_paths, DeferredPathMode::Drain)
+            .unwrap()
+            .is_none()
     );
     assert!(executor.deadline.is_some());
     assert_eq!(counted_solver_invocations(&marker), 1);
@@ -5665,13 +5671,13 @@ fn nested_feasible_path_selection_skips_hard_arithmetic_without_escalating() {
     let mut deferred_paths = VecDeque::new();
     assert!(
         executor
-            .pop_next_feasible_path(&mut nested_paths, &mut deferred_paths, false)
+            .pop_next_feasible_path(&mut nested_paths, &mut deferred_paths, DeferredPathMode::Skip)
             .unwrap()
             .is_some()
     );
     assert!(
         executor
-            .pop_next_feasible_path(&mut nested_paths, &mut deferred_paths, false)
+            .pop_next_feasible_path(&mut nested_paths, &mut deferred_paths, DeferredPathMode::Skip)
             .unwrap()
             .is_none()
     );

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -780,6 +780,208 @@ contract SymbolicQuadraticQuote {
     assert_eq!(result["symbolic"]["solver"]["stats"]["heuristic_witnesses"], 0);
 });
 
+forgetest_init!(symbolic_retries_deferred_nested_arithmetic, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_retries_deferred_nested_arithmetic because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicDeferredExternalCall.t.sol",
+        r#"
+interface Vm {
+    function assume(bool condition) external pure;
+    function unixTime() external returns (uint256);
+}
+
+contract SymbolicConversionTarget {
+    function convert(uint256 base, uint256 coefficient) external pure returns (uint256) {
+        return (base * coefficient + 9) / 10;
+    }
+}
+
+contract SymbolicCreatedConversion {
+    uint256 public value;
+
+    constructor(uint256 base, uint256 coefficient) {
+        value = (base * coefficient + 9) / 10;
+    }
+}
+
+contract SymbolicDeferredExternalCall {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    SymbolicConversionTarget target;
+
+    function setUp() public {
+        target = new SymbolicConversionTarget();
+    }
+
+    /// forge-config: default.symbolic.timeout = 5
+    function checkExternalConversion(uint256 base, uint256 coefficient) external view {
+        vm.assume(base > 0 && base < 1_000);
+        vm.assume(coefficient >= 10 && coefficient <= 100);
+        assert(target.convert(base, coefficient) > 0);
+    }
+
+    /// forge-config: default.symbolic.timeout = 5
+    function checkCreatedConversion(uint256 base, uint256 coefficient) external {
+        vm.assume(base > 0 && base < 1_000);
+        vm.assume(coefficient >= 10 && coefficient <= 100);
+        SymbolicCreatedConversion created = new SymbolicCreatedConversion(base, coefficient);
+        assert(created.value() > 0);
+    }
+
+    /// forge-config: default.symbolic.timeout = 5
+    function checkNondeterministicExternalConversion(uint256 base, uint256 coefficient) external {
+        vm.unixTime();
+        vm.assume(base > 0 && base < 1_000);
+        vm.assume(coefficient >= 10 && coefficient <= 100);
+        assert(target.convert(base, coefficient) > 0);
+    }
+
+    /// forge-config: default.symbolic.max_solver_queries = 16
+    function checkQueryLimitedExternalConversion(uint256 base, uint256 coefficient) external view {
+        vm.assume(base > 0 && base < 1_000);
+        vm.assume(coefficient >= 10 && coefficient <= 100);
+        assert(target.convert(base, coefficient) > 0);
+    }
+}
+"#,
+    );
+
+    for (test, signature) in [
+        ("checkExternalConversion", "checkExternalConversion(uint256,uint256)"),
+        ("checkCreatedConversion", "checkCreatedConversion(uint256,uint256)"),
+    ] {
+        let output = cmd
+            .forge_fuse()
+            .args(["test", "--symbolic", "--json", "--optimize", "--match-test", test])
+            .assert_success()
+            .get_output()
+            .stdout
+            .clone();
+        let result = json_test_result(&output, signature);
+        assert_eq!(result["symbolic"]["status"], "pass");
+        assert!(result["symbolic"]["solver"]["stats"]["smt_queries"].as_u64().unwrap() > 0);
+    }
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--symbolic",
+            "--json",
+            "--optimize",
+            "--match-test",
+            "checkNondeterministicExternalConversion",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+    let result =
+        json_test_result(&output, "checkNondeterministicExternalConversion(uint256,uint256)");
+    assert_eq!(result["symbolic"]["status"], "incomplete");
+    assert!(
+        result["symbolic"]["incomplete"]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("nested hard arithmetic")
+    );
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--symbolic",
+            "--json",
+            "--optimize",
+            "--match-test",
+            "checkQueryLimitedExternalConversion",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+    let result = json_test_result(&output, "checkQueryLimitedExternalConversion(uint256,uint256)");
+    assert_eq!(result["symbolic"]["status"], "incomplete");
+    assert!(
+        result["symbolic"]["incomplete"]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("solver query limit exceeded (16)")
+    );
+    assert_eq!(result["symbolic"]["solver"]["stats"]["solver_queries"], 16);
+    assert!(result["symbolic"]["solver"]["stats"]["paths"].as_u64().unwrap() > 2);
+});
+
+forgetest_init!(symbolic_preserves_completed_external_call_counterexamples, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_preserves_completed_external_call_counterexamples because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicDeferredExternalPriority.t.sol",
+        r#"
+contract SymbolicDeferredPriorityTarget {
+    function evaluate(uint256 x, uint256 y) external pure returns (uint256) {
+        if (x == 0) return 42;
+        unchecked {
+            uint256 product = x * y;
+            if (product == 0 && product == 1) return 1;
+        }
+        return 0;
+    }
+}
+
+contract SymbolicDeferredExternalPriority {
+    SymbolicDeferredPriorityTarget target;
+
+    function setUp() public {
+        target = new SymbolicDeferredPriorityTarget();
+    }
+
+    /// forge-config: default.symbolic.max_solver_queries = 8
+    function checkCompletedCallBfs(uint256 x, uint256 y) external view {
+        assert(target.evaluate(x, y) != 42);
+    }
+
+    /// forge-config: default.symbolic.max_solver_queries = 8
+    /// forge-config: default.symbolic.exploration_order = "dfs"
+    function checkCompletedCallDfs(uint256 x, uint256 y) external view {
+        assert(target.evaluate(x, y) != 42);
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--json",
+            "--optimize",
+            "--match-contract",
+            "SymbolicDeferredExternalPriority",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+    for signature in
+        ["checkCompletedCallBfs(uint256,uint256)", "checkCompletedCallDfs(uint256,uint256)"]
+    {
+        let result = json_test_result(&output, signature);
+        assert_eq!(result["symbolic"]["status"], "fail_counterexample");
+        assert_eq!(result["symbolic"]["replay"]["status"], "confirmed");
+    }
+});
+
 forgetest_init!(symbolic_proves_saturating_mul_equivalence, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -928,33 +928,53 @@ forgetest_init!(symbolic_preserves_completed_external_call_counterexamples, |prj
     prj.add_test(
         "SymbolicDeferredExternalPriority.t.sol",
         r#"
+interface SymbolicDeferredPriorityVm {
+    function assume(bool condition) external pure;
+    function unixTime() external returns (uint256);
+}
+
 contract SymbolicDeferredPriorityTarget {
     function evaluate(uint256 x, uint256 y) external pure returns (uint256) {
-        if (x == 0) return 42;
         unchecked {
-            uint256 product = x * y;
-            if (product == 0 && product == 1) return 1;
+            uint256 value = (x * y + 9) / 10;
+            if (value == 37) return 1;
+            if (value == 38) return 2;
         }
         return 0;
     }
 }
 
 contract SymbolicDeferredExternalPriority {
+    SymbolicDeferredPriorityVm constant vm = SymbolicDeferredPriorityVm(
+        address(uint160(uint256(keccak256("hevm cheat code"))))
+    );
     SymbolicDeferredPriorityTarget target;
 
     function setUp() public {
         target = new SymbolicDeferredPriorityTarget();
     }
 
-    /// forge-config: default.symbolic.max_solver_queries = 8
+    /// forge-config: default.symbolic.max_solver_queries = 16
     function checkCompletedCallBfs(uint256 x, uint256 y) external view {
-        assert(target.evaluate(x, y) != 42);
+        vm.assume(x >= 11 && x <= 18);
+        vm.assume(y >= 19 && y <= 30);
+        assert(target.evaluate(x, y) == 0);
     }
 
-    /// forge-config: default.symbolic.max_solver_queries = 8
+    /// forge-config: default.symbolic.max_solver_queries = 16
     /// forge-config: default.symbolic.exploration_order = "dfs"
     function checkCompletedCallDfs(uint256 x, uint256 y) external view {
-        assert(target.evaluate(x, y) != 42);
+        vm.assume(x >= 11 && x <= 18);
+        vm.assume(y >= 19 && y <= 30);
+        assert(target.evaluate(x, y) == 0);
+    }
+
+    function checkDeferredHostRead(uint256 x, uint256 y) external {
+        vm.assume(x >= 11 && x <= 18);
+        vm.assume(y >= 19 && y <= 30);
+        uint256 value = target.evaluate(x, y);
+        if (value != 0) vm.unixTime();
+        assert(value <= 2);
     }
 }
 "#,
@@ -979,7 +999,17 @@ contract SymbolicDeferredExternalPriority {
         let result = json_test_result(&output, signature);
         assert_eq!(result["symbolic"]["status"], "fail_counterexample");
         assert_eq!(result["symbolic"]["replay"]["status"], "confirmed");
+        assert!(result["symbolic"]["solver"]["stats"]["smt_queries"].as_u64().unwrap() > 0);
     }
+
+    let result = json_test_result(&output, "checkDeferredHostRead(uint256,uint256)");
+    assert_eq!(result["symbolic"]["status"], "incomplete");
+    assert!(
+        result["symbolic"]["incomplete"]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("nested hard arithmetic")
+    );
 });
 
 forgetest_init!(symbolic_proves_saturating_mul_equivalence, |prj, cmd| {


### PR DESCRIPTION
Nested external calls and contract creation can defer solver-required child branches until a later sibling exhausts the shared query budget. The parent then reports incomplete without first inspecting a feasible completed child that may already falsify the property.

This keeps the cheap first pass, then deterministically replays stateless executions in two bounded stages: first yield a completed SMT-deferred child outcome to its parent, and, if that finds no counterexample, replay once more to drain every remaining nested path before reporting a proof. Solver caches plus deadline, query, and path budgets remain cumulative. Replay stays disabled after mutable host inputs such as FFI, environment variables, wall-clock time, project-root lookup, or artifact reads.

On the review regression, where the failure is only reachable after solving `(x * y + 9) / 10 == 37`, the previous commit exhausts 16 queries as incomplete under both BFS and DFS. This version returns a concretely replayed counterexample under the same limit and ordering. The original issue reproduction changes from incomplete to proven while its inline equivalent remains proven.

Closes #16798.

This PR was written with Codex and Omp assistance, including code generation, implementation review, and test development.
