### PR TITLE
fix(fmt): preserve CRLF disabled lines

### DIFF
--- a/.changelog/fmt-crlf-disabled-tabs.md
+++ b/.changelog/fmt-crlf-disabled-tabs.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-fmt: patch
+---
+
+Fixed CRLF line endings being dropped inside disabled regions when formatting with tabs.

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -1245,15 +1245,13 @@ impl CommentConfig {
 }
 
 fn snippet_with_tabs(s: String, tab_width: usize) -> String {
-    // process leading breaks
-    let trimmed = s.trim_start_matches('\n');
-    let num_breaks = s.len() - trimmed.len();
-    let mut formatted = std::iter::repeat_n('\n', num_breaks).collect::<String>();
-
-    // process lines
-    for (pos, line) in trimmed.lines().delimited() {
+    let mut formatted = String::with_capacity(s.len());
+    for line in s.split_inclusive('\n') {
+        let (line, has_newline) =
+            line.strip_suffix('\n').map_or((line, false), |line| (line, true));
+        let line = line.strip_suffix('\r').unwrap_or(line);
         line_with_tabs(&mut formatted, line, tab_width, None);
-        if !pos.is_last {
+        if has_newline {
             formatted.push('\n');
         }
     }

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -1,4 +1,5 @@
 use forge_fmt::FormatterConfig;
+use foundry_config::fmt::IndentStyle;
 use foundry_test_utils::init_tracing;
 use snapbox::{Data, assert_data_eq};
 use solar::sema::Compiler;
@@ -228,6 +229,16 @@ fn trailing_line_comment_separates_following_comment() {
         format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
         expected
     );
+}
+
+#[test]
+fn tab_style_preserves_crlf_disabled_block_lines() {
+    let source = "contract C {\n// forgefmt: disable-start\nfunction  disabled( ) external { uint   value = 1; }\n// forgefmt: disable-end\nuint value;\n}\n"
+        .replace('\n', "\r\n");
+    let expected = "contract C {\n\t// forgefmt: disable-start\nfunction  disabled( ) external { uint   value = 1; }\n// forgefmt: disable-end\n\tuint256 value;\n}\n";
+    let config = Arc::new(FormatterConfig { style: IndentStyle::Tab, ..Default::default() });
+
+    assert_eq!(format(&source, Path::new("test.sol"), config), expected);
 }
 
 fn tests_dir() -> PathBuf {


### PR DESCRIPTION
Tab-style formatting rewrites verbatim disabled spans to normalize their indentation, but its line iterator discards a trailing CRLF. Adjacent `disable-start`, preserved source, and `disable-end` spans can consequently collapse onto one `//` line, removing the preserved declaration from the parsed AST. Preserve every line terminator while converting CRLF to the formatter's canonical LF output. Related to #16649.

Written with Codex assistance for implementation, fuzzing, and regression tests.
