### PR TITLE
fix(anvil): preserve Tempo fork account state

### DIFF
--- a/.changelog/tempo-fork-native-balances.md
+++ b/.changelog/tempo-fork-native-balances.md
@@ -1,0 +1,8 @@
+---
+anvil: patch
+foundry-evm-core: patch
+forge: patch
+cast: patch
+---
+
+Fixed Tempo forks importing placeholder native balances from RPC, which could trigger extra native transfers and incorrect gas usage. Historical Anvil account-info reads now return balance, nonce, and code from the requested block, including when serving downstream forks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=85c305f62cf3e10772fef286bcd5b301fbfac360#85c305f62cf3e10772fef286bcd5b301fbfac360"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=cc6bd939d94d7f86a7711813262e1232f48a16d4#cc6bd939d94d7f86a7711813262e1232f48a16d4"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5811,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=85c305f62cf3e10772fef286bcd5b301fbfac360#85c305f62cf3e10772fef286bcd5b301fbfac360"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=cc6bd939d94d7f86a7711813262e1232f48a16d4#cc6bd939d94d7f86a7711813262e1232f48a16d4"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=85c305f62cf3e10772fef286bcd5b301fbfac360#85c305f62cf3e10772fef286bcd5b301fbfac360"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=cc6bd939d94d7f86a7711813262e1232f48a16d4#cc6bd939d94d7f86a7711813262e1232f48a16d4"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5851,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=85c305f62cf3e10772fef286bcd5b301fbfac360#85c305f62cf3e10772fef286bcd5b301fbfac360"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=cc6bd939d94d7f86a7711813262e1232f48a16d4#cc6bd939d94d7f86a7711813262e1232f48a16d4"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5871,7 +5871,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=85c305f62cf3e10772fef286bcd5b301fbfac360#85c305f62cf3e10772fef286bcd5b301fbfac360"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=cc6bd939d94d7f86a7711813262e1232f48a16d4#cc6bd939d94d7f86a7711813262e1232f48a16d4"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5884,7 +5884,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=85c305f62cf3e10772fef286bcd5b301fbfac360#85c305f62cf3e10772fef286bcd5b301fbfac360"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=cc6bd939d94d7f86a7711813262e1232f48a16d4#cc6bd939d94d7f86a7711813262e1232f48a16d4"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6224,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=85c305f62cf3e10772fef286bcd5b301fbfac360#85c305f62cf3e10772fef286bcd5b301fbfac360"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=cc6bd939d94d7f86a7711813262e1232f48a16d4#cc6bd939d94d7f86a7711813262e1232f48a16d4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=85c305f62cf3e10772fef286bcd5b301fbfac360#85c305f62cf3e10772fef286bcd5b301fbfac360"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=cc6bd939d94d7f86a7711813262e1232f48a16d4#cc6bd939d94d7f86a7711813262e1232f48a16d4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -562,10 +562,10 @@ solar-lsp = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "866584c05a475b4face83bd0fa3c56a55abe394a" }
 
 ## foundry-core
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "85c305f62cf3e10772fef286bcd5b301fbfac360" }
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "85c305f62cf3e10772fef286bcd5b301fbfac360" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "85c305f62cf3e10772fef286bcd5b301fbfac360" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "85c305f62cf3e10772fef286bcd5b301fbfac360" }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "cc6bd939d94d7f86a7711813262e1232f48a16d4" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "cc6bd939d94d7f86a7711813262e1232f48a16d4" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "cc6bd939d94d7f86a7711813262e1232f48a16d4" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "cc6bd939d94d7f86a7711813262e1232f48a16d4" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -43,7 +43,9 @@ use foundry_common::{
 };
 use foundry_config::Config;
 use foundry_evm::{
-    backend::{BlockchainDb, BlockchainDbMeta, ForkBlock, SharedBackend},
+    backend::{
+        BlockchainDb, BlockchainDbMeta, ForkBlock, SharedBackend, account_fetch_policy_for_source,
+    },
     constants::DEFAULT_CREATE2_DEPLOYER,
     hardfork::FoundryHardfork,
     utils::{apply_chain_and_block_specific_env_changes_for_chain, block_env_from_header},
@@ -2069,8 +2071,10 @@ latest block number: {latest_block}"
         }
 
         let source_id = fork_source_id(&self.fork_urls, &self.fork_headers);
+        let account_fetch_policy = account_fetch_policy_for_source(source_chain_id, target_profile);
         let meta = BlockchainDbMeta::new(cache_block_env, eth_rpc_url.clone())
-            .with_fork_identity(block_hash, source_id);
+            .with_fork_identity(block_hash, source_id)
+            .with_account_fetch_policy(account_fetch_policy);
         let cache_path =
             self.block_cache_path_for_rpc(source_chain_id, fork_block_number, &eth_rpc_url);
         let block_chain_db = BlockchainDb::new(meta, cache_path);

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2468,31 +2468,36 @@ impl EthApi<FoundryNetwork> {
     ) -> Result<alloy_rpc_types::eth::AccountInfo> {
         node_info!("eth_getAccountInfo");
 
+        let reads_current = block_number.is_none()
+            || matches!(block_number, Some(BlockId::Number(BlockNumber::Latest)));
         if let Some(fork) = self.get_fork() {
             let block_request = self.block_request(block_number).await?;
-            // check if the number predates the fork, if in fork mode
             if let BlockRequest::Number(number) = block_request {
-                trace!(target: "node", "get_account_info: fork block {}, requested block {number}", fork.block_number());
-                return if fork.predates_fork(number) {
-                    // if this predates the fork we need to fetch balance, nonce, code individually
-                    // because the provider might not support this endpoint
+                if !reads_current && fork.predates_fork_inclusive(number) {
+                    if fork.requires_account_info() {
+                        return Ok(fork.get_account_info(address, number).await?);
+                    }
                     let balance = fork.get_balance(address, number).map_err(BlockchainError::from);
                     let code = fork.get_code(address, number).map_err(BlockchainError::from);
-                    let nonce = self.get_transaction_count(address, Some(number.into()));
+                    let nonce = fork.get_nonce(address, number).map_err(BlockchainError::from);
                     let (balance, code, nonce) = try_join!(balance, code, nonce)?;
+                    return Ok(alloy_rpc_types::eth::AccountInfo { balance, nonce, code });
+                }
 
-                    Ok(alloy_rpc_types::eth::AccountInfo { balance, nonce, code })
-                } else {
-                    // Anvil node is at the same block or higher than the fork block,
-                    // return account info from backend to reflect current state.
-                    let account_info = self.backend.get_account(address).await?;
-                    let code = self.backend.get_code(address, Some(block_request)).await?;
-                    Ok(alloy_rpc_types::eth::AccountInfo {
-                        balance: account_info.balance,
-                        nonce: account_info.nonce,
+                if reads_current || number >= self.backend.best_number() {
+                    let account = self.backend.get_account(address).await?;
+                    let code =
+                        self.backend.get_code(address, Some(BlockRequest::Number(number))).await?;
+                    return Ok(alloy_rpc_types::eth::AccountInfo {
+                        balance: account.balance,
+                        nonce: account.nonce,
                         code,
-                    })
-                };
+                    });
+                }
+                return self
+                    .backend
+                    .get_account_info_at_block(address, Some(BlockRequest::Number(number)))
+                    .await;
             }
         }
 

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -36,7 +36,10 @@ use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse};
 use alloy_serde::WithOtherFields;
 use alloy_transport::TransportError;
 use foundry_common::provider::RetryProvider;
-use foundry_evm::hardfork::FoundryHardfork;
+use foundry_evm::{
+    backend::{AccountFetchPolicy, account_fetch_policy_for_source},
+    hardfork::FoundryHardfork,
+};
 use foundry_evm_networks::{NetworkConfigs, NetworkVariant};
 use foundry_primitives::FoundryTxReceipt;
 use parking_lot::{
@@ -180,6 +183,15 @@ impl<N: Network> ClientFork<N> {
         self.config.read().chain_id
     }
 
+    /// Returns whether this fork source requires the combined account-info RPC.
+    pub fn requires_account_info(&self) -> bool {
+        let config = self.config.read();
+        account_fetch_policy_for_source(
+            config.chain_id,
+            config.endpoint_identity.network_profile.unwrap_or_default(),
+        ) == AccountFetchPolicy::RequireAccountInfo
+    }
+
     /// Returns the execution chain ID exposed by the forked node.
     pub fn execution_chain_id(&self) -> u64 {
         self.config.read().execution_chain_id
@@ -302,6 +314,15 @@ impl<N: Network> ClientFork<N> {
     ) -> Result<U256, TransportError> {
         trace!(target: "backend::fork", "get_balance={:?}", address);
         self.provider().get_balance(address).block_id(blocknumber.into()).await
+    }
+
+    pub async fn get_account_info(
+        &self,
+        address: Address,
+        blocknumber: u64,
+    ) -> Result<AccountInfo, TransportError> {
+        trace!(target: "backend::fork", "get_account_info={:?}", address);
+        self.provider().get_account_info(address).block_id(blocknumber.into()).await
     }
 
     pub async fn get_nonce(&self, address: Address, block: u64) -> Result<u64, TransportError> {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -6408,6 +6408,19 @@ where
         .await?
     }
 
+    pub async fn get_account_info_at_block(
+        &self,
+        address: Address,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
+    ) -> Result<RpcAccountInfo, BlockchainError> {
+        self.with_database_at(block_request, |db, _| {
+            let account = db.basic_ref(address)?.unwrap_or_default();
+            let code = self.get_code_with_state(&db, address)?;
+            Ok(RpcAccountInfo { balance: account.balance, nonce: account.nonce, code })
+        })
+        .await?
+    }
+
     /// Returns the nonce of the address
     ///
     /// If the requested number predates the fork then this will fetch it from the endpoint

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -4123,6 +4123,18 @@ async fn test_fork_get_account_info() {
         }
     );
 
+    let snapshot = api.evm_snapshot().await.unwrap();
+    api.anvil_set_nonce(address!("0x19e53a7397bE5AA7908fE9eA991B03710bdC74Fd"), U256::from(123))
+        .await
+        .unwrap();
+    let info = provider
+        .get_account_info(address!("0x19e53a7397bE5AA7908fE9eA991B03710bdC74Fd"))
+        .number(BLOCK_NUMBER)
+        .await
+        .unwrap();
+    assert_eq!(info.nonce, 6690);
+    assert!(api.evm_revert(snapshot).await.unwrap());
+
     // Mine and check account info at new block number, see https://github.com/foundry-rs/foundry/issues/12148
     api.evm_mine(None).await.unwrap();
     let info = provider

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -33,8 +33,9 @@ use foundry_evm::core::tempo::{
     active_tempo_precompile_addresses,
 };
 use foundry_primitives::{FoundryReceiptEnvelope, FoundryTxEnvelope, TempoTransactionRequest};
+use foundry_test_utils::rpc::spawn_rpc_proxy_canned_method;
 use futures::StreamExt;
-use std::num::NonZeroU64;
+use std::{num::NonZeroU64, sync::atomic::Ordering};
 use tempo_alloy::{TempoNetwork, primitives::TempoTxEnvelope, rpc::TempoHeaderResponse};
 use tempo_hardfork::{
     TempoHardfork,
@@ -501,6 +502,95 @@ async fn test_tempo_fork_forwards_request_extensions() {
         .unwrap();
     assert_eq!(simulated[0]["calls"][0]["status"], "0x0");
     assert_eq!(simulated[0]["transactions"][0]["calls"], serde_json::to_value(calls).unwrap());
+}
+
+/// Forks must use real remote balances while preserving local balance edits and snapshots.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_fork_ignores_rpc_placeholder_balances() {
+    let (source, source_handle) =
+        spawn(NodeConfig::test_tempo().with_chain_id(Some(123456u64))).await;
+    let contract = Address::repeat_byte(0x42);
+    // Return SELFBALANCE, making the imported balance observable in EVM execution.
+    source.anvil_set_code(contract, alloy_primitives::bytes!("4760005260206000f3")).await.unwrap();
+    source.anvil_set_balance(contract, U256::from(42)).await.unwrap();
+    source.mine_one().await.unwrap();
+    let (proxy, balance_requests) = spawn_rpc_proxy_canned_method(
+        source_handle.http_endpoint(),
+        "eth_getBalance",
+        serde_json::json!("0xffff"),
+    )
+    .await;
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(proxy.clone()))
+            .with_fork_block_number(Some(1u64))
+            .with_chain_id(Some(31337u64))
+            .with_no_storage_caching(true),
+    )
+    .await;
+    let provider = handle.http_provider();
+    assert_eq!(
+        provider.get_account_info(contract).number(0).await.unwrap().balance,
+        U256::from(42),
+    );
+    for reset in [false, true] {
+        if reset {
+            api.anvil_reset(Some(Forking {
+                json_rpc_url: Some(proxy.clone()),
+                block_number: Some(1),
+            }))
+            .await
+            .unwrap();
+        }
+        let snapshot = api.evm_snapshot().await.unwrap();
+        let local_code = alloy_primitives::bytes!("6001");
+        api.anvil_set_balance(contract, U256::from(99)).await.unwrap();
+        api.anvil_set_nonce(contract, U256::from(7)).await.unwrap();
+        api.anvil_set_code(contract, local_code.clone()).await.unwrap();
+        let account = provider.get_account_info(contract).await.unwrap();
+        assert_eq!(account.balance, U256::from(99));
+        assert_eq!(account.nonce, 7);
+        assert_eq!(account.code, local_code);
+        assert!(api.evm_revert(snapshot).await.unwrap());
+
+        api.mine_one().await.unwrap();
+        let request = TransactionRequest::default().to(contract);
+        assert_eq!(
+            U256::from_be_slice(&provider.call(request.clone().into()).await.unwrap()),
+            U256::from(42),
+        );
+        let snapshot = api.evm_snapshot().await.unwrap();
+        api.anvil_set_balance(contract, U256::from(99)).await.unwrap();
+        assert_eq!(
+            U256::from_be_slice(&provider.call(request.clone().into()).await.unwrap()),
+            U256::from(99),
+        );
+        assert!(api.evm_revert(snapshot).await.unwrap());
+        assert_eq!(
+            U256::from_be_slice(&provider.call(request.into()).await.unwrap()),
+            U256::from(42),
+        );
+    }
+    assert_eq!(balance_requests.load(Ordering::Relaxed), 0);
+
+    // A downstream fork must receive the historical balance, not this node's current state.
+    api.mine_one().await.unwrap();
+    let historical_block = provider.get_block_number().await.unwrap() - 1;
+    api.anvil_set_balance(contract, U256::from(99)).await.unwrap();
+    api.mine_one().await.unwrap();
+    let (_downstream_api, downstream_handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(handle.http_endpoint()))
+            .with_fork_block_number(Some(historical_block))
+            .with_no_storage_caching(true),
+    )
+    .await;
+    let balance = downstream_handle
+        .http_provider()
+        .call(TransactionRequest::default().to(contract).into())
+        .await
+        .unwrap();
+    assert_eq!(U256::from_be_slice(&balance), U256::from(42));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -14,6 +14,7 @@ use crate::{
         apply_chain_specific_tx_replay_env_changes_for_chain, get_blob_base_fee_update_fraction,
     },
 };
+use alloy_chains::Chain;
 use alloy_consensus::{BlockHeader, Typed2718};
 use alloy_eips::BlockNumHash;
 use alloy_evm::{Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
@@ -27,7 +28,8 @@ use eyre::Context;
 use foundry_common::{SYSTEM_TRANSACTION_TYPE, is_known_system_sender};
 use foundry_evm_networks::{NetworkConfigs, apply_bsc_p256_precompile};
 pub use foundry_fork_db::{
-    BlockchainDb, ForkBlock, ForkBlockEnv, SharedBackend, cache::BlockchainDbMeta,
+    AccountFetchPolicy, BlockchainDb, ForkBlock, ForkBlockEnv, SharedBackend,
+    cache::BlockchainDbMeta,
 };
 use revm::{
     Database, DatabaseCommit, JournalEntry,
@@ -64,6 +66,20 @@ pub use snapshot::{BackendStateSnapshot, RevertStateSnapshotAction, StateSnapsho
 
 // A `revm::Database` that is used in forking mode
 type ForkDB<N, B> = CacheDB<SharedBackend<N, B>>;
+
+/// Returns the account-loading policy required by a fork source.
+///
+/// A recognized source chain ID is authoritative. The endpoint's execution profile is only a
+/// source hint for custom chain IDs, where the chain ID cannot identify the RPC semantics.
+pub fn account_fetch_policy_for_source(
+    source_chain_id: ChainId,
+    network_profile: NetworkConfigs,
+) -> AccountFetchPolicy {
+    let source_chain = Chain::from_id(source_chain_id);
+    let is_tempo =
+        source_chain.is_tempo() || (source_chain.named().is_none() && network_profile.is_tempo());
+    if is_tempo { AccountFetchPolicy::RequireAccountInfo } else { AccountFetchPolicy::Auto }
+}
 
 /// Represents a numeric `ForkId` valid only for the existence of the `Backend`.
 ///

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -752,8 +752,13 @@ async fn create_fork<
         );
     }
     let number = resolved.number();
+    let account_fetch_policy = crate::backend::account_fetch_policy_for_source(
+        fork_context.source_chain_id,
+        fork_context.network_profile,
+    );
     let meta = BlockchainDbMeta::new(evm_env.block_env.clone(), fork.url.clone())
-        .with_fork_identity(resolved.hash(), resolved.source_id());
+        .with_fork_identity(resolved.hash(), resolved.source_id())
+        .with_account_fetch_policy(account_fetch_policy);
 
     // Determine the cache path if caching is enabled.
     let cache_path = if fork.enable_caching {
@@ -780,8 +785,10 @@ async fn create_fork<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_chains::NamedChain;
     use alloy_primitives::B256;
     use foundry_evm_networks::{NetworkConfigs, NetworkVariant};
+    use foundry_fork_db::AccountFetchPolicy;
 
     fn context(block_number: u64) -> ForkContext {
         ForkContext {
@@ -827,5 +834,27 @@ mod tests {
 
         assert_ne!(ForkId::resolved(url, &first), ForkId::resolved(url, &replacement));
         assert_ne!(ForkId::resolved(url, &first), ForkId::resolved(url, &authenticated));
+    }
+
+    #[test]
+    fn account_fetch_policy_follows_source_identity() {
+        assert_eq!(
+            crate::backend::account_fetch_policy_for_source(
+                NamedChain::Tempo as u64,
+                NetworkConfigs::with_ethereum(),
+            ),
+            AccountFetchPolicy::RequireAccountInfo,
+        );
+        assert_eq!(
+            crate::backend::account_fetch_policy_for_source(
+                NamedChain::Mainnet as u64,
+                NetworkConfigs::with_tempo(),
+            ),
+            AccountFetchPolicy::Auto,
+        );
+        assert_eq!(
+            crate::backend::account_fetch_policy_for_source(123_456, NetworkConfigs::with_tempo(),),
+            AccountFetchPolicy::RequireAccountInfo,
+        );
     }
 }


### PR DESCRIPTION
Tempo's `eth_getBalance` returns a placeholder native balance. Importing it into fork state makes Relay's multicaller send an extra native refund, adding 13,836 gas to the canary introduced in #16793. The discrepancy comes from incorrect fork state: with authoritative account data, the replay under T13 matches mainnet's gas usage and full logs without relaxing the canary assertions.

Update all foundry-core pins to `327739f0d2b848725b462271276f27aecd8b8ff9`, which includes merged foundry-rs/foundry-core#194, and require `eth_getAccountInfo` for Tempo fork sources, including custom chain IDs identified by the endpoint profile. The account-loading policy rejects caches populated under incompatible semantics. Historical Anvil account-info reads also use the requested state so downstream forks receive consistent balance, nonce, and code.

Closes #16829.

AI assistance was used for implementation, validation, and this description.
