### PR TITLE
fix(fmt): separate chained comments

### DIFF
--- a/.changelog/fmt-line-comment-chain.md
+++ b/.changelog/fmt-line-comment-chain.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-fmt: patch
+---
+
+Fixed formatting a trailing line comment followed by another comment into invalid Solidity.

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -2083,10 +2083,22 @@ impl<'ast> State<'_, 'ast> {
             self.cursor.advance_to(span.hi(), true);
         }
         // print comments without breaks, as those are handled by the caller.
+        let ends_with_line_comment = self
+            .comments
+            .iter()
+            .take_while(|cmnt| cmnt.pos() < stmt.span.hi())
+            .filter(|cmnt| !cmnt.style.is_blank())
+            .last()
+            .is_some_and(|cmnt| {
+                cmnt.style.is_trailing() && matches!(cmnt.kind, ast::CommentKind::Line)
+            });
         self.print_comments(
             stmt.span.hi(),
             CommentConfig::default().trailing_no_break().mixed_no_break().mixed_prev_space(),
         );
+        if ends_with_line_comment && self.peek_comment().is_some() {
+            self.hardbreak_if_not_bol();
+        }
         self.print_trailing_comment_no_break(stmt.span.hi(), next_pos);
     }
 

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -92,6 +92,33 @@ fn disable_line_uses_comment_context() {
     );
 }
 
+#[test]
+fn trailing_line_comment_separates_following_comment() {
+    let source = r#"contract C {
+    function f() external {
+        uint value;
+        value // Trailing line.
+        ; /* Following block.
+        more text. */
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external {
+        uint256 value;
+        value; // Trailing line.
+        /* Following block.
+        more text. */
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
 fn tests_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata")
 }


### PR DESCRIPTION
A trailing line comment collected with a statement can be followed by another queued comment. Printing both without a forced break places the second comment after `//`, so its block terminator becomes live Solidity and the formatter writes invalid output. Preserve a hard line boundary between those comments while leaving ordinary trailing-comment layout unchanged. Related to #16649.

Written with Codex assistance for implementation, fuzzing, and regression tests.
