### PR TITLE
feat: add Base support MVP

### DIFF
--- a/.changelog/base-network.md
+++ b/.changelog/base-network.md
@@ -1,0 +1,7 @@
+---
+cast: minor
+chisel: minor
+forge: minor
+---
+
+Added Base network support across Cast, Chisel, and Forge, with EIP-8130 gated on Zenith and Base receipt log timestamps preserved.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ env:
 
   # Keep the base features in sync with `release.yml`.
   RUST_PROFILE: dist
-  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer,monad,optimism
+  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer,base,monad,optimism
 
 jobs:
   cargo-cooldown:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ env:
   # Keep the base features in sync with `docker-publish.yml`.
   # Platform-specific release features are added in the build step.
   RUST_PROFILE: dist
-  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer,monad,optimism
+  RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer,base,monad,optimism
 
 jobs:
   cargo-cooldown:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,4 +146,4 @@ jobs:
             args+=(--partition "$NEXTEST_PARTITION")
           fi
           args+=(--no-fail-fast)
-          cargo nextest run --locked --features monad "${args[@]}"
+          cargo nextest run --locked --features base,monad "${args[@]}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,238 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-common-chains"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-chains",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "auto_impl",
+ "base-common-genesis",
+ "revm",
+ "spin",
+]
+
+[[package]]
+name = "base-common-consensus"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-sol-types",
+ "bytes",
+ "reth-codecs 0.6.0",
+ "reth-primitives-traits 0.6.0",
+ "reth-zstd-compressors 0.6.0",
+ "revm",
+ "serde",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "base-common-eip8130"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-primitives",
+ "base-common-consensus",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "base-common-evm"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "auto_impl",
+ "base-common-chains",
+ "base-common-consensus",
+ "base-common-flz",
+ "base-common-genesis",
+ "base-common-l1-fees",
+ "base-common-precompiles",
+ "base-execution-eip8130",
+ "base-metrics",
+ "base-precompile-storage",
+ "revm",
+ "serde",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "base-common-flz"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+
+[[package]]
+name = "base-common-genesis"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "derive_more",
+ "serde",
+ "spin",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
+name = "base-common-l1-fees"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-primitives",
+ "base-common-flz",
+ "base-common-genesis",
+]
+
+[[package]]
+name = "base-common-network"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
+ "async-trait",
+ "base-common-consensus",
+ "base-common-rpc-types",
+ "base-common-rpc-types-engine",
+]
+
+[[package]]
+name = "base-common-precompiles"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "base-common-chains",
+ "base-common-eip8130",
+ "base-common-genesis",
+ "base-precompile-macros",
+ "base-precompile-storage",
+ "revm",
+]
+
+[[package]]
+name = "base-common-rpc-types"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "base-common-consensus",
+ "base-common-evm",
+ "derive_more",
+ "reth-primitives-traits 0.6.0",
+ "revm",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "base-common-rpc-types-engine"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "alloy-serde",
+ "base-common-consensus",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "serde",
+ "sha2 0.10.9",
+ "snap",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "base-execution-eip8130"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "base-common-consensus",
+ "base-common-eip8130",
+ "base-common-precompiles",
+ "base-precompile-macros",
+ "base-precompile-storage",
+ "base64 0.22.1",
+ "k256",
+ "p256 0.13.2",
+ "revm",
+ "sha2 0.10.9",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "base-metrics"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+
+[[package]]
+name = "base-precompile-macros"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-primitives",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "base-precompile-storage"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/base?rev=2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72#2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72"
+dependencies = [
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "base-precompile-macros",
+ "derive_more",
+ "revm",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,6 +3218,7 @@ dependencies = [
  "alloy-transport",
  "anvil",
  "axum",
+ "base-common-network",
  "chrono",
  "clap",
  "clap_complete",
@@ -5740,6 +5973,8 @@ dependencies = [
  "anstream",
  "anstyle",
  "axum",
+ "base-common-network",
+ "base-common-rpc-types",
  "base64 0.23.1",
  "chrono",
  "ciborium",
@@ -5793,6 +6028,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
  "alloy-serde",
+ "base-common-consensus",
+ "base-common-rpc-types",
  "chrono",
  "comfy-table",
  "eyre",
@@ -6043,6 +6280,12 @@ dependencies = [
  "alloy-sol-types",
  "anvil",
  "auto_impl",
+ "base-common-chains",
+ "base-common-consensus",
+ "base-common-evm",
+ "base-common-network",
+ "base-common-precompiles",
+ "base-common-rpc-types",
  "eyre",
  "foundry-cheatcodes-spec",
  "foundry-common",
@@ -6127,6 +6370,8 @@ dependencies = [
  "alloy-hardforks",
  "alloy-op-hardforks",
  "alloy-rpc-types",
+ "base-common-evm",
+ "base-common-genesis",
  "foundry-compilers",
  "monad-revm",
  "op-revm",
@@ -6144,6 +6389,7 @@ dependencies = [
  "alloy-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
+ "base-common-precompiles",
  "clap",
  "foundry-evm-hardforks",
  "monad-revm",
@@ -6191,6 +6437,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "async-trait",
+ "base-common-precompiles",
  "eyre",
  "foundry-block-explorers",
  "foundry-common",
@@ -6279,6 +6526,9 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
+ "base-common-consensus",
+ "base-common-evm",
+ "base-common-rpc-types",
  "derive_more",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
@@ -8568,8 +8818,8 @@ dependencies = [
  "alloy-serde",
  "bytes",
  "derive_more",
- "reth-codecs",
- "reth-zstd-compressors",
+ "reth-codecs 0.7.0",
+ "reth-zstd-compressors 0.7.0",
  "serde",
  "serde_with",
  "thiserror 2.0.20",
@@ -10190,8 +10440,27 @@ dependencies = [
  "derive_more",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "serde_json",
+]
+
+[[package]]
+name = "reth-codecs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "bytes",
+ "modular-bitfield",
+ "parity-scale-codec",
+ "reth-codecs-derive 0.6.0",
+ "reth-zstd-compressors 0.6.0",
+ "serde",
 ]
 
 [[package]]
@@ -10209,10 +10478,21 @@ dependencies = [
  "bytes",
  "modular-bitfield",
  "parity-scale-codec",
- "reth-codecs-derive",
- "reth-zstd-compressors",
+ "reth-codecs-derive 0.7.0",
+ "reth-zstd-compressors 0.7.0",
  "serde",
  "visibility",
+]
+
+[[package]]
+name = "reth-codecs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10236,7 +10516,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "thiserror 2.0.20",
 ]
 
@@ -10250,7 +10530,7 @@ dependencies = [
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
 ]
 
 [[package]]
@@ -10268,10 +10548,10 @@ dependencies = [
  "metrics",
  "modular-bitfield",
  "proptest",
- "reth-codecs",
+ "reth-codecs 0.7.0",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10290,8 +10570,8 @@ dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 0.7.0",
+ "reth-primitives-traits 0.7.0",
  "serde",
 ]
 
@@ -10307,7 +10587,7 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "tracing",
 ]
 
@@ -10333,8 +10613,8 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 0.7.0",
+ "reth-primitives-traits 0.7.0",
  "serde",
 ]
 
@@ -10355,7 +10635,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
@@ -10377,7 +10657,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "reth-storage-errors",
  "revm",
 ]
@@ -10407,7 +10687,7 @@ dependencies = [
  "alloy-rlp",
  "derive_more",
  "reth-ethereum-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "reth-trie-common",
  "revm",
  "serde",
@@ -10425,6 +10705,32 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.20",
  "url",
+]
+
+[[package]]
+name = "reth-primitives-traits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-trie",
+ "bytes",
+ "dashmap",
+ "derive_more",
+ "once_cell",
+ "reth-codecs 0.6.0",
+ "revm-bytecode 42.0.0",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
+ "secp256k1 0.30.0",
+ "serde",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -10450,10 +10756,10 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "quanta",
- "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
+ "reth-codecs 0.7.0",
+ "revm-bytecode 43.0.0",
+ "revm-primitives 43.0.0",
+ "revm-state 43.0.0",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.20",
@@ -10468,7 +10774,7 @@ dependencies = [
  "arbitrary",
  "derive_more",
  "modular-bitfield",
- "reth-codecs",
+ "reth-codecs 0.7.0",
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.20",
@@ -10482,7 +10788,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "reth-storage-api",
  "reth-storage-errors",
  "revm",
@@ -10499,7 +10805,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "thiserror 2.0.20",
 ]
 
@@ -10512,7 +10818,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "reth-codecs",
+ "reth-codecs 0.7.0",
  "reth-trie-common",
  "serde",
 ]
@@ -10546,7 +10852,7 @@ dependencies = [
  "reth-db-models",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10565,8 +10871,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 0.7.0",
+ "reth-primitives-traits 0.7.0",
  "reth-prune-types",
  "reth-static-file-types",
  "revm",
@@ -10602,12 +10908,21 @@ dependencies = [
  "itertools 0.14.0",
  "nybbles",
  "plain_hasher",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 0.7.0",
+ "reth-primitives-traits 0.7.0",
  "revm",
  "serde",
  "serde_with",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "reth-zstd-compressors"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
+dependencies = [
+ "zstd",
 ]
 
 [[package]]
@@ -10625,7 +10940,7 @@ version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55f2322f5ea197fac72c2cdc88cb501b2a7db0b0009911133fd3dda45bfceedd"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 43.0.0",
  "revm-context",
  "revm-context-interface",
  "revm-database",
@@ -10634,8 +10949,20 @@ dependencies = [
  "revm-inspector",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 43.0.0",
+ "revm-state 43.0.0",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
+dependencies = [
+ "bitvec",
+ "phf 0.14.0",
+ "revm-primitives 42.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -10647,7 +10974,7 @@ dependencies = [
  "bitvec",
  "paste",
  "phf 0.14.0",
- "revm-primitives",
+ "revm-primitives 43.0.0",
  "serde",
 ]
 
@@ -10660,11 +10987,11 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 43.0.0",
  "revm-context-interface",
  "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 43.0.0",
+ "revm-state 43.0.0",
  "serde",
 ]
 
@@ -10679,8 +11006,8 @@ dependencies = [
  "auto_impl",
  "either",
  "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 43.0.0",
+ "revm-state 43.0.0",
  "serde",
 ]
 
@@ -10693,10 +11020,10 @@ dependencies = [
  "alloy-eips",
  "derive_more",
  "either",
- "revm-bytecode",
+ "revm-bytecode 43.0.0",
  "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 43.0.0",
+ "revm-state 43.0.0",
  "serde",
 ]
 
@@ -10708,8 +11035,8 @@ checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 43.0.0",
+ "revm-state 43.0.0",
  "serde",
  "thiserror 2.0.20",
 ]
@@ -10722,14 +11049,14 @@ checksum = "73a7409031d87ec281b74efff65d7a4dbea9d80727a55dbc7e4b3fd77b5e03fb"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 43.0.0",
  "revm-context",
  "revm-context-interface",
  "revm-database-interface",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 43.0.0",
+ "revm-state 43.0.0",
  "serde",
 ]
 
@@ -10745,8 +11072,8 @@ dependencies = [
  "revm-database-interface",
  "revm-handler",
  "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 43.0.0",
+ "revm-state 43.0.0",
  "serde",
  "serde_json",
 ]
@@ -10777,10 +11104,10 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "932f7fe05a2cdeb08195dd7e88a09a4da7c3660cdc6e62720839c77ba77f65aa"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 43.0.0",
  "revm-context-interface",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 43.0.0",
+ "revm-state 43.0.0",
  "serde",
 ]
 
@@ -10803,10 +11130,21 @@ dependencies = [
  "k256",
  "p256 0.13.2",
  "revm-context-interface",
- "revm-primitives",
+ "revm-primitives 43.0.0",
  "ripemd 0.2.0",
  "secp256k1 0.31.1",
  "sha2 0.11.0",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
+dependencies = [
+ "alloy-primitives",
+ "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -10822,6 +11160,20 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags 2.13.1",
+ "nonmax",
+ "revm-bytecode 42.0.0",
+ "revm-primitives 42.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
 version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
@@ -10829,8 +11181,8 @@ dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.1",
  "nonmax",
- "revm-bytecode",
- "revm-primitives",
+ "revm-bytecode 43.0.0",
+ "revm-primitives 43.0.0",
  "serde",
 ]
 
@@ -12231,6 +12583,9 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spinning_top"
@@ -12707,7 +13062,7 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-evm",
  "reth-evm-ethereum",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "reth-revm",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12787,10 +13142,10 @@ dependencies = [
  "derive_more",
  "once_cell",
  "p256 0.13.2",
- "reth-codecs",
+ "reth-codecs 0.7.0",
  "reth-db-api",
  "reth-ethereum-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 0.7.0",
  "revm",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -545,6 +545,16 @@ monad-revm = { version = "0.8.0", default-features = false, features = [
     "memory_limit",
 ] }
 
+# Base
+base-common-chains = { git = "https://github.com/foundry-rs/base", rev = "2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72", default-features = false }
+base-common-consensus = { git = "https://github.com/foundry-rs/base", rev = "2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72", default-features = false }
+base-common-evm = { git = "https://github.com/foundry-rs/base", rev = "2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72", default-features = false }
+base-common-genesis = { git = "https://github.com/foundry-rs/base", rev = "2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72", default-features = false }
+base-common-network = { git = "https://github.com/foundry-rs/base", rev = "2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72", default-features = false }
+base-common-precompiles = { git = "https://github.com/foundry-rs/base", rev = "2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72", default-features = false }
+base-common-rpc-types = { git = "https://github.com/foundry-rs/base", rev = "2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72", default-features = false }
+base-execution-eip8130 = { git = "https://github.com/foundry-rs/base", rev = "2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72", default-features = false }
+
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
 # testing

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ CARGO_TARGET_DIR ?= target
 # List of features to use when building. Can be overridden via the environment.
 # No jemalloc on Windows
 ifeq ($(OS),Windows_NT)
-    FEATURES ?= aws-kms gcp-kms turnkey cli asm-keccak monad optimism
+    FEATURES ?= aws-kms gcp-kms turnkey cli asm-keccak base monad optimism
 else
-    FEATURES ?= jemalloc aws-kms gcp-kms turnkey cli asm-keccak monad optimism
+    FEATURES ?= jemalloc aws-kms gcp-kms turnkey cli asm-keccak base monad optimism
 endif
 
 ##@ Help

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -138,6 +138,14 @@ monad = [
     "foundry-evm-networks/monad",
     "foundry-cli?/monad",
 ]
+base = [
+    "foundry-primitives/base",
+    "foundry-common/base",
+    "foundry-config/base",
+    "foundry-evm/base",
+    "foundry-evm-networks/base",
+    "foundry-cli?/base",
+]
 optimism = [
     "dep:op-alloy-consensus",
     "dep:op-alloy-rpc-types",

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -273,6 +273,13 @@ impl NodeArgs {
             self.evm.networks
         };
 
+        #[cfg(feature = "base")]
+        let networks = if self.evm.networks.has_network_selection() {
+            networks
+        } else {
+            crate::config::legacy_base_profile(networks).map_err(eyre::Report::msg)?
+        };
+
         let hardfork = match &self.hardfork {
             Some(hf) => Some(parse_hardfork(hf, &networks)?),
             None => None,
@@ -945,6 +952,22 @@ mod tests {
 
     #[cfg(feature = "optimism")]
     use foundry_evm::hardfork::OpHardfork;
+
+    #[cfg(all(feature = "base", feature = "optimism"))]
+    #[test]
+    fn base_chain_ids_preserve_existing_node_routing() {
+        for chain_id in ["8453", "84532"] {
+            let config =
+                NodeArgs::parse_from(["anvil", "--chain-id", chain_id]).into_node_config().unwrap();
+            assert!(config.networks.is_optimism());
+
+            let config =
+                NodeArgs::parse_from(["anvil", "--chain-id", chain_id, "--network", "ethereum"])
+                    .into_node_config()
+                    .unwrap();
+            assert!(config.networks.execution_network().is_ethereum());
+        }
+    }
 
     #[test]
     fn test_parse_fork_url() {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -78,6 +78,9 @@ use foundry_evm::{
 use foundry_evm_networks::{NetworkConfigs, NetworkVariant};
 use tempo_precompiles::TIP_FEE_MANAGER_ADDRESS;
 
+#[cfg(all(feature = "base", feature = "optimism"))]
+use foundry_evm::hardfork::OpHardfork;
+
 /// Default port the rpc will open
 pub const NODE_PORT: u16 = 8545;
 /// Default chain id of the node
@@ -88,6 +91,31 @@ pub const DEFAULT_GAS_LIMIT: u64 = 30_000_000;
 pub const DEFAULT_SLOTS_IN_AN_EPOCH: u64 = 32;
 /// Default mnemonic for dev accounts
 pub const DEFAULT_MNEMONIC: &str = "test test test test test test test test test test test junk";
+
+/// Keeps inferred Base chains on Anvil's existing OP execution path until native support lands.
+#[cfg(feature = "base")]
+pub(crate) fn legacy_base_profile(profile: NetworkConfigs) -> Result<NetworkConfigs, String> {
+    if profile.is_base() {
+        #[cfg(feature = "optimism")]
+        return Ok(profile.with_rpc_network(NetworkVariant::Optimism));
+        #[cfg(not(feature = "optimism"))]
+        return Err("network family `optimism` is not enabled in this build".to_string());
+    }
+    Ok(profile)
+}
+
+/// Resolves source-chain upgrades using the execution families currently supported by Anvil.
+pub(crate) fn source_hardfork(chain_id: u64, timestamp: u64) -> Option<FoundryHardfork> {
+    #[cfg(feature = "base")]
+    if matches!(NamedChain::try_from(chain_id), Ok(NamedChain::Base | NamedChain::BaseSepolia)) {
+        #[cfg(feature = "optimism")]
+        return OpHardfork::from_chain_and_timestamp(Chain::from_id(chain_id), timestamp)
+            .map(FoundryHardfork::Optimism);
+        #[cfg(not(feature = "optimism"))]
+        return None;
+    }
+    FoundryHardfork::from_chain_and_timestamp(chain_id, timestamp)
+}
 
 #[derive(Clone, Copy, Debug)]
 struct ForkOverrides {
@@ -780,6 +808,12 @@ impl NodeConfig {
         let chain_id = self.get_chain_id();
         let base = self.networks;
         let inferred = base.with_chain_id(chain_id);
+        #[cfg(feature = "base")]
+        let inferred = if base.has_network_selection() {
+            inferred
+        } else {
+            legacy_base_profile(inferred).unwrap_or(base)
+        };
         if !base.has_network_selection() && inferred.has_network_selection() {
             self.chain_id_network_base = Some(base);
         }
@@ -1342,6 +1376,12 @@ impl NodeConfig {
                 ReceiptEnvelope = foundry_primitives::FoundryReceiptEnvelope,
             >,
     {
+        #[cfg(feature = "base")]
+        eyre::ensure!(
+            !self.networks.is_base() && !matches!(self.hardfork, Some(FoundryHardfork::Base(_))),
+            "Base execution is not supported by Anvil yet"
+        );
+
         // configure the revm environment
 
         let mut cfg = CfgEnv::default();
@@ -1565,6 +1605,9 @@ impl NodeConfig {
                 explicit_fallback,
             )
             .map_err(eyre::Report::msg)?;
+            #[cfg(feature = "base")]
+            let network_profile =
+                network_profile.map(legacy_base_profile).transpose().map_err(eyre::Report::msg)?;
             return Ok(ForkEndpointIdentity {
                 execution_chain_id: fallback_execution_chain_id,
                 source_chain_id,
@@ -1614,6 +1657,12 @@ impl NodeConfig {
         )
         .map_err(eyre::Report::msg)?
         .ok_or_else(|| eyre::eyre!("Anvil metadata did not identify an execution profile"))?;
+        #[cfg(feature = "base")]
+        let network_profile = if node_info.network.is_none() {
+            legacy_base_profile(network_profile).map_err(eyre::Report::msg)?
+        } else {
+            network_profile
+        };
         let network = network_profile.execution_network();
         let hardfork = network
             .parse_hardfork(&node_info.hard_fork)
@@ -1871,6 +1920,8 @@ impl NodeConfig {
 
         let target_network = fork_identity.network.unwrap_or(NetworkVariant::Ethereum);
         let target_profile = fork_identity.network_profile.unwrap_or_default();
+        #[cfg(feature = "base")]
+        eyre::ensure!(!target_profile.is_base(), "Base execution is not supported by Anvil yet");
         if self.inferred_fork_network.is_some()
             && !self.networks.supports_fork_source(&target_profile)
         {
@@ -1964,9 +2015,9 @@ latest block number: {latest_block}"
         let effective_network =
             self.networks.resolved_network().unwrap_or(NetworkVariant::Ethereum);
         let endpoint_matches_execution = fork_identity.network == Some(effective_network);
-        let source_hardfork = fork_identity.hardfork.or_else(|| {
-            FoundryHardfork::from_chain_and_timestamp(source_chain_id, block.header.timestamp())
-        });
+        let source_hardfork = fork_identity
+            .hardfork
+            .or_else(|| source_hardfork(source_chain_id, block.header.timestamp()));
         let inferred_hardfork = source_hardfork.filter(|hardfork| {
             endpoint_matches_execution
                 && hardfork.namespace() == effective_network.hardfork_namespace()
@@ -2486,8 +2537,53 @@ mod tests {
     use super::*;
     use foundry_evm::{hardfork::EthereumHardfork, hardforks::latest_active_tempo_hardfork};
 
-    #[cfg(feature = "optimism")]
+    #[cfg(all(feature = "optimism", not(feature = "base")))]
     use foundry_evm::hardfork::OpHardfork;
+
+    #[cfg(feature = "base")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn base_execution_is_deferred() {
+        for config in [
+            NodeConfig::test().with_networks(NetworkConfigs::with_base()),
+            NodeConfig::test().with_hardfork(Some("base:Beryl".parse().unwrap())),
+        ] {
+            let error = crate::try_spawn(config).await.err().unwrap();
+            assert_eq!(error.to_string(), "Base execution is not supported by Anvil yet");
+        }
+    }
+
+    #[cfg(all(feature = "base", feature = "optimism"))]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn base_chain_inference_preserves_optimism_forks() {
+        for chain_id in [8453u64, 84532] {
+            let (origin_api, origin) = crate::spawn(
+                NodeConfig::test()
+                    .with_chain_id(Some(chain_id))
+                    .with_genesis_timestamp(Some(1_710_374_401u64)),
+            )
+            .await;
+            assert!(origin_api.backend.is_optimism());
+            assert_eq!(origin_api.backend.hardfork(), OpHardfork::Ecotone.into());
+
+            let anonymous_url = foundry_test_utils::rpc::spawn_rpc_proxy_rejecting_method_after(
+                origin.http_endpoint(),
+                "anvil_nodeInfo",
+                0,
+            )
+            .await;
+            for endpoint in [origin.http_endpoint(), anonymous_url] {
+                let (api, _handle) =
+                    crate::spawn(NodeConfig::test().with_eth_rpc_url(Some(endpoint))).await;
+                assert!(api.backend.is_optimism());
+                assert_eq!(api.backend.hardfork(), OpHardfork::Ecotone.into());
+                let fork = api.backend.get_fork().unwrap();
+                assert_eq!(
+                    fork.config.read().endpoint_identity.network,
+                    Some(NetworkVariant::Optimism)
+                );
+            }
+        }
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn fork_output_redacts_endpoint_credentials() {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -4960,8 +4960,10 @@ impl EthApi<FoundryNetwork> {
             FoundryTxEnvelope::Eip1559(_) => self.backend.ensure_eip1559_active(),
             FoundryTxEnvelope::Eip4844(_) => self.backend.ensure_eip4844_active(),
             FoundryTxEnvelope::Eip7702(_) => self.backend.ensure_eip7702_active(),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTxEnvelope::Deposit(_) => self.backend.ensure_op_deposits_active(),
+            #[cfg(feature = "base")]
+            FoundryTxEnvelope::Eip8130(_) => Err(BlockchainError::BaseTransactionUnsupported),
             #[cfg(feature = "optimism")]
             FoundryTxEnvelope::PostExec(_) => Err(BlockchainError::InvalidTransactionRequest(
                 "not implemented for post-exec tx".to_string(),
@@ -5311,6 +5313,20 @@ fn reward_at_percentile(rewards: &[u128], percentile: f64) -> u128 {
 mod tests {
     use super::*;
     use crate::{NodeConfig, spawn};
+
+    #[cfg(feature = "base")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn base_requests_are_rejected_without_execution() {
+        let (api, _handle) = spawn(NodeConfig::test()).await;
+        for request in [serde_json::json!({ "type": "0x79" }), serde_json::json!({ "calls": [[]] })]
+        {
+            let request = serde_json::from_value(request).unwrap();
+            assert!(matches!(
+                api.parse_transaction_request(request),
+                Err(BlockchainError::BaseTransactionUnsupported)
+            ));
+        }
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn set_rpc_url_installs_context_equivalent_identity_with_new_instance() {

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -154,12 +154,16 @@ impl FoundryReceiptBuilder {
             FoundryTxType::Eip1559 => FoundryReceiptEnvelope::Eip1559(receipt),
             FoundryTxType::Eip4844 => FoundryReceiptEnvelope::Eip4844(receipt),
             FoundryTxType::Eip7702 => FoundryReceiptEnvelope::Eip7702(receipt),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTxType::Deposit => {
                 panic!("deposit receipts require fork-specific metadata")
             }
             #[cfg(feature = "optimism")]
             FoundryTxType::PostExec => FoundryReceiptEnvelope::PostExec(receipt),
+            #[cfg(feature = "base")]
+            FoundryTxType::Eip8130 => {
+                panic!("Base transactions are rejected before execution")
+            }
             FoundryTxType::Tempo => FoundryReceiptEnvelope::Tempo(receipt),
         }
     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2,7 +2,7 @@
 use self::{in_memory_db::StateRootDb, state::trie_storage};
 use crate::{
     ForkChoice, NodeConfig, PrecompileFactory,
-    config::{ForkTransactionReplay, PruneStateHistoryConfig},
+    config::{ForkTransactionReplay, PruneStateHistoryConfig, source_hardfork},
     eth::{
         backend::{
             cheats::{CheatEcrecover, CheatsManager},
@@ -1407,10 +1407,7 @@ impl<N: Network> Backend<N> {
             configured
             @ (EthereumHardfork::Osaka | EthereumHardfork::Bpo1 | EthereumHardfork::Bpo2),
         ) = configured_hardfork
-            && let Some(hardfork) = FoundryHardfork::from_chain_and_timestamp(
-                self.evm_env.read().cfg_env.chain_id,
-                timestamp,
-            )
+            && let Some(hardfork) = source_hardfork(self.evm_env.read().cfg_env.chain_id, timestamp)
             && let FoundryHardfork::Ethereum(
                 scheduled @ (EthereumHardfork::Osaka
                 | EthereumHardfork::Bpo1
@@ -1443,7 +1440,7 @@ impl<N: Network> Backend<N> {
             return false;
         }
         let hardfork = if self.get_fork().is_some() {
-            FoundryHardfork::from_chain_and_timestamp(self.protocol_chain_id(), header.timestamp())
+            source_hardfork(self.protocol_chain_id(), header.timestamp())
                 .unwrap_or_else(|| self.hardfork())
         } else {
             self.hardfork()
@@ -1491,7 +1488,7 @@ impl<N: Network> Backend<N> {
     }
 
     /// Returns an error if op-stack deposits are not active
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     pub const fn ensure_op_deposits_active(&self) -> Result<(), BlockchainError> {
         if self.is_optimism() {
             return Ok(());
@@ -2971,6 +2968,15 @@ impl<N: Network> Backend<N> {
         request: WithOtherFields<TransactionRequest>,
     ) -> Result<FoundryTransactionRequest, BlockchainError> {
         let transaction_type = request.transaction_type;
+        #[cfg(feature = "base")]
+        if transaction_type == Some(foundry_primitives::FoundryTxType::Eip8130.into())
+            || matches!(
+                FoundryTransactionRequest::try_from(request.clone()),
+                Ok(FoundryTransactionRequest::Base(_))
+            )
+        {
+            return Err(BlockchainError::BaseTransactionUnsupported);
+        }
         if !self.is_tempo() && transaction_type != Some(TEMPO_TX_TYPE_ID) {
             #[cfg(feature = "optimism")]
             if transaction_type == Some(DEPOSIT_TX_TYPE_ID)
@@ -3102,6 +3108,8 @@ impl<N: Network> Backend<N> {
         base_evm_env: Option<&EvmEnv>,
     ) -> Result<PreparedCall, BlockchainError> {
         match request {
+            #[cfg(feature = "base")]
+            FoundryTransactionRequest::Base(_) => Err(BlockchainError::BaseTransactionUnsupported),
             FoundryTransactionRequest::Tempo(tempo_request) => {
                 self.ensure_tempo_active()?;
                 let mut tempo_request = *tempo_request;
@@ -3131,7 +3139,7 @@ impl<N: Network> Backend<N> {
                     block_env,
                     base_evm_env,
                 )),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTransactionRequest::Op(request) => Ok(self.prepare_base_call_env_with_base(
                 request,
                 fee_details,
@@ -5100,8 +5108,7 @@ where
         apply_chain_specific_tx_replay_env_changes_for_chain(&mut replay_env, source_chain_id);
         let inspector_tx_config = self.inspector_tx_config();
 
-        let scheduled_hardfork =
-            FoundryHardfork::from_chain_and_timestamp(source_chain_id, timestamp);
+        let scheduled_hardfork = source_hardfork(source_chain_id, timestamp);
         #[cfg(feature = "monad")]
         let mut monad_replay = self
             .prepare_monad_fork_replay(

--- a/crates/anvil/src/eth/error/mod.rs
+++ b/crates/anvil/src/eth/error/mod.rs
@@ -120,6 +120,9 @@ pub enum BlockchainError {
         "tempo transaction received but is not supported.\n\nYou can use it by running anvil with '--tempo'."
     )]
     TempoTransactionUnsupported,
+    #[cfg(feature = "base")]
+    #[error("Base transactions are not supported by Anvil yet")]
+    BaseTransactionUnsupported,
     #[error("Unknown transaction type not supported")]
     UnknownTransactionType,
     #[error("Excess blob gas not set.")]
@@ -601,6 +604,10 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                     RpcError::invalid_params(err.to_string())
                 }
                 err @ BlockchainError::DepositTransactionUnsupported => {
+                    RpcError::invalid_params(err.to_string())
+                }
+                #[cfg(feature = "base")]
+                err @ BlockchainError::BaseTransactionUnsupported => {
                     RpcError::invalid_params(err.to_string())
                 }
                 err @ BlockchainError::TempoTransactionUnsupported => {

--- a/crates/anvil/src/eth/sign.rs
+++ b/crates/anvil/src/eth/sign.rs
@@ -134,13 +134,17 @@ impl Signer<foundry_primitives::FoundryNetwork> for DevSigner {
                 let sig = signer.sign_transaction_sync(&mut t)?;
                 FoundryTxEnvelope::Eip4844(t.into_signed(sig))
             }
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTypedTx::Deposit(_) => {
                 unreachable!("op deposit txs should not be signed")
             }
             #[cfg(feature = "optimism")]
             FoundryTypedTx::PostExec(_) => {
                 unreachable!("op post-exec txs should not be signed")
+            }
+            #[cfg(feature = "base")]
+            FoundryTypedTx::Eip8130(_) => {
+                return Err(BlockchainError::BaseTransactionUnsupported);
             }
             FoundryTypedTx::Tempo(mut t) => {
                 let sig = signer.sign_transaction_sync(&mut t)?;

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -63,6 +63,9 @@ tempo-alloy.workspace = true
 tempo-contracts.workspace = true
 tempo-primitives.workspace = true
 
+# Base
+base-common-network = { workspace = true, optional = true, features = ["serde", "std"] }
+
 op-alloy-consensus = { workspace = true, features = ["k256"], optional = true }
 op-alloy-flz = { workspace = true, optional = true }
 op-alloy-network = { workspace = true, optional = true }
@@ -139,6 +142,16 @@ monad = [
     "foundry-evm-networks/monad",
     "foundry-evm/monad",
     "foundry-cli/monad",
+]
+base = [
+    "anvil/base",
+    "dep:base-common-network",
+    "dep:op-alloy-flz",
+    "foundry-common/base",
+    "foundry-debugger/base",
+    "foundry-evm/base",
+    "foundry-evm-networks/base",
+    "foundry-cli/base",
 ]
 optimism = [
     "dep:op-alloy-flz",

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -59,28 +59,41 @@ use std::{
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::{ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS};
 
+#[cfg(feature = "base")]
+use base_common_network::Base as BaseNetwork;
+
 #[cfg(feature = "optimism")]
 use op_alloy_network::Optimism;
 
 /// Runs `$body` with `$provider` bound to a provider for the selected `--network`.
+/// Optionally binds `$network_type` to the selected network type.
 ///
 /// The fallback arm is used for Ethereum and when no network is selected: either `$default` is a
 /// provider expression that `$body` runs against, or a full `_ => $default` arm.
 macro_rules! with_network_provider {
-    ($network:expr, $config:expr, $default:expr, |$provider:ident| $body:expr) => {
-        with_network_provider!($network, $config, |$provider| $body, _ => {
+    ($network:expr, $config:expr, $default:expr, |$provider:ident $(, $network_type:ident)?| $body:expr) => {
+        with_network_provider!($network, $config, |$provider $(, $network_type)?| $body, _ => {
+            $(type $network_type = Ethereum;)?
             let $provider = $default;
             $body
         })
     };
-    ($network:expr, $config:expr, |$provider:ident| $body:expr, _ => $default:expr) => {
+    ($network:expr, $config:expr, |$provider:ident $(, $network_type:ident)?| $body:expr, _ => $default:expr) => {
         match $network {
+            #[cfg(feature = "base")]
+            Some(NetworkVariant::Base) => {
+                $(type $network_type = BaseNetwork;)?
+                let $provider = ProviderBuilder::<BaseNetwork>::from_config($config)?.build()?;
+                $body
+            }
             #[cfg(feature = "optimism")]
             Some(NetworkVariant::Optimism) => {
+                $(type $network_type = Optimism;)?
                 let $provider = ProviderBuilder::<Optimism>::from_config($config)?.build()?;
                 $body
             }
             Some(NetworkVariant::Tempo) => {
+                $(type $network_type = TempoNetwork;)?
                 let $provider = ProviderBuilder::<TempoNetwork>::from_config($config)?.build()?;
                 $body
             }
@@ -542,6 +555,15 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         }
         CastSubcommand::Block { block, full, fields, raw, rpc, network } => {
             let config = rpc.load_config()?;
+            #[cfg(feature = "base")]
+            let network = if network.is_none() && (raw || fields.iter().any(|f| f == "raw")) {
+                crate::cmd::resolve_transaction_network(&config, false)
+                    .await?
+                    .is_base()
+                    .then_some(NetworkVariant::Base)
+            } else {
+                network
+            };
             let block = block.unwrap_or_default();
             // Can use either --raw or specify raw as a field
             let output = if raw || fields.contains(&"raw".into()) {
@@ -549,14 +571,16 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                     network,
                     &config,
                     ProviderBuilder::<Ethereum>::from_config(&config)?.build()?,
-                    |provider| {
+                    |provider, N| {
                         let block_id = block;
                         let block = provider
                             .get_block(block_id)
                             .kind(full.into())
                             .await?
                             .ok_or_else(|| eyre::eyre!("block {:?} not found", block_id))?;
-                        hex::encode_prefixed(alloy_rlp::encode(block.header().as_ref()))
+                        hex::encode_prefixed(alloy_rlp::encode(
+                            AsRef::<<N as Network>::Header>::as_ref(block.header()),
+                        ))
                     }
                 )
             } else {
@@ -1007,6 +1031,14 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         }
         CastSubcommand::Tx { tx_hash, from, nonce, field, raw, lane, rpc, to_request, network } => {
             let config = rpc.load_config()?;
+            #[cfg(feature = "base")]
+            let network = match network {
+                Some(network) => Some(network),
+                None => crate::cmd::resolve_transaction_network(&config, false)
+                    .await?
+                    .is_base()
+                    .then_some(NetworkVariant::Base),
+            };
             // Can use either --raw or specify raw as a field
             let is_raw = raw || field.as_deref() == Some("raw");
             let output = if is_raw || lane {
@@ -1238,6 +1270,8 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                 #[cfg(feature = "optimism")]
                 Some(NetworkVariant::Optimism) => decode_raw_transaction::<Optimism>(&tx)?,
                 Some(NetworkVariant::Tempo) => decode_raw_transaction::<TempoNetwork>(&tx)?,
+                #[cfg(feature = "base")]
+                Some(NetworkVariant::Base) => decode_raw_transaction::<BaseNetwork>(&tx)?,
                 Some(NetworkVariant::Ethereum) => decode_raw_transaction::<Ethereum>(&tx)?,
                 #[cfg(feature = "monad")]
                 Some(NetworkVariant::Monad) => decode_raw_transaction::<Ethereum>(&tx)?,
@@ -1263,7 +1297,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         CastSubcommand::KeyAuthorization { command } => command.run().await?,
         CastSubcommand::Tempo { command } => command.run().await?,
         CastSubcommand::VirtualAddress { command } => command.run().await?,
-        #[cfg(feature = "optimism")]
+        #[cfg(any(feature = "base", feature = "optimism"))]
         CastSubcommand::DAEstimate(cmd) => cmd.run().await?,
         CastSubcommand::Trace(cmd) => cmd.run().await?,
     };

--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -16,6 +16,9 @@ use foundry_wallets::{BrowserWalletOpts, WalletOpts};
 use std::str::FromStr;
 use tempo_alloy::TempoNetwork;
 
+#[cfg(feature = "base")]
+use base_common_network::Base;
+
 /// CLI arguments for `cast access-list`.
 #[derive(Debug, Parser)]
 pub struct AccessListArgs {
@@ -70,10 +73,14 @@ impl AccessListArgs {
         let requires_tempo = self.tx.tempo.is_tempo() || self.tx.tempo.session_id()?.is_some();
         let network = super::resolve_transaction_network(&config, requires_tempo).await?;
         if network.is_tempo() {
-            self.run_with_network::<TempoNetwork>(config).await
-        } else {
-            self.run_with_network::<Ethereum>(config).await
+            return self.run_with_network::<TempoNetwork>(config).await;
         }
+        #[cfg(feature = "base")]
+        if network.is_base() {
+            super::validate_base_transaction_options(&self.tx)?;
+            return self.run_with_network::<Base>(config).await;
+        }
+        self.run_with_network::<Ethereum>(config).await
     }
 
     async fn run_with_network<N: Network + Unpin>(self, config: Config) -> Result<()>

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -63,6 +63,9 @@ use foundry_evm_networks::NetworkConfigs;
 use foundry_wallets::{BrowserWalletOpts, WalletOpts};
 use std::str::FromStr;
 
+#[cfg(feature = "base")]
+use foundry_evm::core::evm::BaseEvmNetwork;
+
 #[cfg(feature = "monad")]
 use foundry_evm::core::evm::MonadEvmNetwork;
 
@@ -294,6 +297,19 @@ impl CallArgs {
                     evm_opts,
                     auth_preflight,
                     ExecutorBuilder::<TempoEvmNetwork>::new(),
+                )
+                .await;
+        }
+
+        #[cfg(feature = "base")]
+        if evm_opts.networks.is_base() {
+            super::validate_base_transaction_options(&self.tx)?;
+            return self
+                .run_with_network_and_opts::<BaseEvmNetwork>(
+                    config,
+                    evm_opts,
+                    auth_preflight,
+                    ExecutorBuilder::<BaseEvmNetwork>::new(),
                 )
                 .await;
         }
@@ -995,6 +1011,19 @@ mod tests {
         let config = Config::from_provider(Config::figment().merge(&args)).unwrap();
 
         assert_eq!(config.chain, Some(Chain::mainnet()));
+    }
+
+    /// Base chain IDs resolved to Optimism before Base support existed, so a build without the
+    /// `base` feature — which is what release binaries ship — must keep resolving them that way.
+    #[test]
+    #[cfg(all(not(feature = "base"), feature = "optimism"))]
+    fn chain_id_without_base_still_resolves_to_optimism() {
+        for chain_id in [8453, 84532] {
+            let networks = NetworkConfigs::default()
+                .try_with_chain_id(chain_id)
+                .unwrap_or_else(|error| panic!("chain ID {chain_id} must still resolve: {error}"));
+            assert!(networks.is_optimism(), "chain ID {chain_id} must resolve to Optimism");
+        }
     }
 
     #[test]

--- a/crates/cast/src/cmd/da_estimate.rs
+++ b/crates/cast/src/cmd/da_estimate.rs
@@ -1,7 +1,7 @@
 //! Estimates the data availability size of a block for opstack.
 
 use alloy_consensus::BlockHeader;
-use alloy_network::{AnyNetwork, BlockResponse, Ethereum, Network, eip2718::Encodable2718};
+use alloy_network::{BlockResponse, Ethereum, Network, eip2718::Encodable2718};
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockId;
 use clap::Parser;
@@ -10,6 +10,11 @@ use foundry_cli::{opts::RpcOpts, utils::LoadConfig};
 use foundry_common::provider::ProviderBuilder;
 use foundry_config::Config;
 use foundry_evm_networks::NetworkVariant;
+
+#[cfg(feature = "base")]
+use base_common_network::Base;
+
+#[cfg(feature = "optimism")]
 use op_alloy_network::Optimism;
 
 /// CLI arguments for `cast da-estimate`.
@@ -30,12 +35,12 @@ impl DAEstimateArgs {
         let config = rpc.load_config()?;
         let network = match network {
             Some(n) => n,
-            None => {
-                let provider = ProviderBuilder::<AnyNetwork>::from_config(&config)?.build()?;
-                provider.get_chain_id().await?.into()
-            }
+            None => super::resolve_transaction_network(&config, false).await?,
         };
         match network {
+            #[cfg(feature = "base")]
+            NetworkVariant::Base => da_estimate::<Base>(&config, block).await,
+            #[cfg(feature = "optimism")]
             NetworkVariant::Optimism => da_estimate::<Optimism>(&config, block).await,
             NetworkVariant::Ethereum => da_estimate::<Ethereum>(&config, block).await,
             other => eyre::bail!(

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -17,6 +17,9 @@ use foundry_wallets::{BrowserWalletOpts, WalletOpts};
 use std::str::FromStr;
 use tempo_alloy::TempoNetwork;
 
+#[cfg(feature = "base")]
+use base_common_network::Base;
+
 /// CLI arguments for `cast estimate`.
 #[derive(Debug, Parser)]
 pub struct EstimateArgs {
@@ -94,10 +97,14 @@ impl EstimateArgs {
         let requires_tempo = self.tx.tempo.is_tempo() || self.tx.tempo.session_id()?.is_some();
         let network = super::resolve_transaction_network(&config, requires_tempo).await?;
         if network.is_tempo() {
-            self.run_with_network::<TempoNetwork>(config).await
-        } else {
-            self.run_with_network::<Ethereum>(config).await
+            return self.run_with_network::<TempoNetwork>(config).await;
         }
+        #[cfg(feature = "base")]
+        if network.is_base() {
+            super::validate_base_transaction_options(&self.tx)?;
+            return self.run_with_network::<Base>(config).await;
+        }
+        self.run_with_network::<Ethereum>(config).await
     }
 
     async fn run_with_network<N: Network>(self, config: Config) -> Result<()>

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -22,6 +22,9 @@ use foundry_wallets::{TempoAccountsWallet, WalletSigner};
 use std::{path::PathBuf, str::FromStr};
 use tempo_alloy::TempoNetwork;
 
+#[cfg(feature = "base")]
+use base_common_network::Base;
+
 /// CLI arguments for `cast mktx`.
 #[derive(Debug, Parser)]
 pub struct MakeTxArgs {
@@ -110,10 +113,16 @@ impl MakeTxArgs {
         let (network, signer, access_key) =
             tempo::resolve_transaction_network_and_signer(&self.tx.tempo, &self.eth).await?;
         if network.is_tempo() {
-            self.run_generic::<TempoNetwork>(signer, access_key).await
-        } else {
-            self.run_generic::<Ethereum>(signer, None).await
+            return self.run_generic::<TempoNetwork>(signer, access_key).await;
         }
+
+        #[cfg(feature = "base")]
+        if network.is_base() {
+            super::validate_base_transaction_options(&self.tx)?;
+            return self.run_generic::<Base>(signer, None).await;
+        }
+
+        self.run_generic::<Ethereum>(signer, None).await
     }
 
     async fn run_generic<N: Network>(

--- a/crates/cast/src/cmd/mod.rs
+++ b/crates/cast/src/cmd/mod.rs
@@ -120,7 +120,7 @@ pub mod call_overrides;
 pub mod constructor_args;
 pub mod create2;
 pub mod creation_code;
-#[cfg(feature = "optimism")]
+#[cfg(any(feature = "base", feature = "optimism"))]
 pub mod da_estimate;
 pub mod erc20;
 pub mod erc4626;
@@ -192,9 +192,26 @@ pub(crate) fn disassemble(code: &[u8]) -> Result<String> {
     Ok(output)
 }
 
+/// Rejects blob options before Base's transaction builder can discard them.
+#[cfg(feature = "base")]
+pub(crate) fn validate_base_transaction_options(
+    tx: &foundry_cli::opts::TransactionOpts,
+) -> eyre::Result<()> {
+    eyre::ensure!(
+        !tx.blob && !tx.eip4844 && tx.blob_gas_price.is_none(),
+        "Base does not support blob transactions; remove --blob, --eip4844, and --blob-gas-price"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "base")]
+    use alloy_chains::NamedChain;
+    #[cfg(feature = "base")]
+    use foundry_config::Chain;
 
     #[tokio::test]
     async fn transaction_network_respects_explicit_selection() {
@@ -240,5 +257,89 @@ mod tests {
 
         assert!(config.networks.is_monad());
         assert!(evm_opts.networks.is_monad());
+    }
+
+    #[cfg(feature = "base")]
+    #[tokio::test]
+    async fn resolve_network_preserves_explicit_base() {
+        let config = Config { networks: NetworkVariant::Base.into(), ..Default::default() };
+        assert_eq!(
+            resolve_transaction_network(&config, false).await.unwrap(),
+            NetworkVariant::Base
+        );
+        assert_eq!(
+            resolve_transaction_network(&config, true).await.unwrap_err().to_string(),
+            "Tempo transaction options conflict with configured network `base`"
+        );
+    }
+
+    #[cfg(feature = "base")]
+    #[tokio::test]
+    async fn resolve_network_infers_base_from_chain_id() {
+        let config =
+            Config { chain: Some(Chain::from_named(NamedChain::Base)), ..Default::default() };
+        assert_eq!(
+            resolve_transaction_network(&config, false).await.unwrap(),
+            NetworkVariant::Base
+        );
+    }
+
+    #[cfg(all(any(feature = "base", feature = "optimism"), not(feature = "monad")))]
+    #[tokio::test]
+    async fn resolve_network_allows_rpc_without_local_evm() {
+        let config = Config {
+            chain: Some(foundry_config::Chain::from_named(alloy_chains::NamedChain::Monad)),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_transaction_network(&config, false).await.unwrap(),
+            NetworkVariant::Ethereum
+        );
+    }
+
+    #[cfg(feature = "base")]
+    #[tokio::test]
+    async fn resolve_network_preserves_config_over_chain_in_curl_mode() {
+        let config = Config {
+            networks: NetworkVariant::Base.into(),
+            chain: Some(foundry_config::Chain::from_id(31337)),
+            eth_rpc_curl: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_transaction_network(&config, false).await.unwrap(),
+            NetworkVariant::Base
+        );
+        let config = Config {
+            networks: NetworkVariant::Ethereum.into(),
+            chain: Some(foundry_config::Chain::from_id(8453)),
+            ..config
+        };
+        assert_eq!(
+            resolve_transaction_network(&config, false).await.unwrap(),
+            NetworkVariant::Ethereum
+        );
+    }
+
+    #[cfg(all(feature = "base", not(feature = "optimism")))]
+    #[tokio::test]
+    async fn resolve_network_allows_rpc_without_optimism() {
+        let config =
+            Config { chain: Some(foundry_config::Chain::from_id(10)), ..Default::default() };
+        assert_eq!(
+            resolve_transaction_network(&config, false).await.unwrap(),
+            NetworkVariant::Ethereum
+        );
+    }
+
+    #[cfg(any(feature = "base", feature = "optimism"))]
+    #[tokio::test]
+    async fn resolve_network_still_defaults_unknown_chain_ids_to_ethereum() {
+        let config =
+            Config { chain: Some(foundry_config::Chain::from_id(u64::MAX)), ..Default::default() };
+        assert_eq!(
+            resolve_transaction_network(&config, false).await.unwrap(),
+            NetworkVariant::Ethereum
+        );
     }
 }

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -58,6 +58,9 @@ use foundry_evm_networks::NetworkConfigs;
 use futures::TryFutureExt;
 use revm::{DatabaseRef, context::Block, primitives::hardfork::SpecId};
 
+#[cfg(feature = "base")]
+use foundry_evm::core::evm::BaseEvmNetwork;
+
 #[cfg(feature = "monad")]
 use foundry_evm::core::evm::{BlockContext, ChainFor, MonadEvmNetwork};
 
@@ -224,6 +227,13 @@ impl RunArgs {
         if evm_opts.networks.is_tempo() {
             return self
                 .run_with_evm(config, evm_opts, ExecutorBuilder::<TempoEvmNetwork>::new())
+                .await;
+        }
+
+        #[cfg(feature = "base")]
+        if evm_opts.networks.is_base() {
+            return self
+                .run_with_evm(config, evm_opts, ExecutorBuilder::<BaseEvmNetwork>::new())
                 .await;
         }
 

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -32,6 +32,9 @@ use tempo_contracts::precompiles::{TIP20_FACTORY_ADDRESS, is_iso4217_currency};
 use tempo_primitives::transaction::FEE_PAYER_SIGNATURE_MARKER;
 use url::Url;
 
+#[cfg(feature = "base")]
+use base_common_network::Base;
+
 /// CLI arguments for `cast send`.
 #[derive(Debug, Parser)]
 pub struct SendTxArgs {
@@ -146,10 +149,16 @@ impl SendTxArgs {
                 .await?;
 
         if network.is_tempo() {
-            self.run_generic::<TempoNetwork>(signer, tempo_access_key).await
-        } else {
-            self.run_generic::<Ethereum>(signer, None).await
+            return self.run_generic::<TempoNetwork>(signer, tempo_access_key).await;
         }
+
+        #[cfg(feature = "base")]
+        if network.is_base() {
+            super::validate_base_transaction_options(&self.tx)?;
+            return self.run_generic::<Base>(signer, None).await;
+        }
+
+        self.run_generic::<Ethereum>(signer, None).await
     }
 
     /// Runs a contract call with an already resolved browser signer.

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -44,8 +44,9 @@ use foundry_common::version::{LONG_VERSION, SHORT_VERSION};
 use foundry_evm_networks::NetworkVariant;
 use std::{path::PathBuf, str::FromStr};
 
-#[cfg(feature = "optimism")]
+#[cfg(any(feature = "base", feature = "optimism"))]
 use crate::cmd::da_estimate::DAEstimateArgs;
+
 /// A Swiss Army knife for interacting with Ethereum applications from the command line.
 #[derive(Parser)]
 #[command(
@@ -1370,7 +1371,7 @@ pub enum CastSubcommand {
         command: TxPoolSubcommands,
     },
     /// Estimates the data availability size of a given opstack block.
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     #[command(name = "da-estimate")]
     DAEstimate(DAEstimateArgs),
 

--- a/crates/cast/tests/cli/base.rs
+++ b/crates/cast/tests/cli/base.rs
@@ -1,0 +1,166 @@
+//! CLI tests for Base execution.
+
+use super::*;
+
+#[cfg(feature = "base")]
+use alloy_consensus::{TxEip1559, TypedTransaction};
+
+#[cfg(feature = "base")]
+casttest!(cast_call_trace_selects_base_network, async |prj, cmd| {
+    prj.update_config(|config| {
+        config.networks = foundry_evm_networks::NetworkConfigs::with_base();
+        config.hardfork = Some("base:Beryl".parse().unwrap());
+        config.chain = Some(foundry_config::Chain::from_id(8453));
+    });
+    let (_api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+
+    let output = cmd
+        .args([
+            "call",
+            "0x8453000000000000000000000000000000000001",
+            "admin()(address)",
+            "--rpc-url",
+            &rpc,
+            "--trace",
+            "--chain",
+            "8453",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    // The registered precompile ABI names the call and decodes the return as a typed address,
+    // which renders checksummed rather than as raw hex.
+    assert!(output.contains("ActivationRegistry::admin()"), "{output}");
+    assert!(output.contains("0xcE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9"), "{output}");
+});
+
+#[cfg(feature = "base")]
+casttest!(cast_decode_tx_network_base_short_and_long_equivalent, |_prj, cmd| {
+    let tx = "0x7ef90207a0cbde10ec697aff886f95d2514bab434e455620627b9bb8ba33baaaa4d537d62794d45955f4de64f1840e5686e64278da901e263031944200000000000000000000000000000000000007872386f26fc10000872386f26fc1000083096c4980b901a4d764ad0b0001000000000000000000000000000000000000000000000000000000065132000000000000000000000000fd0bf71f60660e2f608ed56e1659c450eb1131200000000000000000000000004200000000000000000000000000000000000010000000000000000000000000000000000000000000000000002386f26fc1000000000000000000000000000000000000000000000000000000000000000493e000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000a41635f5fd000000000000000000000000ca11bde05977b3631167028862be2a173976ca110000000000000000000000005703b26fe5a7be820db1bf34c901a79da1a46ba4000000000000000000000000000000000000000000000000002386f26fc100000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+    let via_long = cmd
+        .args(["decode-tx", "--network", "base", tx])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+    let via_short = cmd
+        .cast_fuse()
+        .args(["decode-tx", "-n", "base", tx])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+
+    assert_eq!(via_long, via_short, "--network base and -n base should produce same output");
+});
+
+casttest!(cast_base_rejects_blob_options, |prj, cmd| {
+    prj.update_config(|config| {
+        config.networks = foundry_evm_networks::NetworkConfigs::with_base();
+        config.chain = Some(foundry_config::Chain::from_id(8453));
+    });
+    // The nonexistent path proves rejection precedes reading and discarding the blob data.
+    for command in ["mktx", "send", "estimate", "access-list"] {
+        for options in [vec!["--blob"], vec!["--blob", "--eip4844"], vec!["--blob-gas-price", "1"]]
+        {
+            cmd.cast_fuse()
+                .current_dir(prj.root())
+                .args([command, "0x0000000000000000000000000000000000000001"])
+                .args(options)
+                .args(["--rpc-url", "http://127.0.0.1:1"])
+                .assert_failure()
+                .stdout_eq(str![""])
+                .stderr_eq(str![[r#"
+Error: Base does not support blob transactions; remove --blob, --eip4844, and --blob-gas-price
+
+"#]]);
+        }
+    }
+    for command in ["mktx", "send"] {
+        cmd.cast_fuse()
+            .current_dir(prj.root())
+            .args([
+                command,
+                "0x0000000000000000000000000000000000000001",
+                "--blob",
+                "--path",
+                "missing-blob.bin",
+                "--rpc-url",
+                "http://127.0.0.1:1",
+            ])
+            .assert_failure()
+            .stdout_eq(str![""])
+            .stderr_eq(str![[r#"
+Error: Base does not support blob transactions; remove --blob, --eip4844, and --blob-gas-price
+
+"#]]);
+    }
+});
+
+casttest!(cast_base_transaction_roundtrip, async |prj, cmd| {
+    let (_api, handle) = anvil::spawn(NodeConfig::test().with_chain_id(Some(8453u64))).await;
+    let provider = handle.http_provider();
+    let mut accounts = handle.dev_accounts();
+    let from = accounts.next().unwrap();
+    let to = accounts.next().unwrap();
+    let receipt = provider
+        .send_transaction(
+            TransactionRequest::default().from(from).to(to).value(U256::from(1)).into(),
+        )
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let hash = receipt.transaction_hash;
+    let raw = provider.get_raw_transaction_by_hash(hash).await.unwrap().unwrap();
+    cmd.args(["tx", &hash.to_string(), "--raw", "--rpc-url", &handle.http_endpoint()])
+        .assert_success()
+        .stdout_eq(format!("{raw}\n"))
+        .stderr_eq(str![""]);
+
+    // Base construction must preserve ordinary transaction fields too.
+    let encoded = cmd
+        .cast_fuse()
+        .current_dir(prj.root())
+        .args([
+            "mktx",
+            &to.to_string(),
+            "--chain",
+            "8453",
+            "--nonce",
+            "7",
+            "--gas-limit",
+            "21000",
+            "--gas-price",
+            "1000000000",
+            "--priority-gas-price",
+            "1",
+            "--value",
+            "123",
+            "--raw-unsigned",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let bytes = hex::decode(encoded.trim()).unwrap();
+    let tx = TypedTransaction::decode_unsigned(&mut bytes.as_slice()).unwrap();
+    assert_eq!(
+        tx,
+        TypedTransaction::Eip1559(TxEip1559 {
+            chain_id: 8453,
+            nonce: 7,
+            gas_limit: 21000,
+            max_fee_per_gas: 1000000000,
+            max_priority_fee_per_gas: 1,
+            to: to.into(),
+            value: U256::from(123),
+            ..Default::default()
+        })
+    );
+});

--- a/crates/cast/tests/cli/chain.rs
+++ b/crates/cast/tests/cli/chain.rs
@@ -296,3 +296,34 @@ casttest!(base_fee, async |_prj, cmd| {
         .assert_success()
         .stdout_eq("123456789\n");
 });
+
+casttest!(cast_tx_curl_skips_network_probe, |_prj, cmd| {
+    cmd.args([
+        "tx",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "--rpc-url",
+        "http://127.0.0.1:1",
+        "--curl",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+curl -X POST -H 'Content-Type: application/json' --data-raw '{"method":"eth_getTransactionByHash","params":["0x0000000000000000000000000000000000000000000000000000000000000001"],"id":0,"jsonrpc":"2.0"}' 'http://127.0.0.1:1/'
+
+"#]])
+    .stderr_eq(str![""]);
+});
+
+casttest!(cast_raw_block_curl_skips_network_probe, |prj, cmd| {
+    for raw in ["--raw", "--field=raw"] {
+        cmd.cast_fuse().current_dir(prj.root())
+            .args(["block", "latest"])
+            .arg(raw)
+            .args(["--rpc-url", "http://127.0.0.1:1", "--curl"])
+            .assert_success()
+            .stdout_eq(str![[r#"
+curl -X POST -H 'Content-Type: application/json' --data-raw '{"method":"eth_getBlockByNumber","params":["latest",false],"id":0,"jsonrpc":"2.0"}' 'http://127.0.0.1:1/'
+
+"#]])
+            .stderr_eq(str![""]);
+    }
+});

--- a/crates/cast/tests/cli/estimate.rs
+++ b/crates/cast/tests/cli/estimate.rs
@@ -185,7 +185,7 @@ casttest!(
     #[ignore = "public Base RPC endpoint used in CI does not reliably serve this block"]
     flaky_estimate_base_da,
     |_prj, cmd| {
-        cmd.args(["da-estimate", "30558838", "-r", "https://mainnet.base.org/"])
+        cmd.args(["da-estimate", "30558838", "-r", next_rpc_endpoint(NamedChain::Base).as_str()])
             .assert_success()
             .stdout_eq(str![[r#"
 52916546100
@@ -268,4 +268,26 @@ casttest!(cast_estimate_negative_numbers, |_prj, cmd| {
         rpc.as_str(),
     ])
     .assert_success();
+});
+
+#[cfg(any(feature = "base", feature = "optimism"))]
+casttest!(cast_da_estimate_honors_config_and_cli_override, |prj, cmd| {
+    prj.update_config(|config| {
+        config.networks = foundry_evm_networks::NetworkConfigs::with_tempo();
+    });
+    cmd.args(["da-estimate", "latest", "--rpc-url", "http://127.0.0.1:1"])
+        .assert_failure()
+        .stdout_eq(str![""])
+        .stderr_eq(str![[r#"
+Error: DA estimation is not supported for Tempo: EIP-4844 blob transactions are not available on this network
+
+"#]]);
+    cmd.cast_fuse().current_dir(prj.root())
+        .args(["da-estimate", "latest", "--network", "ethereum", "--rpc-url", "http://127.0.0.1:1", "--curl"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+curl -X POST -H 'Content-Type: application/json' --data-raw '{"method":"eth_getBlockByNumber","params":["latest",true],"id":0,"jsonrpc":"2.0"}' 'http://127.0.0.1:1/'
+
+"#]])
+        .stderr_eq(str![""]);
 });

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -112,6 +112,8 @@ async fn deploy_counter_and_set_number(
 mod abi;
 mod access_list;
 mod address;
+#[cfg(feature = "base")]
+mod base;
 mod bytecode;
 mod call;
 mod call_trace;

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -88,6 +88,12 @@ monad = [
     "foundry-evm-fuzz/monad",
     "foundry-evm-traces/monad",
 ]
+base = [
+    "foundry-common/base",
+    "foundry-evm-core/base",
+    "foundry-evm-fuzz/base",
+    "foundry-evm-traces/base",
+]
 optimism = [
     "foundry-common/optimism",
     "foundry-evm-core/optimism",

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -77,6 +77,11 @@ monad = [
     "foundry-evm/monad",
     "foundry-cli/monad",
 ]
+base = [
+    "foundry-common/base",
+    "foundry-evm/base",
+    "foundry-cli/base",
+]
 optimism = [
     "foundry-common/optimism",
     "foundry-evm/optimism",

--- a/crates/chisel/src/args.rs
+++ b/crates/chisel/src/args.rs
@@ -17,6 +17,9 @@ use rustyline::{Editor, config::Configurer, error::ReadlineError};
 use std::{ops::ControlFlow, path::PathBuf};
 use yansi::Paint;
 
+#[cfg(feature = "base")]
+use foundry_evm::core::evm::BaseEvmNetwork;
+
 #[cfg(feature = "monad")]
 use foundry_evm::core::evm::MonadEvmNetwork;
 
@@ -70,6 +73,19 @@ pub async fn run_command(args: Chisel) -> Result<()> {
             config,
             evm_opts,
             ExecutorBuilder::<TempoEvmNetwork>::new(),
+            local_networks,
+            local_chain_id,
+        ))
+        .await;
+    }
+
+    #[cfg(feature = "base")]
+    if evm_opts.networks.is_base() {
+        return Box::pin(run_command_with_network::<BaseEvmNetwork>(
+            args,
+            config,
+            evm_opts,
+            ExecutorBuilder::<BaseEvmNetwork>::new(),
             local_networks,
             local_chain_id,
         ))
@@ -283,6 +299,18 @@ mod tests {
         Chisel::command().debug_assert();
     }
 
+    /// Base chain IDs resolved to Optimism before Base support existed, so a build without the
+    /// `base` feature — which is what release binaries ship — must keep resolving them that way.
+    #[test]
+    #[cfg(all(not(feature = "base"), feature = "optimism"))]
+    fn chain_id_without_base_still_resolves_to_optimism() {
+        for chain_id in [8453, 84532] {
+            let networks = infer_network_from_chain_id(NetworkConfigs::default(), Some(chain_id))
+                .unwrap_or_else(|error| panic!("chain ID {chain_id} must still resolve: {error}"));
+            assert!(networks.is_optimism(), "chain ID {chain_id} must resolve to Optimism");
+        }
+    }
+
     #[test]
     #[cfg(not(feature = "monad"))]
     fn chain_id_rejects_disabled_monad_network() {
@@ -298,9 +326,9 @@ mod tests {
     #[test]
     fn explicit_ethereum_overrides_chain_id_inference() {
         let ethereum = NetworkConfigs::with_ethereum();
-        let inferred = infer_network_from_chain_id(ethereum, Some(143)).unwrap();
-
-        assert_eq!(inferred, ethereum);
+        for chain_id in [8453, 143] {
+            assert_eq!(infer_network_from_chain_id(ethereum, Some(chain_id)).unwrap(), ethereum);
+        }
     }
 
     #[tokio::test]

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -826,6 +826,17 @@ mod tests {
         ensure_loaded_session_network_matches(&current, &loaded, "42").unwrap();
     }
 
+    #[cfg(feature = "base")]
+    #[test]
+    fn ensure_loaded_session_network_matches_preserves_base() {
+        let base = config_with_network(Some("base"));
+        ensure_loaded_session_network_matches(&base, &base, "42").unwrap();
+
+        let err =
+            ensure_loaded_session_network_matches(&Config::default(), &base, "42").unwrap_err();
+        assert!(err.to_string().contains("Rerun with `--network base`"), "{err}");
+    }
+
     #[test]
     fn test_trivia() {
         fn only_trivia(s: &str) -> bool {

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -379,6 +379,20 @@ repl_test!(
     }
 );
 
+#[cfg(feature = "base")]
+repl_test!(
+    eval_base_network_uses_base_executor,
+    "--network base --hardfork base:Beryl --chain 8453",
+    |repl| {
+        repl.sendln_raw(
+            "interface IActivationRegistry { function admin() external view returns (address); }",
+        );
+        repl.expect_prompt();
+        repl.sendln("IActivationRegistry(0x8453000000000000000000000000000000000001).admin()");
+        repl.expect("Data: 0xcE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9");
+    }
+);
+
 repl_test!(
     eval_tempo_named_chain_uses_tempo_executor,
     "--chain tempo eval address(0xfeEC000000000000000000000000000000000000).code.length",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -83,6 +83,12 @@ monad = [
     "foundry-evm-networks/monad",
     "foundry-evm/monad",
 ]
+base = [
+    "foundry-config/base",
+    "foundry-evm-networks/base",
+    "foundry-common/base",
+    "foundry-evm/base",
+]
 optimism = [
     "foundry-evm-networks/optimism",
     "foundry-common/optimism",

--- a/crates/cli/src/opts/evm.rs
+++ b/crates/cli/src/opts/evm.rs
@@ -1,7 +1,9 @@
 //! CLI arguments for configuring the EVM settings.
 
+use crate::opts::RpcCommonOpts;
 use alloy_primitives::{Address, B256, U256};
 use clap::Parser;
+use foundry_common::shell;
 use foundry_config::{
     Chain, Config, FoundryHardfork,
     figment::{
@@ -12,9 +14,6 @@ use foundry_config::{
 };
 use foundry_evm_networks::NetworkConfigs;
 use serde::Serialize;
-
-use crate::opts::RpcCommonOpts;
-use foundry_common::shell;
 
 /// `EvmArgs` and `EnvArgs` take the highest precedence in the Config/Figment hierarchy.
 ///
@@ -364,6 +363,17 @@ mod tests {
 
         let env = EnvArgs::parse_from(["foundry-cli", "--chain-id", "goerli"]);
         assert_eq!(env.chain, Some(NamedChain::Goerli.into()));
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn can_parse_namespaced_base_hardfork() {
+        let args = EvmArgs::parse_from(["foundry-cli", "--hardfork", "base:Beryl"]);
+        assert_eq!(args.hardfork.map(String::from).as_deref(), Some("base:Beryl"));
+
+        let config = Config::from_provider(Config::figment().merge(args)).unwrap();
+        assert!(config.networks.is_base());
+        assert_eq!(config.hardfork.map(String::from).as_deref(), Some("base:Beryl"));
     }
 
     #[test]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -46,6 +46,10 @@ alloy-network.workspace = true
 op-alloy-network = { workspace = true, optional = true }
 op-alloy-rpc-types = { workspace = true, optional = true }
 
+# Base
+base-common-network = { workspace = true, optional = true, features = ["serde", "std"] }
+base-common-rpc-types = { workspace = true, optional = true, features = ["serde", "std"] }
+
 revm.workspace = true
 
 solar.workspace = true
@@ -100,6 +104,12 @@ tempfile.workspace = true
 [features]
 default = ["optimism"]
 monad = ["foundry-config/monad"]
+base = [
+    "dep:base-common-network",
+    "dep:base-common-rpc-types",
+    "foundry-common-fmt/base",
+    "foundry-config/base",
+]
 optimism = [
     "dep:op-alloy-network",
     "dep:op-alloy-rpc-types",

--- a/crates/common/fmt/Cargo.toml
+++ b/crates/common/fmt/Cargo.toml
@@ -32,6 +32,10 @@ revm.workspace = true
 yansi.workspace = true
 comfy-table.workspace = true
 
+# Base
+base-common-consensus = { workspace = true, optional = true, features = ["std"] }
+base-common-rpc-types = { workspace = true, optional = true, features = ["std"] }
+
 # Tempo
 tempo-alloy.workspace = true
 
@@ -42,4 +46,5 @@ proptest.workspace = true
 
 [features]
 default = ["optimism"]
+base = ["dep:base-common-consensus", "dep:base-common-rpc-types"]
 optimism = ["dep:op-alloy-consensus", "dep:op-alloy-rpc-types"]

--- a/crates/common/fmt/src/ui.rs
+++ b/crates/common/fmt/src/ui.rs
@@ -17,7 +17,7 @@ use alloy_rpc_types::{
 };
 use alloy_serde::{OtherFields, WithOtherFields};
 use revm::context_interface::transaction::SignedAuthorization;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::num::NonZeroU64;
 use tempo_alloy::{
     primitives::{
@@ -26,6 +26,13 @@ use tempo_alloy::{
     },
     rpc::{TempoHeaderResponse, TempoTransactionReceipt},
 };
+
+#[cfg(feature = "base")]
+use base_common_consensus::{
+    BaseReceipt, BaseTxEnvelope, Eip8130Signed, TxDeposit as BaseTxDeposit,
+};
+#[cfg(feature = "base")]
+use base_common_rpc_types::{BaseTransactionReceipt, Transaction as BaseRpcTransaction};
 
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{OpTxEnvelope, TxDeposit, TxPostExec};
@@ -180,7 +187,10 @@ impl UIfmt for Signature {
 }
 
 /// Pretty-prints the common fields of any `TransactionReceipt<T>`.
-fn pretty_receipt<T: TxReceipt<Log = Log>>(receipt: &TransactionReceipt<T>, tx_type: u8) -> String {
+fn pretty_receipt<T: TxReceipt>(receipt: &TransactionReceipt<T>, tx_type: u8) -> String
+where
+    T::Log: Serialize,
+{
     let mut pretty = format!(
         "
 blockHash            {}
@@ -208,7 +218,7 @@ blobGasUsed          {}",
         receipt.gas_used.pretty(),
         serde_json::to_string(receipt.inner.logs()).unwrap(),
         receipt.inner.bloom().pretty(),
-        receipt.state_root().pretty(),
+        receipt.inner.status_or_post_state().as_post_state().pretty(),
         receipt.inner.status_or_post_state().pretty(),
         receipt.transaction_hash.pretty(),
         receipt.transaction_index.pretty(),
@@ -227,6 +237,55 @@ blobGasUsed          {}",
 impl UIfmt for TransactionReceipt {
     fn pretty(&self) -> String {
         pretty_receipt(self, self.transaction_type() as u8)
+    }
+}
+
+#[cfg(feature = "base")]
+impl UIfmt for BaseTransactionReceipt {
+    fn pretty(&self) -> String {
+        let (deposit_nonce, deposit_receipt_version) = match &self.inner.inner.receipt {
+            BaseReceipt::Deposit(receipt) => {
+                (receipt.deposit_nonce, receipt.deposit_receipt_version)
+            }
+            _ => (None, None),
+        };
+        format!(
+            "{}
+l1GasPrice           {}
+l1GasUsed            {}
+l1Fee                {}
+l1FeeScalar          {}
+l1BaseFeeScalar      {}
+l1BlobBaseFee        {}
+l1BlobBaseFeeScalar  {}
+operatorFeeScalar    {}
+operatorFeeConstant  {}
+daFootprintGasScalar {}
+depositNonce         {}
+depositReceiptVersion {}
+payer                {}
+phaseStatuses        {}
+metadata             {}",
+            pretty_receipt(&self.inner, self.inner.inner.receipt.tx_type() as u8).trim_end(),
+            self.l1_block_info.l1_gas_price.pretty(),
+            self.l1_block_info.l1_gas_used.pretty(),
+            self.l1_block_info.l1_fee.pretty(),
+            self.l1_block_info.l1_fee_scalar.map(|value| value.to_string()).unwrap_or_default(),
+            self.l1_block_info.l1_base_fee_scalar.pretty(),
+            self.l1_block_info.l1_blob_base_fee.pretty(),
+            self.l1_block_info.l1_blob_base_fee_scalar.pretty(),
+            self.l1_block_info.operator_fee_scalar.pretty(),
+            self.l1_block_info.operator_fee_constant.pretty(),
+            self.l1_block_info
+                .da_footprint_gas_scalar
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+            deposit_nonce.pretty(),
+            deposit_receipt_version.pretty(),
+            self.payer.pretty(),
+            self.phase_statuses.pretty(),
+            self.metadata.pretty(),
+        )
     }
 }
 
@@ -474,6 +533,75 @@ input                {}",
     }
 }
 
+#[cfg(feature = "base")]
+impl UIfmt for BaseTxDeposit {
+    fn pretty(&self) -> String {
+        format!(
+            "
+sourceHash           {}
+from                 {}
+to                   {}
+mint                 {}
+value                {}
+gasLimit             {}
+isSystemTransaction  {}
+input                {}",
+            self.source_hash.pretty(),
+            self.from.pretty(),
+            self.to().pretty(),
+            self.mint.pretty(),
+            self.value.pretty(),
+            self.gas_limit.pretty(),
+            self.is_system_transaction,
+            self.input.pretty(),
+        )
+    }
+}
+
+#[cfg(feature = "base")]
+impl UIfmt for Eip8130Signed {
+    fn pretty(&self) -> String {
+        let tx = self.tx();
+        // `calls` is grouped into phases, and `accountChanges` can be long, so both are summarized
+        // by count rather than dumped inline.
+        format!(
+            "
+chainId              {}
+sender               {}
+payer                {}
+nonceKey             {}
+nonceSequence        {}
+validAfter           {}
+validBefore          {}
+maxFeePerGas         {}
+maxPriorityFeePerGas {}
+gasLimit             {}
+accountChanges       {}
+callPhases           {}
+calls                {}
+metadata             {}
+senderAuth           {}
+payerAuth            {}",
+            tx.chain_id.pretty(),
+            tx.sender.pretty(),
+            tx.payer.pretty(),
+            tx.nonce_key.pretty(),
+            tx.nonce_sequence.pretty(),
+            tx.valid_after.pretty(),
+            tx.valid_before.pretty(),
+            tx.max_fee_per_gas.pretty(),
+            tx.max_priority_fee_per_gas.pretty(),
+            tx.gas_limit.pretty(),
+            tx.account_changes.len(),
+            tx.calls.len(),
+            tx.calls.iter().map(Vec::len).sum::<usize>(),
+            tx.metadata.pretty(),
+            self.sender_auth().pretty(),
+            self.payer_auth().pretty(),
+        )
+    }
+}
+
 #[cfg(feature = "optimism")]
 impl UIfmt for TxPostExec {
     fn pretty(&self) -> String {
@@ -589,6 +717,20 @@ impl UIfmt for TxEnvelope {
     }
 }
 
+#[cfg(feature = "base")]
+impl UIfmt for BaseTxEnvelope {
+    fn pretty(&self) -> String {
+        match self {
+            Self::Legacy(tx) => tx.pretty(),
+            Self::Eip2930(tx) => tx.pretty(),
+            Self::Eip1559(tx) => tx.pretty(),
+            Self::Eip7702(tx) => tx.pretty(),
+            Self::Deposit(tx) => tx.inner().pretty(),
+            Self::Eip8130(tx) => tx.pretty(),
+        }
+    }
+}
+
 impl UIfmt for AnyTxEnvelope {
     fn pretty(&self) -> String {
         match self {
@@ -651,6 +793,21 @@ effectiveGasPrice    {}
             self.transaction_index.pretty(),
             self.effective_gas_price.pretty(),
             self.inner.inner().pretty().trim_start(),
+        )
+    }
+}
+
+#[cfg(feature = "base")]
+impl UIfmt for BaseRpcTransaction {
+    fn pretty(&self) -> String {
+        format!(
+            "
+depositNonce         {}
+depositReceiptVersion {}
+{}",
+            self.deposit_nonce.pretty(),
+            self.deposit_receipt_version.pretty(),
+            self.inner.pretty().trim_start(),
         )
     }
 }
@@ -786,6 +943,13 @@ impl UIfmtSignatureExt for AnyTxEnvelope {
     }
 }
 
+#[cfg(feature = "base")]
+impl UIfmtSignatureExt for BaseTxEnvelope {
+    fn signature_pretty(&self) -> Option<(String, String, String)> {
+        self.signature().map(pretty_signature_fields)
+    }
+}
+
 #[cfg(feature = "optimism")]
 impl UIfmtSignatureExt for OpTxEnvelope {
     fn signature_pretty(&self) -> Option<(String, String, String)> {
@@ -828,11 +992,14 @@ pub trait UIfmtReceiptExt {
     fn tx_type_pretty(&self) -> String;
 }
 
-fn receipt_logs_pretty<T: TxReceipt<Log = Log>>(receipt: &TransactionReceipt<T>) -> String {
+fn receipt_logs_pretty<T: TxReceipt>(receipt: &TransactionReceipt<T>) -> String
+where
+    T::Log: Serialize,
+{
     serde_json::to_string(receipt.inner.logs()).unwrap_or_default()
 }
 
-fn receipt_logs_bloom_pretty<T: TxReceipt<Log = Log>>(receipt: &TransactionReceipt<T>) -> String {
+fn receipt_logs_bloom_pretty<T: TxReceipt>(receipt: &TransactionReceipt<T>) -> String {
     receipt.inner.bloom().pretty()
 }
 
@@ -847,6 +1014,21 @@ impl UIfmtReceiptExt for TransactionReceipt {
 
     fn tx_type_pretty(&self) -> String {
         self.transaction_type().to_string()
+    }
+}
+
+#[cfg(feature = "base")]
+impl UIfmtReceiptExt for BaseTransactionReceipt {
+    fn logs_pretty(&self) -> String {
+        receipt_logs_pretty(&self.inner)
+    }
+
+    fn logs_bloom_pretty(&self) -> String {
+        receipt_logs_bloom_pretty(&self.inner)
+    }
+
+    fn tx_type_pretty(&self) -> String {
+        self.inner.inner.receipt.tx_type().to_string()
     }
 }
 
@@ -1108,6 +1290,9 @@ mod tests {
     use similar_asserts::assert_eq;
     use std::str::FromStr;
 
+    #[cfg(feature = "base")]
+    use base_common_consensus::{Call as BaseCall, TxEip8130};
+
     #[test]
     fn format_date_time() {
         // Fri Aug 29 2025 08:05:38 GMT+0000
@@ -1132,6 +1317,106 @@ mod tests {
         );
         let b: Bytes = val.into();
         assert_eq!(b.pretty(), b32.pretty());
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn can_pretty_print_eip8130_transaction() {
+        let base_call = BaseCall { to: Address::ZERO, data: Bytes::new() };
+        let tx = TxEip8130 {
+            chain_id: 8453,
+            sender: Some(Address::with_last_byte(0x11)),
+            payer: Some(Address::with_last_byte(0x22)),
+            nonce_key: U256::from(7),
+            nonce_sequence: 3,
+            valid_after: 100,
+            valid_before: 200,
+            max_fee_per_gas: 1_000,
+            max_priority_fee_per_gas: 10,
+            gas_limit: 21_000,
+            metadata: Bytes::from_static(&[0xab]),
+            calls: vec![vec![base_call.clone(), base_call.clone()], vec![base_call]],
+            ..Default::default()
+        };
+        let signed =
+            Eip8130Signed::new(tx, Bytes::from_static(&[0x01]), Bytes::from_static(&[0x02]));
+
+        assert_eq!(
+            signed.pretty().trim(),
+            r"chainId              8453
+sender               0x0000000000000000000000000000000000000011
+payer                0x0000000000000000000000000000000000000022
+nonceKey             7
+nonceSequence        3
+validAfter           100
+validBefore          200
+maxFeePerGas         1000
+maxPriorityFeePerGas 10
+gasLimit             21000
+accountChanges       0
+callPhases           2
+calls                3
+metadata             0xab
+senderAuth           0x01
+payerAuth            0x02"
+        );
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn can_pretty_print_base_deposit_receipt_fields() {
+        let receipt: BaseTransactionReceipt = serde_json::from_value(serde_json::json!({
+            "blockHash": "0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67",
+            "blockNumber": "0x6cfef89",
+            "contractAddress": null,
+            "cumulativeGasUsed": "0xfa0d",
+            "depositNonce": "0x8a2d11",
+            "depositReceiptVersion": "0x1",
+            "effectiveGasPrice": "0x0",
+            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+            "gasUsed": "0xfa0d",
+            "logs": [{
+                "address": "0x4200000000000000000000000000000000000015",
+                "topics": [],
+                "data": "0x",
+                "removed": false,
+                "blockTimestampMs": "0x18bcfe568c8",
+                "blockNumber": "0x6cfef89",
+                "blockHash": null,
+                "transactionHash": null,
+                "transactionIndex": null,
+                "logIndex": null
+            }],
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "status": "0x1",
+            "to": "0x4200000000000000000000000000000000000015",
+            "transactionHash": "0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9",
+            "transactionIndex": "0x0",
+            "type": "0x7e",
+            "l1GasPrice": "0x3ef12787",
+            "l1GasUsed": "0x1177",
+            "l1Fee": "0x5bf1ab43d",
+            "l1BaseFeeScalar": "0x1",
+            "l1BlobBaseFee": "0x600ab8f05e64",
+            "l1BlobBaseFeeScalar": "0x1",
+            "operatorFeeScalar": "0x1",
+            "operatorFeeConstant": "0x1",
+            "daFootprintGasScalar": "0x1"
+        }))
+        .unwrap();
+
+        let pretty = receipt.pretty();
+        let logs = receipt.logs_pretty();
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&logs).unwrap()[0]["blockTimestampMs"],
+            "0x18bcfe568c8"
+        );
+        assert!(pretty.contains(&format!("logs                 {logs}")), "{pretty}");
+        assert_eq!(receipt.logs_bloom_pretty(), receipt.inner.inner.bloom().pretty());
+        assert!(pretty.contains("l1Fee                24681034813"), "{pretty}");
+        assert!(pretty.contains("operatorFeeScalar    1"), "{pretty}");
+        assert!(pretty.contains("depositNonce         9055505"), "{pretty}");
+        assert!(pretty.contains("depositReceiptVersion 1"), "{pretty}");
     }
 
     #[cfg(feature = "optimism")]

--- a/crates/common/src/transactions/builder.rs
+++ b/crates/common/src/transactions/builder.rs
@@ -11,6 +11,11 @@ use std::num::NonZeroU64;
 use tempo_alloy::TempoNetwork;
 use tempo_primitives::{SignatureType, TempoTxType, transaction::Call};
 
+#[cfg(feature = "base")]
+use base_common_network::Base;
+#[cfg(feature = "base")]
+use base_common_rpc_types::BaseTransactionRequest;
+
 #[cfg(feature = "optimism")]
 use op_alloy_network::Optimism;
 #[cfg(feature = "optimism")]
@@ -378,6 +383,21 @@ impl FoundryTransactionBuilder<AnyNetwork> for <AnyNetwork as Network>::Transact
 
     fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>) {
         self.authorization_list = Some(authorization_list);
+    }
+}
+
+#[cfg(feature = "base")]
+impl FoundryTransactionBuilder<Base> for BaseTransactionRequest {
+    fn reset_gas_limit(&mut self) {
+        self.as_mut().gas = None;
+    }
+
+    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>> {
+        self.as_ref().authorization_list.as_ref()
+    }
+
+    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>) {
+        self.as_mut().authorization_list = Some(authorization_list);
     }
 }
 

--- a/crates/common/src/transactions/receipt.rs
+++ b/crates/common/src/transactions/receipt.rs
@@ -10,6 +10,9 @@ use foundry_common_fmt::{UIfmt, UIfmtReceiptExt, get_pretty_receipt_attr};
 use serde::{Deserialize, Serialize};
 use tempo_alloy::rpc::TempoTransactionReceipt;
 
+#[cfg(feature = "base")]
+use base_common_rpc_types::BaseTransactionReceipt;
+
 #[cfg(feature = "optimism")]
 use op_alloy_rpc_types::OpTransactionReceipt;
 
@@ -22,6 +25,13 @@ pub trait FoundryReceiptResponse {
 impl FoundryReceiptResponse for TransactionReceipt {
     fn set_contract_address(&mut self, contract_address: Address) {
         self.contract_address = Some(contract_address);
+    }
+}
+
+#[cfg(feature = "base")]
+impl FoundryReceiptResponse for BaseTransactionReceipt {
+    fn set_contract_address(&mut self, contract_address: Address) {
+        self.inner.contract_address = Some(contract_address);
     }
 }
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -63,3 +63,4 @@ tempfile.workspace = true
 
 [features]
 monad = ["foundry-evm-hardforks/monad", "foundry-evm-networks/monad"]
+base = ["foundry-evm-hardforks/base", "foundry-evm-networks/base"]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -68,8 +68,9 @@ pub use endpoints::{
 };
 
 mod etherscan;
-pub use etherscan::EtherscanConfigError;
 use etherscan::{EtherscanConfigs, EtherscanEnvProvider, ResolvedEtherscanConfig};
+
+pub use etherscan::EtherscanConfigError;
 
 pub mod resolve;
 pub use resolve::UnresolvedEnvVarError;
@@ -84,11 +85,13 @@ pub mod lint;
 pub use lint::{LinterConfig, Severity as LintSeverity};
 
 pub mod fs_permissions;
-pub use fs_permissions::FsPermissions;
 use fs_permissions::PathPermission;
+
+pub use fs_permissions::FsPermissions;
 
 pub mod error;
 use error::ExtractConfigError;
+
 pub use error::SolidityErrorCode;
 
 pub mod doc;
@@ -107,8 +110,9 @@ pub use alloy_chains::{Chain, NamedChain};
 pub use figment;
 
 pub mod providers;
-pub use providers::Remappings;
 use providers::*;
+
+pub use providers::Remappings;
 
 mod fuzz;
 pub use fuzz::{FuzzConfig, FuzzCorpusConfig, FuzzCorpusMutationWeights, FuzzDictionaryConfig};
@@ -148,8 +152,8 @@ pub use compilation::{CompilationRestrictions, SettingsOverrides};
 
 pub mod extend;
 use extend::Extends;
-
 use foundry_evm_networks::NetworkConfigs;
+
 pub use semver;
 
 #[cfg(not(test))]
@@ -3300,6 +3304,9 @@ mod tests {
     };
     use tempfile::tempdir;
 
+    #[cfg(feature = "base")]
+    use foundry_evm_hardforks::BaseUpgrade;
+
     // Helper function to clear `__warnings` in config, since it will be populated during loading
     // from file, causing testing problem when comparing to those created from `default()`, etc.
     fn clear_warning(config: &mut Config) {
@@ -5770,6 +5777,26 @@ mod tests {
             let config = Config::load().unwrap();
             assert_eq!(config.hardfork, Some(FoundryHardfork::Tempo(TempoHardfork::T3)));
             assert!(config.networks.is_tempo());
+
+            Ok(())
+        });
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn base_upgrade_infers_base_network() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                hardfork = "base:Beryl"
+            "#,
+            )?;
+
+            let config = Config::load().unwrap();
+            assert_eq!(config.hardfork, Some(FoundryHardfork::Base(BaseUpgrade::Beryl)));
+            assert!(config.networks.is_base());
 
             Ok(())
         });

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -110,6 +110,8 @@ const BACKWARD_COMPATIBLE_KEYS: &[&str] = &[
     "optimism",
     #[cfg(feature = "monad")]
     "monad",
+    #[cfg(feature = "base")]
+    "base",
 ];
 
 const LABELS_KEY: &str = "labels";

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -33,6 +33,11 @@ serde.workspace = true
 
 [features]
 default = ["optimism"]
+base = [
+    "foundry-common/base",
+    "foundry-evm-core/base",
+    "foundry-evm-traces/base",
+]
 optimism = [
     "foundry-common/optimism",
     "foundry-evm-core/optimism",

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -45,6 +45,29 @@ alloy-sol-types.workspace = true
 alloy-rlp.workspace = true
 foundry-fork-db.workspace = true
 
+# Base
+base-common-chains = { workspace = true, optional = true, features = ["std"] }
+base-common-consensus = { workspace = true, optional = true, features = [
+    "alloy-compat",
+    "evm",
+    "k256",
+    "serde",
+    "std",
+] }
+base-common-evm = { workspace = true, optional = true, features = [
+    "blst",
+    "c-kzg",
+    "memory_limit",
+    "optional_block_gas_limit",
+    "optional_eip3607",
+    "optional_no_base_fee",
+    "serde",
+    "std",
+] }
+base-common-network = { workspace = true, optional = true, features = ["serde", "std"] }
+base-common-precompiles = { workspace = true, optional = true, features = ["std"] }
+base-common-rpc-types = { workspace = true, optional = true, features = ["serde", "std"] }
+
 revm = { workspace = true, features = [
     "std",
     "serde",
@@ -90,6 +113,11 @@ anvil.workspace = true
 foundry-test-utils.workspace = true
 tempo-primitives.workspace = true
 
+[[test]]
+name = "base_replay"
+path = "tests/base_replay.rs"
+required-features = ["base"]
+
 [features]
 default = ["optimism"]
 monad = [
@@ -98,6 +126,19 @@ monad = [
     "dep:monad-revm",
     "foundry-evm-hardforks/monad",
     "foundry-evm-networks/monad",
+]
+base = [
+    "anvil/base",
+    "dep:base-common-chains",
+    "dep:base-common-consensus",
+    "dep:base-common-evm",
+    "dep:base-common-network",
+    "dep:base-common-precompiles",
+    "dep:base-common-rpc-types",
+    "foundry-common/base",
+    "foundry-config/base",
+    "foundry-evm-hardforks/base",
+    "foundry-evm-networks/base",
 ]
 optimism = [
     "dep:op-alloy-consensus",

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -306,6 +306,10 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN
         self.backend.active_fork_url()
     }
 
+    fn active_fork_source_chain_id(&self) -> Option<u64> {
+        self.backend.active_fork_source_chain_id()
+    }
+
     fn active_fork_block_number(&self) -> Option<u64> {
         self.backend.active_fork_block_number()
     }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -384,6 +384,9 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
     /// Returns the Fork url that's currently used in the database, if fork mode is on
     fn active_fork_url(&self) -> Option<String>;
 
+    /// Returns the source chain ID of the active fork, independent of execution overrides.
+    fn active_fork_source_chain_id(&self) -> Option<u64>;
+
     /// Returns the active fork's current fork block number, if any.
     fn active_fork_block_number(&self) -> Option<u64> {
         None
@@ -2338,6 +2341,10 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
     fn active_fork_url(&self) -> Option<String> {
         let fork = self.inner.issued_local_fork_ids.get(&self.active_fork_id()?)?;
         self.forks.get_fork_url(fork.clone()).ok()?
+    }
+
+    fn active_fork_source_chain_id(&self) -> Option<u64> {
+        Some(self.inner.get_fork_by_id(self.active_fork_id()?).ok()?.source_chain_id)
     }
 
     fn active_fork_block_number(&self) -> Option<u64> {

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -759,6 +759,132 @@ impl FromAnyRpcTransaction for TempoTxEnv {
     }
 }
 
+#[cfg(feature = "base")]
+mod base {
+    use super::*;
+    use base_common_consensus::BaseTxEnvelope;
+    use base_common_evm::{
+        BaseTransaction, BaseTxTr, DEPOSIT_TRANSACTION_TYPE, EIP8130_TRANSACTION_TYPE,
+    };
+    use base_common_rpc_types::Transaction as BaseRpcTransaction;
+
+    impl<TX: FoundryTransaction> FoundryTransaction for BaseTransaction<TX> {
+        fn set_tx_type(&mut self, tx_type: u8) {
+            self.base.set_tx_type(tx_type);
+        }
+
+        fn set_caller(&mut self, caller: Address) {
+            self.base.set_caller(caller);
+        }
+
+        fn set_gas_limit(&mut self, gas_limit: u64) {
+            self.base.set_gas_limit(gas_limit);
+        }
+
+        fn set_gas_price(&mut self, gas_price: u128) {
+            self.base.set_gas_price(gas_price);
+        }
+
+        fn set_kind(&mut self, kind: TxKind) {
+            self.base.set_kind(kind);
+        }
+
+        fn set_value(&mut self, value: U256) {
+            self.base.set_value(value);
+        }
+
+        fn set_data(&mut self, data: Bytes) {
+            self.base.set_data(data);
+        }
+
+        fn set_nonce(&mut self, nonce: u64) {
+            self.base.set_nonce(nonce);
+        }
+
+        fn set_chain_id(&mut self, chain_id: Option<u64>) {
+            self.base.set_chain_id(chain_id);
+        }
+
+        fn set_access_list(&mut self, access_list: AccessList) {
+            self.base.set_access_list(access_list);
+        }
+
+        fn authorization_list_mut(
+            &mut self,
+        ) -> &mut Vec<Either<SignedAuthorization, RecoveredAuthorization>> {
+            self.base.authorization_list_mut()
+        }
+
+        fn set_gas_priority_fee(&mut self, gas_priority_fee: Option<u128>) {
+            self.base.set_gas_priority_fee(gas_priority_fee);
+        }
+
+        fn set_blob_hashes(&mut self, blob_hashes: Vec<B256>) {
+            self.base.set_blob_hashes(blob_hashes);
+        }
+
+        fn set_max_fee_per_blob_gas(&mut self, max_fee_per_blob_gas: u128) {
+            self.base.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
+        }
+
+        fn enveloped_tx(&self) -> Option<&Bytes> {
+            BaseTxTr::enveloped_tx(self)
+        }
+
+        fn set_enveloped_tx(&mut self, bytes: Bytes) {
+            self.enveloped_tx = Some(bytes);
+        }
+
+        fn source_hash(&self) -> Option<B256> {
+            BaseTxTr::source_hash(self)
+        }
+
+        fn set_source_hash(&mut self, source_hash: B256) {
+            self.deposit.source_hash = source_hash;
+        }
+
+        fn mint(&self) -> Option<u128> {
+            BaseTxTr::mint(self)
+        }
+
+        fn set_mint(&mut self, mint: u128) {
+            self.deposit.mint = Some(mint);
+        }
+
+        fn is_system_transaction(&self) -> bool {
+            BaseTxTr::is_system_transaction(self)
+        }
+
+        fn set_system_transaction(&mut self, is_system_transaction: bool) {
+            self.deposit.is_system_transaction = is_system_transaction;
+        }
+
+        fn is_deposit(&self) -> bool {
+            self.tx_type() == DEPOSIT_TRANSACTION_TYPE
+        }
+    }
+
+    impl FromAnyRpcTransaction for BaseTransaction<TxEnv> {
+        fn from_any_rpc_transaction(tx: &AnyRpcTransaction) -> eyre::Result<Self> {
+            let envelope = match BaseTxEnvelope::try_from(tx.clone()) {
+                Ok(envelope) => envelope,
+                Err(_) if tx.ty() == EIP8130_TRANSACTION_TYPE => {
+                    let rpc_tx =
+                        serde_json::from_value::<BaseRpcTransaction>(serde_json::to_value(tx)?)
+                            .map_err(|err| {
+                                eyre::eyre!(
+                                    "cannot convert RPC transaction to Base envelope: {err}"
+                                )
+                            })?;
+                    rpc_tx.inner.into_inner()
+                }
+                Err(_) => eyre::bail!("cannot convert transaction to BaseTxEnvelope"),
+            };
+            Ok(Self::from_recovered_tx(&envelope, tx.from()))
+        }
+    }
+}
+
 #[cfg(feature = "optimism")]
 mod optimism {
     use super::*;
@@ -980,8 +1106,6 @@ mod optimism {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU64;
-
     use super::*;
     use alloy_consensus::{Signed, TxEip1559, transaction::Recovered};
     use alloy_evm::{EthEvmFactory, EvmFactory};
@@ -991,11 +1115,15 @@ mod tests {
     use alloy_serde::WithOtherFields;
     use foundry_evm_hardforks::TempoHardfork;
     use revm::database::EmptyDB;
+    use std::num::NonZeroU64;
     use tempo_alloy::primitives::{
         AASigned, TempoSignature, TempoTransaction, TempoTxEnvelope,
         transaction::{Call, PrimitiveSignature},
     };
     use tempo_evm::TempoEvmFactory;
+
+    #[cfg(feature = "base")]
+    use base_common_evm::{BaseEvmFactory, BaseSpecId, BaseTransaction, BaseUpgrade};
 
     #[test]
     fn eth_evm_foundry_context_ext_implementation() {
@@ -1014,6 +1142,26 @@ mod tests {
         assert_eq!(evm.ctx().cfg().spec, SpecId::AMSTERDAM);
 
         // Round-trip test to ensure no issues with cloning and setting tx_env and evm_env
+        let tx_env = evm.ctx().tx_clone();
+        evm.ctx_mut().set_tx(tx_env);
+        let evm_env = evm.ctx().evm_clone();
+        evm.ctx_mut().set_evm(evm_env);
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn base_evm_foundry_context_ext_implementation() {
+        let mut evm = BaseEvmFactory::default().create_evm(EmptyDB::default(), EvmEnv::default());
+
+        evm.ctx_mut().block_mut().set_number(U256::from(123));
+        assert_eq!(evm.ctx().block().number(), U256::from(123));
+
+        evm.ctx_mut().tx_mut().set_nonce(99);
+        assert_eq!(evm.ctx().tx().nonce(), 99);
+
+        evm.ctx_mut().cfg_mut().spec = BaseSpecId::new(BaseUpgrade::Beryl);
+        assert_eq!(evm.ctx().cfg().spec, BaseSpecId::new(BaseUpgrade::Beryl));
+
         let tx_env = evm.ctx().tx_clone();
         evm.ctx_mut().set_tx(tx_env);
         let evm_env = evm.ctx().evm_clone();
@@ -1164,6 +1312,25 @@ mod tests {
         assert_eq!(tx_env.gas_limit, 21001);
         assert_eq!(tx_env.value, U256::from(101));
         assert_eq!(tx_env.kind, TxKind::Call(Address::with_last_byte(0xBB)));
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn from_any_rpc_transaction_for_base_eth_envelope() {
+        let from = Address::random();
+        let signed_tx = make_signed_eip1559();
+        let rpc_tx = RpcTransaction::from_transaction(
+            Recovered::new_unchecked(signed_tx.into(), from),
+            TransactionInfo::default(),
+        );
+        let any_tx = <AnyRpcTransaction as From<RpcTransaction>>::from(rpc_tx);
+
+        let tx_env = BaseTransaction::<TxEnv>::from_any_rpc_transaction(&any_tx).unwrap();
+        assert_eq!(tx_env.base.caller, from);
+        assert_eq!(tx_env.base.nonce, 42);
+        assert_eq!(tx_env.base.gas_limit, 21001);
+        assert_eq!(tx_env.base.value, U256::from(101));
+        assert!(tx_env.enveloped_tx.is_some());
     }
 
     #[test]

--- a/crates/evm/core/src/evm/base.rs
+++ b/crates/evm/core/src/evm/base.rs
@@ -84,9 +84,11 @@ impl FoundryEvmFactory for BaseEvmFactory {
         inspector: I,
     ) -> Self::FoundryEvm<'db, I> {
         let upgrade = evm_env.cfg_env.spec.upgrade();
+        // Nested EVMs use the same fork database, so execution chain-ID overrides cannot
+        // change the source-chain registry configuration when rebuilding their precompiles.
         let activation_admin = self.activation_admin_address().or_else(|| {
             ChainConfig::activation_admin_address_for_upgrade_by_chain_id(
-                evm_env.cfg_env.chain_id,
+                db.active_fork_source_chain_id().unwrap_or(evm_env.cfg_env.chain_id),
                 upgrade,
             )
         });
@@ -183,12 +185,18 @@ impl<'db, I: FoundryInspectorExt<BaseContext<&'db mut dyn DatabaseExt<BaseEvmFac
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::Backend;
+    use crate::{
+        backend::{Backend, CowBackend},
+        evm::with_cloned_context,
+        opts::EvmOpts,
+    };
     use alloy_sol_types::SolCall;
     use base_common_precompiles::{
         ActivationRegistryStorage, B20FactoryStorage, IActivationRegistry, NonceManagerStorage,
         PolicyRegistryStorage, TxContextStorage,
     };
+    use foundry_config::Config;
+    use foundry_evm_networks::NetworkConfigs;
     use revm::{
         ExecuteEvm, context::CfgEnv, inspector::NoOpInspector, primitives::TxKind,
         state::AccountInfo,
@@ -237,6 +245,83 @@ mod tests {
                 IActivationRegistry::adminCall::abi_decode_returns(result.output().unwrap())
                     .unwrap();
             assert_eq!(admin, expected_admin);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fork_activation_admin_uses_source_chain_in_nested_deployment() {
+        let (_api, handle) =
+            anvil::spawn(anvil::NodeConfig::test().with_chain_id(Some(8453u64))).await;
+        let expected =
+            ChainConfig::activation_admin_address_for_upgrade_by_chain_id(8453, BaseUpgrade::Beryl)
+                .unwrap();
+        for chain_id in [31337, 84532] {
+            let mut opts = EvmOpts {
+                fork_url: Some(handle.http_endpoint()),
+                networks: NetworkConfigs::with_base(),
+                ..Default::default()
+            };
+            opts.env.chain_id = Some(chain_id);
+            let fork = opts.get_fork(&Config::default(), 8453, Some(0)).unwrap();
+            let backend = Backend::<BaseEvmNetwork>::spawn(Some(fork)).unwrap();
+            assert_eq!(backend.active_fork_source_chain_id(), Some(8453));
+            let mut db = CowBackend::new_borrowed(&backend);
+            let env = base_env(chain_id, BaseUpgrade::Beryl);
+            let mut evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+                &mut db,
+                env,
+                NoOpInspector,
+            );
+            let tx = BaseTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .chain_id(Some(chain_id))
+                        .kind(TxKind::Call(ActivationRegistryStorage::ADDRESS))
+                        .data(Bytes::from(IActivationRegistry::adminCall {}.abi_encode()))
+                        .gas_limit(100_000),
+                )
+                .build_fill();
+            let result = evm.transact_one(tx).unwrap();
+            assert_eq!(
+                IActivationRegistry::adminCall::abi_decode_returns(result.output().unwrap())
+                    .unwrap(),
+                expected
+            );
+            // Deploy initcode that calls admin() and returns it as the deployed code.
+            let mut initcode = vec![0x63];
+            initcode.extend(IActivationRegistry::adminCall::SELECTOR);
+            initcode
+                .extend([0x60, 0xe0, 0x1b, 0x5f, 0x52, 0x60, 0x20, 0x5f, 0x60, 0x04, 0x5f, 0x73]);
+            initcode.extend(ActivationRegistryStorage::ADDRESS.as_slice());
+            initcode.extend([0x5a, 0xfa, 0x50, 0x60, 0x20, 0x5f, 0xf3]);
+            with_cloned_context(evm.ctx_mut(), |db, env, journal| {
+                let mut nested = BaseEvmFactory::default().create_nested_evm(db, env);
+                *nested.journal_inner_mut() = journal;
+                let result = nested
+                    .transact_raw(
+                        BaseTransaction::builder()
+                            .base(
+                                TxEnv::builder()
+                                    .chain_id(Some(chain_id))
+                                    .nonce(1)
+                                    .kind(TxKind::Create)
+                                    .data(Bytes::from(initcode))
+                                    .gas_limit(200_000),
+                            )
+                            .build_fill(),
+                    )
+                    .unwrap();
+                assert!(result.result.is_success(), "{:?}", result.result);
+                assert_eq!(
+                    IActivationRegistry::adminCall::abi_decode_returns(
+                        result.result.output().unwrap()
+                    )
+                    .unwrap(),
+                    expected
+                );
+                Ok((nested.to_evm_env(), nested.journal_inner_mut().clone()))
+            })
+            .unwrap();
         }
     }
 

--- a/crates/evm/core/src/evm/base.rs
+++ b/crates/evm/core/src/evm/base.rs
@@ -1,0 +1,294 @@
+use crate::{
+    FoundryChain, FoundryContextExt, FoundryInspectorExt,
+    backend::{DatabaseExt, JournaledState},
+    constants::SYSTEM_PRECOMPILE_STUB,
+    evm::{
+        FoundryEvmFactory, FoundryEvmNetwork, IntoInstructionResult, NestedEvm, NestedEvmFor,
+        run_inspected_frame,
+    },
+};
+use alloy_evm::{Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
+use alloy_primitives::{Address, Bytes};
+use base_common_chains::ChainConfig;
+use base_common_evm::{
+    BaseContext, BaseEvm, BaseEvmFactory, BaseHaltReason, BaseHandler, BaseSpecId, BaseTransaction,
+    BaseTransactionError, BaseUpgrade, L1BlockInfo,
+};
+use base_common_network::Base;
+// Only the tests below need this crate, but Cargo forbids optional dev-dependencies, so it is an
+// optional regular dependency that the `base` feature turns on.
+use base_common_precompiles as _;
+use foundry_evm_networks::{BASE_CODE_SENTINEL_ADDRESSES, is_base_precompile_active_at};
+use foundry_fork_db::DatabaseError;
+use revm::{
+    context::{
+        BlockEnv, ContextTr, Journal, JournalTr, TxEnv,
+        result::{EVMError, HaltReason, ResultAndState},
+    },
+    handler::{EthFrame, EvmTr, FrameResult},
+    interpreter::{FrameInput, InstructionResult, interpreter::EthInterpreter},
+    state::Bytecode,
+};
+
+/// Base EVM network.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BaseEvmNetwork;
+
+impl FoundryEvmNetwork for BaseEvmNetwork {
+    type Network = Base;
+    type EvmFactory = BaseEvmFactory;
+}
+
+impl IntoInstructionResult for BaseHaltReason {
+    fn into_instruction_result(self) -> InstructionResult {
+        match self {
+            Self::Base(eth) => eth.into(),
+            Self::FailedDeposit => InstructionResult::Stop,
+        }
+    }
+}
+
+pub type BaseRevmEvm<'db, I> = BaseEvm<&'db mut dyn DatabaseExt<BaseEvmFactory>, I, PrecompilesMap>;
+
+type BaseEvmHandler<'db, I> = BaseHandler<
+    BaseRevmEvm<'db, I>,
+    EVMError<DatabaseError, BaseTransactionError>,
+    EthFrame<EthInterpreter>,
+>;
+
+/// Base precompiles installed at `upgrade` that hold state but carry no bytecode.
+///
+/// Solidity emits an `extcodesize` check for high-level calls to functions without return data,
+/// so a code-less precompile makes the *caller* revert before the precompile ever runs. Base
+/// mainnet plants a one-byte sentinel on exactly these accounts, so mirroring it keeps local
+/// execution faithful to the chain.
+pub fn base_code_sentinel_addresses(upgrade: BaseUpgrade) -> impl Iterator<Item = Address> {
+    BASE_CODE_SENTINEL_ADDRESSES
+        .iter()
+        .copied()
+        .filter(move |address| is_base_precompile_active_at(*address, upgrade))
+}
+
+impl FoundryChain<BaseTransaction<TxEnv>> for L1BlockInfo {}
+
+impl FoundryEvmFactory for BaseEvmFactory {
+    type Chain = L1BlockInfo;
+    type FoundryContext<'db> = BaseContext<&'db mut dyn DatabaseExt<Self>>;
+
+    type FoundryEvm<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>> = BaseRevmEvm<'db, I>;
+
+    fn create_foundry_evm_with_inspector<'db, I: FoundryInspectorExt<Self::FoundryContext<'db>>>(
+        &self,
+        db: &'db mut dyn DatabaseExt<Self>,
+        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
+        inspector: I,
+    ) -> Self::FoundryEvm<'db, I> {
+        let upgrade = evm_env.cfg_env.spec.upgrade();
+        let activation_admin = self.activation_admin_address().or_else(|| {
+            ChainConfig::activation_admin_address_for_upgrade_by_chain_id(
+                evm_env.cfg_env.chain_id,
+                upgrade,
+            )
+        });
+        let factory = self.with_activation_admin_address(activation_admin);
+        let mut base_evm = factory.create_evm_with_inspector(db, evm_env, inspector);
+        base_evm.ctx_mut().cfg.tx_chain_id_check = true;
+        // Preserve existing code, including sentinels already present on forks.
+        let sentinel = Bytecode::new_legacy(Bytes::from_static(SYSTEM_PRECOMPILE_STUB));
+        let sentinel_hash = sentinel.hash_slow();
+        let journal = base_evm.ctx_mut().journal_mut();
+        for address in base_code_sentinel_addresses(upgrade) {
+            if let Ok(account) = journal.load_account_with_code(address)
+                && account.info.code.as_ref().is_none_or(|code| code.is_empty())
+            {
+                journal.set_code_with_hash(address, sentinel.clone(), sentinel_hash);
+            }
+        }
+        base_evm
+    }
+
+    fn create_nested_evm_with_inspector<'db, I>(
+        &self,
+        db: &'db mut dyn DatabaseExt<Self>,
+        evm_env: EvmEnv<Self::Spec, Self::BlockEnv>,
+        inspector: I,
+    ) -> NestedEvmFor<'db, Self>
+    where
+        I: FoundryInspectorExt<Self::FoundryContext<'db>> + 'db,
+    {
+        Box::new(self.create_foundry_evm_with_inspector(db, evm_env, inspector))
+    }
+}
+
+fn map_base_error(error: EVMError<DatabaseError, BaseTransactionError>) -> EVMError<DatabaseError> {
+    match error {
+        EVMError::Database(db) => EVMError::Database(db),
+        EVMError::Header(header) => EVMError::Header(header),
+        EVMError::Custom(message) => EVMError::Custom(message),
+        EVMError::Transaction(transaction) => {
+            EVMError::Custom(format!("base transaction error: {transaction}"))
+        }
+        EVMError::CustomAny(error) => EVMError::CustomAny(error),
+    }
+}
+
+impl<'db, I: FoundryInspectorExt<BaseContext<&'db mut dyn DatabaseExt<BaseEvmFactory>>>> NestedEvm
+    for BaseRevmEvm<'db, I>
+{
+    type Spec = BaseSpecId;
+    type Block = BlockEnv;
+    type Tx = BaseTransaction<TxEnv>;
+    type Chain = L1BlockInfo;
+    type Journal = Journal<&'db mut dyn DatabaseExt<BaseEvmFactory>>;
+
+    fn journal_inner_mut(&mut self) -> &mut JournaledState {
+        &mut self.ctx_mut().journaled_state.inner
+    }
+
+    fn tx_mut(&mut self) -> &mut Self::Tx {
+        self.ctx_mut().tx_mut()
+    }
+
+    fn chain_mut(&mut self) -> &mut Self::Chain {
+        &mut self.ctx_mut().chain
+    }
+
+    fn journal_mut(&mut self) -> &mut Self::Journal {
+        &mut self.ctx_mut().journaled_state
+    }
+
+    fn precompiles_mut(&mut self) -> &mut PrecompilesMap {
+        Evm::precompiles_mut(self)
+    }
+
+    fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
+        run_inspected_frame(self, BaseEvmHandler::<I>::new(), frame).map_err(map_base_error)
+    }
+
+    fn transact_raw(&mut self, tx: Self::Tx) -> eyre::Result<ResultAndState<HaltReason>> {
+        let ResultAndState { result, state } =
+            Evm::transact_raw(self, tx).map_err(map_base_error)?;
+        let result = result.map_haltreason(|halt| match halt {
+            BaseHaltReason::Base(eth) => eth,
+            BaseHaltReason::FailedDeposit => HaltReason::PrecompileError,
+        });
+        Ok(ResultAndState::new(result, state))
+    }
+
+    fn to_evm_env(&self) -> EvmEnv<Self::Spec, Self::Block> {
+        self.ctx_ref().evm_clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::Backend;
+    use alloy_sol_types::SolCall;
+    use base_common_precompiles::{
+        ActivationRegistryStorage, B20FactoryStorage, IActivationRegistry, NonceManagerStorage,
+        PolicyRegistryStorage, TxContextStorage,
+    };
+    use revm::{
+        ExecuteEvm, context::CfgEnv, inspector::NoOpInspector, primitives::TxKind,
+        state::AccountInfo,
+    };
+
+    fn base_env(chain_id: u64, upgrade: BaseUpgrade) -> EvmEnv<BaseSpecId, BlockEnv> {
+        let mut cfg = CfgEnv::new_with_spec(BaseSpecId::new(upgrade));
+        cfg.chain_id = chain_id;
+        EvmEnv::new(cfg, BlockEnv::default())
+    }
+
+    #[test]
+    fn failed_deposit_maps_to_stop() {
+        assert_eq!(
+            BaseHaltReason::FailedDeposit.into_instruction_result(),
+            InstructionResult::Stop
+        );
+    }
+
+    #[test]
+    fn constructor_resolves_activation_admin_and_preserves_override() {
+        let chain_admin =
+            ChainConfig::activation_admin_address_for_upgrade_by_chain_id(8453, BaseUpgrade::Beryl)
+                .unwrap();
+        let custom_admin = Address::repeat_byte(0xaa);
+        for (override_admin, expected_admin) in
+            [(None, chain_admin), (Some(custom_admin), custom_admin)]
+        {
+            let mut db = Backend::<BaseEvmNetwork>::spawn(None).unwrap();
+            let mut evm = BaseEvmFactory::new(override_admin).create_foundry_evm_with_inspector(
+                &mut db,
+                base_env(8453, BaseUpgrade::Beryl),
+                NoOpInspector,
+            );
+            let tx = BaseTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .chain_id(Some(8453))
+                        .kind(TxKind::Call(ActivationRegistryStorage::ADDRESS))
+                        .data(Bytes::from(IActivationRegistry::adminCall {}.abi_encode()))
+                        .gas_limit(100_000),
+                )
+                .build_fill();
+            let result = evm.transact_one(tx).unwrap();
+            let admin =
+                IActivationRegistry::adminCall::abi_decode_returns(result.output().unwrap())
+                    .unwrap();
+            assert_eq!(admin, expected_admin);
+        }
+    }
+
+    #[test]
+    fn constructor_plants_only_active_registry_sentinels() {
+        for upgrade in [BaseUpgrade::Azul, BaseUpgrade::Beryl] {
+            let mut db = Backend::<BaseEvmNetwork>::spawn(None).unwrap();
+            let mut evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+                &mut db,
+                base_env(8453, upgrade),
+                NoOpInspector,
+            );
+            for (address, registry) in [
+                (ActivationRegistryStorage::ADDRESS, true),
+                (PolicyRegistryStorage::ADDRESS, true),
+                (B20FactoryStorage::ADDRESS, false),
+                (NonceManagerStorage::ADDRESS, false),
+                (TxContextStorage::ADDRESS, false),
+            ] {
+                let expected = if upgrade == BaseUpgrade::Beryl && registry {
+                    Bytecode::new_legacy(Bytes::from_static(SYSTEM_PRECOMPILE_STUB))
+                } else {
+                    Bytecode::default()
+                };
+                let account = evm.ctx_mut().journal_mut().load_account_with_code(address).unwrap();
+                assert_eq!(
+                    account.info.code.as_ref().unwrap(),
+                    &expected,
+                    "{upgrade:?}: {address}"
+                );
+                assert_eq!(account.info.code_hash, expected.hash_slow());
+            }
+        }
+    }
+
+    #[test]
+    fn constructor_preserves_existing_registry_code() {
+        let address = ActivationRegistryStorage::ADDRESS;
+        let code = Bytecode::new_legacy(Bytes::from_static(&[0x60, 0x00, 0x00]));
+        let code_hash = code.hash_slow();
+        let mut db = Backend::<BaseEvmNetwork>::spawn(None).unwrap();
+        db.insert_account_info(
+            address,
+            AccountInfo { code_hash, code: Some(code.clone()), ..Default::default() },
+        );
+        let mut evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+            &mut db,
+            base_env(8453, BaseUpgrade::Beryl),
+            NoOpInspector,
+        );
+        let account = evm.ctx_mut().journal_mut().load_account_with_code(address).unwrap();
+        assert_eq!(account.info.code.as_ref().unwrap(), &code);
+        assert_eq!(account.info.code_hash, code_hash);
+    }
+}

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -2,8 +2,6 @@
 //!
 //! Each network module owns its network marker and concrete EVM implementations.
 
-use std::{fmt::Debug, ops::DerefMut};
-
 use crate::{
     FoundryBlock, FoundryChain, FoundryContextExt, FoundryInspectorExt, FoundryJournal,
     FoundryTransaction, FromAnyRpcTransaction,
@@ -33,7 +31,10 @@ use revm::{
     primitives::hardfork::SpecId,
 };
 use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, ops::DerefMut};
 
+#[cfg(feature = "base")]
+pub mod base;
 pub mod eth;
 #[cfg(feature = "monad")]
 pub mod monad;
@@ -43,6 +44,9 @@ pub mod tempo;
 
 pub use eth::*;
 pub use tempo::*;
+
+#[cfg(feature = "base")]
+pub use base::*;
 
 #[cfg(feature = "monad")]
 pub use monad::*;

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -1587,6 +1587,9 @@ mod tests {
     };
     use revm::context::{BlockEnv, TxEnv};
 
+    #[cfg(feature = "base")]
+    use foundry_evm_hardforks::BaseUpgrade;
+
     #[cfg(feature = "optimism")]
     use op_revm::OpSpecId;
 
@@ -2167,6 +2170,8 @@ mod tests {
             assert!(!evm_opts.networks.is_tempo());
             #[cfg(feature = "optimism")]
             assert!(!evm_opts.networks.is_optimism());
+            #[cfg(feature = "base")]
+            assert!(!evm_opts.networks.is_base());
             assert!(!evm_opts.networks.is_celo());
             assert_eq!(evm_opts.networks, NetworkConfigs::default());
         }
@@ -2195,6 +2200,8 @@ mod tests {
         profiles.push(NetworkConfigs::with_optimism());
         #[cfg(feature = "monad")]
         profiles.push(NetworkConfigs::with_monad());
+        #[cfg(feature = "base")]
+        profiles.push(NetworkConfigs::with_base());
 
         for networks in profiles {
             let mut evm_opts = EvmOpts {
@@ -2250,6 +2257,31 @@ mod tests {
         let evm_opts = EvmOpts { fork_url: Some(handle.http_endpoint()), ..Default::default() };
 
         assert_eq!(evm_opts.fork_network().await.unwrap(), (chain_id, NetworkVariant::Ethereum));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "base")]
+    async fn base_endpoint_identity_uses_generic_chain_profile() {
+        let endpoint = "http://127.0.0.1:1";
+        let provider = EvmOpts::default().fork_provider_with_url::<AnyNetwork>(endpoint).unwrap();
+
+        let identity = EvmOpts::resolve_fork_endpoint_identity(
+            &provider,
+            endpoint,
+            NamedChain::Base as u64,
+            None,
+            None,
+            EndpointHardforkPolicy::Optional,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(identity.execution_chain_id, NamedChain::Base as u64);
+        assert_eq!(identity.source_chain_id, NamedChain::Base as u64);
+        assert_eq!(identity.network, NetworkVariant::Base);
+        assert!(identity.network_profile.is_base());
+        assert_eq!(identity.reported_hardfork, None);
+        assert_eq!(identity.hardfork, None);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2680,6 +2712,29 @@ mod tests {
         );
     }
 
+    #[test]
+    #[cfg(feature = "base")]
+    fn unknown_base_endpoint_hardfork_is_optional_only_for_remote_execution() {
+        assert_eq!(NetworkVariant::from_node_info_name("base").unwrap(), NetworkVariant::Base);
+        assert_eq!(
+            endpoint_hardfork(NetworkVariant::Base, "BaseFuture", EndpointHardforkPolicy::Optional)
+                .unwrap(),
+            None
+        );
+
+        let error =
+            endpoint_hardfork(NetworkVariant::Base, "BaseFuture", EndpointHardforkPolicy::Required)
+                .unwrap_err();
+        assert!(
+            error.to_string().contains("unsupported hardfork `BaseFuture` reported for `base`")
+        );
+        assert_eq!(
+            endpoint_hardfork(NetworkVariant::Base, "Beryl", EndpointHardforkPolicy::Required)
+                .unwrap(),
+            Some(FoundryHardfork::Base(BaseUpgrade::Beryl))
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "monad")]
     async fn fork_network_detects_monad_anvil() {
@@ -2704,6 +2759,22 @@ mod tests {
 
         assert!(error.to_string().contains("failed to retrieve chain ID"));
         assert!(evm_opts.networks.is_monad());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(feature = "base")]
+    async fn infer_network_base_propagates_unavailable_rpc() {
+        let mut evm_opts = EvmOpts {
+            fork_url: Some("http://127.0.0.1:1".to_string()),
+            networks: NetworkConfigs::with_base(),
+            ..Default::default()
+        };
+
+        let error = evm_opts.infer_network_from_fork().await.unwrap_err();
+
+        assert!(error.to_string().contains("failed to retrieve chain ID"));
+        assert!(evm_opts.networks.is_base());
+        assert_eq!(evm_opts.fork_endpoint, None);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/evm/core/tests/base_replay.rs
+++ b/crates/evm/core/tests/base_replay.rs
@@ -1,0 +1,467 @@
+use alloy_consensus::{
+    Sealable,
+    transaction::{Recovered, SignerRecoverable},
+};
+use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+use alloy_evm::{Evm, EvmEnv, FromRecoveredTx};
+use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, UnknownTxEnvelope};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex};
+use alloy_rpc_types::Transaction as RpcTransaction;
+use alloy_serde::WithOtherFields;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use base_common_consensus::{
+    BaseTransactionInfo, BaseTxEnvelope, Eip8130Signed, Predeploys, TxDeposit, TxEip8130,
+};
+use base_common_evm::{
+    BaseEvmFactory, BaseHaltReason, BaseSpecId, BaseTransaction, BaseUpgrade, Eip8130ExecutionMode,
+    L1BlockInfo,
+};
+use base_common_rpc_types::Transaction;
+use foundry_evm_core::{
+    FoundryBlock, FoundryTransaction, FromAnyRpcTransaction,
+    backend::Backend,
+    evm::{BaseEvmNetwork, FoundryEvmFactory},
+    fork::MultiFork,
+    utils::get_blob_base_fee_update_fraction,
+};
+use revm::{
+    Database,
+    context::{BlockEnv, CfgEnv, TxEnv},
+    inspector::NoOpInspector,
+    state::{AccountInfo, Bytecode},
+};
+use serde::Deserialize;
+use std::str::FromStr;
+
+const AZUL_FIXTURE: &str = include_str!("fixtures/base/azul-transfer.json");
+const BERYL_FIXTURE: &str = include_str!("fixtures/base/beryl-transfer.json");
+const JOVIAN_FIXTURE: &str = include_str!("fixtures/base/jovian-transfer.json");
+
+#[derive(Debug, Deserialize)]
+struct ReplayFixture {
+    chain_id: String,
+    upgrade: String,
+    block: FixtureBlock,
+    transaction: FixtureTransaction,
+    parent_state: FixtureParentState,
+    expected: FixtureExpected,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureBlock {
+    number: String,
+    timestamp: String,
+    gas_limit: String,
+    base_fee_per_gas: String,
+    beneficiary: String,
+    prevrandao: String,
+    excess_blob_gas: String,
+    receipts_root: String,
+    state_root: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureTransaction {
+    hash: String,
+    raw: String,
+    from: String,
+    to: String,
+    value: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureParentState {
+    caller_balance: String,
+    caller_nonce: String,
+    recipient_balance: String,
+    recipient_code: String,
+    l1_block_info_storage: Vec<(String, String)>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureExpected {
+    status: bool,
+    gas_used: String,
+    effective_gas_price: String,
+    l1_gas_used: String,
+    l1_fee: String,
+    log_count: usize,
+}
+
+fn fixture(data: &str) -> ReplayFixture {
+    serde_json::from_str(data).expect("valid Base replay fixture")
+}
+
+fn u256(value: &str) -> U256 {
+    U256::from_str(value).expect("valid U256 fixture value")
+}
+
+fn u64_hex(value: &str) -> u64 {
+    u64::from_str_radix(value.trim_start_matches("0x"), 16).expect("valid u64 fixture value")
+}
+
+fn bytes(value: &str) -> Bytes {
+    hex::decode(value.trim_start_matches("0x")).expect("valid byte fixture").into()
+}
+
+fn in_memory_base_backend() -> Backend<BaseEvmNetwork> {
+    let (forks, _fork_handler) = MultiFork::new();
+    Backend::new(forks, None).expect("in-memory Base backend")
+}
+
+fn seed_fixture_backend(fixture: &ReplayFixture) -> Backend<BaseEvmNetwork> {
+    let mut db = in_memory_base_backend();
+    let caller = fixture.transaction.from.parse().unwrap();
+    let recipient = fixture.transaction.to.parse().unwrap();
+
+    db.insert_account_info(
+        caller,
+        AccountInfo {
+            balance: u256(&fixture.parent_state.caller_balance),
+            nonce: u64_hex(&fixture.parent_state.caller_nonce),
+            ..Default::default()
+        },
+    );
+    assert_eq!(fixture.parent_state.recipient_code, "0x");
+    db.insert_account_info(
+        recipient,
+        AccountInfo {
+            balance: u256(&fixture.parent_state.recipient_balance),
+            ..Default::default()
+        },
+    );
+    db.insert_account_info(Predeploys::L1_BLOCK_INFO, AccountInfo::default());
+    for (slot, value) in &fixture.parent_state.l1_block_info_storage {
+        db.insert_account_storage(Predeploys::L1_BLOCK_INFO, u256(slot), u256(value))
+            .expect("insert L1BlockInfo storage");
+    }
+    db
+}
+
+fn fixture_env(fixture: &ReplayFixture, upgrade: BaseUpgrade) -> EvmEnv<BaseSpecId, BlockEnv> {
+    let chain_id = u64_hex(&fixture.chain_id);
+    let timestamp = u64_hex(&fixture.block.timestamp);
+    let mut cfg = CfgEnv::new_with_spec(BaseSpecId::new(upgrade));
+    cfg.chain_id = chain_id;
+
+    let mut block = BlockEnv::default();
+    block.set_number(u256(&fixture.block.number));
+    block.set_timestamp(U256::from(timestamp));
+    block.set_gas_limit(u64_hex(&fixture.block.gas_limit));
+    block.set_basefee(u64_hex(&fixture.block.base_fee_per_gas));
+    block.set_beneficiary(fixture.block.beneficiary.parse().unwrap());
+    block.set_prevrandao(Some(fixture.block.prevrandao.parse().unwrap()));
+    block.set_blob_excess_gas_and_price(
+        u64_hex(&fixture.block.excess_blob_gas),
+        get_blob_base_fee_update_fraction(chain_id, timestamp),
+    );
+    EvmEnv::new(cfg, block)
+}
+
+fn decode_fixture_transaction(
+    fixture: &ReplayFixture,
+) -> (Bytes, BaseTxEnvelope, BaseTransaction<TxEnv>) {
+    let raw = bytes(&fixture.transaction.raw);
+    let envelope =
+        BaseTxEnvelope::decode_2718(&mut raw.as_ref()).expect("decode Base transaction envelope");
+    assert_eq!(envelope.encoded_2718(), raw);
+    assert_eq!(*envelope.tx_hash(), fixture.transaction.hash.parse::<B256>().unwrap());
+
+    let signer = envelope.recover_signer().expect("recover Base transaction signer");
+    assert_eq!(signer, fixture.transaction.from.parse::<Address>().unwrap());
+    let tx = BaseTransaction::from_recovered_tx(&envelope, signer);
+    assert_eq!(tx.enveloped_tx(), Some(&raw));
+    (raw, envelope, tx)
+}
+
+fn balance(db: &mut Backend<BaseEvmNetwork>, address: Address) -> U256 {
+    db.basic(address).unwrap().unwrap_or_default().balance
+}
+
+fn nonce(db: &mut Backend<BaseEvmNetwork>, address: Address) -> u64 {
+    db.basic(address).unwrap().unwrap_or_default().nonce
+}
+
+fn replay_transfer_fixture(fixture: ReplayFixture) {
+    let upgrade = BaseUpgrade::from_str(&fixture.upgrade).expect("valid Base fixture upgrade");
+    assert_ne!(fixture.block.receipts_root.parse::<B256>().unwrap(), B256::ZERO);
+    assert_ne!(fixture.block.state_root.parse::<B256>().unwrap(), B256::ZERO);
+    let (raw, _envelope, tx) = decode_fixture_transaction(&fixture);
+    let mut db = seed_fixture_backend(&fixture);
+    let spec = BaseSpecId::new(upgrade);
+    let block_number = u256(&fixture.block.number);
+
+    let mut l1_block_info =
+        L1BlockInfo::try_fetch(&mut db, block_number, spec).expect("load L1BlockInfo");
+    assert_eq!(l1_block_info.data_gas(&raw, spec), u256(&fixture.expected.l1_gas_used));
+    assert_eq!(l1_block_info.calculate_tx_l1_cost(&raw, spec), u256(&fixture.expected.l1_fee));
+
+    let mut evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+        &mut db,
+        fixture_env(&fixture, upgrade),
+        NoOpInspector,
+    );
+    let result = evm.transact_commit(tx).expect("replay Base transfer");
+    assert_eq!(result.is_success(), fixture.expected.status);
+    assert_eq!(result.tx_gas_used(), u64_hex(&fixture.expected.gas_used));
+    assert_eq!(result.logs().len(), fixture.expected.log_count);
+    drop(evm);
+
+    let caller = fixture.transaction.from.parse().unwrap();
+    let recipient = fixture.transaction.to.parse().unwrap();
+    let gas_fee = u256(&fixture.expected.effective_gas_price) * U256::from(result.tx_gas_used());
+    let expected_caller = u256(&fixture.parent_state.caller_balance)
+        - u256(&fixture.transaction.value)
+        - gas_fee
+        - u256(&fixture.expected.l1_fee);
+    assert_eq!(balance(&mut db, caller), expected_caller);
+    assert_eq!(
+        balance(&mut db, recipient),
+        u256(&fixture.parent_state.recipient_balance) + u256(&fixture.transaction.value)
+    );
+    assert_eq!(nonce(&mut db, caller), u64_hex(&fixture.parent_state.caller_nonce) + 1);
+    assert_eq!(balance(&mut db, Predeploys::L1_FEE_VAULT), u256(&fixture.expected.l1_fee));
+    assert_eq!(
+        balance(&mut db, Predeploys::BASE_FEE_VAULT),
+        u256(&fixture.block.base_fee_per_gas) * U256::from(result.tx_gas_used())
+    );
+    assert_eq!(balance(&mut db, Predeploys::OPERATOR_FEE_VAULT), U256::ZERO);
+}
+
+#[test]
+fn replays_azul_transfer_with_wire_fees_and_state_deltas() {
+    replay_transfer_fixture(fixture(AZUL_FIXTURE));
+}
+
+#[test]
+fn replays_jovian_transfer_with_wire_fees_and_state_deltas() {
+    replay_transfer_fixture(fixture(JOVIAN_FIXTURE));
+}
+
+#[test]
+fn replays_beryl_transfer_with_wire_fees_and_state_deltas() {
+    replay_transfer_fixture(fixture(BERYL_FIXTURE));
+}
+
+#[test]
+fn replays_beryl_operator_fee_charge_and_refund() {
+    let fixture = fixture(BERYL_FIXTURE);
+    let (_raw, _envelope, tx) = decode_fixture_transaction(&fixture);
+    let mut db = seed_fixture_backend(&fixture);
+    let mut evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+        &mut db,
+        fixture_env(&fixture, BaseUpgrade::Beryl),
+        NoOpInspector,
+    );
+    evm.ctx_mut().chain = L1BlockInfo {
+        l2_block: Some(u256(&fixture.block.number)),
+        operator_fee_scalar: Some(U256::from(2)),
+        operator_fee_constant: Some(U256::from(5)),
+        ..Default::default()
+    };
+
+    let result = evm.transact_commit(tx).expect("replay Base transfer with operator fee");
+    assert!(result.is_success());
+    let operator_fee = U256::from(result.tx_gas_used()) * U256::from(200) + U256::from(5);
+    drop(evm);
+
+    let caller = fixture.transaction.from.parse().unwrap();
+    let expected_caller = u256(&fixture.parent_state.caller_balance)
+        - u256(&fixture.transaction.value)
+        - u256(&fixture.expected.effective_gas_price) * U256::from(result.tx_gas_used())
+        - operator_fee;
+    assert_eq!(balance(&mut db, caller), expected_caller);
+    assert_eq!(balance(&mut db, Predeploys::OPERATOR_FEE_VAULT), operator_fee);
+    assert_eq!(balance(&mut db, Predeploys::L1_FEE_VAULT), U256::ZERO);
+}
+
+fn deposit_envelope(to: Address) -> BaseTxEnvelope {
+    BaseTxEnvelope::Deposit(
+        TxDeposit {
+            source_hash: B256::repeat_byte(0x11),
+            from: Address::repeat_byte(0xaa),
+            to: TxKind::Call(to),
+            mint: 1_000,
+            value: U256::from(600),
+            gas_limit: 100_000,
+            is_system_transaction: false,
+            input: Bytes::new(),
+        }
+        .seal_slow(),
+    )
+}
+
+fn simple_base_env(upgrade: BaseUpgrade) -> EvmEnv<BaseSpecId, BlockEnv> {
+    let mut cfg = CfgEnv::new_with_spec(BaseSpecId::new(upgrade));
+    cfg.chain_id = 8453;
+    let mut block = BlockEnv::default();
+    block.set_number(U256::ONE);
+    block.set_timestamp(U256::ONE);
+    block.set_gas_limit(30_000_000);
+    block.set_basefee(1_000_000);
+    EvmEnv::new(cfg, block)
+}
+
+#[test]
+fn replays_successful_and_failed_base_deposits() {
+    let sender = Address::repeat_byte(0xaa);
+    let recipient = Address::repeat_byte(0xbb);
+    let envelope = deposit_envelope(recipient);
+    let raw: Bytes = envelope.encoded_2718().into();
+    assert_eq!(raw[0], 0x7e);
+    assert_eq!(
+        L1BlockInfo::default().calculate_tx_l1_cost(&raw, BaseSpecId::new(BaseUpgrade::Beryl)),
+        U256::ZERO
+    );
+
+    let mut db = in_memory_base_backend();
+    let tx = BaseTransaction::from_recovered_tx(&envelope, sender);
+    assert_eq!(tx.enveloped_tx(), Some(&raw));
+    let mut evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+        &mut db,
+        simple_base_env(BaseUpgrade::Beryl),
+        NoOpInspector,
+    );
+    evm.ctx_mut().chain.l2_block = Some(U256::ONE);
+    let result = evm.transact_commit(tx).expect("execute Base deposit");
+    assert!(result.is_success());
+    assert_eq!(result.tx_gas_used(), 21_000);
+    drop(evm);
+    assert_eq!(balance(&mut db, sender), U256::from(400));
+    assert_eq!(balance(&mut db, recipient), U256::from(600));
+    assert_eq!(balance(&mut db, Predeploys::L1_FEE_VAULT), U256::ZERO);
+
+    let reverter = Address::repeat_byte(0xcc);
+    let mut db = in_memory_base_backend();
+    db.insert_account_info(
+        reverter,
+        AccountInfo::default().with_code(Bytecode::new_raw(Bytes::from_static(&[0xfe]))),
+    );
+    let envelope = deposit_envelope(reverter);
+    let tx = BaseTransaction::from_recovered_tx(&envelope, sender);
+    let mut evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+        &mut db,
+        simple_base_env(BaseUpgrade::Beryl),
+        NoOpInspector,
+    );
+    evm.ctx_mut().chain.l2_block = Some(U256::ONE);
+    let result = evm.transact_commit(tx).expect("execute failed Base deposit");
+    assert!(matches!(
+        result,
+        revm::context::result::ExecutionResult::Halt { reason: BaseHaltReason::FailedDeposit, .. }
+    ));
+    assert_eq!(result.tx_gas_used(), 100_000);
+    drop(evm);
+    assert_eq!(balance(&mut db, sender), U256::from(1_000));
+    assert_eq!(balance(&mut db, reverter), U256::ZERO);
+    assert_eq!(nonce(&mut db, sender), 1);
+}
+
+fn eip8130_transaction(signer: &PrivateKeySigner) -> (BaseTxEnvelope, BaseTransaction<TxEnv>) {
+    let tx = TxEip8130 {
+        chain_id: 8453,
+        sender: None,
+        nonce_key: U256::ZERO,
+        nonce_sequence: 0,
+        valid_after: 0,
+        valid_before: 0,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: 1_000_000_000,
+        gas_limit: 200_000,
+        account_changes: Vec::new(),
+        calls: Vec::new(),
+        metadata: Bytes::new(),
+        payer: None,
+    };
+    let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
+    let signed = Eip8130Signed::new(tx, signature.as_bytes().to_vec().into(), Bytes::new());
+    let envelope = BaseTxEnvelope::Eip8130(signed);
+    let base_tx = BaseTransaction::from_recovered_tx(&envelope, signer.address());
+    (envelope, base_tx)
+}
+
+fn eip8130_backend(sender: Address) -> Backend<BaseEvmNetwork> {
+    let mut db = in_memory_base_backend();
+    db.insert_account_info(
+        sender,
+        AccountInfo { balance: U256::from(10u64).pow(U256::from(18)), ..Default::default() },
+    );
+    db
+}
+
+#[test]
+fn simulates_and_commits_eip8130_without_placeholder_txenv() {
+    let signer = PrivateKeySigner::from_bytes(&B256::with_last_byte(1)).unwrap();
+    let sender = signer.address();
+    let (envelope, tx) = eip8130_transaction(&signer);
+    let raw: Bytes = envelope.encoded_2718().into();
+    assert_eq!(raw[0], 0x79);
+    assert_eq!(tx.enveloped_tx(), Some(&raw));
+    assert!(tx.eip8130.is_some());
+
+    let mut simulation_tx = tx.clone();
+    simulation_tx.eip8130.as_mut().unwrap().mode = Eip8130ExecutionMode::Simulate;
+    let mut simulation_db = eip8130_backend(sender);
+    let initial_balance = balance(&mut simulation_db, sender);
+    let mut simulation_evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+        &mut simulation_db,
+        simple_base_env(BaseUpgrade::Zenith),
+        NoOpInspector,
+    );
+    simulation_evm.ctx_mut().chain.l2_block = Some(U256::ONE);
+    let simulation_result =
+        simulation_evm.transact_commit(simulation_tx).expect("simulate EIP-8130");
+    assert!(simulation_result.is_success());
+    assert!(simulation_result.tx_gas_used() > 0);
+    drop(simulation_evm);
+    assert_eq!(balance(&mut simulation_db, sender), initial_balance);
+    assert_eq!(nonce(&mut simulation_db, sender), 0);
+
+    let mut db = eip8130_backend(sender);
+    let mut evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+        &mut db,
+        simple_base_env(BaseUpgrade::Zenith),
+        NoOpInspector,
+    );
+    evm.ctx_mut().chain.l2_block = Some(U256::ONE);
+    let result = evm.transact_commit(tx.clone()).expect("commit EIP-8130");
+    assert!(result.is_success());
+    assert!(result.tx_gas_used() > 0);
+    drop(evm);
+    assert!(balance(&mut db, sender) < initial_balance);
+
+    let mut replay_evm = BaseEvmFactory::default().create_foundry_evm_with_inspector(
+        &mut db,
+        simple_base_env(BaseUpgrade::Zenith),
+        NoOpInspector,
+    );
+    replay_evm.ctx_mut().chain.l2_block = Some(U256::ONE);
+    assert!(replay_evm.transact_commit(tx).is_err(), "protocol nonce replay must fail");
+}
+
+#[test]
+fn converts_eip8130_from_any_rpc_transaction() {
+    let signer = PrivateKeySigner::from_bytes(&B256::with_last_byte(2)).unwrap();
+    let (envelope, expected) = eip8130_transaction(&signer);
+    let hash = *envelope.tx_hash();
+    let rpc_tx = Transaction::from_transaction(
+        Recovered::new_unchecked(envelope, signer.address()),
+        BaseTransactionInfo::default(),
+    );
+    let mut rpc_value = serde_json::to_value(rpc_tx).unwrap();
+    rpc_value
+        .as_object_mut()
+        .unwrap()
+        .insert("hash".to_string(), serde_json::to_value(hash).unwrap());
+    let unknown = serde_json::from_value::<UnknownTxEnvelope>(rpc_value).unwrap();
+    let any_tx = RpcTransaction::from_transaction(
+        Recovered::new_unchecked(AnyTxEnvelope::Unknown(unknown), signer.address()),
+        Default::default(),
+    );
+    let any = AnyRpcTransaction::new(WithOtherFields::new(any_tx));
+
+    let converted = BaseTransaction::<TxEnv>::from_any_rpc_transaction(&any).unwrap();
+    assert_eq!(converted.enveloped_tx(), expected.enveloped_tx());
+    assert_eq!(converted.eip8130, expected.eip8130);
+}

--- a/crates/evm/core/tests/fixtures/base/README.md
+++ b/crates/evm/core/tests/fixtures/base/README.md
@@ -1,0 +1,15 @@
+# Base replay fixtures
+
+These fixtures contain the minimum parent state and wire transaction bytes needed for deterministic
+Base EVM replay. They are captured once from public Base RPC data and do not contact RPC endpoints
+during tests.
+
+`jovian-transfer.json`, `azul-transfer.json`, and `beryl-transfer.json` were captured from Base
+mainnet blocks `0x2bf82ef`, `0x2cec52f`, and `0x2f4a86c` on 2026-08-05. Raw transactions came from
+`debug_getRawTransaction`; account balances, nonces, and L1BlockInfo storage were read at each
+parent block; expected execution fields came from `eth_getTransactionReceipt`.
+
+Fixtures intentionally include sampled parent state rather than a full state trie. Tests may assert
+the transaction result, gas, logs, fee-vault credits, and touched-account deltas, but must not claim
+the canonical block state or receipt root unless the complete block state and transaction list are
+included.

--- a/crates/evm/core/tests/fixtures/base/azul-transfer.json
+++ b/crates/evm/core/tests/fixtures/base/azul-transfer.json
@@ -1,0 +1,43 @@
+{
+  "chain_id": "0x2105",
+  "upgrade": "Azul",
+  "block": {
+    "number": "0x2cec52f",
+    "timestamp": "0x6a27e741",
+    "gas_limit": "0x17d78400",
+    "base_fee_per_gas": "0x4c4b40",
+    "beneficiary": "0x4200000000000000000000000000000000000011",
+    "prevrandao": "0x04fbdf553b3ad1934509230ac0e921f9be5d37234b37f4ec2b58910f235bbd63",
+    "excess_blob_gas": "0x0",
+    "parent_beacon_block_root": "0xcd3ba43fbc5bf8ce774016b7d46375b5e00b4990beea138a8152f5c8dc292006",
+    "receipts_root": "0x803abb6d7b0bea097ee972ec819a378f6f534606d5d276f6e6bf98d9e5b6461e",
+    "state_root": "0x5f25c26c6cb53289a050f880fbf48f668ce944bbe4592917dcf2c17859c1c450"
+  },
+  "transaction": {
+    "hash": "0x1304308f42386396b1a2607e22616eabc82506d5db3c81dc0d112e57ca3e3b33",
+    "raw": "0x02f87382210582028e835b8d8083c28cb0825208942d32b281144421abcd351a767269a9cbdc16fa6f8720fca886bd500080c080a0232c1d3e199f83911b457d97b3ce8be5b69050d097720f604eb93c7d762395faa06b5c2136bd6edab1c049ac187b9907ee000ccdbb4033f4c56a4a516638e03612",
+    "from": "0x77dfd3391d071e0d42cfb6682512bfb65735cae1",
+    "to": "0x2d32b281144421abcd351a767269a9cbdc16fa6f",
+    "value": "0x20fca886bd5000"
+  },
+  "parent_state": {
+    "caller_balance": "0x21ac628ea7b40c",
+    "caller_nonce": "0x28e",
+    "recipient_balance": "0x144200844c29",
+    "recipient_code": "0x",
+    "l1_block_info_storage": [
+      ["0x1", "0x000000000000000000000000000000000000000000000000000000000754caea"],
+      ["0x3", "0x00000000000000000000000000000000000008dd00101c120000000000000000"],
+      ["0x7", "0x00000000000000000000000000000000000000000000000000000000006b3409"],
+      ["0x8", "0x0000000000000000000000000000000000000094000000000000000000000000"]
+    ]
+  },
+  "expected": {
+    "status": true,
+    "gas_used": "0x5208",
+    "effective_gas_price": "0xa7d8c0",
+    "l1_gas_used": "0x640",
+    "l1_fee": "0x46d39efc",
+    "log_count": 0
+  }
+}

--- a/crates/evm/core/tests/fixtures/base/beryl-transfer.json
+++ b/crates/evm/core/tests/fixtures/base/beryl-transfer.json
@@ -1,0 +1,43 @@
+{
+  "chain_id": "0x2105",
+  "upgrade": "Beryl",
+  "block": {
+    "number": "0x2f4a86c",
+    "timestamp": "0x6a73adbb",
+    "gas_limit": "0x17d78400",
+    "base_fee_per_gas": "0x4c4b40",
+    "beneficiary": "0x4200000000000000000000000000000000000011",
+    "prevrandao": "0x0cda1d64ddf6cc46d3fac7eeb694170cbc526ab6d7f19413e24a72371f000373",
+    "excess_blob_gas": "0x0",
+    "parent_beacon_block_root": "0x7f1d71c6435bca667b35230362349a86d9c944c8c66ae1c73e991e0b6788ad7a",
+    "receipts_root": "0x43c0efac7d601d05e6c5aeb019396fe41915a9ea430c20141f3bfb36f6306c40",
+    "state_root": "0xd1751057c179aedf082a270a2f630930c624ed1d787246235b07363170118af3"
+  },
+  "transaction": {
+    "hash": "0x6d05122b7b96dd136db5fbd32d06f43d419e370eb7b937da8490f42ee53f6b8e",
+    "raw": "0x02f872822105823492830f424083a7d8c0825208944142fae9016da79039766351c67013544c9604a4860fd1f76b6e1680c001a0df62c066f583599b69dd50cecf0f8bb65f584c2d26b8b4a7a1a7d1d3e833f953a03b2db2297738bd498cab80e66b5beddea7fde1978679740beae23dbb1ac25fa1",
+    "from": "0x3f4e979d1b11f4a2e9c52b83e7e0f8f2fb8e9ec3",
+    "to": "0x4142fae9016da79039766351c67013544c9604a4",
+    "value": "0xfd1f76b6e16"
+  },
+  "parent_state": {
+    "caller_balance": "0x8e1b517c7801",
+    "caller_nonce": "0x3492",
+    "recipient_balance": "0x20a70521fa8e",
+    "recipient_code": "0x",
+    "l1_block_info_storage": [
+      ["0x1", "0x0000000000000000000000000000000000000000000000000000000007fc9e4b"],
+      ["0x3", "0x00000000000000000000000000000000000008dd00101c120000000000000002"],
+      ["0x7", "0x0000000000000000000000000000000000000000000000000000000000784987"],
+      ["0x8", "0x0000000000000000000000000000000000000094000000000000000000000000"]
+    ]
+  },
+  "expected": {
+    "status": true,
+    "gas_used": "0x5208",
+    "effective_gas_price": "0x5b8d80",
+    "l1_gas_used": "0x640",
+    "l1_fee": "0x4e9a3fe4",
+    "log_count": 0
+  }
+}

--- a/crates/evm/core/tests/fixtures/base/jovian-transfer.json
+++ b/crates/evm/core/tests/fixtures/base/jovian-transfer.json
@@ -1,0 +1,43 @@
+{
+  "chain_id": "0x2105",
+  "upgrade": "Jovian",
+  "block": {
+    "number": "0x2bf82ef",
+    "timestamp": "0x6a0962c1",
+    "gas_limit": "0x17d78400",
+    "base_fee_per_gas": "0x4c4b40",
+    "beneficiary": "0x4200000000000000000000000000000000000011",
+    "prevrandao": "0x9219110ff1635fa6bc52a073ed7ddd139eb2768ad02585acabb3204ca7a8ee77",
+    "excess_blob_gas": "0x0",
+    "parent_beacon_block_root": "0x4fe0ecb40aefa1691fb36b87dda0cee747b27030465c28ff8f5ee51796dacc85",
+    "receipts_root": "0xd451d2a3af6cfc6985d2919d6dae871790420642201e91ec20ccf7f07f9de7ba",
+    "state_root": "0x289628c5fa503e60838930880925807314bdb08e49dab41d2cb0035fd89a85b3"
+  },
+  "transaction": {
+    "hash": "0xae293444da78703ad63bf2517f8f083770fff67e79dcce72279e0a503748c86c",
+    "raw": "0x02f86e8221055e830f4240838b04eb826aa494a2baf0592072bd884d0b2ece27f88c29ec18dd1b843b9aca0080c001a0e046d4b6295ce98ad0bcd8ece87deb34c49db3b34e38359b5095252000b99329a03b6bcd33274e14607f3362ccc1cb9d0ea10d5de2ec2a7e468adc0cf873e18cb4",
+    "from": "0x89583a150b8c7f6b3405e3aa35a03dd77bd806b4",
+    "to": "0xa2baf0592072bd884d0b2ece27f88c29ec18dd1b",
+    "value": "0x3b9aca00"
+  },
+  "parent_state": {
+    "caller_balance": "0x1fc9c3b78abf",
+    "caller_nonce": "0x5e",
+    "recipient_balance": "0x301f3fc354906b1",
+    "recipient_code": "0x",
+    "l1_block_info_storage": [
+      ["0x1", "0x0000000000000000000000000000000000000000000000000000000006b6114e"],
+      ["0x3", "0x00000000000000000000000000000000000008dd00101c120000000000000000"],
+      ["0x7", "0x000000000000000000000000000000000000000000000000000000000052ca80"],
+      ["0x8", "0x0000000000000000000000000000000000000094000000000000000000000000"]
+    ]
+  },
+  "expected": {
+    "status": true,
+    "gas_used": "0x5208",
+    "effective_gas_price": "0x5b8d80",
+    "l1_gas_used": "0x640",
+    "l1_fee": "0x3a82088e",
+    "log_count": 0
+  }
+}

--- a/crates/evm/coverage/Cargo.toml
+++ b/crates/evm/coverage/Cargo.toml
@@ -29,4 +29,5 @@ solar.workspace = true
 [features]
 default = ["optimism"]
 monad = ["foundry-evm-core/monad"]
+base = ["foundry-common/base", "foundry-evm-core/base"]
 optimism = ["foundry-common/optimism", "foundry-evm-core/optimism"]

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -76,6 +76,17 @@ monad = [
     "foundry-evm-fuzz/monad",
     "foundry-evm-traces/monad",
 ]
+base = [
+    "foundry-cheatcodes/base",
+    "foundry-common/base",
+    "foundry-config/base",
+    "foundry-evm-core/base",
+    "foundry-evm-coverage/base",
+    "foundry-evm-fuzz/base",
+    "foundry-evm-hardforks/base",
+    "foundry-evm-networks/base",
+    "foundry-evm-traces/base",
+]
 optimism = [
     "foundry-evm-core/optimism",
     "foundry-evm-hardforks/optimism",

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -13,6 +13,9 @@ use foundry_evm_core::{
 use foundry_evm_networks::NetworkConfigs;
 use revm::context::{Block, Transaction};
 
+#[cfg(feature = "base")]
+use foundry_evm_core::evm::BaseEvmNetwork;
+
 #[cfg(feature = "monad")]
 use foundry_evm_core::{constants::MONAD_CHEATCODE_ADDRESS, evm::MonadEvmNetwork};
 
@@ -127,6 +130,15 @@ impl<FEN: FoundryEvmNetwork> ExecutorBuilder<FEN> {
 
 impl ExecutorBuilder<EthEvmNetwork> {
     /// Creates the default Ethereum executor builder.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "base")]
+impl ExecutorBuilder<BaseEvmNetwork> {
+    /// Creates the default Base executor builder.
     #[inline]
     pub fn new() -> Self {
         Self::default()

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -970,6 +970,18 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         target_tx_env: TxEnvFor<FEN>,
         replay: Vec<(B256, TxEnvFor<FEN>)>,
     ) -> eyre::Result<RawCallResult<FEN>> {
+        // EIP-8130 requires phase-aware execution and has no ordinary call/create kind.
+        // Check the entire prefix before executing anything or accessing ordinary tx fields.
+        eyre::ensure!(
+            target_tx_env.tx_type() != 0x79,
+            "EIP-8130 target transactions are not supported by tooling replay"
+        );
+        for (hash, tx) in &replay {
+            eyre::ensure!(
+                tx.tx_type() != 0x79,
+                "EIP-8130 prefix transaction {hash} is not supported by tooling replay"
+            );
+        }
         let block_number = evm_env.block_env.number();
         let mut stack = self.inspector().clone();
         let sancov_edges = stack.inner.sancov_edges;
@@ -1969,6 +1981,9 @@ mod tests {
     use revm::context::{CfgEnv, TxEnv};
     use std::{sync::mpsc, thread};
 
+    #[cfg(feature = "base")]
+    use foundry_evm_core::evm::BaseEvmNetwork;
+
     #[cfg(feature = "monad")]
     use foundry_evm_core::constants::MONAD_CHEATCODE_ADDRESS;
 
@@ -2117,6 +2132,64 @@ mod tests {
 
         let err = raw.into_evm_error(None);
         assert!(matches!(err, EvmError::Execution(_)));
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn base_block_replay_rejects_eip8130_before_execution() {
+        for target_is_eip8130 in [true, false] {
+            let mut executor = ExecutorBuilder::<BaseEvmNetwork>::new().build(
+                EvmEnvFor::<BaseEvmNetwork>::default(),
+                TxEnvFor::<BaseEvmNetwork>::default(),
+                Backend::spawn(None).unwrap(),
+                NetworkConfigs::with_base(),
+            );
+            let unsupported = TxEnvFor::<BaseEvmNetwork> {
+                eip8130: Some(
+                    serde_json::from_value(serde_json::json!({
+                        "signed": {
+                            "tx": {
+                                "chainId": 8453, "sender": null, "nonceKey": "0x0",
+                                "nonceSequence": 0, "validAfter": 0, "validBefore": 0,
+                                "maxPriorityFeePerGas": "0x0", "maxFeePerGas": "0x0",
+                                "gasLimit": 100000, "accountChanges": [], "calls": [],
+                                "metadata": "0x", "payer": null
+                            },
+                            "senderAuth": "0x", "payerAuth": "0x"
+                        },
+                        "mode": "Verified", "simulation_sender_actor_id": null
+                    }))
+                    .unwrap(),
+                ),
+                ..Default::default()
+            };
+            let ordinary = TxEnvFor::<BaseEvmNetwork>::default();
+            let hash = B256::repeat_byte(1);
+            let (target, prefix, expected) = if target_is_eip8130 {
+                (
+                    unsupported,
+                    vec![(hash, ordinary)],
+                    "EIP-8130 target transactions are not supported by tooling replay".to_string(),
+                )
+            } else {
+                (
+                    ordinary.clone(),
+                    vec![(B256::ZERO, ordinary), (hash, unsupported)],
+                    format!(
+                        "EIP-8130 prefix transaction {hash} is not supported by tooling replay"
+                    ),
+                )
+            };
+            let error = executor
+                .transact_with_ordinary_block_replay(
+                    EvmEnvFor::<BaseEvmNetwork>::default(),
+                    target,
+                    prefix,
+                )
+                .unwrap_err();
+            assert_eq!(error.to_string(), expected);
+            assert_eq!(executor.get_nonce(Address::ZERO).unwrap(), 0);
+        }
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -252,6 +252,11 @@ mod tests {
     use foundry_evm_core::{FoundryTransaction, evm::EthEvmNetwork};
     use revm::context::Transaction;
 
+    #[cfg(feature = "base")]
+    use foundry_evm_core::evm::BaseEvmNetwork;
+    #[cfg(feature = "base")]
+    use foundry_evm_hardforks::{BaseSpecId, BaseUpgrade};
+
     fn assert_trace_spec_authority<FEN>(
         networks: NetworkConfigs,
         configured: FoundryHardfork,
@@ -306,6 +311,18 @@ mod tests {
             EvmVersion::Cancun,
             spec,
             Some(spec.into()),
+        );
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn trace_spec_base_override_reports_executed_hardfork() {
+        assert_trace_spec_authority::<BaseEvmNetwork>(
+            NetworkConfigs::with_base(),
+            FoundryHardfork::Base(BaseUpgrade::Cobalt),
+            EvmVersion::Cancun,
+            BaseSpecId::new(BaseUpgrade::Ecotone),
+            Some(FoundryHardfork::Base(BaseUpgrade::Ecotone)),
         );
     }
 

--- a/crates/evm/fuzz/Cargo.toml
+++ b/crates/evm/fuzz/Cargo.toml
@@ -54,6 +54,12 @@ tracing.workspace = true
 [features]
 default = ["optimism"]
 monad = ["foundry-evm-core/monad"]
+base = [
+    "foundry-common/base",
+    "foundry-evm-core/base",
+    "foundry-evm-coverage/base",
+    "foundry-evm-traces/base",
+]
 optimism = [
     "foundry-common/optimism",
     "foundry-evm-core/optimism",

--- a/crates/evm/hardforks/Cargo.toml
+++ b/crates/evm/hardforks/Cargo.toml
@@ -19,6 +19,8 @@ alloy-hardforks = { workspace = true, features = ["serde"] }
 alloy-op-hardforks = { workspace = true, features = ["serde"], optional = true }
 alloy-rpc-types.workspace = true
 monad-revm = { workspace = true, optional = true }
+base-common-genesis = { workspace = true, optional = true }
+base-common-evm = { workspace = true, optional = true }
 op-revm = { workspace = true, optional = true }
 revm.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -28,4 +30,5 @@ foundry-compilers.workspace = true
 [features]
 default = ["optimism"]
 monad = ["dep:monad-revm"]
+base = ["dep:base-common-genesis", "dep:base-common-evm"]
 optimism = ["dep:alloy-op-hardforks", "dep:op-revm"]

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -19,6 +19,11 @@ use op_revm::OpSpecId;
 pub use alloy_hardforks::EthereumHardfork;
 pub use tempo_hardfork::TempoHardfork;
 
+#[cfg(feature = "base")]
+pub use base_common_evm::BaseSpecId;
+#[cfg(feature = "base")]
+pub use base_common_genesis::BaseUpgrade;
+
 #[cfg(feature = "monad")]
 pub use monad_revm::MonadHardfork;
 
@@ -31,6 +36,8 @@ pub enum FoundryHardfork {
     Ethereum(EthereumHardfork),
     #[cfg(feature = "optimism")]
     Optimism(OpHardfork),
+    #[cfg(feature = "base")]
+    Base(BaseUpgrade),
     Tempo(TempoHardfork),
     #[cfg(feature = "monad")]
     Monad(MonadHardfork),
@@ -42,6 +49,8 @@ impl From<FoundryHardfork> for String {
             FoundryHardfork::Ethereum(h) => format!("{h}"),
             #[cfg(feature = "optimism")]
             FoundryHardfork::Optimism(h) => format!("optimism:{h}"),
+            #[cfg(feature = "base")]
+            FoundryHardfork::Base(h) => format!("base:{h}"),
             FoundryHardfork::Tempo(h) => format!("tempo:{h}"),
             #[cfg(feature = "monad")]
             FoundryHardfork::Monad(h) => format!("monad:{h}"),
@@ -84,6 +93,11 @@ impl FromStr for FoundryHardfork {
                 .map(Self::Optimism)
                 .map_err(|_| format!("unknown optimism hardfork '{fork_raw}'")),
 
+            #[cfg(feature = "base")]
+            "base" => BaseUpgrade::from_str(&fork)
+                .map(Self::Base)
+                .map_err(|_| format!("unknown base hardfork '{fork_raw}'")),
+
             "t" | "tempo" => TempoHardfork::from_str(&fork)
                 .map(Self::Tempo)
                 .map_err(|_| format!("unknown tempo hardfork '{fork_raw}'")),
@@ -109,6 +123,11 @@ impl FoundryHardfork {
         Self::Optimism(h)
     }
 
+    #[cfg(feature = "base")]
+    pub const fn base(h: BaseUpgrade) -> Self {
+        Self::Base(h)
+    }
+
     pub const fn tempo(h: TempoHardfork) -> Self {
         Self::Tempo(h)
     }
@@ -124,6 +143,8 @@ impl FoundryHardfork {
             Self::Ethereum(h) => format!("{h}"),
             #[cfg(feature = "optimism")]
             Self::Optimism(h) => format!("{h}"),
+            #[cfg(feature = "base")]
+            Self::Base(h) => format!("{h}"),
             Self::Tempo(h) => format!("{h}"),
             #[cfg(feature = "monad")]
             Self::Monad(h) => format!("{h}"),
@@ -138,6 +159,8 @@ impl FoundryHardfork {
             Self::Ethereum(_) => None,
             #[cfg(feature = "optimism")]
             Self::Optimism(_) => Some("optimism"),
+            #[cfg(feature = "base")]
+            Self::Base(_) => Some("base"),
             Self::Tempo(_) => Some("tempo"),
             #[cfg(feature = "monad")]
             Self::Monad(_) => Some("monad"),
@@ -151,6 +174,10 @@ impl FoundryHardfork {
         let chain = Chain::from_id(chain_id);
         if let Some(fork) = EthereumHardfork::from_chain_and_timestamp(chain, timestamp) {
             return Some(Self::Ethereum(fork));
+        }
+        #[cfg(feature = "base")]
+        if let Some(fork) = BaseUpgrade::from_chain_and_timestamp(chain_id, timestamp) {
+            return Some(Self::Base(fork));
         }
         #[cfg(feature = "optimism")]
         if let Some(fork) = OpHardfork::from_chain_and_timestamp(chain, timestamp) {
@@ -199,6 +226,33 @@ impl From<FoundryHardfork> for OpHardfork {
     }
 }
 
+#[cfg(feature = "base")]
+impl From<BaseUpgrade> for FoundryHardfork {
+    fn from(value: BaseUpgrade) -> Self {
+        Self::Base(value)
+    }
+}
+
+#[cfg(feature = "base")]
+impl From<FoundryHardfork> for BaseUpgrade {
+    fn from(fork: FoundryHardfork) -> Self {
+        match fork {
+            FoundryHardfork::Base(upgrade) => upgrade,
+            _ => Self::default(),
+        }
+    }
+}
+
+#[cfg(feature = "base")]
+impl From<FoundryHardfork> for BaseSpecId {
+    fn from(fork: FoundryHardfork) -> Self {
+        match fork {
+            FoundryHardfork::Base(upgrade) => Self::new(upgrade),
+            _ => Self::default(),
+        }
+    }
+}
+
 impl From<TempoHardfork> for FoundryHardfork {
     fn from(value: TempoHardfork) -> Self {
         Self::Tempo(value)
@@ -237,6 +291,8 @@ impl From<FoundryHardfork> for SpecId {
             FoundryHardfork::Ethereum(hardfork) => spec_id_from_ethereum_hardfork(hardfork),
             #[cfg(feature = "optimism")]
             FoundryHardfork::Optimism(hardfork) => eth_spec_id_from_optimism_hardfork(hardfork),
+            #[cfg(feature = "base")]
+            FoundryHardfork::Base(hardfork) => BaseSpecId::new(hardfork).into_eth_spec(),
             FoundryHardfork::Tempo(hardfork) => spec_id_from_tempo_hardfork(hardfork),
             #[cfg(feature = "monad")]
             FoundryHardfork::Monad(hardfork) => hardfork.into(),
@@ -460,6 +516,11 @@ impl ExecutionSpec for OpSpecId {
             _ => None,
         }
     }
+
+    fn historical_hardfork(chain_id: u64, timestamp: u64) -> Option<FoundryHardfork> {
+        OpHardfork::from_chain_and_timestamp(Chain::from_id(chain_id), timestamp)
+            .map(FoundryHardfork::Optimism)
+    }
 }
 
 impl FromEvmVersion for TempoHardfork {
@@ -522,6 +583,54 @@ impl ExecutionSpec for MonadHardfork {
 
     fn reported_hardfork(self) -> Option<FoundryHardfork> {
         Some(self.into())
+    }
+}
+
+#[cfg(feature = "base")]
+impl FromEvmVersion for BaseSpecId {
+    fn from_evm_version(version: EvmVersion) -> Self {
+        let upgrade = match version {
+            EvmVersion::Homestead
+            | EvmVersion::TangerineWhistle
+            | EvmVersion::SpuriousDragon
+            | EvmVersion::Byzantium
+            | EvmVersion::Constantinople
+            | EvmVersion::Petersburg
+            | EvmVersion::Istanbul
+            | EvmVersion::Berlin
+            | EvmVersion::London
+            | EvmVersion::Paris => BaseUpgrade::Bedrock,
+            EvmVersion::Shanghai => BaseUpgrade::Canyon,
+            EvmVersion::Cancun => BaseUpgrade::Ecotone,
+            EvmVersion::Prague => BaseUpgrade::Isthmus,
+            EvmVersion::Osaka | EvmVersion::Amsterdam => BaseUpgrade::Azul,
+        };
+        Self::new(upgrade)
+    }
+}
+
+#[cfg(feature = "base")]
+impl ExecutionSpec for BaseSpecId {
+    // Returns the user-facing name for the active execution spec.
+    fn evm_version_name(&self) -> String {
+        self.to_string()
+    }
+
+    // Parses an unnamespaced Base hardfork name.
+    fn from_network_hardfork(hardfork: &str) -> Option<Self> {
+        Self::from_str(hardfork).ok()
+    }
+
+    // Converts only Base namespaced hardforks to a Base spec.
+    fn from_foundry_hardfork(hardfork: FoundryHardfork) -> Option<Self> {
+        match hardfork {
+            FoundryHardfork::Base(hardfork) => Some(Self::new(hardfork)),
+            _ => None,
+        }
+    }
+
+    fn reported_hardfork(self) -> Option<FoundryHardfork> {
+        Some(FoundryHardfork::Base(self.upgrade()))
     }
 }
 
@@ -843,9 +952,96 @@ mod tests {
         assert_eq!(FoundryHardfork::from_chain_and_timestamp(999999, 0), None);
     }
 
+    #[cfg(feature = "base")]
+    mod base {
+        use super::*;
+        use base_common_genesis::UpgradeConfig;
+
+        #[test]
+        fn test_base_hardfork_serialization() {
+            assert_eq!(String::from(FoundryHardfork::Base(BaseUpgrade::Azul)), "base:Azul");
+            assert_eq!(FoundryHardfork::Base(BaseUpgrade::Azul).namespace(), Some("base"));
+            assert_eq!(FoundryHardfork::Base(BaseUpgrade::Azul).name(), "Azul");
+        }
+
+        #[test]
+        fn test_base_hardfork_spec_id_mapping() {
+            assert_eq!(SpecId::from(FoundryHardfork::Base(BaseUpgrade::Azul)), SpecId::OSAKA);
+            assert_eq!(SpecId::from(FoundryHardfork::Base(BaseUpgrade::Jovian)), SpecId::PRAGUE);
+            assert_eq!(
+                BaseSpecId::from(FoundryHardfork::Base(BaseUpgrade::Azul)),
+                BaseSpecId::new(BaseUpgrade::Azul)
+            );
+        }
+
+        #[test]
+        fn test_base_hardfork_parsing() {
+            assert_eq!(
+                "base:Azul".parse::<FoundryHardfork>().unwrap(),
+                FoundryHardfork::Base(BaseUpgrade::Azul)
+            );
+            assert_eq!(
+                "base:Beryl".parse::<FoundryHardfork>().unwrap(),
+                FoundryHardfork::Base(BaseUpgrade::Beryl)
+            );
+        }
+
+        #[test]
+        fn test_base_hardfork_from_chain_and_timestamp() {
+            let mainnet_config = UpgradeConfig::BASE_MAINNET;
+            let sepolia_config = UpgradeConfig::BASE_SEPOLIA;
+            assert_eq!(
+                FoundryHardfork::from_chain_and_timestamp(8453, u64::MAX),
+                Some(FoundryHardfork::Base(BaseUpgrade::Beryl))
+            );
+            assert_eq!(
+                FoundryHardfork::from_chain_and_timestamp(84532, u64::MAX),
+                Some(FoundryHardfork::Base(BaseUpgrade::Beryl))
+            );
+            assert_eq!(
+                FoundryHardfork::from_chain_and_timestamp(8453, mainnet_config.base.azul.unwrap()),
+                Some(FoundryHardfork::Base(BaseUpgrade::Azul))
+            );
+            assert_eq!(
+                FoundryHardfork::from_chain_and_timestamp(84532, sepolia_config.base.azul.unwrap()),
+                Some(FoundryHardfork::Base(BaseUpgrade::Azul))
+            );
+            assert_eq!(
+                FoundryHardfork::from_chain_and_timestamp(
+                    8453,
+                    mainnet_config.base.azul.unwrap() - 1
+                ),
+                Some(FoundryHardfork::Base(BaseUpgrade::Jovian))
+            );
+            assert_eq!(
+                FoundryHardfork::from_chain_and_timestamp(
+                    84532,
+                    sepolia_config.base.azul.unwrap() - 1
+                ),
+                Some(FoundryHardfork::Base(BaseUpgrade::Jovian))
+            );
+        }
+
+        #[test]
+        fn test_evm_spec_id_from_str_parses_base_upgrades() {
+            assert_eq!(
+                evm_spec_id_from_str::<BaseSpecId>("Azul"),
+                Some(BaseSpecId::new(BaseUpgrade::Azul))
+            );
+            assert_eq!(
+                evm_spec_id_from_str::<BaseSpecId>("base:Beryl"),
+                Some(BaseSpecId::new(BaseUpgrade::Beryl))
+            );
+            assert_eq!(evm_spec_id_from_str::<BaseSpecId>("tempo:T3"), None);
+        }
+    }
+
     #[cfg(feature = "optimism")]
     mod optimism {
         use super::*;
+
+        #[cfg(feature = "base")]
+        use base_common_genesis::UpgradeConfig;
 
         #[test]
         fn test_optimism_spec_id_mapping() {
@@ -872,6 +1068,37 @@ mod tests {
         }
 
         #[test]
+        #[cfg(feature = "base")]
+        fn test_base_chain_historical_hardfork_is_execution_family_specific() {
+            let chains = [
+                (8453, UpgradeConfig::BASE_MAINNET.ecotone_time.unwrap()),
+                (84532, UpgradeConfig::BASE_SEPOLIA.ecotone_time.unwrap()),
+            ];
+
+            for (chain_id, timestamp) in chains {
+                assert_eq!(
+                    FoundryHardfork::from_chain_and_timestamp(chain_id, timestamp),
+                    Some(FoundryHardfork::Base(BaseUpgrade::Ecotone))
+                );
+                assert_eq!(
+                    BaseSpecId::historical_hardfork(chain_id, timestamp),
+                    Some(FoundryHardfork::Base(BaseUpgrade::Ecotone))
+                );
+                assert_eq!(
+                    OpSpecId::historical_hardfork(chain_id, timestamp),
+                    Some(FoundryHardfork::Optimism(OpHardfork::Ecotone))
+                );
+                assert_eq!(
+                    OpSpecId::fork_hardfork(chain_id, timestamp, None),
+                    Some(FoundryHardfork::Optimism(OpHardfork::Ecotone))
+                );
+            }
+        }
+
+        /// Base is an OP-stack chain, so without the `base` feature its chain IDs must still map
+        /// to an Optimism hardfork rather than resolving to nothing.
+        #[test]
+        #[cfg(not(feature = "base"))]
         fn test_from_chain_and_timestamp_base() {
             let base_chain_id = 8453;
             assert!(matches!(

--- a/crates/evm/networks/Cargo.toml
+++ b/crates/evm/networks/Cargo.toml
@@ -27,6 +27,9 @@ alloy-primitives = { workspace = true, features = [
     "rlp",
 ] }
 
+# Base
+base-common-precompiles = { workspace = true, optional = true, features = ["std"] }
+
 revm = { workspace = true, features = [
     "std",
     "serde",
@@ -51,3 +54,4 @@ serde_json.workspace = true
 default = ["optimism"]
 monad = ["dep:monad-revm", "foundry-evm-hardforks/monad"]
 optimism = ["dep:alloy-op-hardforks", "foundry-evm-hardforks/optimism"]
+base = ["dep:base-common-precompiles", "foundry-evm-hardforks/base"]

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -641,11 +641,11 @@ impl NetworkConfigs {
     /// without rebuilding the instantiated EVM.
     ///
     /// Monad uses a distinct EVM factory and instruction provider, so forks cannot cross the
-    /// Monad boundary. Existing non-Monad fork-source compatibility remains unchanged.
+    /// Monad boundary. Base execution requires a Base source, while existing Ethereum, Optimism,
+    /// and Tempo execution can continue using Base as a state source without switching engines.
     pub const fn supports_fork_source(&self, source: &Self) -> bool {
-        // Base also has its own EVM factory, so its boundary is impassable too.
         #[cfg(feature = "base")]
-        if self.is_base() != source.is_base() {
+        if self.is_base() && !source.is_base() {
             return false;
         }
         self.is_monad() == source.is_monad()
@@ -1219,8 +1219,8 @@ mod tests {
 
     #[test]
     #[cfg(feature = "base")]
-    fn fork_sources_isolate_base() {
-        #[cfg_attr(not(any(feature = "optimism", feature = "monad")), allow(unused_mut))]
+    fn fork_sources_preserve_base_state_source_compatibility() {
+        #[cfg_attr(not(feature = "optimism"), allow(unused_mut))]
         let mut non_base = vec![
             NetworkConfigs::default(),
             NetworkConfigs::with_ethereum(),
@@ -1229,14 +1229,21 @@ mod tests {
         ];
         #[cfg(feature = "optimism")]
         non_base.push(NetworkConfigs::with_optimism());
-        #[cfg(feature = "monad")]
-        non_base.push(NetworkConfigs::with_monad());
-
-        for source in &non_base {
-            assert!(!NetworkConfigs::with_base().supports_fork_source(source));
-            assert!(!source.supports_fork_source(&NetworkConfigs::with_base()));
+        for execution in &non_base {
+            assert!(execution.supports_fork_source(&NetworkConfigs::with_base()));
+            assert!(!NetworkConfigs::with_base().supports_fork_source(execution));
         }
         assert!(NetworkConfigs::with_base().supports_fork_source(&NetworkConfigs::with_base()));
+
+        #[cfg(feature = "monad")]
+        {
+            assert!(
+                !NetworkConfigs::with_monad().supports_fork_source(&NetworkConfigs::with_base())
+            );
+            assert!(
+                !NetworkConfigs::with_base().supports_fork_source(&NetworkConfigs::with_monad())
+            );
+        }
     }
 
     #[test]

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -23,8 +23,6 @@ use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use alloy_primitives::{Address, ChainId, address, map::AddressHashMap};
 use clap::Parser;
-#[cfg(feature = "monad")]
-type MonadHardfork = foundry_evm_hardforks::MonadHardfork;
 use foundry_evm_hardforks::{
     EthereumHardfork, ExecutionSpec, FoundryHardfork, TempoHardfork, latest_active_tempo_hardfork,
 };
@@ -42,8 +40,19 @@ use tempo_contracts::precompiles::{
     VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
 
+#[cfg(feature = "base")]
+use base_common_precompiles::{
+    ActivationRegistryStorage, B20FactoryStorage, NonceManagerStorage, PolicyRegistryStorage,
+    TxContextStorage,
+};
+#[cfg(feature = "base")]
+use foundry_evm_hardforks::BaseUpgrade;
+
 #[cfg(feature = "optimism")]
 use foundry_evm_hardforks::OpHardfork;
+
+#[cfg(feature = "monad")]
+type MonadHardfork = foundry_evm_hardforks::MonadHardfork;
 
 /// The Monad cheatcode handler address.
 pub const MONAD_CHEATCODE_ADDRESS: Address = address!("0xc0FFeeCD43A10e1C2b0De63c6CDCFe5B7d0e0CEA");
@@ -82,6 +91,40 @@ const MONAD_PRECOMPILES: &[(&str, Address)] = &[
     ("MonadStaking", monad_revm::staking::STAKING_ADDRESS),
     ("MonadReserveBalance", monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS),
 ];
+
+#[cfg(feature = "base")]
+const BASE_PRECOMPILES: &[(&str, Address)] = &[
+    ("B20Factory", B20FactoryStorage::ADDRESS),
+    ("ActivationRegistry", ActivationRegistryStorage::ADDRESS),
+    ("PolicyRegistry", PolicyRegistryStorage::ADDRESS),
+    ("TxContext", TxContextStorage::ADDRESS),
+    ("NonceManager", NonceManagerStorage::ADDRESS),
+];
+
+/// All fixed Base precompile addresses.
+#[cfg(feature = "base")]
+pub const BASE_PRECOMPILE_ADDRESSES: &[Address] = &[
+    B20FactoryStorage::ADDRESS,
+    ActivationRegistryStorage::ADDRESS,
+    PolicyRegistryStorage::ADDRESS,
+    TxContextStorage::ADDRESS,
+    NonceManagerStorage::ADDRESS,
+];
+
+/// Fixed Base precompiles that expose at least one function returning no data.
+///
+/// Solidity guards high-level calls to such functions with an `extcodesize` check, which a
+/// code-less account fails in the caller, so these must carry code. Base mainnet plants a one-byte
+/// sentinel on exactly these two. The factory, nonce manager, and transaction context return data
+/// from every function and are code-less on chain, so stubbing them would diverge — a contract
+/// guarding calls with an `isContract` probe would pass locally and revert on Base.
+///
+/// The nonce manager separately receives a stub at Zenith from Base's own
+/// `ensure_eip8130_system_accounts` transition, for EIP-161 state clearing rather than for
+/// `extcodesize`. That transition owns it; this list must not.
+#[cfg(feature = "base")]
+pub const BASE_CODE_SENTINEL_ADDRESSES: &[Address] =
+    &[ActivationRegistryStorage::ADDRESS, PolicyRegistryStorage::ADDRESS];
 
 /// BSC secp256r1 precompile address introduced by the Haber hardfork.
 const BSC_P256_ADDRESS: Address = address!("0000000000000000000000000000000000000100");
@@ -130,6 +173,8 @@ pub const TEMPO_PRECOMPILE_ADDRESSES: &[Address] = &[
 pub enum NetworkVariant {
     #[default]
     Ethereum,
+    #[cfg(feature = "base")]
+    Base,
     #[cfg(feature = "optimism")]
     Optimism,
     Tempo,
@@ -152,6 +197,8 @@ impl std::str::FromStr for NetworkVariant {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "ethereum" => Ok(Self::Ethereum),
+            #[cfg(feature = "base")]
+            "base" => Ok(Self::Base),
             #[cfg(feature = "optimism")]
             "optimism" => Ok(Self::Optimism),
             "tempo" => Ok(Self::Tempo),
@@ -176,6 +223,14 @@ impl NetworkVariant {
         if matches!(chain.named(), Some(NamedChain::Celo | NamedChain::CeloSepolia)) {
             return Ok(Some(Self::Ethereum));
         }
+        // Only claim Base when the feature is on. `is_optimism()` below already covers Base chain
+        // IDs, and that is what shipped binaries resolve them to today, so erroring here would
+        // regress builds that never asked for Base. Monad errors instead because no shipped EVM
+        // approximates it.
+        #[cfg(feature = "base")]
+        if matches!(chain.named(), Some(NamedChain::Base | NamedChain::BaseSepolia)) {
+            return Ok(Some(Self::Base));
+        }
         if matches!(chain.named(), Some(NamedChain::Monad | NamedChain::MonadTestnet)) {
             #[cfg(feature = "monad")]
             return Ok(Some(Self::Monad));
@@ -195,6 +250,10 @@ impl NetworkVariant {
     pub fn from_node_info_name(network: &str) -> Result<Self, String> {
         match network {
             "ethereum" => Ok(Self::Ethereum),
+            #[cfg(feature = "base")]
+            "base" => Ok(Self::Base),
+            #[cfg(not(feature = "base"))]
+            "base" => Err("network family `base` is not enabled in this build".to_string()),
             #[cfg(feature = "optimism")]
             "optimism" => Ok(Self::Optimism),
             #[cfg(not(feature = "optimism"))]
@@ -272,12 +331,22 @@ impl NetworkVariant {
             Self::Monad => MonadHardfork::from_chain_and_timestamp(chain_id, timestamp)
                 .unwrap_or_default()
                 .into(),
+            #[cfg(feature = "base")]
+            Self::Base => BaseUpgrade::from_chain_and_timestamp(chain_id, timestamp)
+                .unwrap_or_default()
+                .into(),
         }
     }
 
     /// Returns `true` if this is the Ethereum network variant.
     pub const fn is_ethereum(&self) -> bool {
         matches!(self, Self::Ethereum)
+    }
+
+    /// Returns `true` if this is the Base network variant.
+    #[cfg(feature = "base")]
+    pub const fn is_base(&self) -> bool {
+        matches!(self, Self::Base)
     }
 
     /// Returns `true` if this is the Optimism network variant.
@@ -313,6 +382,8 @@ impl NetworkVariant {
     pub const fn name(&self) -> &'static str {
         match self {
             Self::Ethereum => "ethereum",
+            #[cfg(feature = "base")]
+            Self::Base => "base",
             #[cfg(feature = "optimism")]
             Self::Optimism => "optimism",
             Self::Tempo => "tempo",
@@ -325,6 +396,8 @@ impl NetworkVariant {
     pub const fn hardfork_namespace(&self) -> Option<&'static str> {
         match self {
             Self::Ethereum => None,
+            #[cfg(feature = "base")]
+            Self::Base => Some("base"),
             #[cfg(feature = "optimism")]
             Self::Optimism => Some("optimism"),
             Self::Tempo => Some("tempo"),
@@ -390,9 +463,8 @@ pub struct NetworkConfigs {
 }
 
 // Custom `Serialize` impl: always emits the *resolved* network as the canonical
-// `network = "..."` field, and never emits the legacy `tempo` / `optimism` / `monad` aliases.
-// This avoids confusing output like `network = "monad"` next to `monad = false`, and ensures
-// legacy aliases in foundry.toml round-trip as canonical network values.
+// `network = "..."` field, and never emits legacy network aliases. This avoids contradictory
+// canonical and legacy selectors, and ensures old foundry.toml keys round-trip canonically.
 impl Serialize for NetworkConfigs {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
@@ -459,6 +531,11 @@ impl NetworkConfigs {
         Self { network: Some(NetworkVariant::Monad), monad: true, ..Default::default() }
     }
 
+    #[cfg(feature = "base")]
+    pub fn with_base() -> Self {
+        Self { network: Some(NetworkVariant::Base), ..Default::default() }
+    }
+
     pub const fn is_tempo(&self) -> bool {
         if let Some(network) = self.resolved_network() { network.is_tempo() } else { false }
     }
@@ -480,6 +557,11 @@ impl NetworkConfigs {
         false
     }
 
+    #[cfg(feature = "base")]
+    pub const fn is_base(&self) -> bool {
+        matches!(self.resolved_network(), Some(NetworkVariant::Base))
+    }
+
     /// Coerces `hardfork` into this network's family.
     ///
     /// Execution and fee rules apply the same lossy `From` conversions, so a cross-namespace
@@ -493,6 +575,10 @@ impl NetworkConfigs {
         #[cfg(feature = "monad")]
         if self.is_monad() {
             return MonadHardfork::from(hardfork).into();
+        }
+        #[cfg(feature = "base")]
+        if self.is_base() {
+            return BaseUpgrade::from(hardfork).into();
         }
         hardfork
     }
@@ -557,6 +643,11 @@ impl NetworkConfigs {
     /// Monad uses a distinct EVM factory and instruction provider, so forks cannot cross the
     /// Monad boundary. Existing non-Monad fork-source compatibility remains unchanged.
     pub const fn supports_fork_source(&self, source: &Self) -> bool {
+        // Base also has its own EVM factory, so its boundary is impassable too.
+        #[cfg(feature = "base")]
+        if self.is_base() != source.is_base() {
+            return false;
+        }
         self.is_monad() == source.is_monad()
     }
 
@@ -567,20 +658,24 @@ impl NetworkConfigs {
 
     /// Returns the base fee parameters for the configured network.
     ///
-    /// For Optimism networks, returns Canyon parameters if the Canyon hardfork is active
-    /// at the given timestamp, otherwise returns pre-Canyon parameters.
-    #[cfg(feature = "optimism")]
+    /// For OP Stack networks, returns Canyon parameters if the Canyon hardfork is active at the
+    /// given timestamp, otherwise returns pre-Canyon parameters.
     pub fn base_fee_params(&self, timestamp: u64) -> BaseFeeParams {
+        #[cfg(feature = "base")]
+        if self.is_base() {
+            let canyon_active =
+                BaseUpgrade::from_chain_and_timestamp(NamedChain::Base as u64, timestamp)
+                    .is_some_and(|upgrade| upgrade >= BaseUpgrade::Canyon);
+            return if canyon_active {
+                BaseFeeParams::new(250, 6)
+            } else {
+                BaseFeeParams::new(50, 6)
+            };
+        }
+        #[cfg(feature = "optimism")]
         if self.is_optimism() {
             return self.op_base_fee_params(timestamp);
         }
-        BaseFeeParams::ethereum()
-    }
-
-    /// Returns the base fee parameters for the configured network.
-    #[cfg(not(feature = "optimism"))]
-    pub const fn base_fee_params(&self, timestamp: u64) -> BaseFeeParams {
-        let _ = timestamp;
         BaseFeeParams::ethereum()
     }
 
@@ -596,6 +691,10 @@ impl NetworkConfigs {
         parent_blob_gas_used: u64,
         parent_base_fee: u64,
     ) -> u64 {
+        #[cfg(feature = "base")]
+        if self.is_base() {
+            return 0;
+        }
         if self.is_optimism() {
             return 0;
         }
@@ -774,6 +873,8 @@ impl NetworkConfigs {
         let network = match hardfork {
             FoundryHardfork::Ethereum(_) => self,
             FoundryHardfork::Tempo(_) => Self::with_tempo(),
+            #[cfg(feature = "base")]
+            FoundryHardfork::Base(_) => Self::with_base(),
             #[cfg(feature = "optimism")]
             FoundryHardfork::Optimism(_) => Self::with_optimism(),
             #[cfg(feature = "monad")]
@@ -828,6 +929,23 @@ impl NetworkConfigs {
                     .map(|(label, address)| (address, label.to_string())),
             );
         }
+        #[cfg(feature = "base")]
+        if self.is_base() {
+            let base_upgrade = hardfork.and_then(|hardfork| match hardfork {
+                FoundryHardfork::Base(upgrade) => Some(upgrade),
+                _ => None,
+            });
+            labels.extend(
+                BASE_PRECOMPILES
+                    .iter()
+                    .copied()
+                    .filter(|(_, address)| {
+                        base_upgrade
+                            .is_none_or(|upgrade| is_base_precompile_active_at(*address, upgrade))
+                    })
+                    .map(|(label, address)| (address, label.to_string())),
+            );
+        }
         labels
     }
 
@@ -867,6 +985,23 @@ impl NetworkConfigs {
                     .map(|(label, address)| (label.to_string(), address)),
             );
         }
+        #[cfg(feature = "base")]
+        if self.is_base() {
+            let base_upgrade = hardfork.and_then(|hardfork| match hardfork {
+                FoundryHardfork::Base(upgrade) => Some(upgrade),
+                _ => None,
+            });
+            precompiles.extend(
+                BASE_PRECOMPILES
+                    .iter()
+                    .copied()
+                    .filter(|(_, address)| {
+                        base_upgrade
+                            .is_none_or(|upgrade| is_base_precompile_active_at(*address, upgrade))
+                    })
+                    .map(|(label, address)| (label.to_string(), address)),
+            );
+        }
         precompiles
     }
 }
@@ -898,6 +1033,8 @@ impl From<NetworkVariant> for NetworkConfigs {
             NetworkVariant::Monad => {
                 Self { network: Some(network), monad: true, ..Default::default() }
             }
+            #[cfg(feature = "base")]
+            NetworkVariant::Base => Self { network: Some(network), ..Default::default() },
             #[cfg(feature = "optimism")]
             NetworkVariant::Optimism => {
                 Self { network: Some(network), optimism: true, ..Default::default() }
@@ -939,6 +1076,12 @@ pub fn resolved_precompile_labels(hardfork: Option<FoundryHardfork>) -> AddressH
             .filter(|(_, address)| is_monad_precompile_active_at(*address, hardfork))
             .map(|(label, address)| (*address, (*label).to_string()))
             .collect(),
+        #[cfg(feature = "base")]
+        Some(FoundryHardfork::Base(upgrade)) => BASE_PRECOMPILES
+            .iter()
+            .filter(|(_, address)| is_base_precompile_active_at(*address, upgrade))
+            .map(|(label, address)| (*address, (*label).to_string()))
+            .collect(),
         _ => AddressHashMap::default(),
     }
 }
@@ -974,6 +1117,34 @@ pub fn is_monad_precompile_active_at(address: Address, hardfork: MonadHardfork) 
     address == monad_revm::staking::STAKING_ADDRESS
         || (address == monad_revm::reserve_balance::abi::RESERVE_BALANCE_ADDRESS
             && MonadHardfork::MonadNine.is_enabled_in(hardfork))
+}
+
+/// Returns whether a fixed Base precompile is active at `upgrade`.
+#[cfg(feature = "base")]
+pub fn is_base_precompile_active_at(address: Address, upgrade: BaseUpgrade) -> bool {
+    if matches!(address, TxContextStorage::ADDRESS | NonceManagerStorage::ADDRESS) {
+        upgrade >= BaseUpgrade::Cobalt
+    } else if matches!(
+        address,
+        B20FactoryStorage::ADDRESS
+            | ActivationRegistryStorage::ADDRESS
+            | PolicyRegistryStorage::ADDRESS
+    ) {
+        upgrade >= BaseUpgrade::Beryl
+    } else {
+        false
+    }
+}
+
+/// Returns the fixed Base precompiles active at `upgrade`.
+#[cfg(feature = "base")]
+pub fn active_base_precompiles(
+    upgrade: BaseUpgrade,
+) -> impl Iterator<Item = (&'static str, Address)> {
+    BASE_PRECOMPILES
+        .iter()
+        .copied()
+        .filter(move |(_, address)| is_base_precompile_active_at(*address, upgrade))
 }
 
 #[cfg(test)]
@@ -1014,6 +1185,14 @@ mod tests {
             #[cfg(feature = "monad")]
             assert!(!NetworkVariant::Optimism.is_monad());
         }
+
+        #[cfg(feature = "base")]
+        {
+            assert!(NetworkVariant::Base.is_base());
+            assert!(!NetworkVariant::Base.is_ethereum());
+            assert!(!NetworkVariant::Base.is_optimism());
+            assert!(!NetworkVariant::Base.is_tempo());
+        }
     }
 
     #[test]
@@ -1036,6 +1215,28 @@ mod tests {
             assert!(!NetworkConfigs::with_monad().supports_fork_source(execution));
         }
         assert!(NetworkConfigs::with_monad().supports_fork_source(&NetworkConfigs::with_monad()));
+    }
+
+    #[test]
+    #[cfg(feature = "base")]
+    fn fork_sources_isolate_base() {
+        #[cfg_attr(not(any(feature = "optimism", feature = "monad")), allow(unused_mut))]
+        let mut non_base = vec![
+            NetworkConfigs::default(),
+            NetworkConfigs::with_ethereum(),
+            NetworkConfigs::with_celo(),
+            NetworkConfigs::with_tempo(),
+        ];
+        #[cfg(feature = "optimism")]
+        non_base.push(NetworkConfigs::with_optimism());
+        #[cfg(feature = "monad")]
+        non_base.push(NetworkConfigs::with_monad());
+
+        for source in &non_base {
+            assert!(!NetworkConfigs::with_base().supports_fork_source(source));
+            assert!(!source.supports_fork_source(&NetworkConfigs::with_base()));
+        }
+        assert!(NetworkConfigs::with_base().supports_fork_source(&NetworkConfigs::with_base()));
     }
 
     #[test]
@@ -1456,6 +1657,52 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "base")]
+    #[test]
+    fn base_precompile_labels_follow_upgrade_boundaries() {
+        let config = NetworkConfigs::with_base();
+
+        assert!(config.precompiles_label(Some(BaseUpgrade::Azul.into())).is_empty());
+
+        let beryl = config.precompiles_label(Some(BaseUpgrade::Beryl.into()));
+        assert_eq!(beryl.get(&B20FactoryStorage::ADDRESS), Some(&"B20Factory".to_string()));
+        assert_eq!(
+            beryl.get(&ActivationRegistryStorage::ADDRESS),
+            Some(&"ActivationRegistry".to_string())
+        );
+        assert_eq!(beryl.get(&PolicyRegistryStorage::ADDRESS), Some(&"PolicyRegistry".to_string()));
+        assert!(!beryl.contains_key(&TxContextStorage::ADDRESS));
+        assert!(!beryl.contains_key(&NonceManagerStorage::ADDRESS));
+
+        let cobalt = config.precompiles_label(Some(BaseUpgrade::Cobalt.into()));
+        assert_eq!(cobalt.len(), BASE_PRECOMPILES.len());
+        assert_eq!(config.precompiles_label(None).len(), BASE_PRECOMPILES.len());
+
+        for upgrade in [BaseUpgrade::Azul, BaseUpgrade::Beryl, BaseUpgrade::Cobalt] {
+            assert_eq!(
+                resolved_precompile_labels(Some(upgrade.into())),
+                config.precompiles_label(Some(upgrade.into()))
+            );
+        }
+
+        // The name-keyed precompile map must honor the same upgrade boundaries.
+        assert!(config.precompiles(Some(BaseUpgrade::Azul.into())).is_empty());
+        let beryl = config.precompiles(Some(BaseUpgrade::Beryl.into()));
+        assert_eq!(beryl.get("B20Factory"), Some(&B20FactoryStorage::ADDRESS));
+        assert!(!beryl.contains_key("NonceManager"));
+        assert_eq!(
+            config.precompiles(Some(BaseUpgrade::Cobalt.into())).get("NonceManager"),
+            Some(&NonceManagerStorage::ADDRESS)
+        );
+
+        // A non-Base profile must not pick up Base labels even when an upgrade is supplied.
+        assert!(
+            NetworkConfigs::default()
+                .precompiles_label(Some(BaseUpgrade::Cobalt.into()))
+                .is_empty()
+        );
+    }
+
     #[test]
     fn new_tempo_flag_equivalent_to_legacy() {
         let via_new = NetworkConfigs { network: Some(NetworkVariant::Tempo), ..Default::default() };
@@ -1639,6 +1886,29 @@ mod tests {
         assert!(!cfg.is_optimism());
     }
 
+    /// Base chain IDs resolved to Optimism before Base support existed, and `is_optimism()` still
+    /// covers them, so a build without the `base` feature must keep resolving them rather than
+    /// erroring. Shipped release binaries are exactly that build.
+    #[test]
+    #[cfg(all(not(feature = "base"), feature = "optimism"))]
+    fn chain_id_inference_falls_back_to_optimism_without_base() {
+        for chain_id in [NamedChain::Base as u64, NamedChain::BaseSepolia as u64] {
+            let configs = NetworkConfigs::default()
+                .try_with_chain_id(chain_id)
+                .unwrap_or_else(|error| panic!("chain ID {chain_id} must still resolve: {error}"));
+            assert!(configs.is_optimism(), "chain ID {chain_id} must resolve to Optimism");
+        }
+    }
+
+    #[test]
+    #[cfg(not(feature = "base"))]
+    fn node_info_rejects_disabled_base() {
+        assert_eq!(
+            NetworkVariant::from_node_info_name("base").unwrap_err(),
+            "network family `base` is not enabled in this build"
+        );
+    }
+
     // --- Serde round-trip ---
 
     #[test]
@@ -1792,6 +2062,75 @@ mod tests {
         assert_eq!(NetworkVariant::from(10143), NetworkVariant::Monad);
 
         assert!(NetworkConfigs::default().try_with_chain_id(143).unwrap().is_monad());
+    }
+
+    #[cfg(feature = "base")]
+    mod base {
+        use super::*;
+
+        #[test]
+        fn active_network_name_base() {
+            let cfg = NetworkConfigs::with_base();
+            assert_eq!(cfg.active_network_name(), Some("base"));
+        }
+
+        #[test]
+        fn base_fee_params_follow_canyon_boundary() {
+            const CANYON_TIMESTAMP: u64 = 1_704_992_401;
+
+            let config = NetworkConfigs::with_base();
+            assert_eq!(config.base_fee_params(CANYON_TIMESTAMP - 1), BaseFeeParams::new(50, 6));
+            assert_eq!(config.base_fee_params(CANYON_TIMESTAMP), BaseFeeParams::new(250, 6));
+        }
+
+        #[test]
+        fn base_does_not_inherit_ethereum_blob_excess_gas() {
+            let params = BlobParams::prague();
+            assert_eq!(
+                NetworkConfigs::with_base().next_block_blob_excess_gas(
+                    params,
+                    0,
+                    params.target_blob_gas_per_block() + 1,
+                    1,
+                ),
+                0
+            );
+        }
+
+        #[test]
+        fn serde_roundtrip_base() {
+            let original = NetworkConfigs::with_base();
+            let json = serde_json::to_string(&original).unwrap();
+            let restored: NetworkConfigs = serde_json::from_str(&json).unwrap();
+            assert!(restored.is_base());
+            assert!(!restored.is_tempo());
+        }
+
+        #[test]
+        fn serde_base_field_deserialized() {
+            let json_base = r#"{"network": "base", "celo": false, "bypass_prevrandao": false}"#;
+            let cfg_base: NetworkConfigs = serde_json::from_str(json_base).unwrap();
+            assert!(cfg_base.is_base());
+        }
+
+        #[test]
+        fn chain_id_detects_base_networks() {
+            assert_eq!(NetworkVariant::from(8453), NetworkVariant::Base);
+            assert_eq!(NetworkVariant::from(84532), NetworkVariant::Base);
+            assert!(NetworkConfigs::default().try_with_chain_id(8453).unwrap().is_base());
+            assert_eq!(NetworkVariant::from_node_info_name("base").unwrap(), NetworkVariant::Base);
+        }
+
+        #[test]
+        fn hardfork_infers_base_network() {
+            assert_eq!(
+                NetworkConfigs::default()
+                    .normalize_for_hardfork(FoundryHardfork::Base(BaseUpgrade::Beryl))
+                    .unwrap()
+                    .resolved_network(),
+                Some(NetworkVariant::Base)
+            );
+        }
     }
 
     #[cfg(feature = "optimism")]

--- a/crates/evm/symbolic/Cargo.toml
+++ b/crates/evm/symbolic/Cargo.toml
@@ -38,4 +38,5 @@ wait-timeout.workspace = true
 
 [features]
 default = ["optimism"]
+base = ["foundry-evm/base"]
 optimism = ["foundry-evm/optimism"]

--- a/crates/evm/traces/Cargo.toml
+++ b/crates/evm/traces/Cargo.toml
@@ -37,6 +37,7 @@ revm-inspectors.workspace = true
 tempo-contracts.workspace = true
 tempo-precompiles.workspace = true
 monad-revm = { workspace = true, optional = true }
+base-common-precompiles = { workspace = true, optional = true, features = ["std"] }
 
 async-trait.workspace = true
 eyre.workspace = true
@@ -66,6 +67,13 @@ monad = [
     "foundry-evm-core/monad",
     "foundry-evm-hardforks/monad",
     "foundry-evm-networks/monad",
+]
+base = [
+    "dep:base-common-precompiles",
+    "foundry-common/base",
+    "foundry-evm-core/base",
+    "foundry-evm-hardforks/base",
+    "foundry-evm-networks/base",
 ]
 optimism = [
     "foundry-common/optimism",

--- a/crates/evm/traces/src/decoder/base.rs
+++ b/crates/evm/traces/src/decoder/base.rs
@@ -1,0 +1,684 @@
+//! Base precompile ABIs for trace decoding.
+//!
+//! `base-common-precompiles` declares these interfaces without `#[sol(abi)]`, so it exposes no
+//! [`JsonAbi`](alloy_json_abi::JsonAbi) for `register_address_abi` to consume. These declarations
+//! mirror the canonical ones so traces name Base precompile calls, events, and errors, following
+//! the same approach `super::monad` takes for its staking interfaces.
+//!
+//! The `abi_matches_canonical_selectors` tests below pin every selector against the canonical
+//! types, so an interface change in Base fails here instead of silently decoding traces wrong.
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// Mirror of `base_common_precompiles::IActivationRegistry`.
+    #[sol(abi)]
+    interface IActivationRegistry {
+        event FeatureActivated(bytes32 indexed feature, address indexed caller);
+        event FeatureDeactivated(bytes32 indexed feature, address indexed caller);
+        event AdminChanged(
+            address indexed previousAdmin,
+            address indexed newAdmin,
+            address indexed caller
+        );
+
+        error Unauthorized(address caller);
+        error AlreadyActivated(bytes32 feature);
+        error FeatureNotActivated(bytes32 feature);
+        error DelegateCallNotAllowed();
+        error StaticCallNotAllowed();
+        error NonPayable();
+        error AdminStorageNotEnabled();
+        error ZeroAdminAddress();
+
+        function isActivated(bytes32 feature) external view returns (bool);
+        function checkActivated(bytes32 feature) external view;
+        function admin() external view returns (address);
+        function setAdmin(address newAdmin) external;
+        function activate(bytes32 feature) external;
+        function deactivate(bytes32 feature) external;
+    }
+}
+
+sol! {
+    /// Mirror of `base_common_precompiles::IB20Factory`, the surface frozen at Beryl.
+    #[sol(abi)]
+    interface IB20Factory {
+        enum B20Variant {
+            ASSET,
+            STABLECOIN
+        }
+
+        struct B20StablecoinCreateParams {
+            uint8 version;
+            string name;
+            string symbol;
+            address initialAdmin;
+            string currency;
+        }
+
+        struct B20AssetCreateParams {
+            uint8 version;
+            string name;
+            string symbol;
+            address initialAdmin;
+            uint8 decimals;
+        }
+
+        error NonPayable();
+        error TokenAlreadyExists(address token);
+        error InvalidVariant();
+        error UnsupportedVersion(uint8 version, B20Variant variant);
+        error MissingRequiredField(string field);
+        error InvalidCurrency(string code);
+        error InvalidDecimals(uint8 decimals);
+        error InitCallFailed(uint256 index);
+
+        event B20Created(
+            address indexed token,
+            B20Variant indexed variant,
+            string name,
+            string symbol,
+            uint8 decimals,
+            bytes variantParams
+        );
+
+        struct B20StablecoinEventParams {
+            uint8 version;
+            string currency;
+        }
+
+        function createB20(
+            B20Variant variant,
+            bytes32 salt,
+            bytes calldata params,
+            bytes[] calldata initCalls
+        ) external returns (address token);
+        function getB20Address(B20Variant variant, address sender, bytes32 salt) external view returns (address);
+        function isB20(address token) external view returns (bool);
+        function isB20Initialized(address token) external view returns (bool);
+    }
+}
+
+sol! {
+    /// **Deliberately partial** mirror of `base_common_precompiles::IB20`, the B-20 token surface.
+    ///
+    /// B-20 tokens are created by the factory at derived addresses, so they cannot be registered
+    /// per address like the fixed precompiles. These members are therefore available as a
+    /// Base-only fallback after address-scoped and caller-supplied metadata.
+    ///
+    /// Only Base-specific members belong here. The ERC-20, EIP-2612 and AccessControl portions are
+    /// omitted on purpose: the global function map is not network-scoped, so adding competing
+    /// candidates for `transfer`, `balanceOf`, `approve` or `permit` could change how ordinary
+    /// token traces decode in any Base-enabled build. Foundry already has to order
+    /// `IStorageCredits` against `ITIP20` to keep `balanceOf`'s return type stable, which is the
+    /// same hazard. `b20_surface_excludes_erc20_members` pins this boundary.
+    #[sol(abi)]
+    interface IB20Extensions {
+        enum PausableFeature {
+            TRANSFER,
+            MINT,
+            BURN,
+            SEIZE
+        }
+
+        event Memo(address indexed caller, bytes32 indexed memo);
+        event BurnedBlocked(address indexed caller, address indexed from, uint256 amount);
+        event Seized(address indexed caller, address indexed from, address indexed to, uint256 amount);
+        event LastAdminRenounced(address indexed previousAdmin);
+        event Paused(address indexed updater, PausableFeature[] features);
+        event Unpaused(address indexed updater, PausableFeature[] features);
+        event PolicyUpdated(bytes32 indexed policyScope, uint64 oldPolicyId, uint64 newPolicyId);
+
+        function mintWithMemo(address to, uint256 amount, bytes32 memo) external;
+        function burnWithMemo(uint256 amount, bytes32 memo) external;
+        function burnBlocked(address from, uint256 amount) external;
+        function transferWithMemo(address to, uint256 amount, bytes32 memo) external returns (bool);
+        function seizeWithMemo(address from, address to, uint256 amount, bytes32 memo) external;
+        function pausedFeatures() external view returns (PausableFeature[] memory);
+        function isPaused(PausableFeature feature) external view returns (bool);
+        function pause(PausableFeature[] calldata features) external;
+        function unpause(PausableFeature[] calldata features) external;
+        function policyId(bytes32 policyScope) external view returns (uint64);
+        function updatePolicy(bytes32 policyScope, uint64 newPolicyId) external;
+        function contractURI() external view returns (string);
+        function updateContractURI(string calldata newURI) external;
+    }
+}
+
+sol! {
+    /// Mirror of `base_common_precompiles::IPolicyRegistry`, the canonical Cobalt surface.
+    ///
+    /// Only this surface is mirrored: its call set is a strict superset of Beryl's V1, so it also
+    /// names Beryl-era policy traces. `policy_registry_covers_v1_selectors` pins that.
+    #[sol(abi)]
+    interface IPolicyRegistry {
+        enum PolicyType {
+            BLOCKLIST,
+            ALLOWLIST,
+            UNION,
+            INTERSECT
+        }
+
+        error NonPayable();
+        error Unauthorized();
+        error PolicyNotFound();
+        error IncompatiblePolicyType();
+        error ZeroAddress();
+        error BatchSizeTooLarge(uint256 maxBatchSize);
+        error NoPendingAdmin();
+        error ChildPoliciesOutsideOfRange();
+        error InvalidChildPolicy(uint64 childPolicyId);
+
+        event PolicyCreated(uint64 indexed policyId, address indexed creator, PolicyType policyType);
+        event PolicyAdminStaged(uint64 indexed policyId, address indexed currentAdmin, address indexed pendingAdmin);
+        event PolicyAdminUpdated(uint64 indexed policyId, address indexed previousAdmin, address indexed newAdmin);
+        event AllowlistUpdated(uint64 indexed policyId, address indexed updater, bool allowed, address[] accounts);
+        event BlocklistUpdated(uint64 indexed policyId, address indexed updater, bool blocked, address[] accounts);
+        event CompositePolicyUpdated(uint64 indexed policyId, address indexed updater, uint64[] childPolicyIds);
+
+        function createPolicy(address admin, PolicyType policyType) external returns (uint64);
+        function createPolicyWithAccounts(address admin, PolicyType policyType, address[] calldata accounts) external returns (uint64);
+        function createCompositePolicy(address admin, PolicyType policyType, uint64[] calldata childPolicyIds) external returns (uint64);
+        function updateComposite(uint64 policyId, uint64[] calldata childPolicyIds) external;
+        function stageUpdateAdmin(uint64 policyId, address newAdmin) external;
+        function finalizeUpdateAdmin(uint64 policyId) external;
+        function renounceAdmin(uint64 policyId) external;
+        function updateAllowlist(uint64 policyId, bool allowed, address[] calldata accounts) external;
+        function updateBlocklist(uint64 policyId, bool blocked, address[] calldata accounts) external;
+        function isAuthorized(uint64 policyId, address account) external view returns (bool);
+        function MIN_COMPOSITE_CHILD_POLICIES() external view returns (uint256);
+        function MAX_COMPOSITE_CHILD_POLICIES() external view returns (uint256);
+        function policyExists(uint64 policyId) external view returns (bool);
+        function policyAdmin(uint64 policyId) external view returns (address);
+        function pendingPolicyAdmin(uint64 policyId) external view returns (address);
+        function compositePolicyChildIds(uint64 policyId) external view returns (uint64[] memory);
+    }
+}
+
+sol! {
+    /// Mirror of `base_common_precompiles::INonceManager`.
+    #[sol(abi)]
+    interface INonceManager {
+        error DelegateCallNotAllowed();
+        error NonPayable();
+        error ProtocolNonceNotSupported();
+        error InvalidNonceKey();
+        error NonceOverflow();
+        error InvalidExpiringNonceExpiry();
+        error ExpiringNonceReplay();
+        error ExpiringNonceSetFull();
+
+        event NonceIncremented(address indexed account, uint256 indexed nonceKey, uint64 newNonce);
+
+        function getNonce(address account, uint256 nonceKey) external view returns (uint64);
+    }
+}
+
+sol! {
+    /// Mirror of `base_common_precompiles::ITransactionContext`.
+    #[sol(abi)]
+    interface ITransactionContext {
+        error DelegateCallNotAllowed();
+        error NonPayable();
+
+        function getTransactionSender() external view returns (address);
+        function getTransactionPayer() external view returns (address);
+        function getTransactionSenderActorId() external view returns (bytes32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CallTrace, CallTraceDecoderBuilder};
+    use alloy_dyn_abi::{DynSolValue, FunctionExt};
+    use alloy_primitives::{Address, B256, Bytes, U256};
+    use alloy_sol_types::{SolCall, SolEnum, SolError, SolEvent, SolInterface};
+    use base_common_precompiles::{
+        self as canonical, ActivationRegistryStorage, B20FactoryStorage, NonceManagerStorage,
+        TxContextStorage,
+    };
+    use foundry_evm_hardforks::{BaseUpgrade, FoundryHardfork};
+    use foundry_evm_networks::NetworkConfigs;
+    use revm::interpreter::InstructionResult;
+
+    #[tokio::test]
+    async fn registered_abis_decode_base_precompile_calls() {
+        let decoder = CallTraceDecoderBuilder::new()
+            .with_networks(NetworkConfigs::with_base())
+            .with_hardfork(Some(FoundryHardfork::Base(BaseUpgrade::Cobalt)))
+            .build();
+
+        let activate =
+            super::IActivationRegistry::activateCall { feature: B256::repeat_byte(0x11) };
+        let trace = CallTrace {
+            address: ActivationRegistryStorage::ADDRESS,
+            data: activate.abi_encode().into(),
+            success: true,
+            ..Default::default()
+        };
+        let decoded = decoder.decode_function(&trace).await;
+        assert_eq!(decoded.label.as_deref(), Some("ActivationRegistry"));
+        assert_eq!(
+            decoded.call_data.expect("activate should decode").signature,
+            "activate(bytes32)"
+        );
+
+        let get_nonce = super::INonceManager::getNonceCall {
+            account: Address::repeat_byte(0x22),
+            nonceKey: U256::from(7),
+        };
+        let trace = CallTrace {
+            address: NonceManagerStorage::ADDRESS,
+            data: get_nonce.abi_encode().into(),
+            success: true,
+            ..Default::default()
+        };
+        let decoded = decoder.decode_function(&trace).await;
+        assert_eq!(
+            decoded.call_data.expect("getNonce should decode").signature,
+            "getNonce(address,uint256)"
+        );
+
+        let create = super::IB20Factory::createB20Call {
+            variant: super::IB20Factory::B20Variant::ASSET,
+            salt: B256::repeat_byte(0x33),
+            params: Bytes::new(),
+            initCalls: Vec::new(),
+        };
+        let trace = CallTrace {
+            address: B20FactoryStorage::ADDRESS,
+            data: create.abi_encode().into(),
+            success: true,
+            ..Default::default()
+        };
+        let decoded = decoder.decode_function(&trace).await;
+        assert_eq!(decoded.label.as_deref(), Some("B20Factory"));
+        let signature = decoded.call_data.expect("createB20 should decode").signature;
+        assert!(signature.starts_with("createB20("), "{signature}");
+    }
+
+    #[tokio::test]
+    async fn b20_transfer_with_memo_decodes_bool_output() {
+        let call = super::IB20Extensions::transferWithMemoCall {
+            to: Address::repeat_byte(0x11),
+            amount: U256::from(1),
+            memo: B256::repeat_byte(0x22),
+        };
+        let abi = super::IB20Extensions::abi::contract();
+        let function = abi.functions.get("transferWithMemo").unwrap().first().unwrap();
+        let trace = CallTrace {
+            address: Address::repeat_byte(0x33),
+            data: call.abi_encode().into(),
+            output: function.abi_encode_output(&[DynSolValue::Bool(true)]).unwrap().into(),
+            success: true,
+            ..Default::default()
+        };
+
+        let base =
+            CallTraceDecoderBuilder::new().with_networks(NetworkConfigs::with_base()).build();
+        let decoded = base.decode_function(&trace).await;
+        assert_eq!(
+            decoded.call_data.unwrap().signature,
+            "transferWithMemo(address,uint256,bytes32)"
+        );
+        assert_eq!(decoded.return_data.as_deref(), Some("true"));
+
+        let custom_abi = alloy_json_abi::JsonAbi::parse([
+            "function transferWithMemo(address,uint256,bytes32) returns (uint256)",
+        ])
+        .unwrap();
+        let custom_base = CallTraceDecoderBuilder::new()
+            .with_networks(NetworkConfigs::with_base())
+            .with_abi(&custom_abi)
+            .build();
+        assert_eq!(custom_base.decode_function(&trace).await.return_data.as_deref(), Some("1"));
+
+        let tempo =
+            CallTraceDecoderBuilder::new().with_networks(NetworkConfigs::with_tempo()).build();
+        assert_eq!(tempo.decode_function(&trace).await.return_data, None);
+    }
+
+    #[tokio::test]
+    async fn base_precompile_errors_are_address_scoped() {
+        let trace = CallTrace {
+            address: ActivationRegistryStorage::ADDRESS,
+            output: super::IActivationRegistry::NonPayable {}.abi_encode().into(),
+            success: false,
+            status: Some(InstructionResult::Revert),
+            ..Default::default()
+        };
+        let base = CallTraceDecoderBuilder::new()
+            .with_networks(NetworkConfigs::with_base())
+            .with_hardfork(Some(FoundryHardfork::Base(BaseUpgrade::Beryl)))
+            .build();
+        assert_eq!(base.decode_function(&trace).await.return_data.as_deref(), Some("NonPayable()"));
+
+        let ethereum = CallTraceDecoderBuilder::new()
+            .with_networks(NetworkConfigs::with_ethereum())
+            .with_hardfork(Some(FoundryHardfork::Base(BaseUpgrade::Beryl)))
+            .build();
+        assert_ne!(
+            ethereum.decode_function(&trace).await.return_data.as_deref(),
+            Some("NonPayable()")
+        );
+    }
+
+    /// The transaction-context precompile only exists from Cobalt, so a Beryl decoder must not
+    /// name its calls. This uses a Base-unique selector on purpose: generic names like
+    /// `getNonce(address,uint256)` also exist in Tempo's globally registered nonce ABI and would
+    /// decode regardless of the Base upgrade.
+    #[tokio::test]
+    async fn pre_cobalt_decoder_does_not_register_eip8130_surfaces() {
+        let call = super::ITransactionContext::getTransactionSenderActorIdCall {};
+        let trace = CallTrace {
+            address: TxContextStorage::ADDRESS,
+            data: call.abi_encode().into(),
+            success: true,
+            ..Default::default()
+        };
+
+        let beryl = CallTraceDecoderBuilder::new()
+            .with_networks(NetworkConfigs::with_base())
+            .with_hardfork(Some(FoundryHardfork::Base(BaseUpgrade::Beryl)))
+            .build();
+        assert!(
+            beryl.decode_function(&trace).await.call_data.is_none(),
+            "Beryl must not decode a Cobalt-only precompile"
+        );
+
+        let cobalt = CallTraceDecoderBuilder::new()
+            .with_networks(NetworkConfigs::with_base())
+            .with_hardfork(Some(FoundryHardfork::Base(BaseUpgrade::Cobalt)))
+            .build();
+        assert_eq!(
+            cobalt.decode_function(&trace).await.call_data.expect("Cobalt should decode").signature,
+            "getTransactionSenderActorId()"
+        );
+    }
+
+    #[test]
+    fn activation_registry_abi_matches_canonical_selectors() {
+        assert_eq!(
+            super::IActivationRegistry::activateCall::SELECTOR,
+            canonical::IActivationRegistry::activateCall::SELECTOR
+        );
+        assert_eq!(
+            super::IActivationRegistry::deactivateCall::SELECTOR,
+            canonical::IActivationRegistry::deactivateCall::SELECTOR
+        );
+        assert_eq!(
+            super::IActivationRegistry::isActivatedCall::SELECTOR,
+            canonical::IActivationRegistry::isActivatedCall::SELECTOR
+        );
+        assert_eq!(
+            super::IActivationRegistry::checkActivatedCall::SELECTOR,
+            canonical::IActivationRegistry::checkActivatedCall::SELECTOR
+        );
+        assert_eq!(
+            super::IActivationRegistry::adminCall::SELECTOR,
+            canonical::IActivationRegistry::adminCall::SELECTOR
+        );
+        assert_eq!(
+            super::IActivationRegistry::setAdminCall::SELECTOR,
+            canonical::IActivationRegistry::setAdminCall::SELECTOR
+        );
+        assert_eq!(
+            super::IActivationRegistry::Unauthorized::SELECTOR,
+            canonical::IActivationRegistry::Unauthorized::SELECTOR
+        );
+        assert_eq!(
+            super::IActivationRegistry::StaticCallNotAllowed::SELECTOR,
+            canonical::IActivationRegistry::StaticCallNotAllowed::SELECTOR
+        );
+        assert_eq!(
+            super::IActivationRegistry::NonPayable::SELECTOR,
+            canonical::IActivationRegistry::NonPayable::SELECTOR
+        );
+        assert_eq!(
+            super::IActivationRegistry::FeatureActivated::SIGNATURE_HASH,
+            canonical::IActivationRegistry::FeatureActivated::SIGNATURE_HASH
+        );
+        assert_eq!(
+            super::IActivationRegistry::AdminChanged::SIGNATURE_HASH,
+            canonical::IActivationRegistry::AdminChanged::SIGNATURE_HASH
+        );
+    }
+
+    /// Base pins this surface with an `AbiFingerprint`, but that type is only exported under its
+    /// `test-utils` feature, so this compares against the canonical types directly instead.
+    /// `B20Variant`'s ordinals are asserted explicitly because they are the one thing selectors
+    /// cannot catch: Solidity encodes enums as `uint8`, so a reorder moves no signature, yet the
+    /// ordinal is byte `[10]` of every token address the factory deploys.
+    #[test]
+    fn b20_factory_abi_matches_canonical_surface() {
+        assert_eq!(
+            super::IB20Factory::createB20Call::SELECTOR,
+            canonical::IB20Factory::createB20Call::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Factory::getB20AddressCall::SELECTOR,
+            canonical::IB20Factory::getB20AddressCall::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Factory::isB20Call::SELECTOR,
+            canonical::IB20Factory::isB20Call::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Factory::isB20InitializedCall::SELECTOR,
+            canonical::IB20Factory::isB20InitializedCall::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Factory::TokenAlreadyExists::SELECTOR,
+            canonical::IB20Factory::TokenAlreadyExists::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Factory::UnsupportedVersion::SELECTOR,
+            canonical::IB20Factory::UnsupportedVersion::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Factory::B20Created::SIGNATURE_HASH,
+            canonical::IB20Factory::B20Created::SIGNATURE_HASH
+        );
+
+        assert_eq!(
+            super::IB20Factory::B20Variant::COUNT,
+            canonical::IB20Factory::B20Variant::COUNT
+        );
+        assert_eq!(
+            super::IB20Factory::B20Variant::ASSET as u8,
+            canonical::IB20Factory::B20Variant::ASSET as u8
+        );
+        assert_eq!(
+            super::IB20Factory::B20Variant::STABLECOIN as u8,
+            canonical::IB20Factory::B20Variant::STABLECOIN as u8
+        );
+    }
+
+    /// `PolicyType` ordinals ride the top byte of every policy ID, so they are asserted alongside
+    /// the selectors for the same reason as `B20Variant`.
+    #[test]
+    fn policy_registry_abi_matches_canonical_surface() {
+        assert_eq!(
+            super::IPolicyRegistry::createPolicyCall::SELECTOR,
+            canonical::IPolicyRegistry::createPolicyCall::SELECTOR
+        );
+        assert_eq!(
+            super::IPolicyRegistry::createCompositePolicyCall::SELECTOR,
+            canonical::IPolicyRegistry::createCompositePolicyCall::SELECTOR
+        );
+        assert_eq!(
+            super::IPolicyRegistry::isAuthorizedCall::SELECTOR,
+            canonical::IPolicyRegistry::isAuthorizedCall::SELECTOR
+        );
+        assert_eq!(
+            super::IPolicyRegistry::updateAllowlistCall::SELECTOR,
+            canonical::IPolicyRegistry::updateAllowlistCall::SELECTOR
+        );
+        assert_eq!(
+            super::IPolicyRegistry::InvalidChildPolicy::SELECTOR,
+            canonical::IPolicyRegistry::InvalidChildPolicy::SELECTOR
+        );
+        assert_eq!(
+            super::IPolicyRegistry::PolicyCreated::SIGNATURE_HASH,
+            canonical::IPolicyRegistry::PolicyCreated::SIGNATURE_HASH
+        );
+        assert_eq!(
+            super::IPolicyRegistry::CompositePolicyUpdated::SIGNATURE_HASH,
+            canonical::IPolicyRegistry::CompositePolicyUpdated::SIGNATURE_HASH
+        );
+
+        assert_eq!(
+            super::IPolicyRegistry::PolicyType::COUNT,
+            canonical::IPolicyRegistry::PolicyType::COUNT
+        );
+        for (mirror, expected) in [
+            (
+                super::IPolicyRegistry::PolicyType::BLOCKLIST as u8,
+                canonical::IPolicyRegistry::PolicyType::BLOCKLIST as u8,
+            ),
+            (
+                super::IPolicyRegistry::PolicyType::ALLOWLIST as u8,
+                canonical::IPolicyRegistry::PolicyType::ALLOWLIST as u8,
+            ),
+            (
+                super::IPolicyRegistry::PolicyType::UNION as u8,
+                canonical::IPolicyRegistry::PolicyType::UNION as u8,
+            ),
+            (
+                super::IPolicyRegistry::PolicyType::INTERSECT as u8,
+                canonical::IPolicyRegistry::PolicyType::INTERSECT as u8,
+            ),
+        ] {
+            assert_eq!(mirror, expected);
+        }
+    }
+
+    /// Mirroring only the Cobalt surface is safe because it is a strict superset of Beryl's. If
+    /// Base ever diverges a shared signature, this fails and V1 needs its own mirror.
+    #[test]
+    fn policy_registry_covers_v1_selectors() {
+        let mirrored: Vec<[u8; 4]> =
+            super::IPolicyRegistry::IPolicyRegistryCalls::selectors().collect();
+        for selector in canonical::IPolicyRegistryV1::IPolicyRegistryCalls::selectors() {
+            assert!(
+                mirrored.contains(&selector),
+                "Beryl selector {selector:?} is absent from the mirrored Cobalt surface"
+            );
+        }
+    }
+
+    #[test]
+    fn b20_extensions_abi_matches_canonical_surface() {
+        assert_eq!(
+            super::IB20Extensions::mintWithMemoCall::SELECTOR,
+            canonical::IB20::mintWithMemoCall::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Extensions::burnWithMemoCall::SELECTOR,
+            canonical::IB20::burnWithMemoCall::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Extensions::burnBlockedCall::SELECTOR,
+            canonical::IB20::burnBlockedCall::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Extensions::seizeWithMemoCall::SELECTOR,
+            canonical::IB20::seizeWithMemoCall::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Extensions::policyIdCall::SELECTOR,
+            canonical::IB20::policyIdCall::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Extensions::pauseCall::SELECTOR,
+            canonical::IB20::pauseCall::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Extensions::contractURICall::SELECTOR,
+            canonical::IB20::contractURICall::SELECTOR
+        );
+        assert_eq!(
+            super::IB20Extensions::Seized::SIGNATURE_HASH,
+            canonical::IB20::Seized::SIGNATURE_HASH
+        );
+        assert_eq!(
+            super::IB20Extensions::Memo::SIGNATURE_HASH,
+            canonical::IB20::Memo::SIGNATURE_HASH
+        );
+        assert_eq!(
+            super::IB20Extensions::PolicyUpdated::SIGNATURE_HASH,
+            canonical::IB20::PolicyUpdated::SIGNATURE_HASH
+        );
+
+        // Pausable ordinals are load-bearing in `pause`/`unpause` calldata.
+        assert_eq!(
+            super::IB20Extensions::PausableFeature::COUNT,
+            canonical::IB20::PausableFeature::COUNT
+        );
+        assert_eq!(
+            super::IB20Extensions::PausableFeature::SEIZE as u8,
+            canonical::IB20::PausableFeature::SEIZE as u8
+        );
+    }
+
+    /// This surface is registered globally rather than per address, so it must never carry the
+    /// ERC-20, EIP-2612 or AccessControl members: a competing candidate for those selectors could
+    /// change how ordinary token traces decode on every network in a Base-enabled build.
+    #[test]
+    fn b20_surface_excludes_erc20_members() {
+        let mirrored: Vec<[u8; 4]> =
+            super::IB20Extensions::IB20ExtensionsCalls::selectors().collect();
+        for excluded in [
+            canonical::IB20::transferCall::SELECTOR,
+            canonical::IB20::transferFromCall::SELECTOR,
+            canonical::IB20::approveCall::SELECTOR,
+            canonical::IB20::balanceOfCall::SELECTOR,
+            canonical::IB20::allowanceCall::SELECTOR,
+            canonical::IB20::permitCall::SELECTOR,
+            canonical::IB20::hasRoleCall::SELECTOR,
+            canonical::IB20::grantRoleCall::SELECTOR,
+        ] {
+            assert!(
+                !mirrored.contains(&excluded),
+                "standard selector {excluded:?} must stay out of the global map"
+            );
+        }
+    }
+
+    #[test]
+    fn nonce_manager_abi_matches_canonical_selectors() {
+        assert_eq!(
+            super::INonceManager::getNonceCall::SELECTOR,
+            canonical::INonceManager::getNonceCall::SELECTOR
+        );
+        assert_eq!(
+            super::INonceManager::ExpiringNonceReplay::SELECTOR,
+            canonical::INonceManager::ExpiringNonceReplay::SELECTOR
+        );
+        assert_eq!(
+            super::INonceManager::InvalidExpiringNonceExpiry::SELECTOR,
+            canonical::INonceManager::InvalidExpiringNonceExpiry::SELECTOR
+        );
+        assert_eq!(
+            super::INonceManager::NonceIncremented::SIGNATURE_HASH,
+            canonical::INonceManager::NonceIncremented::SIGNATURE_HASH
+        );
+    }
+
+    #[test]
+    fn transaction_context_abi_matches_canonical_selectors() {
+        assert_eq!(
+            super::ITransactionContext::getTransactionSenderCall::SELECTOR,
+            canonical::ITransactionContext::getTransactionSenderCall::SELECTOR
+        );
+        assert_eq!(
+            super::ITransactionContext::getTransactionPayerCall::SELECTOR,
+            canonical::ITransactionContext::getTransactionPayerCall::SELECTOR
+        );
+        assert_eq!(
+            super::ITransactionContext::getTransactionSenderActorIdCall::SELECTOR,
+            canonical::ITransactionContext::getTransactionSenderActorIdCall::SELECTOR
+        );
+    }
+}

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -27,14 +27,11 @@ use foundry_evm_core::{
         EC_RECOVER, IDENTITY, MOD_EXP, POINT_EVALUATION, RIPEMD_160, SHA_256,
     },
 };
-#[cfg(feature = "monad")]
-type MonadHardfork = foundry_evm_hardforks::MonadHardfork;
 use foundry_evm_hardforks::{ExecutionSpec, FoundryHardfork, TempoHardfork};
 use foundry_evm_networks::{NetworkConfigs, NetworkVariant, celo::transfer::CELO_TRANSFER_LABEL};
 use itertools::Itertools;
 use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
 use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
-
 use std::{collections::BTreeMap, sync::OnceLock};
 use tempo_contracts::precompiles::{
     CURRENT_COMMITTEE_ADDRESS, IAccountKeychain, IAddressRegistry, ICurrentCommittee, IFeeManager,
@@ -49,6 +46,21 @@ use tempo_precompiles::{
     tip20::ITIP20,
 };
 
+#[cfg(feature = "base")]
+use base_common_precompiles::{
+    ActivationRegistryStorage, B20FactoryStorage, NonceManagerStorage, PolicyRegistryStorage,
+    TxContextStorage,
+};
+#[cfg(feature = "base")]
+use foundry_evm_hardforks::BaseSpecId;
+#[cfg(feature = "base")]
+use foundry_evm_networks::{active_base_precompiles, is_base_precompile_active_at};
+
+#[cfg(feature = "monad")]
+type MonadHardfork = foundry_evm_hardforks::MonadHardfork;
+
+#[cfg(feature = "base")]
+mod base;
 #[cfg(feature = "monad")]
 mod monad;
 pub(crate) mod precompiles;
@@ -210,6 +222,8 @@ impl CallTraceDecoderBuilder {
         self.decoder.register_tempo_metadata();
         #[cfg(feature = "monad")]
         self.decoder.register_monad_metadata();
+        #[cfg(feature = "base")]
+        self.decoder.register_base_metadata();
         self.decoder
     }
 }
@@ -313,6 +327,55 @@ impl CallTraceDecoder {
         }
     }
 
+    #[cfg(feature = "base")]
+    fn register_base_metadata(&mut self) {
+        if self.networks.is_some_and(|networks| !networks.is_base()) {
+            return;
+        }
+        let Some(upgrade) =
+            self.hardfork.and_then(BaseSpecId::from_foundry_hardfork).map(|spec| spec.upgrade())
+        else {
+            return;
+        };
+
+        for (label, address) in active_base_precompiles(upgrade) {
+            self.labels.entry(address).or_insert_with(|| label.to_string());
+        }
+
+        // Labels alone leave calls showing a raw selector, so register the ABIs too. Each is
+        // scoped to its address and gated on the upgrade that installs it.
+        if is_base_precompile_active_at(ActivationRegistryStorage::ADDRESS, upgrade) {
+            self.register_address_abi(
+                ActivationRegistryStorage::ADDRESS,
+                &base::IActivationRegistry::abi::contract(),
+            );
+        }
+        if is_base_precompile_active_at(PolicyRegistryStorage::ADDRESS, upgrade) {
+            self.register_address_abi(
+                PolicyRegistryStorage::ADDRESS,
+                &base::IPolicyRegistry::abi::contract(),
+            );
+        }
+        if is_base_precompile_active_at(B20FactoryStorage::ADDRESS, upgrade) {
+            self.register_address_abi(
+                B20FactoryStorage::ADDRESS,
+                &base::IB20Factory::abi::contract(),
+            );
+        }
+        if is_base_precompile_active_at(NonceManagerStorage::ADDRESS, upgrade) {
+            self.register_address_abi(
+                NonceManagerStorage::ADDRESS,
+                &base::INonceManager::abi::contract(),
+            );
+        }
+        if is_base_precompile_active_at(TxContextStorage::ADDRESS, upgrade) {
+            self.register_address_abi(
+                TxContextStorage::ADDRESS,
+                &base::ITransactionContext::abi::contract(),
+            );
+        }
+    }
+
     /// Creates a new call trace decoder.
     ///
     /// The call trace decoder always knows how to decode calls to the cheatcode address, as well
@@ -397,7 +460,7 @@ impl CallTraceDecoder {
             (PATH_USD_ADDRESS, "PathUSD".to_string()),
         ]);
 
-        let function_groups: Vec<_> = console::hh::abi::functions()
+        let functions = console::hh::abi::functions()
             .into_values()
             .chain(Vm::abi::functions().into_values())
             .chain(IFeeManager::abi::functions().into_values())
@@ -415,14 +478,11 @@ impl CallTraceDecoder {
             .chain(ITIP20ChannelReserve::abi::functions().into_values())
             .chain(ISignatureVerifier::abi::functions().into_values())
             .chain(IReceivePolicyGuard::abi::functions().into_values())
-            .collect();
-        let functions = function_groups
-            .into_iter()
             .flatten()
             .map(|func| (func.selector(), vec![func]))
             .collect();
 
-        let event_groups: Vec<_> = console::ds::abi::events()
+        let events = console::ds::abi::events()
             .into_values()
             .chain(IFeeManager::abi::events().into_values())
             .chain(ITIP20::abi::events().into_values())
@@ -436,9 +496,6 @@ impl CallTraceDecoder {
             .chain(ITIP20ChannelReserve::abi::events().into_values())
             .chain(ISignatureVerifier::abi::events().into_values())
             .chain(IReceivePolicyGuard::abi::events().into_values())
-            .collect();
-        let events = event_groups
-            .into_iter()
             .flatten()
             .map(|event| ((event.selector(), indexed_inputs(&event)), vec![event]))
             .collect();
@@ -498,6 +555,8 @@ impl CallTraceDecoder {
         self.register_tempo_metadata();
         #[cfg(feature = "monad")]
         self.register_monad_metadata();
+        #[cfg(feature = "base")]
+        self.register_base_metadata();
     }
 
     /// Returns labels for precompiles active in this decoder's chain context.
@@ -613,7 +672,7 @@ impl CallTraceDecoder {
 
     /// Returns the functions registered for `selector` at `address`.
     ///
-    /// Address-scoped metadata takes precedence over globally registered functions.
+    /// Address-scoped and caller-supplied metadata takes precedence over network fallbacks.
     pub fn functions_for_selector(
         &self,
         address: Address,
@@ -634,11 +693,112 @@ impl CallTraceDecoder {
                 return Some(functions);
             }
         }
-        self.functions_by_address
+        if let Some(functions) =
+            self.functions_by_address.get(&address).and_then(|functions| functions.get(selector))
+        {
+            return Some(functions);
+        }
+        #[cfg(feature = "base")]
+        let base_functions = self.base_functions_for_selector(selector);
+        // Tempo's function with this selector has no output, while B20 returns a bool.
+        #[cfg(feature = "base")]
+        if let Some(functions) = base_functions
+            && functions.first().is_some_and(|function| function.name == "transferWithMemo")
+        {
+            if let Some(global) = self.functions.get(selector) {
+                let tempo_fallback = global.first().is_some_and(|function| {
+                    function.name == "transferWithMemo" && function.outputs.is_empty()
+                });
+                if !tempo_fallback {
+                    return Some(global);
+                }
+                if global.len() > 1 {
+                    return Some(&global[1..]);
+                }
+            }
+            return Some(functions);
+        }
+        let functions = self.functions.get(selector);
+        #[cfg(feature = "base")]
+        let functions = functions.or(base_functions);
+        functions.map(Vec::as_slice)
+    }
+
+    #[cfg(feature = "base")]
+    fn is_base_context(&self) -> bool {
+        self.networks.map_or_else(
+            || self.hardfork.and_then(BaseSpecId::from_foundry_hardfork).is_some(),
+            |networks| networks.is_base(),
+        )
+    }
+
+    #[cfg(feature = "base")]
+    fn base_functions_for_selector(&self, selector: &Selector) -> Option<&'static Vec<Function>> {
+        if !self.is_base_context() {
+            return None;
+        }
+        static FUNCTIONS: OnceLock<HashMap<Selector, Vec<Function>>> = OnceLock::new();
+        FUNCTIONS
+            .get_or_init(|| {
+                base::IB20Extensions::abi::functions()
+                    .into_values()
+                    .flatten()
+                    .map(|function| (function.selector(), vec![function]))
+                    .collect()
+            })
+            .get(selector)
+    }
+
+    #[cfg(feature = "base")]
+    fn base_events(&self) -> Option<&'static BTreeMap<(B256, usize), Vec<Event>>> {
+        if !self.is_base_context() {
+            return None;
+        }
+        static EVENTS: OnceLock<BTreeMap<(B256, usize), Vec<Event>>> = OnceLock::new();
+        Some(EVENTS.get_or_init(|| {
+            base::IB20Extensions::abi::events()
+                .into_values()
+                .flatten()
+                .map(|event| ((event.selector(), indexed_inputs(&event)), vec![event]))
+                .collect()
+        }))
+    }
+
+    #[cfg(feature = "base")]
+    fn base_revert_decoder(&self, address: Address) -> Option<&'static RevertDecoder> {
+        let upgrade =
+            self.hardfork.and_then(BaseSpecId::from_foundry_hardfork).map(|spec| spec.upgrade())?;
+        if !self.is_base_context() || !is_base_precompile_active_at(address, upgrade) {
+            return None;
+        }
+
+        static DECODERS: OnceLock<HashMap<Address, RevertDecoder>> = OnceLock::new();
+        DECODERS
+            .get_or_init(|| {
+                HashMap::from_iter([
+                    (
+                        ActivationRegistryStorage::ADDRESS,
+                        RevertDecoder::new().with_abi(&base::IActivationRegistry::abi::contract()),
+                    ),
+                    (
+                        PolicyRegistryStorage::ADDRESS,
+                        RevertDecoder::new().with_abi(&base::IPolicyRegistry::abi::contract()),
+                    ),
+                    (
+                        B20FactoryStorage::ADDRESS,
+                        RevertDecoder::new().with_abi(&base::IB20Factory::abi::contract()),
+                    ),
+                    (
+                        NonceManagerStorage::ADDRESS,
+                        RevertDecoder::new().with_abi(&base::INonceManager::abi::contract()),
+                    ),
+                    (
+                        TxContextStorage::ADDRESS,
+                        RevertDecoder::new().with_abi(&base::ITransactionContext::abi::contract()),
+                    ),
+                ])
+            })
             .get(&address)
-            .and_then(|functions| functions.get(selector))
-            .or_else(|| self.functions.get(selector))
-            .map(Vec::as_slice)
     }
 
     #[cfg(feature = "monad")]
@@ -679,7 +839,7 @@ impl CallTraceDecoder {
         }
     }
 
-    #[cfg(feature = "monad")]
+    #[cfg(any(feature = "base", feature = "monad"))]
     fn register_address_abi(&mut self, address: Address, abi: &JsonAbi) {
         for function in abi.functions() {
             self.push_address_function(address, function.clone());
@@ -1339,6 +1499,12 @@ impl CallTraceDecoder {
         output: &[u8],
         status: Option<InstructionResult>,
     ) -> String {
+        #[cfg(feature = "base")]
+        if let Some(reason) =
+            self.base_revert_decoder(address).and_then(|decoder| decoder.maybe_decode_known(output))
+        {
+            return reason;
+        }
         if self.is_current_committee_active(address) {
             static DECODER: OnceLock<RevertDecoder> = OnceLock::new();
             let decoder = DECODER
@@ -1383,13 +1549,18 @@ impl CallTraceDecoder {
         let events = address.and_then(|address| self.events_by_address.as_deref()?.get(&address));
         let address_events = key.and_then(|(topic, count)| events?.get(&(Some(topic), count)));
         let global_events = key.and_then(|key| self.events.get(&key));
-        let regular_events = address_events.or(global_events);
+        #[cfg(feature = "base")]
+        let base_events = key.and_then(|key| self.base_events()?.get(&key));
+        #[cfg(not(feature = "base"))]
+        let base_events: Option<&Vec<Event>> = None;
+        let fallback_events = global_events.or(base_events);
+        let regular_events = address_events.or(fallback_events);
         let anonymous_events = events.and_then(|events| events.get(&(None, log.topics().len())));
 
         let decoded = if canonical_signature && address_events.is_none() {
             // Topic zero does not encode indexed parameter placement, so global metadata is only
             // a hint. Try every compatible layout and reject ambiguity.
-            let mut events = global_events
+            let mut events = fallback_events
                 .into_iter()
                 .flatten()
                 .flat_map(|event| indexed_event_candidates(event.clone(), log))
@@ -1710,6 +1881,11 @@ mod tests {
     use foundry_evm_core::precompiles::P256_VERIFY;
     use std::borrow::Cow;
 
+    #[cfg(feature = "base")]
+    use foundry_evm_hardforks::BaseUpgrade;
+    #[cfg(feature = "base")]
+    use foundry_evm_networks::BASE_PRECOMPILE_ADDRESSES;
+
     #[cfg(feature = "monad")]
     fn function_abi_items(functions: impl IntoIterator<Item = Function>) -> Vec<(String, String)> {
         let mut items = functions
@@ -1879,6 +2055,37 @@ mod tests {
         // Should return only the function that can decode the calldata (func2)
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].signature(), "gasprice_bit_ether(int128)");
+    }
+
+    #[cfg(feature = "base")]
+    #[tokio::test]
+    async fn base_fallback_does_not_shadow_ethereum_abi() {
+        let abi = JsonAbi::parse(["function pause(uint8[] features) returns (bool)"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let trace = CallTrace {
+            address: Address::repeat_byte(0x12),
+            data: function
+                .abi_encode_input(&[DynSolValue::Array(vec![DynSolValue::Uint(U256::ZERO, 8)])])
+                .unwrap()
+                .into(),
+            output: function.abi_encode_output(&[DynSolValue::Bool(true)]).unwrap().into(),
+            success: true,
+            ..Default::default()
+        };
+
+        let ethereum = CallTraceDecoderBuilder::new()
+            .with_execution_network(NetworkVariant::Ethereum)
+            .with_abi(&abi)
+            .build();
+        let decoded = ethereum.decode_function(&trace).await;
+        assert_eq!(decoded.call_data.unwrap().signature, "pause(uint8[])");
+        assert_eq!(decoded.return_data.as_deref(), Some("true"));
+
+        let base =
+            CallTraceDecoderBuilder::new().with_execution_network(NetworkVariant::Base).build();
+        let decoded = base.decode_function(&trace).await;
+        assert_eq!(decoded.call_data.unwrap().signature, "pause(uint8[])");
+        assert_eq!(decoded.return_data, None);
     }
 
     #[tokio::test]
@@ -3585,6 +3792,25 @@ mod tests {
             inferred_celo.precompile_labels().get(&CELO_TRANSFER),
             Some(&CELO_TRANSFER_LABEL.to_string())
         );
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn test_precompile_labels_follow_base_upgrade_boundaries() {
+        let labels_for_upgrade = |upgrade| {
+            CallTraceDecoderBuilder::new()
+                .with_chain_id(Some(8453))
+                .with_hardfork(Some(FoundryHardfork::Base(upgrade)))
+                .build()
+                .precompile_labels()
+        };
+        let base_label_count = |labels: &AddressHashMap<String>| {
+            BASE_PRECOMPILE_ADDRESSES.iter().filter(|address| labels.contains_key(*address)).count()
+        };
+
+        assert_eq!(base_label_count(&labels_for_upgrade(BaseUpgrade::Azul)), 0);
+        assert_eq!(base_label_count(&labels_for_upgrade(BaseUpgrade::Beryl)), 3);
+        assert_eq!(base_label_count(&labels_for_upgrade(BaseUpgrade::Cobalt)), 5);
     }
 
     #[tokio::test]

--- a/crates/evm/traces/src/decoder/precompiles.rs
+++ b/crates/evm/traces/src/decoder/precompiles.rs
@@ -551,6 +551,31 @@ pub(crate) fn is_known_precompile(
             }
         }
     }
+    // Base precompiles (only on a Base chain or in an explicitly configured Base context).
+    #[cfg(feature = "base")]
+    {
+        let base_upgrade = hardfork
+            .and_then(foundry_evm_hardforks::BaseSpecId::from_foundry_hardfork)
+            .map(|spec| spec.upgrade());
+        let is_base_context = networks.map_or_else(
+            || {
+                chain_id.is_some_and(|id| {
+                    matches!(
+                        Chain::from_id(id).named(),
+                        Some(NamedChain::Base | NamedChain::BaseSepolia)
+                    )
+                }) || base_upgrade.is_some()
+            },
+            |networks| networks.is_base(),
+        );
+        if is_base_context
+            && base_upgrade.is_some_and(|upgrade| {
+                foundry_evm_networks::is_base_precompile_active_at(address, upgrade)
+            })
+        {
+            return true;
+        }
+    }
     // Celo transfer precompile (only on Celo chains).
     let is_celo_context = networks.map_or_else(
         || {
@@ -624,6 +649,11 @@ mod tests {
     use super::*;
     use alloy_primitives::{address, hex};
 
+    #[cfg(feature = "base")]
+    use base_common_precompiles::ActivationRegistryStorage;
+    #[cfg(feature = "base")]
+    use foundry_evm_hardforks::BaseUpgrade;
+
     #[test]
     fn known_precompile_boundaries() {
         assert!(is_known_precompile(P256_VERIFY, None, None, None));
@@ -638,6 +668,19 @@ mod tests {
             None,
             None,
             None
+        ));
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn base_precompiles_require_a_known_upgrade() {
+        let address = ActivationRegistryStorage::ADDRESS;
+        assert!(!is_known_precompile(address, Some(NetworkConfigs::with_base()), Some(8453), None));
+        assert!(is_known_precompile(
+            address,
+            Some(NetworkConfigs::with_base()),
+            Some(8453),
+            Some(FoundryHardfork::Base(BaseUpgrade::Beryl))
         ));
     }
 

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -147,6 +147,19 @@ monad = [
     "forge-script/monad",
     "forge-verify/monad",
 ]
+base = [
+    "anvil/base",
+    "foundry-evm/base",
+    "foundry-evm-networks/base",
+    "foundry-evm-symbolic/base",
+    "foundry-common/base",
+    "foundry-config/base",
+    "foundry-cli/base",
+    "foundry-debugger/base",
+    "foundry-test-utils/base",
+    "forge-script/base",
+    "forge-verify/base",
+]
 optimism = [
     "foundry-evm/optimism",
     "foundry-evm-networks/optimism",

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -93,6 +93,9 @@ use std::{
 use tempfile::TempDir;
 use yansi::Paint;
 
+#[cfg(feature = "base")]
+use foundry_evm::core::evm::BaseEvmNetwork;
+
 #[cfg(feature = "monad")]
 use foundry_evm::core::evm::MonadEvmNetwork;
 
@@ -103,8 +106,9 @@ mod evm_profile_server;
 mod filter;
 mod summary;
 use filter::RerunFailures;
-pub use filter::{FilterArgs, ProjectPathsAwareFilter, RerunFailure};
 use summary::{TestSummaryReport, format_invariant_metrics_table};
+
+pub use filter::{FilterArgs, ProjectPathsAwareFilter, RerunFailure};
 
 const DEBUGGER_MATCHING_TESTS_DISPLAY_LIMIT: usize = 12;
 const AUTO_FUZZ_FAILURE_DIR: &str = "fuzz";
@@ -216,6 +220,8 @@ fn count_fuzz_minimize_targets<FEN: FoundryEvmNetwork>(
 #[derive(Clone, Copy)]
 enum NetworkDispatchKind {
     Tempo,
+    #[cfg(feature = "base")]
+    Base,
     #[cfg(feature = "monad")]
     Monad,
     #[cfg(feature = "optimism")]
@@ -227,6 +233,12 @@ const fn network_dispatch_kind(evm_opts: &EvmOpts) -> NetworkDispatchKind {
     if evm_opts.networks.is_tempo() {
         return NetworkDispatchKind::Tempo;
     }
+
+    #[cfg(feature = "base")]
+    if evm_opts.networks.is_base() {
+        return NetworkDispatchKind::Base;
+    }
+
     #[cfg(feature = "monad")]
     if evm_opts.networks.is_monad() {
         return NetworkDispatchKind::Monad;
@@ -242,6 +254,11 @@ const fn network_dispatch_kind(evm_opts: &EvmOpts) -> NetworkDispatchKind {
 macro_rules! dispatch_network {
     ($evm_opts:expr, | $fen:ident | $body:expr) => {
         match network_dispatch_kind($evm_opts) {
+            #[cfg(feature = "base")]
+            NetworkDispatchKind::Base => {
+                type $fen = BaseEvmNetwork;
+                $body
+            }
             NetworkDispatchKind::Tempo => {
                 type $fen = TempoEvmNetwork;
                 $body

--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -42,6 +42,9 @@ use std::{
 };
 use tempfile::TempDir;
 
+#[cfg(feature = "base")]
+use foundry_evm::core::evm::BaseEvmNetwork;
+
 #[cfg(feature = "monad")]
 use foundry_evm::core::evm::MonadEvmNetwork;
 
@@ -638,6 +641,18 @@ fn compile_and_test(
             ExecutorBuilder::<TempoEvmNetwork>::new(),
         )
     } else {
+        #[cfg(feature = "base")]
+        if evm.opts.networks.is_base() {
+            return compile_and_test_inner::<BaseEvmNetwork>(
+                config,
+                evm,
+                filter_args,
+                rerun_failures,
+                selected_sources_relative,
+                isolate,
+                ExecutorBuilder::<BaseEvmNetwork>::new(),
+            );
+        }
         #[cfg(feature = "monad")]
         if evm.opts.networks.is_monad() {
             return compile_and_test_inner::<MonadEvmNetwork>(

--- a/crates/forge/tests/cli/test_cmd/base.rs
+++ b/crates/forge/tests/cli/test_cmd/base.rs
@@ -1,0 +1,118 @@
+use foundry_test_utils::util::OutputExt;
+
+forgetest!(base_azul_excludes_beryl_precompiles, |prj, cmd| {
+    prj.add_test("BaseEvm.t.sol", include_str!("../../fixtures/BaseEvm.t.sol"));
+
+    cmd.args([
+        "test",
+        "--network",
+        "base",
+        "--hardfork",
+        "base:Azul",
+        "--chain-id",
+        "8453",
+        "--match-test",
+        "test_azul_excludes_beryl_precompiles",
+    ])
+    .assert_success();
+});
+
+forgetest!(base_defaults_to_azul, |prj, cmd| {
+    prj.add_test("BaseEvm.t.sol", include_str!("../../fixtures/BaseEvm.t.sol"));
+
+    cmd.args([
+        "test",
+        "--network",
+        "base",
+        "--chain-id",
+        "8453",
+        "--match-test",
+        "test_azul_excludes_beryl_precompiles",
+    ])
+    .assert_success();
+});
+
+forgetest!(base_beryl_precompiles_and_nested_evm, |prj, cmd| {
+    prj.add_test("BaseEvm.t.sol", include_str!("../../fixtures/BaseEvm.t.sol"));
+
+    let stdout = cmd
+        .args([
+            "test",
+            "--network",
+            "base",
+            "--hardfork",
+            "base:Beryl",
+            "--chain-id",
+            "8453",
+            "--match-test",
+            "test_beryl",
+            "-vvvv",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("ActivationRegistry"), "{stdout}");
+    assert!(stdout.contains("B20Factory"), "{stdout}");
+});
+
+forgetest!(base_list_accepts_base_network, |prj, cmd| {
+    prj.add_test("BaseEvm.t.sol", include_str!("../../fixtures/BaseEvm.t.sol"));
+
+    cmd.args([
+        "test",
+        "--network",
+        "base",
+        "--hardfork",
+        "base:Beryl",
+        "--chain-id",
+        "8453",
+        "--list",
+    ])
+    .assert_success();
+});
+
+forgetest!(base_local_allows_stateful_precompile_writes, |prj, cmd| {
+    prj.add_test("BaseForkWrites.t.sol", include_str!("../../fixtures/BaseForkWrites.t.sol"));
+
+    cmd.args([
+        "test",
+        "--network",
+        "base",
+        "--hardfork",
+        "base:Beryl",
+        "--chain-id",
+        "8453",
+        "--match-contract",
+        "BaseForkWritesTest",
+        "-vvvv",
+    ])
+    .assert_success();
+});
+
+forgetest!(base_script_uses_native_network, |prj, cmd| {
+    let script = prj.add_script(
+        "BaseScript.s.sol",
+        r#"
+interface IActivationRegistry {
+    function admin() external view returns (address);
+}
+
+contract BaseScript {
+    address constant ACTIVATION_REGISTRY = 0x8453000000000000000000000000000000000001;
+    address constant MAINNET_BERYL_ADMIN = 0xcE3a3bEE7E72E2A24079f3c0Cb3b97740ED425A9;
+
+    function run() external view {
+        require(
+            IActivationRegistry(ACTIVATION_REGISTRY).admin() == MAINNET_BERYL_ADMIN,
+            "Base EVM not selected"
+        );
+    }
+}
+   "#,
+    );
+
+    cmd.arg("script")
+        .arg(script)
+        .args(["--network", "base", "--hardfork", "base:Beryl", "--chain-id", "8453"])
+        .assert_success();
+});

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -16,6 +16,8 @@ use std::{io::Write, path::PathBuf, str::FromStr};
 #[cfg(unix)]
 use std::fs;
 
+#[cfg(feature = "base")]
+mod base;
 mod brutalize;
 mod core;
 mod exact_fork;

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -623,6 +623,28 @@ forgetest_async!(can_verify_bytecode_without_explorer, |prj, cmd| {
     assert!(stdout.contains("Runtime code matched"), "{stdout}");
     assert!(stderr.contains("Creation data is unavailable"), "{stderr}");
 
+    #[cfg(feature = "base")]
+    {
+        cmd.forge_fuse();
+        cmd.unset_env("ETHERSCAN_API_KEY");
+        cmd.unset_env("VERIFIER_API_KEY");
+        cmd.unset_env("VERIFIER_URL");
+        let output = cmd
+            .args([
+                "verify-bytecode",
+                &address,
+                "Counter",
+                "--rpc-url",
+                rpc.as_str(),
+                "--network",
+                "base",
+            ])
+            .assert_success()
+            .get_output()
+            .stdout_lossy();
+        assert!(output.contains("Runtime code matched"), "{output}");
+    }
+
     // Dependencies and projects with Vyper sources retain full-project compilation. The unrelated
     // invalid source therefore makes both builds fail.
     prj.create_file("lib/Dependency.sol", "contract Dependency {}");

--- a/crates/forge/tests/fixtures/BaseEvm.t.sol
+++ b/crates/forge/tests/fixtures/BaseEvm.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+interface IActivationRegistry {
+    function admin() external view returns (address);
+}
+
+interface IB20Factory {
+    function isB20(address token) external view returns (bool);
+}
+
+interface Vm {
+    function deployCode(string calldata artifactPath) external returns (address);
+}
+
+contract NestedBaseCanary {
+    IActivationRegistry internal constant ACTIVATION_REGISTRY =
+        IActivationRegistry(0x8453000000000000000000000000000000000001);
+
+    address public activationAdmin;
+
+    constructor() {
+        activationAdmin = ACTIVATION_REGISTRY.admin();
+    }
+}
+
+contract BaseEvmTest {
+    Vm internal constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+    address internal constant ACTIVATION_REGISTRY = 0x8453000000000000000000000000000000000001;
+    address internal constant B20_FACTORY = address(bytes20(hex"B20F000000000000000000000000000000000000"));
+    address internal constant MAINNET_BERYL_ACTIVATION_ADMIN =
+        address(bytes20(hex"ce3a3bee7e72e2a24079f3c0cb3b97740ed425a9"));
+
+    function test_azul_excludes_beryl_precompiles() public view {
+        (bool activationSuccess, bytes memory activationOutput) =
+            ACTIVATION_REGISTRY.staticcall(abi.encodeWithSelector(IActivationRegistry.admin.selector));
+        require(activationSuccess, "activation registry call failed");
+        require(activationOutput.length == 0, "activation registry is installed");
+
+        (bool factorySuccess, bytes memory factoryOutput) =
+            B20_FACTORY.staticcall(abi.encodeCall(IB20Factory.isB20, (B20_FACTORY)));
+        require(factorySuccess, "B20 factory call failed");
+        require(factoryOutput.length == 0, "B20 factory is installed");
+    }
+
+    function test_beryl_installs_native_precompiles() public view {
+        require(
+            IActivationRegistry(ACTIVATION_REGISTRY).admin() == MAINNET_BERYL_ACTIVATION_ADMIN,
+            "unexpected activation admin"
+        );
+        require(!IB20Factory(B20_FACTORY).isB20(B20_FACTORY), "factory identified as B20");
+    }
+
+    function test_beryl_nested_deploy_code_uses_base_evm() public {
+        address deployed = vm.deployCode("test/BaseEvm.t.sol:NestedBaseCanary");
+        require(
+            NestedBaseCanary(deployed).activationAdmin() == MAINNET_BERYL_ACTIVATION_ADMIN,
+            "nested EVM used the wrong activation admin"
+        );
+    }
+}

--- a/crates/forge/tests/fixtures/BaseForkWrites.t.sol
+++ b/crates/forge/tests/fixtures/BaseForkWrites.t.sol
@@ -1,0 +1,49 @@
+interface IActivationRegistry {
+    function admin() external view returns (address);
+    function isActivated(bytes32 feature) external view returns (bool);
+    function activate(bytes32 feature) external;
+}
+
+interface IB20Factory {
+    function getB20Address(uint8 variant, address sender, bytes32 salt) external view returns (address);
+    function isB20(address token) external view returns (bool);
+}
+
+interface Vm {
+    function prank(address sender) external;
+    function deal(address account, uint256 newBalance) external;
+}
+
+contract BaseForkWritesTest {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    address constant ACTIVATION_REGISTRY = 0x8453000000000000000000000000000000000001;
+    address constant B20_FACTORY = 0xB20f000000000000000000000000000000000000;
+    bytes32 constant B20_ASSET = 0xcdcc772fe4cbdb1029f822861176d09e646db96723d4c1e82ddfdeb8163ef54c;
+
+    // The factory returns data from every function, so Solidity emits no `extcodesize` check
+    // against it and it needs no code — which is why Base leaves it code-less on chain. Planting a
+    // sentinel here anyway would let an `isContract` probe pass locally and revert on Base.
+    function test_factory_is_code_less_and_still_callable() public view {
+        require(B20_FACTORY.code.length == 0, "factory must stay code-less, as on Base");
+
+        address token =
+            IB20Factory(B20_FACTORY).getB20Address(0, address(this), bytes32(uint256(1)));
+        require(token != address(0), "high-level factory call should return an address");
+        require(!IB20Factory(B20_FACTORY).isB20(address(this)), "test contract is not a B20");
+    }
+
+    // `activate` returns nothing, so Solidity guards the high-level call with an `extcodesize`
+    // check. That check is why a code-less precompile makes the caller revert before the
+    // precompile runs, so this must stay a high-level call rather than a raw `.call()`.
+    function test_fork_activation_write() public {
+        address admin = IActivationRegistry(ACTIVATION_REGISTRY).admin();
+        require(admin != address(0), "activation admin unresolved");
+        require(!IActivationRegistry(ACTIVATION_REGISTRY).isActivated(B20_ASSET), "already active");
+
+        vm.deal(admin, 1 ether);
+        vm.prank(admin);
+        IActivationRegistry(ACTIVATION_REGISTRY).activate(B20_ASSET);
+
+        require(IActivationRegistry(ACTIVATION_REGISTRY).isActivated(B20_ASSET), "not activated");
+    }
+}

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -27,6 +27,27 @@ op-alloy-consensus = { workspace = true, features = ["serde", "alloy-compat"], o
 op-alloy-rpc-types = { workspace = true, optional = true }
 alloy-op-evm = { workspace = true, optional = true }
 op-revm = { workspace = true, optional = true }
+
+# Base
+base-common-consensus = { workspace = true, optional = true, features = [
+    "alloy-compat",
+    "evm",
+    "k256",
+    "serde",
+    "std",
+] }
+base-common-evm = { workspace = true, optional = true, features = [
+    "blst",
+    "c-kzg",
+    "memory_limit",
+    "optional_block_gas_limit",
+    "optional_eip3607",
+    "optional_no_base_fee",
+    "serde",
+    "std",
+] }
+base-common-rpc-types = { workspace = true, optional = true, features = ["serde", "std"] }
+
 revm.workspace = true
 serde_json.workspace = true
 serde = { version = "1.0", features = ["derive"] }
@@ -37,6 +58,13 @@ tempo-revm.workspace = true
 
 [features]
 default = ["optimism"]
+base = [
+    "dep:base-common-consensus",
+    "dep:base-common-evm",
+    "dep:base-common-rpc-types",
+    "dep:op-alloy-consensus",
+    "dep:op-revm",
+]
 optimism = [
     "dep:op-alloy-consensus",
     "dep:op-alloy-rpc-types",

--- a/crates/primitives/src/network/mod.rs
+++ b/crates/primitives/src/network/mod.rs
@@ -1,7 +1,7 @@
 use alloy_network::Network;
 
 mod header;
-#[cfg(feature = "optimism")]
+#[cfg(any(feature = "base", feature = "optimism"))]
 mod optimism;
 mod receipt;
 

--- a/crates/primitives/src/network/optimism.rs
+++ b/crates/primitives/src/network/optimism.rs
@@ -1,15 +1,15 @@
 //! OP-stack-specific helpers and type aliases used by [`super::FoundryNetwork`] and
 //! [`super::FoundryTxReceipt`].
 
+use crate::FoundryReceiptEnvelope;
 use alloy_consensus::{Receipt, ReceiptWithBloom, TxReceipt};
 use alloy_primitives::U64;
 use alloy_rpc_types::Log;
 use alloy_serde::OtherFields;
 use op_alloy_consensus::{OpDepositReceipt, OpDepositReceiptWithBloom};
 
-use crate::FoundryReceiptEnvelope;
-
 /// JSON-RPC transaction response type used by [`super::FoundryNetwork`].
+#[cfg(feature = "optimism")]
 pub type FoundryTransactionResponse = op_alloy_rpc_types::Transaction<crate::FoundryTxEnvelope>;
 
 /// Build a [`FoundryReceiptEnvelope::Deposit`] from a `ReceiptWithBloom<Log>` plus the OP

--- a/crates/primitives/src/network/receipt.rs
+++ b/crates/primitives/src/network/receipt.rs
@@ -7,11 +7,48 @@ use derive_more::AsRef;
 use serde::{Deserialize, Serialize};
 use tempo_primitives::TEMPO_TX_TYPE_ID;
 
-#[cfg(feature = "optimism")]
+#[cfg(any(feature = "base", feature = "optimism"))]
 use super::optimism::build_deposit_receipt_envelope;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, AsRef)]
+#[cfg(feature = "base")]
+use alloy_consensus::ReceiptWithBloom;
+#[cfg(feature = "base")]
+use alloy_serde::OtherFields;
+#[cfg(feature = "base")]
+use base_common_consensus::Eip8130Receipt;
+#[cfg(feature = "base")]
+use base_common_evm::EIP8130_TRANSACTION_TYPE;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, AsRef)]
 pub struct FoundryTxReceipt(pub WithOtherFields<TransactionReceipt<FoundryReceiptEnvelope<Log>>>);
+
+impl<'de> Deserialize<'de> for FoundryTxReceipt {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[allow(unused_mut)]
+        let mut receipt =
+            WithOtherFields::<TransactionReceipt<FoundryReceiptEnvelope<Log>>>::deserialize(
+                deserializer,
+            )?;
+        #[cfg(feature = "base")]
+        if let FoundryReceiptEnvelope::Eip8130(inner) = &mut receipt.inner.inner {
+            inner.receipt.phase_statuses =
+                rpc_phase_statuses(&receipt.other).map_err(serde::de::Error::custom)?;
+        }
+        Ok(Self(receipt))
+    }
+}
+
+#[cfg(feature = "base")]
+fn rpc_phase_statuses(other: &OtherFields) -> serde_json::Result<Vec<u8>> {
+    #[derive(Deserialize)]
+    struct PhaseStatuses(#[serde(with = "alloy_serde::quantity::vec")] Vec<u8>);
+    Ok(other
+        .get_deserialized::<Option<PhaseStatuses>>("phaseStatuses")
+        .transpose()?
+        .flatten()
+        .map(|statuses| statuses.0)
+        .unwrap_or_default())
+}
 
 impl FoundryTxReceipt {
     pub fn new(inner: TransactionReceipt<FoundryReceiptEnvelope<Log>>) -> Self {
@@ -130,6 +167,13 @@ impl TryFrom<AnyTransactionReceipt> for FoundryTxReceipt {
             other,
         } = receipt.0;
 
+        #[cfg(feature = "base")]
+        let phase_statuses = if r#type == EIP8130_TRANSACTION_TYPE {
+            rpc_phase_statuses(&other).map_err(|err| ConversionError::Custom(err.to_string()))?
+        } else {
+            Vec::new()
+        };
+
         Ok(Self(WithOtherFields {
             inner: TransactionReceipt {
                 transaction_hash,
@@ -149,8 +193,13 @@ impl TryFrom<AnyTransactionReceipt> for FoundryTxReceipt {
                     0x02 => FoundryReceiptEnvelope::Eip1559(receipt_with_bloom),
                     0x03 => FoundryReceiptEnvelope::Eip4844(receipt_with_bloom),
                     0x04 => FoundryReceiptEnvelope::Eip7702(receipt_with_bloom),
+                    #[cfg(feature = "base")]
+                    EIP8130_TRANSACTION_TYPE => FoundryReceiptEnvelope::Eip8130(ReceiptWithBloom {
+                        receipt: Eip8130Receipt::new(receipt_with_bloom.receipt, phase_statuses),
+                        logs_bloom: receipt_with_bloom.logs_bloom,
+                    }),
                     TEMPO_TX_TYPE_ID => FoundryReceiptEnvelope::Tempo(receipt_with_bloom),
-                    #[cfg(feature = "optimism")]
+                    #[cfg(any(feature = "base", feature = "optimism"))]
                     0x7E => build_deposit_receipt_envelope(receipt_with_bloom, &other),
                     // Chains anvil can fork but not execute, such as Arbitrum and its Orbit
                     // rollups, mint their own transaction types. Keep those receipts verbatim
@@ -169,6 +218,42 @@ impl TryFrom<AnyTransactionReceipt> for FoundryTxReceipt {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn eip8130_rpc_receipt_preserves_phase_statuses() {
+        let receipt: AnyTransactionReceipt = serde_json::from_value(serde_json::json!({
+            "type": "0x79", "status": "0x1", "cumulativeGasUsed": "0x1", "gasUsed": "0x1",
+            "logs": [], "logsBloom": alloy_primitives::Bloom::ZERO,
+            "transactionHash": B256::ZERO, "from": Address::ZERO
+        }))
+        .unwrap();
+        for (statuses, expected) in [
+            (None, vec![]),
+            (Some(serde_json::Value::Null), vec![]),
+            (Some(serde_json::json!([])), vec![]),
+            (Some(serde_json::json!(["0x1", "0x0"])), vec![1, 0]),
+        ] {
+            let mut original = receipt.clone();
+            if let Some(statuses) = statuses {
+                original.0.other.insert("phaseStatuses".into(), statuses);
+            }
+            let converted = FoundryTxReceipt::try_from(original.clone()).unwrap();
+            assert_eq!(converted.0.inner.inner.eip8130_phase_statuses(), expected);
+            let json = serde_json::to_value(&converted).unwrap();
+            let typed: FoundryTxReceipt = serde_json::from_value(json.clone()).unwrap();
+            assert_eq!(typed, converted);
+            let roundtrip: AnyTransactionReceipt = serde_json::from_value(json).unwrap();
+            assert_eq!(roundtrip, original);
+        }
+        let mut invalid = receipt;
+        invalid.0.other.insert("phaseStatuses".into(), serde_json::json!(["invalid"]));
+        assert!(
+            serde_json::from_value::<FoundryTxReceipt>(serde_json::to_value(&invalid).unwrap())
+                .is_err()
+        );
+        assert!(FoundryTxReceipt::try_from(invalid).is_err());
+    }
 
     // <https://github.com/foundry-rs/foundry/issues/10852>
     #[test]

--- a/crates/primitives/src/transaction/base.rs
+++ b/crates/primitives/src/transaction/base.rs
@@ -1,0 +1,232 @@
+//! Base-specific transaction conversions.
+
+use super::FoundryTxEnvelope;
+use alloy_consensus::Typed2718;
+use alloy_evm::{FromRecoveredTx, FromTxWithEncoded};
+use alloy_network::eip2718::Encodable2718;
+use alloy_primitives::{Address, Bytes};
+use alloy_rpc_types::TransactionRequest;
+use base_common_consensus::{BaseTxEnvelope, TxEip8130};
+use base_common_evm::{BaseTransaction, DepositTransactionParts, EIP8130_TRANSACTION_TYPE};
+use base_common_rpc_types::{BaseTransactionRequest, Eip8130RequestFields};
+use revm::context::TxEnv;
+use serde::Serialize;
+
+impl FromRecoveredTx<FoundryTxEnvelope> for BaseTransaction<TxEnv> {
+    fn from_recovered_tx(tx: &FoundryTxEnvelope, caller: Address) -> Self {
+        let encoded = tx.encoded_2718().into();
+        Self::from_encoded_tx(tx, caller, encoded)
+    }
+}
+
+impl FromTxWithEncoded<FoundryTxEnvelope> for BaseTransaction<TxEnv> {
+    fn from_encoded_tx(tx: &FoundryTxEnvelope, caller: Address, encoded: Bytes) -> Self {
+        match tx {
+            FoundryTxEnvelope::Legacy(signed) => Self {
+                base: TxEnv::from_recovered_tx(signed, caller),
+                enveloped_tx: Some(encoded),
+                deposit: Default::default(),
+                eip8130: None,
+            },
+            FoundryTxEnvelope::Eip2930(signed) => Self {
+                base: TxEnv::from_recovered_tx(signed, caller),
+                enveloped_tx: Some(encoded),
+                deposit: Default::default(),
+                eip8130: None,
+            },
+            FoundryTxEnvelope::Eip1559(signed) => Self {
+                base: TxEnv::from_recovered_tx(signed, caller),
+                enveloped_tx: Some(encoded),
+                deposit: Default::default(),
+                eip8130: None,
+            },
+            FoundryTxEnvelope::Eip4844(signed) => Self {
+                base: TxEnv::from_recovered_tx(signed, caller),
+                enveloped_tx: Some(encoded),
+                deposit: Default::default(),
+                eip8130: None,
+            },
+            FoundryTxEnvelope::Eip7702(signed) => Self {
+                base: TxEnv::from_recovered_tx(signed, caller),
+                enveloped_tx: Some(encoded),
+                deposit: Default::default(),
+                eip8130: None,
+            },
+            #[cfg(any(feature = "base", feature = "optimism"))]
+            FoundryTxEnvelope::Deposit(sealed) => {
+                let deposit = sealed.inner();
+                let base = TxEnv {
+                    tx_type: deposit.ty(),
+                    caller,
+                    gas_limit: deposit.gas_limit,
+                    kind: deposit.to,
+                    value: deposit.value,
+                    data: deposit.input.clone(),
+                    ..Default::default()
+                };
+                Self {
+                    base,
+                    enveloped_tx: None,
+                    deposit: DepositTransactionParts {
+                        source_hash: deposit.source_hash,
+                        mint: Some(deposit.mint),
+                        is_system_transaction: deposit.is_system_transaction,
+                    },
+                    eip8130: None,
+                }
+            }
+            #[cfg(feature = "optimism")]
+            FoundryTxEnvelope::PostExec(_) => {
+                unreachable!("post-execution transaction in Base context")
+            }
+            FoundryTxEnvelope::Eip8130(signed) => {
+                let envelope = BaseTxEnvelope::Eip8130(signed.clone());
+                Self::from_encoded_tx(&envelope, caller, encoded)
+            }
+            FoundryTxEnvelope::Tempo(_) => unreachable!("Tempo transaction in Base context"),
+        }
+    }
+}
+
+/// Projects the complete AA body into a simulation request without inventing a single call.
+pub(super) fn simulation_request(
+    tx: TxEip8130,
+    from: Option<Address>,
+    sender_auth: Option<Bytes>,
+    payer_auth: Option<Bytes>,
+) -> BaseTransactionRequest {
+    let inner = TransactionRequest {
+        transaction_type: Some(EIP8130_TRANSACTION_TYPE),
+        chain_id: Some(tx.chain_id),
+        from,
+        nonce: Some(tx.nonce_sequence),
+        gas: Some(tx.gas_limit),
+        max_fee_per_gas: Some(tx.max_fee_per_gas),
+        max_priority_fee_per_gas: Some(tx.max_priority_fee_per_gas),
+        ..Default::default()
+    };
+    let fields = Eip8130RequestFields {
+        nonce_key: Some(tx.nonce_key),
+        account_changes: Some(tx.account_changes),
+        calls: Some(tx.calls),
+        valid_after: Some(tx.valid_after),
+        valid_before: Some(tx.valid_before),
+        metadata: Some(tx.metadata),
+        sender: tx.sender,
+        sender_auth,
+        payer: tx.payer,
+        payer_auth,
+        ..Default::default()
+    };
+    // The upstream request exposes no constructor for its private AA fields.
+    #[derive(Serialize)]
+    struct SimulationRequest {
+        #[serde(flatten)]
+        inner: TransactionRequest,
+        #[serde(flatten)]
+        fields: Eip8130RequestFields,
+    }
+    let value = serde_json::to_value(SimulationRequest { inner, fields })
+        .expect("serializable Base simulation request");
+    serde_json::from_value(value).expect("compatible Base simulation fields")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{FoundryTransactionRequest, FoundryTypedTx};
+    use alloy_network::NetworkTransactionBuilder;
+    use alloy_primitives::U256;
+    use base_common_consensus::{AccountChange, Call, Delegation, Eip8130Signed};
+
+    #[test]
+    fn eip8130_simulation_projection() {
+        let body = TxEip8130 {
+            chain_id: 8453,
+            sender: Some(Address::repeat_byte(1)),
+            payer: Some(Address::repeat_byte(2)),
+            nonce_key: U256::from(7),
+            nonce_sequence: 9,
+            gas_limit: 100_000,
+            max_fee_per_gas: 20,
+            max_priority_fee_per_gas: 3,
+            valid_after: 100,
+            valid_before: 200,
+            calls: vec![vec![Call {
+                to: Address::repeat_byte(3),
+                data: Bytes::from_static(b"call"),
+            }]],
+            account_changes: vec![AccountChange::Delegation(Delegation {
+                target: Address::repeat_byte(4),
+            })],
+            metadata: Bytes::from_static(b"metadata"),
+        };
+        let signed = Eip8130Signed::new(
+            body.clone(),
+            Bytes::from_static(b"sender"),
+            Bytes::from_static(b"payer"),
+        );
+        let envelope = FoundryTxEnvelope::Eip8130(signed.clone());
+        for (request, from, sender_auth, payer_auth) in [
+            (
+                FoundryTransactionRequest::from(FoundryTypedTx::Eip8130(body.clone())),
+                None,
+                None,
+                None,
+            ),
+            (
+                FoundryTransactionRequest::from(envelope),
+                body.sender,
+                Some(signed.sender_auth().clone()),
+                Some(signed.payer_auth().clone()),
+            ),
+        ] {
+            assert!(!request.can_build());
+            let base = request.as_base().unwrap();
+            assert_eq!(
+                base.as_eip8130(),
+                Some(&Eip8130RequestFields {
+                    nonce_key: Some(body.nonce_key),
+                    account_changes: Some(body.account_changes.clone()),
+                    calls: Some(body.calls.clone()),
+                    valid_after: Some(body.valid_after),
+                    valid_before: Some(body.valid_before),
+                    metadata: Some(body.metadata.clone()),
+                    sender: body.sender,
+                    payer: body.payer,
+                    sender_auth,
+                    payer_auth,
+                    ..Default::default()
+                })
+            );
+            assert_eq!(
+                base.as_ref(),
+                &TransactionRequest {
+                    transaction_type: Some(EIP8130_TRANSACTION_TYPE),
+                    chain_id: Some(body.chain_id),
+                    from,
+                    nonce: Some(body.nonce_sequence),
+                    gas: Some(body.gas_limit),
+                    max_fee_per_gas: Some(body.max_fee_per_gas),
+                    max_priority_fee_per_gas: Some(body.max_priority_fee_per_gas),
+                    ..Default::default()
+                }
+            );
+            let roundtrip: FoundryTransactionRequest =
+                serde_json::from_value(serde_json::to_value(&request).unwrap()).unwrap();
+            assert_eq!(request, roundtrip);
+        }
+    }
+    #[test]
+    fn eip8130_conversion_preserves_supplied_encoding() {
+        let envelope = FoundryTxEnvelope::Eip8130(Eip8130Signed::new(
+            TxEip8130::default(),
+            Bytes::new(),
+            Bytes::new(),
+        ));
+        let encoded = Bytes::from_static(b"already encoded");
+        let env =
+            BaseTransaction::<TxEnv>::from_encoded_tx(&envelope, Address::ZERO, encoded.clone());
+        assert_eq!(env.enveloped_tx, Some(encoded));
+    }
+}

--- a/crates/primitives/src/transaction/deposit.rs
+++ b/crates/primitives/src/transaction/deposit.rs
@@ -1,0 +1,68 @@
+//! Deposit helpers shared by Base and Optimism.
+
+use super::FoundryReceiptEnvelope;
+use alloy_primitives::{B256, U256};
+use alloy_serde::OtherFields;
+use op_alloy_consensus::OpDepositReceipt;
+use op_revm::transaction::deposit::DepositTransactionParts;
+
+/// Converts `OtherFields` to `DepositTransactionParts`, produces error with missing fields.
+pub fn get_deposit_tx_parts(
+    other: &OtherFields,
+) -> Result<DepositTransactionParts, Vec<&'static str>> {
+    let mut missing = Vec::new();
+    let source_hash =
+        other.get_deserialized::<B256>("sourceHash").transpose().ok().flatten().unwrap_or_else(
+            || {
+                missing.push("sourceHash");
+                Default::default()
+            },
+        );
+    let mint = other
+        .get_deserialized::<U256>("mint")
+        .transpose()
+        .unwrap_or_else(|_| {
+            missing.push("mint");
+            Default::default()
+        })
+        .map(|value| value.saturating_to::<u128>());
+    let is_system_transaction =
+        other.get_deserialized::<bool>("isSystemTx").transpose().ok().flatten().unwrap_or_else(
+            || {
+                missing.push("isSystemTx");
+                Default::default()
+            },
+        );
+    if missing.is_empty() {
+        Ok(DepositTransactionParts { source_hash, mint, is_system_transaction })
+    } else {
+        Err(missing)
+    }
+}
+
+/// Deposit accessors shared by Base and Optimism.
+impl<T> FoundryReceiptEnvelope<T> {
+    /// Return the receipt's deposit_nonce if it is a deposit receipt.
+    pub const fn deposit_nonce(&self) -> Option<u64> {
+        match self.as_deposit_receipt() {
+            Some(receipt) => receipt.deposit_nonce,
+            None => None,
+        }
+    }
+
+    /// Return the receipt's deposit version if it is a deposit receipt.
+    pub const fn deposit_receipt_version(&self) -> Option<u64> {
+        match self.as_deposit_receipt() {
+            Some(receipt) => receipt.deposit_receipt_version,
+            None => None,
+        }
+    }
+
+    /// Returns the deposit receipt if it is a deposit receipt.
+    pub const fn as_deposit_receipt(&self) -> Option<&OpDepositReceipt<T>> {
+        match self {
+            Self::Deposit(t) => Some(&t.receipt),
+            _ => None,
+        }
+    }
+}

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -17,8 +17,21 @@ use revm::context::TxEnv;
 use tempo_primitives::{AASigned, TEMPO_TX_TYPE_ID, TempoSignature, TempoTransaction};
 use tempo_revm::TempoTxEnv;
 
+#[cfg(all(feature = "base", not(feature = "optimism")))]
+use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, TxDeposit};
+
+#[cfg(any(feature = "base", feature = "optimism"))]
+use alloy_consensus::Sealed;
+
+#[cfg(feature = "base")]
+use base_common_consensus::{BaseTxEnvelope, Eip8130Signed, TxEip8130};
+#[cfg(feature = "base")]
+use base_common_evm::EIP8130_TRANSACTION_TYPE;
+#[cfg(feature = "base")]
+use base_common_rpc_types::Transaction;
+
 #[cfg(feature = "optimism")]
-use alloy_consensus::{Sealed, Transaction as _};
+use alloy_consensus::Transaction as _;
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, POST_EXEC_TX_TYPE_ID, TxDeposit, TxPostExec};
 
@@ -58,13 +71,17 @@ pub enum FoundryTxEnvelope {
     /// OP stack deposit transaction.
     ///
     /// See <https://docs.optimism.io/op-stack/bridging/deposit-flow>.
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     #[envelope(ty = 126)]
     Deposit(Sealed<TxDeposit>),
     /// OP stack post-execution synthetic transaction.
     #[cfg(feature = "optimism")]
     #[envelope(ty = 0x7D)]
     PostExec(Sealed<TxPostExec>),
+    /// Base EIP-8130 account-abstraction transaction.
+    #[cfg(feature = "base")]
+    #[envelope(ty = 0x79, typed = TxEip8130)]
+    Eip8130(Eip8130Signed),
     /// Tempo transaction type.
     ///
     /// See <https://docs.tempo.xyz/protocol/transactions>.
@@ -104,7 +121,7 @@ impl FoundryTxEnvelope {
     }
 
     /// Returns `true` if this is an OP stack deposit transaction.
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     #[inline]
     pub const fn is_deposit(&self) -> bool {
         matches!(self, Self::Deposit(_))
@@ -117,6 +134,13 @@ impl FoundryTxEnvelope {
         matches!(self, Self::PostExec(_))
     }
 
+    /// Returns `true` if this is a Base EIP-8130 transaction.
+    #[cfg(feature = "base")]
+    #[inline]
+    pub const fn is_eip8130(&self) -> bool {
+        matches!(self, Self::Eip8130(_))
+    }
+
     /// Converts the transaction into an Ethereum [`TxEnvelope`].
     ///
     /// Returns an error if the transaction is not part of the standard Ethereum transaction types.
@@ -127,10 +151,12 @@ impl FoundryTxEnvelope {
             Self::Eip1559(tx) => Ok(TxEnvelope::Eip1559(tx)),
             Self::Eip4844(tx) => Ok(TxEnvelope::Eip4844(tx)),
             Self::Eip7702(tx) => Ok(TxEnvelope::Eip7702(tx)),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(_) => Err(self),
             #[cfg(feature = "optimism")]
             Self::PostExec(_) => Err(self),
+            #[cfg(feature = "base")]
+            Self::Eip8130(_) => Err(self),
             Self::Tempo(_) => Err(self),
         }
     }
@@ -181,10 +207,12 @@ impl FoundryTxEnvelope {
             Self::Eip1559(tx) => tx.recover_signer()?,
             Self::Eip4844(tx) => tx.recover_signer()?,
             Self::Eip7702(tx) => tx.recover_signer()?,
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(tx) => tx.from,
             #[cfg(feature = "optimism")]
             Self::PostExec(tx) => tx.inner().signer_address(),
+            #[cfg(feature = "base")]
+            Self::Eip8130(tx) => tx.recover_sender()?,
             Self::Tempo(tx) => tx.signature().recover_signer(&tx.signature_hash())?,
         })
     }
@@ -232,7 +260,7 @@ impl FoundryTxType {
     }
 
     /// Returns `true` if this is an OP stack deposit transaction type.
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     pub const fn is_deposit(&self) -> bool {
         matches!(self, Self::Deposit)
     }
@@ -241,6 +269,12 @@ impl FoundryTxType {
     #[cfg(feature = "optimism")]
     pub const fn is_post_exec(&self) -> bool {
         matches!(self, Self::PostExec)
+    }
+
+    /// Returns `true` if this is a Base EIP-8130 transaction type.
+    #[cfg(feature = "base")]
+    pub const fn is_eip8130(&self) -> bool {
+        matches!(self, Self::Eip8130)
     }
 
     /// Returns `true` if this is a Tempo transaction type.
@@ -265,11 +299,15 @@ impl FoundryTypedTx {
             Self::Eip1559(tx) => FoundryTxEnvelope::Eip1559(tx.into_signed(signature)),
             Self::Eip7702(tx) => FoundryTxEnvelope::Eip7702(tx.into_signed(signature)),
             Self::Eip4844(tx) => FoundryTxEnvelope::Eip4844(tx.into_signed(signature)),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(tx) => FoundryTxEnvelope::Deposit(Sealed::new(tx)),
             #[cfg(feature = "optimism")]
             Self::PostExec(_) => {
                 unreachable!("op post-exec txs should not be impersonated")
+            }
+            #[cfg(feature = "base")]
+            Self::Eip8130(_) => {
+                unreachable!("EIP-8130 requires a signed raw transaction envelope")
             }
             Self::Tempo(tx) => {
                 let tempo_sig: TempoSignature = signature.into();
@@ -279,7 +317,7 @@ impl FoundryTypedTx {
     }
 
     /// Returns `true` if this is an OP stack deposit transaction.
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     pub const fn is_deposit(&self) -> bool {
         matches!(self, Self::Deposit(_))
     }
@@ -288,6 +326,12 @@ impl FoundryTypedTx {
     #[cfg(feature = "optimism")]
     pub const fn is_post_exec(&self) -> bool {
         matches!(self, Self::PostExec(_))
+    }
+
+    /// Returns `true` if this is a Base EIP-8130 transaction.
+    #[cfg(feature = "base")]
+    pub const fn is_eip8130(&self) -> bool {
+        matches!(self, Self::Eip8130(_))
     }
 
     /// Returns `true` if this is a Tempo transaction.
@@ -304,10 +348,12 @@ impl TxHashRef for FoundryTxEnvelope {
             Self::Eip1559(t) => t.hash(),
             Self::Eip4844(t) => t.hash(),
             Self::Eip7702(t) => t.hash(),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(t) => t.hash_ref(),
             #[cfg(feature = "optimism")]
             Self::PostExec(t) => t.hash_ref(),
+            #[cfg(feature = "base")]
+            Self::Eip8130(t) => t.hash(),
             Self::Tempo(t) => t.hash(),
         }
     }
@@ -359,6 +405,18 @@ impl TryFrom<AnyRpcTransaction> for FoundryTxEnvelope {
     type Error = ConversionError;
 
     fn try_from(value: AnyRpcTransaction) -> Result<Self, Self::Error> {
+        #[cfg(feature = "base")]
+        if value.ty() == EIP8130_TRANSACTION_TYPE {
+            let rpc = serde_json::from_value::<Transaction>(
+                serde_json::to_value(&value)
+                    .map_err(|err| ConversionError::Custom(err.to_string()))?,
+            )
+            .map_err(|err| ConversionError::Custom(err.to_string()))?;
+            return match rpc.inner.into_inner() {
+                BaseTxEnvelope::Eip8130(tx) => Ok(Self::Eip8130(tx)),
+                _ => Err(ConversionError::Custom("expected Base EIP-8130 transaction".to_string())),
+            };
+        }
         let transaction = value.into_inner();
         let from = transaction.from();
         match transaction.into_inner() {
@@ -379,6 +437,26 @@ impl TryFrom<AnyRpcTransaction> for FoundryTxEnvelope {
                     return Ok(Self::Tempo(tempo_tx));
                 }
 
+                #[cfg(all(feature = "base", not(feature = "optimism")))]
+                {
+                    let mut tx = tx;
+                    if tx.ty() == DEPOSIT_TX_TYPE_ID {
+                        tx.inner
+                            .fields
+                            .insert("from".to_string(), serde_json::to_value(from).unwrap());
+                        let deposit =
+                            tx.inner.fields.deserialize_into::<TxDeposit>().map_err(|err| {
+                                ConversionError::Custom(format!(
+                                    "Failed to deserialize deposit transaction: {err}"
+                                ))
+                            })?;
+                        return Ok(Self::Deposit(Sealed::new(deposit)));
+                    }
+                    let tx_type = tx.ty();
+                    Err(ConversionError::Custom(format!(
+                        "Unknown transaction type: 0x{tx_type:02X}"
+                    )))
+                }
                 #[cfg(feature = "optimism")]
                 {
                     let mut tx = tx;
@@ -414,7 +492,7 @@ impl TryFrom<AnyRpcTransaction> for FoundryTxEnvelope {
                         "Unknown transaction type: 0x{tx_type:02X}"
                     )))
                 }
-                #[cfg(not(feature = "optimism"))]
+                #[cfg(not(any(feature = "base", feature = "optimism")))]
                 {
                     let _ = from;
                     let tx_type = tx.ty();
@@ -435,7 +513,7 @@ impl FromRecoveredTx<FoundryTxEnvelope> for TxEnv {
             FoundryTxEnvelope::Eip1559(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
             FoundryTxEnvelope::Eip4844(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
             FoundryTxEnvelope::Eip7702(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTxEnvelope::Deposit(sealed_tx) => {
                 let tx = sealed_tx.inner();
                 Self {
@@ -458,6 +536,10 @@ impl FromRecoveredTx<FoundryTxEnvelope> for TxEnv {
                     data: tx.input.clone(),
                     ..Default::default()
                 }
+            }
+            #[cfg(feature = "base")]
+            FoundryTxEnvelope::Eip8130(_) => {
+                unreachable!("EIP-8130 transaction in Ethereum context")
             }
             FoundryTxEnvelope::Tempo(_) => unreachable!("Tempo tx in Ethereum context"),
         }
@@ -488,10 +570,14 @@ impl FromRecoveredTx<FoundryTxEnvelope> for TempoTxEnv {
             FoundryTxEnvelope::Eip7702(signed_tx) => {
                 Self::from(TxEnv::from_recovered_tx(signed_tx, caller))
             }
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTxEnvelope::Deposit(_) => unreachable!("Deposit tx in Tempo context"),
             #[cfg(feature = "optimism")]
             FoundryTxEnvelope::PostExec(_) => unreachable!("Post-exec tx in Tempo context"),
+            #[cfg(feature = "base")]
+            FoundryTxEnvelope::Eip8130(_) => {
+                unreachable!("EIP-8130 transaction in Tempo context")
+            }
             FoundryTxEnvelope::Tempo(aa_signed) => Self::from_recovered_tx(aa_signed, caller),
         }
     }
@@ -511,10 +597,12 @@ impl std::fmt::Display for FoundryTxType {
             Self::Eip1559 => write!(f, "eip1559"),
             Self::Eip4844 => write!(f, "eip4844"),
             Self::Eip7702 => write!(f, "eip7702"),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit => write!(f, "deposit"),
             #[cfg(feature = "optimism")]
             Self::PostExec => write!(f, "post-exec"),
+            #[cfg(feature = "base")]
+            Self::Eip8130 => write!(f, "eip8130"),
             Self::Tempo => write!(f, "tempo"),
         }
     }
@@ -540,10 +628,12 @@ impl From<FoundryTxEnvelope> for FoundryTypedTx {
             FoundryTxEnvelope::Eip1559(signed_tx) => Self::Eip1559(signed_tx.strip_signature()),
             FoundryTxEnvelope::Eip4844(signed_tx) => Self::Eip4844(signed_tx.strip_signature()),
             FoundryTxEnvelope::Eip7702(signed_tx) => Self::Eip7702(signed_tx.strip_signature()),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTxEnvelope::Deposit(sealed_tx) => Self::Deposit(sealed_tx.into_inner()),
             #[cfg(feature = "optimism")]
             FoundryTxEnvelope::PostExec(sealed_tx) => Self::PostExec(sealed_tx.into_inner()),
+            #[cfg(feature = "base")]
+            FoundryTxEnvelope::Eip8130(signed_tx) => Self::Eip8130(signed_tx.into_tx()),
             FoundryTxEnvelope::Tempo(signed_tx) => Self::Tempo(signed_tx.strip_signature()),
         }
     }
@@ -551,12 +641,10 @@ impl From<FoundryTxEnvelope> for FoundryTypedTx {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
+    use super::*;
     use alloy_primitives::{TxKind, U256, b256, hex};
     use alloy_rlp::Decodable;
-
-    use super::*;
+    use std::str::FromStr;
 
     fn signed<T>(tx: T) -> Signed<T> {
         Signed::new_unchecked(tx, Signature::test_signature(), B256::ZERO)
@@ -596,9 +684,12 @@ mod tests {
         assert!(FoundryTxType::Tempo.is_tempo());
         assert!(!FoundryTxType::Tempo.is_legacy());
 
+        #[cfg(any(feature = "base", feature = "optimism"))]
+        assert!(FoundryTxType::Deposit.is_deposit());
+        #[cfg(feature = "base")]
+        assert!(FoundryTxType::Eip8130.is_eip8130());
         #[cfg(feature = "optimism")]
         {
-            assert!(FoundryTxType::Deposit.is_deposit());
             assert!(FoundryTxType::PostExec.is_post_exec());
             assert!(!FoundryTxType::Deposit.is_post_exec());
         }
@@ -615,9 +706,12 @@ mod tests {
         assert!(FoundryTypedTx::Eip7702(TxEip7702::default()).is_eip7702());
         assert!(FoundryTypedTx::Tempo(TempoTransaction::default()).is_tempo());
 
+        #[cfg(any(feature = "base", feature = "optimism"))]
+        assert!(FoundryTypedTx::Deposit(TxDeposit::default()).is_deposit());
+        #[cfg(feature = "base")]
+        assert!(FoundryTypedTx::Eip8130(TxEip8130::default()).is_eip8130());
         #[cfg(feature = "optimism")]
         {
-            assert!(FoundryTypedTx::Deposit(TxDeposit::default()).is_deposit());
             assert!(FoundryTypedTx::PostExec(TxPostExec::default()).is_post_exec());
         }
     }
@@ -633,9 +727,19 @@ mod tests {
         );
         assert!(FoundryTxEnvelope::Eip7702(signed(TxEip7702::default())).is_eip7702());
 
+        #[cfg(any(feature = "base", feature = "optimism"))]
+        assert!(FoundryTxEnvelope::Deposit(Sealed::new(TxDeposit::default())).is_deposit());
+        #[cfg(feature = "base")]
+        assert!(
+            FoundryTxEnvelope::Eip8130(Eip8130Signed::new(
+                TxEip8130::default(),
+                Default::default(),
+                Default::default()
+            ))
+            .is_eip8130()
+        );
         #[cfg(feature = "optimism")]
         {
-            assert!(FoundryTxEnvelope::Deposit(Sealed::new(TxDeposit::default())).is_deposit());
             assert!(FoundryTxEnvelope::PostExec(Sealed::new(TxPostExec::default())).is_post_exec());
         }
     }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "base")]
+mod base;
+#[cfg(any(feature = "base", feature = "optimism"))]
+mod deposit;
 mod envelope;
 #[cfg(feature = "optimism")]
 mod optimism;
@@ -8,5 +12,5 @@ pub use envelope::{FoundryTxEnvelope, FoundryTxType, FoundryTypedTx};
 pub use receipt::FoundryReceiptEnvelope;
 pub use request::{FoundryTransactionRequest, TempoTransactionRequest};
 
-#[cfg(feature = "optimism")]
-pub use optimism::get_deposit_tx_parts;
+#[cfg(any(feature = "base", feature = "optimism"))]
+pub use deposit::get_deposit_tx_parts;

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -1,17 +1,15 @@
 //! OP-stack-specific impls for [`FoundryTxEnvelope`] and [`FoundryTransactionRequest`].
 
+use super::{FoundryTransactionRequest, FoundryTxEnvelope};
 use alloy_consensus::{Sealed, Transaction as _, Typed2718};
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded};
 use alloy_op_evm::OpTx;
-use alloy_primitives::{Address, B256, Bytes, U256};
-use alloy_serde::OtherFields;
+use alloy_primitives::{Address, Bytes};
 use op_alloy_consensus::{
-    OpDepositReceipt, OpTransaction as OpTransactionTrait, OpTxEnvelope, TxDeposit, TxPostExec,
+    OpTransaction as OpTransactionTrait, OpTxEnvelope, TxDeposit, TxPostExec,
 };
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 use revm::context::TxEnv;
-
-use super::{FoundryReceiptEnvelope, FoundryTransactionRequest, FoundryTxEnvelope};
 
 impl OpTransactionTrait for FoundryTxEnvelope {
     fn is_deposit(&self) -> bool {
@@ -95,6 +93,10 @@ impl FromRecoveredTx<FoundryTxEnvelope> for OpTransaction<TxEnv> {
                 };
                 Self { base, enveloped_tx: None, deposit: Default::default() }
             }
+            #[cfg(feature = "base")]
+            FoundryTxEnvelope::Eip8130(_) => {
+                unreachable!("EIP-8130 transaction in Optimism context")
+            }
             FoundryTxEnvelope::Tempo(_) => unreachable!("Tempo tx in Optimism context"),
         }
     }
@@ -126,68 +128,12 @@ impl From<op_alloy_rpc_types::Transaction<FoundryTxEnvelope>> for FoundryTransac
     }
 }
 
-/// Converts `OtherFields` to `DepositTransactionParts`, produces error with missing fields.
-pub fn get_deposit_tx_parts(
-    other: &OtherFields,
-) -> Result<DepositTransactionParts, Vec<&'static str>> {
-    let mut missing = Vec::new();
-    let source_hash =
-        other.get_deserialized::<B256>("sourceHash").transpose().ok().flatten().unwrap_or_else(
-            || {
-                missing.push("sourceHash");
-                Default::default()
-            },
-        );
-    let mint = other
-        .get_deserialized::<U256>("mint")
-        .transpose()
-        .unwrap_or_else(|_| {
-            missing.push("mint");
-            Default::default()
-        })
-        .map(|value| value.saturating_to::<u128>());
-    let is_system_transaction =
-        other.get_deserialized::<bool>("isSystemTx").transpose().ok().flatten().unwrap_or_else(
-            || {
-                missing.push("isSystemTx");
-                Default::default()
-            },
-        );
-    if missing.is_empty() {
-        Ok(DepositTransactionParts { source_hash, mint, is_system_transaction })
-    } else {
-        Err(missing)
-    }
-}
-
-/// OP-stack-specific accessors on [`FoundryReceiptEnvelope`].
-impl<T> FoundryReceiptEnvelope<T> {
-    /// Return the receipt's deposit_nonce if it is a deposit receipt.
-    pub fn deposit_nonce(&self) -> Option<u64> {
-        self.as_deposit_receipt().and_then(|r| r.deposit_nonce)
-    }
-
-    /// Return the receipt's deposit version if it is a deposit receipt.
-    pub fn deposit_receipt_version(&self) -> Option<u64> {
-        self.as_deposit_receipt().and_then(|r| r.deposit_receipt_version)
-    }
-
-    /// Returns the deposit receipt if it is a deposit receipt.
-    pub const fn as_deposit_receipt(&self) -> Option<&OpDepositReceipt<T>> {
-        match self {
-            Self::Deposit(t) => Some(&t.receipt),
-            _ => None,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use super::*;
     use alloy_network::eip2718::Encodable2718;
     use alloy_primitives::TxHash;
     use alloy_rlp::Decodable;
-
-    use super::*;
 
     #[test]
     fn test_from_recovered_tx_legacy_op() {

--- a/crates/primitives/src/transaction/receipt.rs
+++ b/crates/primitives/src/transaction/receipt.rs
@@ -15,6 +15,14 @@ use alloy_rpc_types::{BlockNumHash, trace::otterscan::OtsReceipt};
 use serde::{Deserialize, Serialize};
 use tempo_primitives::TEMPO_TX_TYPE_ID;
 
+#[cfg(all(feature = "base", not(feature = "optimism")))]
+use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpDepositReceipt, OpDepositReceiptWithBloom};
+
+#[cfg(feature = "base")]
+use base_common_consensus::Eip8130Receipt;
+#[cfg(feature = "base")]
+use base_common_evm::EIP8130_TRANSACTION_TYPE;
+
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{
     DEPOSIT_TX_TYPE_ID, OpDepositReceipt, OpDepositReceiptWithBloom, POST_EXEC_TX_TYPE_ID,
@@ -36,9 +44,12 @@ pub enum FoundryReceiptEnvelope<T = Log> {
     #[cfg(feature = "optimism")]
     #[serde(rename = "0x7D", alias = "0x7d")]
     PostExec(ReceiptWithBloom<Receipt<T>>),
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     #[serde(rename = "0x7E", alias = "0x7e")]
     Deposit(OpDepositReceiptWithBloom<T>),
+    #[cfg(feature = "base")]
+    #[serde(rename = "0x79")]
+    Eip8130(ReceiptWithBloom<Eip8130Receipt<T>>),
     #[serde(rename = "0x76")]
     Tempo(ReceiptWithBloom<Receipt<T>>),
     /// A receipt with a transaction type Foundry does not model.
@@ -57,8 +68,10 @@ impl FoundryReceiptEnvelope<alloy_rpc_types::Log> {
         cumulative_gas_used: u64,
         logs: impl IntoIterator<Item = alloy_rpc_types::Log>,
         tx_type: FoundryTxType,
-        #[cfg_attr(not(feature = "optimism"), allow(unused_variables))] deposit_nonce: Option<u64>,
-        #[cfg_attr(not(feature = "optimism"), allow(unused_variables))]
+        #[cfg(feature = "base")] eip8130_phase_statuses: Vec<u8>,
+        #[cfg_attr(not(any(feature = "base", feature = "optimism")), allow(unused_variables))]
+        deposit_nonce: Option<u64>,
+        #[cfg_attr(not(any(feature = "base", feature = "optimism")), allow(unused_variables))]
         deposit_receipt_version: Option<u64>,
     ) -> Self {
         let logs = logs.into_iter().collect::<Vec<_>>();
@@ -85,7 +98,7 @@ impl FoundryReceiptEnvelope<alloy_rpc_types::Log> {
             FoundryTxType::PostExec => {
                 Self::PostExec(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTxType::Deposit => {
                 let inner = OpDepositReceiptWithBloom {
                     receipt: OpDepositReceipt {
@@ -97,6 +110,11 @@ impl FoundryReceiptEnvelope<alloy_rpc_types::Log> {
                 };
                 Self::Deposit(inner)
             }
+            #[cfg(feature = "base")]
+            FoundryTxType::Eip8130 => Self::Eip8130(ReceiptWithBloom {
+                receipt: Eip8130Receipt::new(inner_receipt, eip8130_phase_statuses),
+                logs_bloom,
+            }),
             FoundryTxType::Tempo => {
                 Self::Tempo(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
@@ -133,7 +151,7 @@ impl FoundryReceiptEnvelope<Log> {
 
 impl<T> FoundryReceiptEnvelope<T> {
     /// Returns `true` if this is an OP stack deposit receipt.
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     pub const fn is_deposit(&self) -> bool {
         matches!(self, Self::Deposit(_))
     }
@@ -142,6 +160,21 @@ impl<T> FoundryReceiptEnvelope<T> {
     #[cfg(feature = "optimism")]
     pub const fn is_post_exec(&self) -> bool {
         matches!(self, Self::PostExec(_))
+    }
+
+    /// Returns `true` if this is a Base EIP-8130 receipt.
+    #[cfg(feature = "base")]
+    pub const fn is_eip8130(&self) -> bool {
+        matches!(self, Self::Eip8130(_))
+    }
+
+    /// Returns EIP-8130 per-phase statuses, or an empty slice for other receipt types.
+    #[cfg(feature = "base")]
+    pub fn eip8130_phase_statuses(&self) -> &[u8] {
+        match self {
+            Self::Eip8130(receipt) => &receipt.receipt.phase_statuses,
+            _ => &[],
+        }
     }
 
     /// Returns `true` if this is a Tempo receipt.
@@ -164,8 +197,10 @@ impl<T> FoundryReceiptEnvelope<T> {
             Self::Eip7702(_) => EIP7702_TX_TYPE_ID,
             #[cfg(feature = "optimism")]
             Self::PostExec(_) => POST_EXEC_TX_TYPE_ID,
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(_) => DEPOSIT_TX_TYPE_ID,
+            #[cfg(feature = "base")]
+            Self::Eip8130(_) => EIP8130_TRANSACTION_TYPE,
             Self::Tempo(_) => TEMPO_TX_TYPE_ID,
             Self::Unknown(r) => r.r#type,
         }
@@ -181,8 +216,10 @@ impl<T> FoundryReceiptEnvelope<T> {
             Self::Eip7702(_) => FoundryTxType::Eip7702,
             #[cfg(feature = "optimism")]
             Self::PostExec(_) => FoundryTxType::PostExec,
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(_) => FoundryTxType::Deposit,
+            #[cfg(feature = "base")]
+            Self::Eip8130(_) => FoundryTxType::Eip8130,
             Self::Tempo(_) => FoundryTxType::Tempo,
             Self::Unknown(_) => return None,
         })
@@ -210,10 +247,14 @@ impl<T> FoundryReceiptEnvelope<T> {
             Self::Eip7702(r) => FoundryReceiptEnvelope::Eip7702(r.map_logs(f)),
             #[cfg(feature = "optimism")]
             Self::PostExec(r) => FoundryReceiptEnvelope::PostExec(r.map_logs(f)),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(r) => FoundryReceiptEnvelope::Deposit(
                 r.map_receipt(|r: OpDepositReceipt<T>| r.map_logs(f)),
             ),
+            #[cfg(feature = "base")]
+            Self::Eip8130(r) => {
+                FoundryReceiptEnvelope::Eip8130(r.map_receipt(|r: Eip8130Receipt<T>| r.map_logs(f)))
+            }
             Self::Tempo(r) => FoundryReceiptEnvelope::Tempo(r.map_logs(f)),
             Self::Unknown(r) => FoundryReceiptEnvelope::Unknown(AnyReceiptEnvelope {
                 inner: r.inner.map_logs(f),
@@ -242,8 +283,10 @@ impl<T> FoundryReceiptEnvelope<T> {
             Self::Eip7702(t) => &t.logs_bloom,
             #[cfg(feature = "optimism")]
             Self::PostExec(t) => &t.logs_bloom,
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(t) => &t.logs_bloom,
+            #[cfg(feature = "base")]
+            Self::Eip8130(t) => &t.logs_bloom,
             Self::Tempo(t) => &t.logs_bloom,
             Self::Unknown(t) => &t.inner.logs_bloom,
         }
@@ -260,8 +303,10 @@ impl<T> FoundryReceiptEnvelope<T> {
             | Self::Tempo(t) => t.receipt,
             #[cfg(feature = "optimism")]
             Self::PostExec(t) => t.receipt,
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(t) => t.receipt.into_inner(),
+            #[cfg(feature = "base")]
+            Self::Eip8130(t) => t.receipt.into_inner(),
             Self::Unknown(t) => t.inner.receipt,
         }
     }
@@ -277,8 +322,10 @@ impl<T> FoundryReceiptEnvelope<T> {
             | Self::Tempo(t) => &t.receipt,
             #[cfg(feature = "optimism")]
             Self::PostExec(t) => &t.receipt,
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(t) => &t.receipt.inner,
+            #[cfg(feature = "base")]
+            Self::Eip8130(t) => &t.receipt.inner,
             Self::Unknown(t) => &t.inner.receipt,
         }
     }
@@ -350,8 +397,10 @@ impl Encodable2718 for FoundryReceiptEnvelope {
             Self::Eip7702(r) => 1 + r.length(),
             #[cfg(feature = "optimism")]
             Self::PostExec(r) => 1 + r.length(),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(r) => 1 + r.length(),
+            #[cfg(feature = "base")]
+            Self::Eip8130(r) => 1 + r.length(),
             Self::Tempo(r) => 1 + r.length(),
             Self::Unknown(r) => r.rlp_payload_length(),
         }
@@ -370,8 +419,10 @@ impl Encodable2718 for FoundryReceiptEnvelope {
             | Self::Tempo(r) => r.encode(out),
             #[cfg(feature = "optimism")]
             Self::PostExec(r) => r.encode(out),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Deposit(r) => r.encode(out),
+            #[cfg(feature = "base")]
+            Self::Eip8130(r) => r.encode(out),
             Self::Unknown(r) => r.inner.encode(out),
         }
     }
@@ -379,6 +430,14 @@ impl Encodable2718 for FoundryReceiptEnvelope {
 
 impl Decodable2718 for FoundryReceiptEnvelope {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Result<Self, Eip2718Error> {
+        #[cfg(feature = "base")]
+        if ty == EIP8130_TRANSACTION_TYPE {
+            return Ok(Self::Eip8130(ReceiptWithBloom::decode(buf)?));
+        }
+        #[cfg(all(feature = "base", not(feature = "optimism")))]
+        if ty == DEPOSIT_TX_TYPE_ID {
+            return Ok(Self::Deposit(OpDepositReceiptWithBloom::decode(buf)?));
+        }
         #[cfg(feature = "optimism")]
         {
             if ty == DEPOSIT_TX_TYPE_ID {
@@ -445,6 +504,8 @@ mod tests {
             0,
             Vec::new(),
             tx_type,
+            #[cfg(feature = "base")]
+            Vec::new(),
             None,
             None,
         )
@@ -471,13 +532,15 @@ mod tests {
             FoundryTxType::Eip4844,
             FoundryTxType::Eip7702,
             FoundryTxType::Tempo,
+            #[cfg(feature = "base")]
+            FoundryTxType::Eip8130,
+            #[cfg(any(feature = "base", feature = "optimism"))]
+            FoundryTxType::Deposit,
         ] {
             assert_roundtrip(receipt_for(tx_type));
         }
         #[cfg(feature = "optimism")]
-        for tx_type in [FoundryTxType::PostExec, FoundryTxType::Deposit] {
-            assert_roundtrip(receipt_for(tx_type));
-        }
+        assert_roundtrip(receipt_for(FoundryTxType::PostExec));
 
         // Varied payload so encodings differ beyond the type byte.
         let logs = vec![Log {
@@ -495,7 +558,7 @@ mod tests {
         }));
         // A deposit receipt with set deposit fields; op-alloy encodes them only when `Some`, so
         // this catches decode paths that drop them.
-        #[cfg(feature = "optimism")]
+        #[cfg(any(feature = "base", feature = "optimism"))]
         assert_roundtrip(FoundryReceiptEnvelope::Deposit(OpDepositReceiptWithBloom {
             receipt: OpDepositReceipt {
                 inner: receipt,
@@ -586,11 +649,35 @@ mod tests {
         assert!(receipt_for(FoundryTxType::Tempo).is_tempo());
         assert!(!receipt_for(FoundryTxType::Tempo).is_legacy());
 
+        #[cfg(any(feature = "base", feature = "optimism"))]
+        assert!(receipt_for(FoundryTxType::Deposit).is_deposit());
+        #[cfg(feature = "base")]
+        assert!(receipt_for(FoundryTxType::Eip8130).is_eip8130());
         #[cfg(feature = "optimism")]
         {
-            assert!(receipt_for(FoundryTxType::Deposit).is_deposit());
             assert!(receipt_for(FoundryTxType::PostExec).is_post_exec());
         }
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn eip8130_receipt_preserves_phase_statuses_outside_consensus_encoding() {
+        let receipt = FoundryReceiptEnvelope::<alloy_rpc_types::Log>::from_parts(
+            false,
+            42_000,
+            Vec::new(),
+            FoundryTxType::Eip8130,
+            vec![0x01, 0x00],
+            None,
+            None,
+        )
+        .map_logs(|log| log.inner);
+        assert_eq!(receipt.eip8130_phase_statuses(), &[0x01, 0x00]);
+
+        let encoded = receipt.encoded_2718();
+        let decoded = FoundryReceiptEnvelope::decode_2718(&mut encoded.as_slice()).unwrap();
+        assert!(decoded.eip8130_phase_statuses().is_empty());
+        assert_eq!(decoded.encoded_2718(), encoded);
     }
 
     #[test]
@@ -736,6 +823,8 @@ mod tests {
             100000,
             vec![],
             FoundryTxType::Tempo,
+            #[cfg(feature = "base")]
+            Vec::new(),
             None,
             None,
         );
@@ -744,7 +833,7 @@ mod tests {
         assert!(receipt.status());
         assert_eq!(receipt.cumulative_gas_used(), 100000);
         assert!(receipt.logs().is_empty());
-        #[cfg(feature = "optimism")]
+        #[cfg(any(feature = "base", feature = "optimism"))]
         {
             assert!(receipt.deposit_nonce().is_none());
             assert!(receipt.deposit_receipt_version().is_none());

--- a/crates/primitives/src/transaction/request.rs
+++ b/crates/primitives/src/transaction/request.rs
@@ -15,15 +15,24 @@ use tempo_primitives::{
     transaction::{Call, SignedKeyAuthorization, TempoSignedAuthorization},
 };
 
-#[cfg(any(test, feature = "optimism"))]
+#[cfg(all(feature = "base", not(feature = "optimism")))]
+use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, TxDeposit};
+
+#[cfg(any(feature = "base", feature = "optimism"))]
+use super::get_deposit_tx_parts;
+#[cfg(any(feature = "base", feature = "optimism"))]
+use op_revm::transaction::deposit::DepositTransactionParts;
+
+#[cfg(any(test, feature = "base", feature = "optimism"))]
 use alloy_serde::OtherFields;
 
-#[cfg(feature = "optimism")]
-use super::optimism::get_deposit_tx_parts;
+#[cfg(feature = "base")]
+use base_common_evm::EIP8130_TRANSACTION_TYPE;
+#[cfg(feature = "base")]
+use base_common_rpc_types::BaseTransactionRequest;
+
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, POST_EXEC_TX_TYPE_ID, TxDeposit};
-#[cfg(feature = "optimism")]
-use op_revm::transaction::deposit::DepositTransactionParts;
 
 pub use tempo_alloy::rpc::TempoTransactionRequest;
 
@@ -40,7 +49,9 @@ pub use tempo_alloy::rpc::TempoTransactionRequest;
 #[allow(clippy::large_enum_variant)]
 pub enum FoundryTransactionRequest {
     Ethereum(TransactionRequest),
-    #[cfg(feature = "optimism")]
+    #[cfg(feature = "base")]
+    Base(BaseTransactionRequest),
+    #[cfg(any(feature = "base", feature = "optimism"))]
     Op(WithOtherFields<TransactionRequest>),
     Tempo(Box<TempoTransactionRequest>),
 }
@@ -65,8 +76,23 @@ impl FoundryTransactionRequest {
         matches!(self, Self::Ethereum(_))
     }
 
+    /// Returns `true` if this is a Base EIP-8130 request.
+    #[cfg(feature = "base")]
+    pub const fn is_base(&self) -> bool {
+        matches!(self, Self::Base(_))
+    }
+
+    /// Returns the native Base request.
+    #[cfg(feature = "base")]
+    pub const fn as_base(&self) -> Option<&BaseTransactionRequest> {
+        match self {
+            Self::Base(request) => Some(request),
+            _ => None,
+        }
+    }
+
     /// Returns `true` if this is an OP stack transaction request.
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     pub const fn is_op(&self) -> bool {
         matches!(self, Self::Op(_))
     }
@@ -87,7 +113,9 @@ impl FoundryTransactionRequest {
     pub fn into_inner(self) -> TransactionRequest {
         match self {
             Self::Ethereum(tx) => tx,
-            #[cfg(feature = "optimism")]
+            #[cfg(feature = "base")]
+            Self::Base(tx) => tx.into(),
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Op(tx) => tx.inner,
             Self::Tempo(tx) => tx.inner,
         }
@@ -99,7 +127,7 @@ impl FoundryTransactionRequest {
     /// # Returns
     /// - Ok(deposit_tx_parts) if all necessary keys are present to build a deposit transaction.
     /// - Err(missing) if some keys are missing to build a deposit transaction.
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     pub fn get_deposit_tx_parts(&self) -> Result<DepositTransactionParts, Vec<&'static str>> {
         match self {
             Self::Op(tx) => get_deposit_tx_parts(&tx.other),
@@ -114,11 +142,13 @@ impl FoundryTransactionRequest {
     pub fn preferred_type(&self) -> FoundryTxType {
         match self {
             Self::Ethereum(tx) => tx.preferred_type().into(),
+            #[cfg(feature = "base")]
+            Self::Base(_) => FoundryTxType::Eip8130,
             #[cfg(feature = "optimism")]
             Self::Op(tx) if tx.inner.transaction_type == Some(POST_EXEC_TX_TYPE_ID) => {
                 FoundryTxType::PostExec
             }
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Op(_) => FoundryTxType::Deposit,
             Self::Tempo(_) => FoundryTxType::Tempo,
         }
@@ -142,7 +172,7 @@ impl FoundryTransactionRequest {
 
     /// Check if all necessary keys are present to build a Deposit transaction, returning a list of
     /// keys that are missing.
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     pub fn complete_deposit(&self) -> Result<(), Vec<&'static str>> {
         self.get_deposit_tx_parts().map(|_| ())
     }
@@ -164,10 +194,14 @@ impl FoundryTransactionRequest {
             FoundryTxType::Eip1559 => self.as_ref().complete_1559(),
             FoundryTxType::Eip4844 => self.as_ref().complete_4844(),
             FoundryTxType::Eip7702 => self.as_ref().complete_7702(),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTxType::Deposit => self.complete_deposit(),
             #[cfg(feature = "optimism")]
             FoundryTxType::PostExec => Err(vec!["not implemented for post-exec tx"]),
+            #[cfg(feature = "base")]
+            FoundryTxType::Eip8130 => {
+                Err(vec!["EIP-8130 requires a signed raw transaction envelope"])
+            }
             FoundryTxType::Tempo => self.complete_tempo(),
         }
     }
@@ -189,7 +223,11 @@ impl FoundryTransactionRequest {
     /// Converts the request into a `FoundryTypedTx`, handling all Ethereum and OP-stack transaction
     /// types.
     pub fn build_typed_tx(self) -> Result<FoundryTypedTx, Self> {
-        #[cfg(feature = "optimism")]
+        #[cfg(feature = "base")]
+        if self.is_base() {
+            return Err(self);
+        }
+        #[cfg(any(feature = "base", feature = "optimism"))]
         if let Ok(deposit_tx_parts) = self.get_deposit_tx_parts() {
             // Build deposit transaction
             return Ok(FoundryTypedTx::Deposit(TxDeposit {
@@ -245,7 +283,9 @@ impl Serialize for FoundryTransactionRequest {
     {
         match self {
             Self::Ethereum(tx) => tx.serialize(serializer),
-            #[cfg(feature = "optimism")]
+            #[cfg(feature = "base")]
+            Self::Base(tx) => tx.serialize(serializer),
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Op(tx) => tx.serialize(serializer),
             Self::Tempo(tx) => tx.serialize(serializer),
         }
@@ -267,7 +307,9 @@ impl AsRef<TransactionRequest> for FoundryTransactionRequest {
     fn as_ref(&self) -> &TransactionRequest {
         match self {
             Self::Ethereum(tx) => tx,
-            #[cfg(feature = "optimism")]
+            #[cfg(feature = "base")]
+            Self::Base(tx) => tx.as_ref(),
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Op(tx) => tx,
             Self::Tempo(tx) => tx.as_ref(),
         }
@@ -278,7 +320,9 @@ impl AsMut<TransactionRequest> for FoundryTransactionRequest {
     fn as_mut(&mut self) -> &mut TransactionRequest {
         match self {
             Self::Ethereum(tx) => tx,
-            #[cfg(feature = "optimism")]
+            #[cfg(feature = "base")]
+            Self::Base(tx) => tx.as_mut(),
+            #[cfg(any(feature = "base", feature = "optimism"))]
             Self::Op(tx) => tx,
             Self::Tempo(tx) => tx.as_mut(),
         }
@@ -296,6 +340,40 @@ impl TryFrom<WithOtherFields<TransactionRequest>> for FoundryTransactionRequest 
             )]
             Option<NonZeroU64>,
         );
+
+        #[cfg(feature = "base")]
+        {
+            let present = |field: &str| tx.other.get(field).is_some_and(|value| !value.is_null());
+            let base_fields =
+                ["accountChanges", "metadata", "sender", "senderAuth", "payer", "payerAuth"]
+                    .iter()
+                    .any(|field| present(field));
+            let phased_calls = tx
+                .other
+                .get("calls")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|calls| calls.first().is_some_and(serde_json::Value::is_array));
+            let explicit_base = tx.transaction_type == Some(EIP8130_TRANSACTION_TYPE);
+            if base_fields || phased_calls || explicit_base {
+                if tx.transaction_type.is_some() && !explicit_base {
+                    return Err(serde::de::Error::custom(
+                        "Base fields conflict with transaction type",
+                    ));
+                }
+                if TEMPO_REQUEST_FIELDS.iter().any(|field| {
+                    !matches!(*field, "nonceKey" | "calls" | "validBefore" | "validAfter")
+                        && present(field)
+                }) {
+                    return Err(serde::de::Error::custom(
+                        "conflicting Base and Tempo request fields",
+                    ));
+                }
+                let mut base =
+                    serde_json::from_value::<BaseTransactionRequest>(serde_json::to_value(&tx)?)?;
+                base.as_mut().transaction_type = Some(EIP8130_TRANSACTION_TYPE);
+                return Ok(Self::Base(base));
+            }
+        }
 
         if tx.transaction_type == Some(TEMPO_TX_TYPE_ID)
             || TEMPO_REQUEST_FIELDS.iter().any(|field| {
@@ -351,6 +429,12 @@ impl TryFrom<WithOtherFields<TransactionRequest>> for FoundryTransactionRequest 
                 tx.other.get_deserialized::<Option<_>>("feePayerSignature").transpose()?.flatten();
             return Ok(Self::Tempo(Box::new(tempo_tx_req)));
         }
+        #[cfg(all(feature = "base", not(feature = "optimism")))]
+        if tx.transaction_type == Some(DEPOSIT_TX_TYPE_ID)
+            || get_deposit_tx_parts(&tx.other).is_ok()
+        {
+            return Ok(Self::Op(tx));
+        }
         #[cfg(feature = "optimism")]
         if tx.transaction_type == Some(DEPOSIT_TX_TYPE_ID)
             || tx.transaction_type == Some(POST_EXEC_TX_TYPE_ID)
@@ -376,7 +460,7 @@ impl From<FoundryTypedTx> for FoundryTransactionRequest {
             FoundryTypedTx::Eip1559(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
             FoundryTypedTx::Eip4844(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
             FoundryTypedTx::Eip7702(tx) => Self::Ethereum(Into::<TransactionRequest>::into(tx)),
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             FoundryTypedTx::Deposit(tx) => {
                 let other = OtherFields::from_iter([
                     ("sourceHash", serde_json::to_value(tx.source_hash).unwrap()),
@@ -385,7 +469,7 @@ impl From<FoundryTypedTx> for FoundryTransactionRequest {
                 ]);
                 WithOtherFields { inner: Into::<TransactionRequest>::into(tx), other }
                     .try_into()
-                    .expect("valid OP transaction request")
+                    .expect("valid deposit transaction request")
             }
             #[cfg(feature = "optimism")]
             FoundryTypedTx::PostExec(tx) => WithOtherFields {
@@ -394,6 +478,10 @@ impl From<FoundryTypedTx> for FoundryTransactionRequest {
             }
             .try_into()
             .expect("valid OP post-exec transaction request"),
+            #[cfg(feature = "base")]
+            FoundryTypedTx::Eip8130(tx) => {
+                Self::Base(super::base::simulation_request(tx, None, None, None))
+            }
             FoundryTypedTx::Tempo(tx) => Self::Tempo(Box::new(tx.into())),
         }
     }
@@ -401,6 +489,18 @@ impl From<FoundryTypedTx> for FoundryTransactionRequest {
 
 impl From<FoundryTxEnvelope> for FoundryTransactionRequest {
     fn from(tx: FoundryTxEnvelope) -> Self {
+        #[cfg(feature = "base")]
+        if let FoundryTxEnvelope::Eip8130(tx) = tx {
+            let from = tx.recover_sender().ok();
+            let sender_auth = Some(tx.sender_auth().clone());
+            let payer_auth = Some(tx.payer_auth().clone());
+            return Self::Base(super::base::simulation_request(
+                tx.into_tx(),
+                from,
+                sender_auth,
+                payer_auth,
+            ));
+        }
         FoundryTypedTx::from(tx).into()
     }
 }
@@ -538,10 +638,14 @@ impl NetworkTransactionBuilder<FoundryNetwork> for FoundryTransactionRequest {
     }
 
     fn can_build(&self) -> bool {
+        #[cfg(feature = "base")]
+        if self.is_base() {
+            return false;
+        }
         if self.as_ref().can_build() || self.complete_tempo().is_ok() {
             return true;
         }
-        #[cfg(feature = "optimism")]
+        #[cfg(any(feature = "base", feature = "optimism"))]
         if self.complete_deposit().is_ok() {
             return true;
         }
@@ -561,16 +665,20 @@ impl NetworkTransactionBuilder<FoundryNetwork> for FoundryTransactionRequest {
     /// Prepares [`FoundryTransactionRequest`] by trimming conflicting fields, and filling with
     /// default values the mandatory fields.
     fn prep_for_submission(&mut self) {
+        #[cfg(feature = "base")]
+        if self.is_base() {
+            return;
+        }
         let preferred_type = self.preferred_type();
         let inner = self.as_mut();
         inner.transaction_type = Some(preferred_type as u8);
         inner.gas.is_none().then(|| inner.set_gas_limit(Default::default()));
         let is_deposit = {
-            #[cfg(feature = "optimism")]
+            #[cfg(any(feature = "base", feature = "optimism"))]
             {
                 preferred_type.is_deposit()
             }
-            #[cfg(not(feature = "optimism"))]
+            #[cfg(not(any(feature = "base", feature = "optimism")))]
             {
                 false
             }
@@ -644,13 +752,12 @@ impl TransactionBuilder4844 for FoundryTransactionRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use alloy_primitives::{B256, Bytes, Signature};
     use tempo_primitives::{
         TempoSignature, TempoTransaction,
         transaction::{Authorization, KeyAuthorization, PrimitiveSignature},
     };
-
-    use super::*;
 
     fn default_tx_req() -> TransactionRequest {
         TransactionRequest::default()
@@ -672,7 +779,7 @@ mod tests {
         assert!(tempo.is_tempo());
         assert!(!tempo.is_ethereum());
 
-        #[cfg(feature = "optimism")]
+        #[cfg(any(feature = "base", feature = "optimism"))]
         {
             let op = FoundryTransactionRequest::Op(WithOtherFields::default());
             assert!(op.is_op());
@@ -703,6 +810,48 @@ mod tests {
         assert!(matches!(req.build_unsigned(), Ok(FoundryTypedTx::Tempo(_))));
     }
 
+    #[cfg(feature = "base")]
+    #[test]
+    fn base_and_tempo_request_routing() {
+        let call = serde_json::json!({ "to": Address::ZERO, "data": "0x", "value": "0x0" });
+        for (value, expected_type) in [
+            (serde_json::json!({"calls": [call]}), FoundryTxType::Tempo),
+            (serde_json::json!({"nonceKey": "0x1"}), FoundryTxType::Tempo),
+            (serde_json::json!({"validBefore": "0x123"}), FoundryTxType::Tempo),
+            (serde_json::json!({"calls": []}), FoundryTxType::Eip1559),
+            (serde_json::json!({"calls": [[call]], "validBefore": 123}), FoundryTxType::Eip8130),
+            (serde_json::json!({"type": "0x79"}), FoundryTxType::Eip8130),
+            (serde_json::json!({"type": "0x79", "nonceKey": "0x1"}), FoundryTxType::Eip8130),
+            (serde_json::json!({"type": "0x76", "calls": [call]}), FoundryTxType::Tempo),
+            (
+                serde_json::json!({"sender": Address::ZERO, "feeToken": null}),
+                FoundryTxType::Eip8130,
+            ),
+        ] {
+            let request: FoundryTransactionRequest = serde_json::from_value(value.clone())
+                .unwrap_or_else(|err| panic!("{value}: {err}"));
+            assert_eq!(request.preferred_type(), expected_type, "{value}");
+            if expected_type == FoundryTxType::Eip8130 {
+                assert!(request.is_base(), "{value}");
+                assert!(!request.can_build(), "{value}");
+            }
+            let roundtrip: FoundryTransactionRequest =
+                serde_json::from_value(serde_json::to_value(&request).unwrap()).unwrap();
+            assert_eq!(request, roundtrip);
+        }
+        for value in [
+            serde_json::json!({"type": "0x76", "calls": [[call]]}),
+            serde_json::json!({"type": "0x79", "feeToken": Address::ZERO}),
+            serde_json::json!({"type": "0x2", "sender": Address::ZERO}),
+            serde_json::json!({"type": "0x79", "calls": [call]}),
+        ] {
+            assert!(
+                serde_json::from_value::<FoundryTransactionRequest>(value.clone()).is_err(),
+                "{value}"
+            );
+        }
+    }
+
     #[test]
     fn test_routing_serialized_non_aa_tempo_request_to_ethereum() {
         let request = TempoTransactionRequest { inner: default_tx_req(), ..Default::default() };
@@ -718,7 +867,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     fn test_routing_op_by_deposit_fields() {
         let tx = default_tx_req();
         let mut other = OtherFields::default();
@@ -773,7 +922,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     fn test_serialization_op() {
         let tx = default_tx_req();
         let mut other = OtherFields::default();
@@ -910,7 +1059,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "optimism")]
+    #[cfg(any(feature = "base", feature = "optimism"))]
     fn test_deposit_typed_tx_roundtrip() {
         let deposit_tx = TxDeposit {
             from: Address::random(),

--- a/crates/script-sequence/Cargo.toml
+++ b/crates/script-sequence/Cargo.toml
@@ -31,4 +31,5 @@ alloy-primitives.workspace = true
 [features]
 default = ["optimism"]
 monad = ["foundry-common/monad", "foundry-config/monad"]
+base = ["foundry-common/base"]
 optimism = ["foundry-common/optimism"]

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -79,6 +79,17 @@ monad = [
     "forge-script-sequence/monad",
     "forge-verify/monad",
 ]
+base = [
+    "anvil/base",
+    "foundry-evm/base",
+    "foundry-evm-networks/base",
+    "foundry-common/base",
+    "foundry-cheatcodes/base",
+    "foundry-cli/base",
+    "foundry-debugger/base",
+    "forge-script-sequence/base",
+    "forge-verify/base",
+]
 optimism = [
     "foundry-evm/optimism",
     "foundry-evm-networks/optimism",

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -67,6 +67,9 @@ use foundry_wallets::MultiWalletOpts;
 use serde::Serialize;
 use std::path::PathBuf;
 
+#[cfg(feature = "base")]
+use foundry_evm::core::evm::BaseEvmNetwork;
+
 #[cfg(feature = "monad")]
 use foundry_evm::core::evm::MonadEvmNetwork;
 
@@ -442,6 +445,16 @@ impl ScriptArgs {
                 }
                 Ok(())
             })
+            .await;
+        }
+
+        #[cfg(feature = "base")]
+        if evm_opts.networks.is_base() {
+            return Box::pin(self.run_generic_script::<BaseEvmNetwork>(
+                config,
+                evm_opts,
+                ExecutorBuilder::<BaseEvmNetwork>::new(),
+            ))
             .await;
         }
 
@@ -2333,6 +2346,8 @@ mod tests {
             for (networks, name) in [
                 (NetworkConfigs::with_ethereum(), "ethereum"),
                 (NetworkConfigs::with_celo(), "celo"),
+                #[cfg(feature = "base")]
+                (NetworkConfigs::with_base(), "base"),
             ] {
                 let evm_opts = EvmOpts { networks, ..Default::default() };
                 let err = args.resolved_evm_opts(Config::default(), evm_opts).await.unwrap_err();

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -46,4 +46,5 @@ idna_adapter.workspace = true
 
 [features]
 default = ["optimism"]
+base = ["foundry-common/base"]
 optimism = ["foundry-common/optimism"]

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -59,6 +59,12 @@ monad = [
     "foundry-evm-networks/monad",
     "foundry-cli/monad",
 ]
+base = [
+    "foundry-common/base",
+    "foundry-evm/base",
+    "foundry-evm-networks/base",
+    "foundry-cli/base",
+]
 optimism = [
     "foundry-common/optimism",
     "foundry-evm/optimism",

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -48,6 +48,9 @@ use foundry_evm_networks::NetworkVariant;
 use revm::{context::Block as _, state::AccountInfo};
 use std::path::PathBuf;
 
+#[cfg(feature = "base")]
+use foundry_evm::core::evm::BaseEvmNetwork;
+
 #[cfg(feature = "monad")]
 use foundry_evm::core::evm::{BlockContext, MonadEvmNetwork};
 
@@ -257,6 +260,16 @@ impl VerifyBytecodeArgs {
                     endpoint_identity,
                     network_was_inferred,
                     ExecutorBuilder::<EthEvmNetwork>::new(),
+                )
+                .await
+            }
+            #[cfg(feature = "base")]
+            NetworkVariant::Base => {
+                self.run_with_network::<BaseEvmNetwork>(
+                    config,
+                    endpoint_identity,
+                    network_was_inferred,
+                    ExecutorBuilder::<BaseEvmNetwork>::new(),
                 )
                 .await
             }
@@ -1379,6 +1392,16 @@ mod tests {
                 .unwrap()
                 .id(),
             1
+        );
+    }
+
+    #[cfg(feature = "base")]
+    #[test]
+    fn configured_network_preserves_base() {
+        let config = Config { networks: NetworkVariant::Base.into(), ..Default::default() };
+        assert_eq!(
+            VerifyBytecodeArgs::configured_network(None, &config),
+            Some(NetworkVariant::Base)
         );
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -118,6 +118,8 @@ allow-git = [
     # Tempo
     "https://github.com/tempoxyz/tempo",
     "https://github.com/tempoxyz/mpp-rs",
+    # Base
+    "https://github.com/foundry-rs/base",
     # Transitive dependency of Tempo
     "https://github.com/commonwarexyz/monorepo",
     "https://github.com/paradigmxyz/reth",


### PR DESCRIPTION
This PR extracts the reviewed Base tooling support from #16224, originally implemented by @lukasrosario, with my follow-up fixes and refinements. It lets the tooling integration land while native Base support in Anvil remains deferred.

Base becomes a feature-gated execution family across Forge, Cast, Chisel, and scripts, connecting network discovery, configuration, hardfork selection, and dispatch to the native Base EVM. Local execution, forks, replay, and nested EVMs use the selected Base context. Trace decoding adds precompile labels, ABIs, and B20 decoding scoped to the appropriate network and upgrade.

Shared transaction and receipt types gain Base deposit and EIP-8130 support, with EIP-8130 execution gated on Zenith. Conversions preserve phases, account changes, authorizations, receipt phase statuses, and log timestamps. Ambiguous request fields retain existing Ethereum/Tempo routing, and signed EIP-8130 submission requires a raw envelope. Cast gains the corresponding transaction and receipt formatting.

Dependencies use **[foundry-rs/base](https://github.com/foundry-rs/base)**, pinned to [`2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72`](https://github.com/foundry-rs/base/commit/2aa8bc46e6b4272ef3bf0905e1a5660ee2525e72) from `mablr/revm-43` for compatibility with Foundry’s REVM 43 workspace. Dependency declarations, the lockfile, and `deny.toml` consistently reference this fork.

Anvil retains its existing Optimism routing and historical hardfork selection for Base-chain forks. Only compatibility changes for the expanded shared types and explicit rejection of unsupported native Base execution are included. Native Base node support and its dependent tests remain in #16224; the reviewed tooling implementation and standalone replay coverage are preserved.
