### PR TITLE
fix(lint): exclude internal unused returns

### DIFF
--- a/.changelog/unused-return-internal-calls.md
+++ b/.changelog/unused-return-internal-calls.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+forge-lint: patch
+---
+
+Fixed `unused-return` incorrectly warning on internal library and qualified base-contract calls.

--- a/crates/lint/docs/unused-return.md
+++ b/crates/lint/docs/unused-return.md
@@ -5,10 +5,11 @@
 
 ## What it does
 
-Detects high-level external calls (member calls on contract-typed variables or interface-cast
-addresses) that return one or more values when the entire result is discarded or any slot of a
-tuple return is omitted. ERC20 `transfer` and `transferFrom` are excluded as they are handled by
-the separate `erc20-unchecked-transfer` lint.
+Detects high-level external calls, including external library calls, that return one or more
+values when the entire result is discarded or any slot of a tuple return is omitted. ERC20
+`transfer` and `transferFrom` are excluded as they are handled by the separate
+`erc20-unchecked-transfer` lint. Internal calls, including library calls and
+qualified base-contract calls, are excluded.
 
 ## Why is this bad?
 

--- a/crates/lint/src/sol/med/unused_return.rs
+++ b/crates/lint/src/sol/med/unused_return.rs
@@ -3,12 +3,13 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{
         Severity, SolLint,
-        analysis::{is_elementary, receiver_contract_id, tuple_elems},
+        analysis::{is_elementary, tuple_elems},
     },
 };
 use solar::sema::{
     Gcx,
     hir::{Expr, ExprKind, Stmt, StmtKind},
+    ty::{TyFnKind, TyKind},
 };
 
 declare_forge_lint!(
@@ -41,13 +42,15 @@ impl<'gcx> LateLintPass<'gcx> for UnusedReturn {
     }
 }
 
-/// True if `expr` is a member call on a contract whose selected function has return values,
+/// True if `expr` is an external member call whose selected function has return values,
 /// excluding ERC20 `transfer`/`transferFrom` (covered by
 /// `erc20-unchecked-transfer`).
 fn is_unused_return_call<'gcx>(gcx: Gcx<'gcx>, expr: &Expr<'gcx>) -> bool {
     let ExprKind::Call(callee, ..) = &expr.peel_parens().kind else { return false };
-    let ExprKind::Member(receiver, name) = &callee.peel_parens().kind else { return false };
-    if receiver_contract_id(gcx, receiver).is_none() {
+    let ExprKind::Member(_, name) = &callee.peel_parens().kind else { return false };
+    let Some(ty) = gcx.type_of_expr(callee.peel_parens().id) else { return false };
+    if !matches!(ty.kind, TyKind::Fn(f) if matches!(f.kind(), TyFnKind::External | TyFnKind::DelegateCall))
+    {
         return false;
     }
     let Some(fid) = gcx.resolved_function(callee) else { return false };

--- a/crates/lint/testdata/UnusedReturnInternal.sol
+++ b/crates/lint/testdata/UnusedReturnInternal.sol
@@ -1,0 +1,47 @@
+//@compile-flags: --only-lint unused-return
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+library Challenge {
+    function compute(uint256 value) internal pure returns (uint256, uint256) {
+        return (value, value);
+    }
+
+    function computePublic(uint256 value) public pure returns (uint256, uint256) {
+        return (value, value);
+    }
+}
+
+contract ChallengeBase {
+    function computeBase() public pure returns (uint256, uint256) {
+        return (1, 2);
+    }
+}
+
+contract UnusedReturnInternal is ChallengeBase {
+    using Challenge for uint256;
+
+    function internalCalls(uint256 value) external pure returns (uint256 challenge) {
+        // Internal library calls may discard all or part of their result.
+        Challenge.compute(value);
+        (, uint256 result) = Challenge.compute(value);
+        (, challenge) = Challenge.compute(result);
+        value.compute();
+        (, challenge) = value.compute();
+
+        // A public base function is still called internally through its name or super.
+        ChallengeBase.computeBase();
+        (, challenge) = ChallengeBase.computeBase();
+        super.computeBase();
+    }
+
+    function externalCalls(uint256 value) external view {
+        // Public library calls and calls through this remain external.
+        Challenge.computePublic(value); //~WARN: return value of an external call is not used
+        (, uint256 result) = Challenge.computePublic(value); //~WARN: return value of an external call is not used
+        (, result) = Challenge.computePublic(value); //~WARN: return value of an external call is not used
+        value.computePublic(); //~WARN: return value of an external call is not used
+        (, result) = value.computePublic(); //~WARN: return value of an external call is not used
+        this.computeBase(); //~WARN: return value of an external call is not used
+    }
+}

--- a/crates/lint/testdata/UnusedReturnInternal.stderr
+++ b/crates/lint/testdata/UnusedReturnInternal.stderr
@@ -1,0 +1,48 @@
+warning[unused-return]: return value of an external call is not used
+   ╭▸ ROOT/testdata/UnusedReturnInternal.sol:LL:CC
+   │
+LL │         Challenge.computePublic(value);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-return
+
+warning[unused-return]: return value of an external call is not used
+   ╭▸ ROOT/testdata/UnusedReturnInternal.sol:LL:CC
+   │
+LL │         (, uint256 result) = Challenge.computePublic(value);
+   │                              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-return
+
+warning[unused-return]: return value of an external call is not used
+   ╭▸ ROOT/testdata/UnusedReturnInternal.sol:LL:CC
+   │
+LL │         (, result) = Challenge.computePublic(value);
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-return
+
+warning[unused-return]: return value of an external call is not used
+   ╭▸ ROOT/testdata/UnusedReturnInternal.sol:LL:CC
+   │
+LL │         value.computePublic();
+   │         ━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-return
+
+warning[unused-return]: return value of an external call is not used
+   ╭▸ ROOT/testdata/UnusedReturnInternal.sol:LL:CC
+   │
+LL │         (, result) = value.computePublic();
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-return
+
+warning[unused-return]: return value of an external call is not used
+   ╭▸ ROOT/testdata/UnusedReturnInternal.sol:LL:CC
+   │
+LL │         this.computeBase();
+   │         ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-return
+


### PR DESCRIPTION
Fixes `unused-return` incorrectly warning on internal library and qualified base-contract calls. Uses Solar’s resolved call kind to preserve warnings for external calls, including public library calls through `using for`. Adds regression coverage for discarded results and partially captured tuples.

AI-assisted
