### PR TITLE
fix(fmt): trim statement comment blanks

### DIFF
--- a/.changelog/fmt-statement-comment-blank.md
+++ b/.changelog/fmt-statement-comment-blank.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-fmt: patch
+---
+
+Fixed blank lines after statement comments changing across repeated formatting runs.

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -2094,7 +2094,10 @@ impl<'ast> State<'_, 'ast> {
             });
         self.print_comments(
             stmt.span.hi(),
-            CommentConfig::default().trailing_no_break().mixed_no_break().mixed_prev_space(),
+            CommentConfig::skip_trailing_ws()
+                .trailing_no_break()
+                .mixed_no_break()
+                .mixed_prev_space(),
         );
         if ends_with_line_comment && self.peek_comment().is_some() {
             self.hardbreak_if_not_bol();

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -61,6 +61,33 @@ fn chained_named_call_layout_ignores_source_spacing() {
     }
 }
 
+#[test]
+fn statement_trailing_blank_line_is_idempotent() {
+    let source = r#"contract C {
+    function f() external {
+        uint value;
+        value += 1
+        /* detail. */
+
+        ;
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external {
+        uint256 value;
+        value += 1;
+        /* detail. */
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
 // <https://github.com/foundry-rs/foundry/issues/3831>
 #[test]
 fn disable_line_uses_comment_context() {


### PR DESCRIPTION
A blank-line token after a statement comment can be consumed as part of the statement even though the semicolon moves ahead of it during formatting. The next pass then sees a different comment boundary and removes the blank line. Ignore trailing blank tokens in the bounded statement-comment flush so one pass produces the stable layout. Related to #16649.

Written with Codex assistance for implementation, fuzzing, and regression tests.
