### PR TITLE
fix(fmt): stabilize comment formatting

### DIFF
--- a/.changelog/fmt-fuzz-idempotency-followups.md
+++ b/.changelog/fmt-fuzz-idempotency-followups.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-fmt: patch
+---
+
+Fixed formatter idempotency around array type comments, Yul assignment comments, and commented return expressions.

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1189,6 +1189,13 @@ impl<'ast> State<'_, 'ast> {
             }
             ast::TypeKind::Array(ast::TypeArray { element, size }) => {
                 self.print_ty(element);
+                let open_bracket = self
+                    .find_uncommented_char(Span::new(element.span.hi(), ty.span.hi()), '[')
+                    .unwrap();
+                self.print_comments(
+                    open_bracket,
+                    CommentConfig::skip_ws().mixed_prev_space().mixed_post_nbsp(),
+                );
                 if let Some(size) = size {
                     self.word("[");
                     self.print_expr(size);
@@ -2377,7 +2384,7 @@ impl<'ast> State<'_, 'ast> {
                 expr.span.lo(),
                 CommentConfig::skip_ws().mixed_no_break().mixed_prev_space().mixed_post_nbsp(),
             ) {
-                Some(cmnt) if cmnt.is_trailing() && !is_simple => self.s.offset(self.ind),
+                Some(_) if !is_simple => self.s.offset(self.ind),
                 None => self.print_sep(Separator::SpaceOrNbsp(allow_break)),
                 _ => {}
             }

--- a/crates/fmt/src/state/yul.rs
+++ b/crates/fmt/src/state/yul.rs
@@ -29,8 +29,14 @@ impl<'ast> State<'_, 'ast> {
             yul::StmtKind::Block(stmts) => self.print_yul_block(stmts, span, false, 0),
             yul::StmtKind::AssignSingle(path, expr) => {
                 self.print_path(path, false);
-                self.word(" := ");
+                self.word(" :=");
                 self.neverbreak();
+                if self
+                    .print_comments(expr.span.lo(), CommentConfig::skip_ws().mixed_prev_space())
+                    .is_none()
+                {
+                    self.nbsp();
+                }
                 self.cursor.advance_to(expr.span.lo(), self.cursor.enabled);
                 self.print_yul_expr(expr);
             }

--- a/crates/fmt/testdata/ArrayExpressions/fmt.sol
+++ b/crates/fmt/testdata/ArrayExpressions/fmt.sol
@@ -6,7 +6,7 @@ contract ArrayExpressions {
         uint256 length = 10;
         uint256[] memory sample2 = new uint256[](length);
 
-        uint256[] memory /* comment1 */ /* comment2 */ sample3; // comment3
+        uint256 /* comment1 */ [] memory /* comment2 */ sample3; // comment3
 
         /* ARRAY SLICE */
         msg.data[4:];

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -282,6 +282,85 @@ fn tab_style_preserves_crlf_disabled_block_lines() {
     assert_eq!(format(&source, Path::new("test.sol"), config), expected);
 }
 
+#[test]
+fn array_type_comment_before_bracket_is_idempotent() {
+    let source = r#"contract C {
+    function f() external {
+        uint256 /* first */ [
+            /* second */
+
+            3
+        ] memory values;
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external {
+        uint256 /* first */ [
+            /* second */
+
+            3] memory values;
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
+#[test]
+fn yul_assignment_comment_is_idempotent() {
+    let source = r#"contract C {
+    function f() external pure returns (uint256 x) {
+        assembly {
+            x := /* comment */ add(1, 2)
+        }
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f() external pure returns (uint256 x) {
+        assembly {
+            x := /* comment */
+            add(1, 2)
+        }
+    }
+}
+"#;
+
+    assert_eq!(
+        format(source, Path::new("test.sol"), Arc::new(FormatterConfig::default())),
+        expected
+    );
+}
+
+#[test]
+fn return_expression_comment_is_idempotent() {
+    let source = r#"contract C {
+    function f() external pure returns (uint256, uint256, bool) {
+        return /* return values */ (1234567890, 9876543210, false);
+    }
+}
+"#;
+    let expected = r#"contract C {
+    function f()
+        external
+        pure
+        returns (uint256, uint256, bool)
+    {
+        return /* return values */
+            (1234567890, 9876543210, false);
+    }
+}
+"#;
+    let config =
+        Arc::new(FormatterConfig { line_length: 60, wrap_comments: true, ..Default::default() });
+
+    assert_eq!(format(source, Path::new("test.sol"), config), expected);
+}
+
 fn tests_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata")
 }


### PR DESCRIPTION
Keep comments before array brackets, normalize spacing before commented Yul assignment values, and consistently indent commented return expressions. Includes minimized regressions and a changelog.

Follow-up to #16649. AI-assisted implementation and validation with Codex and Amp.