### PR TITLE
fix(fmt): align narrow block comments

### DIFF
--- a/.changelog/fmt-narrow-comment-followup.md
+++ b/.changelog/fmt-narrow-comment-followup.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-fmt: patch
+---
+
+Fixed multiline comments losing indentation on the first formatting pass at narrow widths.

--- a/crates/fmt/src/pp/mod.rs
+++ b/crates/fmt/src/pp/mod.rs
@@ -415,6 +415,7 @@ impl Printer {
                 IndentStyle::Block { offset } => {
                     usize::try_from(self.indent as isize + offset).unwrap()
                 }
+                IndentStyle::Visual if self.out.ends_with('\n') => self.pending_indentation,
                 IndentStyle::Visual => (self.margin - self.space) as usize,
             };
         } else {

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -816,6 +816,7 @@ impl<'sess> State<'sess, '_> {
             CommentStyle::Mixed => {
                 let Some(prefix) = cmnt.prefix() else { return };
                 let never_break = self.last_token_is_neverbreak();
+                let starts_line = self.is_bol_or_only_ind() || self.last_token_is_break();
                 if !self.is_bol_or_only_ind() {
                     match (never_break || config.mixed_no_break_prev, config.mixed_prev_space) {
                         (false, true) => config.space(&mut self.s),
@@ -826,12 +827,18 @@ impl<'sess> State<'sess, '_> {
                 }
                 if self.config.wrap_comments {
                     // Merge and wrap comments
+                    if starts_line {
+                        self.ibox(config.offset);
+                    }
                     let merged_lines = self.merge_comment_lines(&cmnt.lines, prefix);
                     for (pos, line) in merged_lines.into_iter().delimited() {
                         self.print_wrapped_line(&line, prefix, 0, cmnt.is_doc);
                         if !pos.is_last {
                             self.hardbreak();
                         }
+                    }
+                    if starts_line {
+                        self.end();
                     }
                 } else {
                     // Match the opening-column normalization of continuation lines.

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -204,6 +204,47 @@ fn disable_line_uses_comment_context() {
 }
 
 #[test]
+fn narrow_multiline_comment_is_idempotent() {
+    let source = r#"contract C {
+    function f() external {
+        for (uint i = 0; i < 10; ++i) /* detail.
+        more text. */ {}
+    }
+}
+"#;
+    let expected = "contract C {\n    function f() external {\n        for (uint256 i = 0; i < 10; ++i) \n        /* detail.\n        more text. */\n        {}\n    }\n}\n";
+    let config = Arc::new(FormatterConfig { line_length: 40, ..Default::default() });
+
+    let first = format(source, Path::new("test.sol"), config.clone());
+    assert_eq!(first, expected);
+    assert_eq!(format(&first, Path::new("test.sol"), config), first);
+}
+
+#[test]
+fn wrapped_mixed_comment_at_line_start_is_idempotent() {
+    let source = r#"contract C {
+    function f() external {
+        /* detail.
+        more text. */ uint value;
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external {
+        /* detail.
+        more text. */
+        uint256 value;
+    }
+}
+"#;
+    let config = Arc::new(FormatterConfig { wrap_comments: true, ..Default::default() });
+
+    let first = format(source, Path::new("test.sol"), config.clone());
+    assert_eq!(first, expected);
+    assert_eq!(format(&first, Path::new("test.sol"), config), first);
+}
+
+#[test]
 fn trailing_line_comment_separates_following_comment() {
     let source = r#"contract C {
     function f() external {


### PR DESCRIPTION
Multiline mixed comments that break onto a new line at narrow widths can compute visual indentation from the printer's clamped remaining space, yielding column zero on the first pass. Use exact pending indentation at line starts and establish a block for wrapped mixed comments that already begin a line. This follows #16788 and is related to #16649.

Written with Codex assistance for implementation, fuzzing, and regression tests.
