### PR TITLE
fix(ci): allow alloy-chains git source

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,8 @@ unknown-registry = "warn"
 # in the allow list is encountered
 unknown-git = "deny"
 allow-git = [
+    # Temporary: alloy-chains until HyperliquidTestnet is released.
+    "https://github.com/alloy-rs/chains",
     "https://github.com/foundry-rs/foundry-core",
     "https://github.com/paradigmxyz/solar",
     # Only for tests.


### PR DESCRIPTION
Allow `https://github.com/alloy-rs/chains` in cargo-deny's Git sources. The temporary `alloy-chains` patch in #16799 adds HyperliquidTestnet support but fails the source check because this repository is missing from the allowlist. The allowance can be removed once that support is released on crates.io and the patch is dropped.

This CI-only change uses the `L-ignore` changelog exemption.

This PR was authored and validated with Codex assistance.
