### PR TITLE
fix(fmt): stabilize for header comments

### DIFF
--- a/.changelog/fmt-for-header-comments.md
+++ b/.changelog/fmt-for-header-comments.md
@@ -3,4 +3,4 @@ forge: patch
 forge-fmt: patch
 ---
 
-Fixed comments in `for` loop headers changing position across repeated formatting runs.
+Fixed comments around `for` loop headers changing position across repeated formatting runs.

--- a/.changelog/fmt-for-header-comments.md
+++ b/.changelog/fmt-for-header-comments.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-fmt: patch
+---
+
+Fixed comments in `for` loop headers changing position across repeated formatting runs.

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -543,6 +543,7 @@ impl<'sess> State<'sess, '_> {
         let mut is_leading = true;
         let config_cache = config;
         let mut buffered_blank = None;
+        let mut previous_mixed_at_bol = false;
         while self.peek_comment().is_some_and(|c| c.pos() < pos) {
             let mut cmnt = self.next_comment().unwrap();
             let style_cache = cmnt.style;
@@ -607,6 +608,13 @@ impl<'sess> State<'sess, '_> {
                 self.print_comment(blank, config);
             }
 
+            if previous_mixed_at_bol
+                && cmnt.style.is_trailing()
+                && matches!(cmnt.kind, ast::CommentKind::Line)
+            {
+                self.hardbreak_if_not_bol();
+            }
+
             // Handle mixed with follow-up comment
             if cmnt.style.is_mixed() {
                 if let Some(cmnt) = self.peek_comment_before(pos) {
@@ -635,6 +643,7 @@ impl<'sess> State<'sess, '_> {
             }
 
             last_style = Some(cmnt.style);
+            previous_mixed_at_bol = cmnt.style.is_mixed() && self.is_bol_or_only_ind();
             self.print_comment(cmnt, config);
             config = config_cache;
         }

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -327,11 +327,16 @@ impl State<'_, '_> {
 
     /// Returns the position of the first `{` within the span, ignoring the ones inside comments.
     fn find_opening_brace(&self, span: Span) -> Option<BytePos> {
+        self.find_uncommented_char(span, '{')
+    }
+
+    /// Returns the position of the first matching character within the span, ignoring comments.
+    fn find_uncommented_char(&self, span: Span, needle: char) -> Option<BytePos> {
         let snip = self.sm.span_to_snippet(span).ok()?;
         let mut idx = 0;
         while idx < snip.len() {
             let rest = &snip[idx..];
-            if rest.starts_with('{') {
+            if rest.starts_with(needle) {
                 return Some(span.lo() + idx as u32);
             }
             idx += if let Some(line) = rest.strip_prefix("//") {

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -2196,7 +2196,19 @@ impl<'ast> State<'_, 'ast> {
     ) {
         self.cbox(0);
         self.s.ibox(self.ind);
-        self.print_word("for (");
+        let open_paren = self.find_uncommented_char(span, '(').unwrap();
+        self.print_word("for");
+        if self
+            .print_comments(
+                open_paren,
+                CommentConfig::skip_ws().mixed_prev_space().mixed_post_nbsp(),
+            )
+            .is_none()
+        {
+            self.nbsp();
+        }
+        self.cursor.advance_to(open_paren, true);
+        self.print_word("(");
         let init_has_leading_comment =
             init.as_ref().is_some_and(|stmt| self.peek_comment_before(stmt.span.lo()).is_some());
         if !init_has_leading_comment {

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -2197,14 +2197,22 @@ impl<'ast> State<'_, 'ast> {
         self.cbox(0);
         self.s.ibox(self.ind);
         self.print_word("for (");
-        self.zerobreak();
+        let init_has_leading_comment =
+            init.as_ref().is_some_and(|stmt| self.peek_comment_before(stmt.span.lo()).is_some());
+        if !init_has_leading_comment {
+            self.zerobreak();
+        }
 
         // Print init.
         self.s.cbox(0);
         let init_trailing_comment = match init {
             Some(init_stmt) => {
                 let has_trailing_comment = cond.as_ref().is_some_and(|cond| {
-                    self.peek_trailing_comment(init_stmt.span.hi(), Some(cond.span.lo())).is_some()
+                    self.comments
+                        .iter()
+                        .skip_while(|cmnt| cmnt.pos() < init_stmt.span.hi())
+                        .take_while(|cmnt| cmnt.pos() < cond.span.lo())
+                        .any(|cmnt| cmnt.style.is_trailing())
                 });
                 self.print_stmt_bound(init_stmt, Some(init_stmt.span.hi()));
                 has_trailing_comment

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -146,6 +146,67 @@ fn trailing_line_comment_separates_following_comment() {
     );
 }
 
+#[test]
+fn for_initializer_leading_comment_is_idempotent() {
+    let source = r#"contract C {
+    function f() external {
+        for (
+            /* lead
+            detail */ uint i = 0; i < 1; ++i
+        ) {}
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external {
+        for (
+            /* lead
+            detail */
+            uint256 i = 0;
+            i < 1;
+            ++i
+        ) {}
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
+#[test]
+fn for_initializer_comment_run_is_idempotent() {
+    let source = r#"contract C {
+    function f() external {
+        for (uint i = 0 /* detail
+        more */; // after init
+        i < 1; ++i) {}
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external {
+        for (
+            uint256 i = 0;
+
+            /* detail
+            more */
+            // after init
+            i < 1;
+            ++i
+        ) {}
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
 fn tests_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata")
 }

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -27,6 +27,90 @@ fn assert_eof(content: &str) {
 }
 
 #[test]
+fn for_initializer_leading_comment_is_idempotent() {
+    let source = r#"contract C {
+    function f() external {
+        for (
+            /* lead
+            detail */ uint i = 0; i < 1; ++i
+        ) {}
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external {
+        for (
+            /* lead
+            detail */
+            uint256 i = 0;
+            i < 1;
+            ++i
+        ) {}
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
+#[test]
+fn for_initializer_comment_run_is_idempotent() {
+    let source = r#"contract C {
+    function f() external {
+        for (uint i = 0 /* detail
+        more */; // after init
+        i < 1; ++i) {}
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external {
+        for (
+            uint256 i = 0;
+
+            /* detail
+            more */
+            // after init
+            i < 1;
+            ++i
+        ) {}
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
+#[test]
+fn for_keyword_comment_is_idempotent() {
+    let source = r#"contract C {
+    function f() external {
+        for // comment
+        (; ; ++i) {}
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external {
+        for // comment
+            (;; ++i) {}
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
+#[test]
 fn chained_named_call_layout_ignores_source_spacing() {
     let path = Path::new("test.sol");
 
@@ -136,67 +220,6 @@ fn trailing_line_comment_separates_following_comment() {
         value; // Trailing line.
         /* Following block.
         more text. */
-    }
-}
-"#;
-
-    assert_eq!(
-        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
-        expected
-    );
-}
-
-#[test]
-fn for_initializer_leading_comment_is_idempotent() {
-    let source = r#"contract C {
-    function f() external {
-        for (
-            /* lead
-            detail */ uint i = 0; i < 1; ++i
-        ) {}
-    }
-}
-"#;
-    let expected = r#"contract C {
-    function f() external {
-        for (
-            /* lead
-            detail */
-            uint256 i = 0;
-            i < 1;
-            ++i
-        ) {}
-    }
-}
-"#;
-
-    assert_eq!(
-        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
-        expected
-    );
-}
-
-#[test]
-fn for_initializer_comment_run_is_idempotent() {
-    let source = r#"contract C {
-    function f() external {
-        for (uint i = 0 /* detail
-        more */; // after init
-        i < 1; ++i) {}
-    }
-}
-"#;
-    let expected = r#"contract C {
-    function f() external {
-        for (
-            uint256 i = 0;
-
-            /* detail
-            more */
-            // after init
-            i < 1;
-            ++i
-        ) {}
     }
 }
 "#;


### PR DESCRIPTION
Comments around `for` loop headers can be classified differently after the first formatting pass, causing leading initializer comments to gain blank lines, adjacent block/line comment runs to move, and comments between `for` and `(` to drift into later clauses. Print the keyword and opening parenthesis separately, avoid the unconditional opening break when an initializer already has a leading comment, and detect trailing comments across the complete gap between initializer and condition so the first pass is stable. Related to #16649.

Written with Codex assistance for implementation, fuzzing, and regression tests.
