### PR TITLE
fix: enforce existing foundry.lock

### DIFF
--- a/.changelog/automatic-foundry-lock.md
+++ b/.changelog/automatic-foundry-lock.md
@@ -1,0 +1,8 @@
+---
+forge: patch
+cast: patch
+chisel: patch
+foundry-cli: patch
+---
+
+Check existing foundry.lock files before Forge, Cast, or Chisel compile or consume project artifacts. Dependency mismatches fail before automatic installation.

--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -4,6 +4,7 @@ use clap::{Args, Parser, Subcommand};
 use eyre::{Result, WrapErr};
 use foundry_cli::{
     json::print_scalar,
+    lockfile::check_foundry_lock,
     opts::BuildOpts,
     utils::{LoadConfig, find_contract_artifacts, parse_constructor_args},
 };
@@ -41,6 +42,7 @@ struct InitCodeHashArgs {
 impl InitCodeHashArgs {
     fn run(&self) -> Result<()> {
         let config = self.load_config()?;
+        check_foundry_lock(&config.root, false)?;
         let project = config.project()?;
         let target_path = if let Some(path) = &self.contract.path {
             canonicalize(project.root().join(path))?

--- a/crates/cast/src/cmd/events.rs
+++ b/crates/cast/src/cmd/events.rs
@@ -13,6 +13,7 @@ use clap::{ArgGroup, Parser};
 use eyre::Result;
 use foundry_cli::{
     json::print_json_object,
+    lockfile::check_foundry_lock,
     opts::{EtherscanOpts, RpcOpts},
     utils::{self, load_config_from_provider},
 };
@@ -128,6 +129,7 @@ async fn local_event_abis<N: Network, P: Provider<N>>(
     logs: &[Log],
     config: &Config,
 ) -> Result<BTreeMap<Address, JsonAbi>> {
+    check_foundry_lock(&config.root, false)?;
     let addresses = logs.iter().map(Log::address).collect::<BTreeSet<_>>();
     let Some(block_number) = logs.first().and_then(|log| log.block_number) else {
         return Ok(BTreeMap::new());

--- a/crates/cast/src/cmd/interface.rs
+++ b/crates/cast/src/cmd/interface.rs
@@ -5,6 +5,7 @@ use eyre::{Context, Result};
 use forge_fmt::FormatterConfig;
 use foundry_cli::{
     json::print_json_object,
+    lockfile::check_foundry_lock,
     opts::EtherscanOpts,
     utils::{LoadConfig, fetch_abi_from_etherscan},
 };
@@ -123,6 +124,7 @@ pub(crate) fn load_abi_from_file(path: &str) -> Result<JsonAbi> {
 /// Load the ABI and name from the artifact of a locally compiled contract.
 fn load_abi_from_artifact(path_or_contract: &str) -> Result<(JsonAbi, String)> {
     let config = load_config()?;
+    check_foundry_lock(&config.root, false)?;
     let mut project = config.project()?;
     project.no_artifacts = true;
     let compiler = ProjectCompiler::new().quiet(true);

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -1,5 +1,8 @@
 use alloy_primitives::{Bytes, map::AddressHashMap};
-use foundry_cli::utils::{TraceResult, print_traces};
+use foundry_cli::{
+    lockfile::check_foundry_lock,
+    utils::{TraceResult, print_traces},
+};
 use foundry_common::{ContractsByArtifactBuilder, compile::ProjectCompiler};
 use foundry_compilers::artifacts::output_selection::ContractOutputSelection;
 use foundry_config::{Config, FoundryHardfork, TracingConfig};
@@ -64,6 +67,7 @@ pub(crate) async fn handle_traces(
     debug: bool,
 ) -> eyre::Result<()> {
     let (known_contracts, mut sources) = if with_local_artifacts {
+        check_foundry_lock(&config.root, false)?;
         // Status prose goes to stderr so `--json` output on stdout stays machine-readable.
         let _ = sh_status!("Compiling project to generate artifacts");
         let mut config = config.clone();

--- a/crates/cast/tests/cli/address.rs
+++ b/crates/cast/tests/cli/address.rs
@@ -143,6 +143,27 @@ contract InitCodeHash {
         .assert_json_stdout(format!(
             r#"{{"schema_version":1,"success":true,"data":"{expected}","errors":[],"warnings":[]}}"#
         ));
+
+    // A warm compiler cache must not bypass lockfile validation.
+    fs::write(prj.root().join("foundry.lock"), "not json").unwrap();
+    cmd.cast_fuse()
+        .current_dir(prj.root())
+        .args([
+            "create2",
+            "init-code-hash",
+            "src/InitCodeHash.sol:InitCodeHash",
+            "42",
+            &owner.to_string(),
+        ])
+        .assert_failure()
+        .stdout_eq("")
+        .stderr_eq(str![[r#"
+Error: Failed to read foundry.lock
+
+Context:
+- expected ident at line 1 column 2
+
+"#]]);
 });
 
 casttest!(create2_init_code_hash_rejects_abstract_contract, |prj, cmd| {

--- a/crates/cast/tests/cli/call_trace.rs
+++ b/crates/cast/tests/cli/call_trace.rs
@@ -135,6 +135,8 @@ forgetest_async!(cast_call_debug_trace_call_with_local_artifacts, |prj, cmd| {
         "script",
         "--private-key",
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "--sender",
+        "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
         "--rpc-url",
         &handle.http_endpoint(),
         "--broadcast",
@@ -166,6 +168,24 @@ Traces:
 Transaction successfully executed.
 [GAS]
 
+"#]]);
+
+    // A warm compiler cache must not bypass lockfile validation.
+    fs::write(prj.root().join("foundry.lock"), "not json").unwrap();
+    cmd.cast_fuse();
+    cmd.args([
+        "call",
+        "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        "number()(uint256)",
+        "--debug-trace-call",
+        "--with-local-artifacts",
+        "--rpc-url",
+        &handle.http_endpoint(),
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+Error: Failed to read foundry.lock
+...
 "#]]);
 });
 

--- a/crates/chisel/src/session.rs
+++ b/crates/chisel/src/session.rs
@@ -5,9 +5,10 @@
 
 use crate::prelude::{SessionSource, SessionSourceConfig};
 use eyre::Result;
+use foundry_config::find_project_root;
 use foundry_evm::{core::evm::FoundryEvmNetwork, executors::ExecutorBuilder};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use time::{OffsetDateTime, format_description};
 
 /// Rejects a session id that would let `chisel-<id>.json` escape the cache directory when
@@ -32,12 +33,19 @@ pub struct ChiselSession<FEN: FoundryEvmNetwork> {
     pub source: SessionSource<FEN>,
     /// The current session's identifier
     pub id: Option<String>,
+    /// The project that owned this session when it was saved.
+    #[serde(default)]
+    project_root: Option<PathBuf>,
 }
 
 // ChiselSession Common Associated Functions
 impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
     fn deserialize_cached(contents: &str, executor_builder: ExecutorBuilder<FEN>) -> Result<Self> {
         let mut session: Self = serde_json::from_str(contents)?;
+        // Legacy caches did not retain `Config::root`; bind those to the project in which Chisel
+        // is currently running rather than silently validating `.`.
+        session.source.config.foundry_config.root =
+            session.project_root.clone().map_or_else(|| find_project_root(None), Ok)?;
         // A session load must not run project cleanup requested by cached configuration.
         session.source.config.foundry_config.force = false;
         session.source.config.executor_builder = executor_builder;
@@ -54,8 +62,9 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
     ///
     /// A new instance of [ChiselSession]
     pub fn new(config: SessionSourceConfig<FEN>) -> Result<Self> {
+        let project_root = Some(config.foundry_config.root.clone());
         // Return initialized ChiselSession with set solc version
-        Ok(Self { source: SessionSource::new(config)?, id: None })
+        Ok(Self { source: SessionSource::new(config)?, id: None, project_root })
     }
 
     /// Render the full source code for the current session.
@@ -113,6 +122,12 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
         let cache_dir = Self::cache_dir()?;
         std::fs::create_dir_all(&cache_dir)?;
 
+        self.write_to(&cache_dir)
+    }
+
+    fn write_to(&mut self, cache_dir: &str) -> Result<String> {
+        self.project_root = Some(self.source.config.foundry_config.root.clone());
+
         let cache_file_name = match self.id.as_ref() {
             Some(id) => {
                 // ID is already set- use the existing cache file.
@@ -121,7 +136,7 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
             }
             None => {
                 // Get the next session cache ID / file
-                let (id, file_name) = Self::next_cached_session()?;
+                let (id, file_name) = Self::next_cached_session_in(cache_dir)?;
                 // Set the session's ID
                 self.id = Some(id);
                 // Return the new session's cache file name
@@ -301,6 +316,7 @@ mod tests {
     use foundry_config::{Config, SolcReq};
     use foundry_evm::core::evm::EthEvmNetwork;
     use semver::Version;
+    use std::process::Command;
 
     #[cfg(feature = "monad")]
     use foundry_evm::core::{constants::MONAD_CHEATCODE_ADDRESS, evm::MonadEvmNetwork};
@@ -364,6 +380,69 @@ mod tests {
         .unwrap();
 
         assert!(!session.source.config.foundry_config.force);
+    }
+
+    #[test]
+    fn loaded_session_checks_lock_in_owning_project() {
+        let project = tempfile::tempdir().unwrap();
+        assert_ne!(std::env::current_dir().unwrap(), project.path());
+        assert!(
+            Command::new("git")
+                .args(["init", "-q"])
+                .current_dir(project.path())
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        let cache = tempfile::tempdir().unwrap();
+        let cache_dir = format!("{}/", cache.path().display());
+        let mut session = ChiselSession::<EthEvmNetwork>::new(SessionSourceConfig {
+            foundry_config: Config {
+                root: project.path().to_path_buf(),
+                solc: Some(SolcReq::Version(Version::new(0, 8, 29))),
+                ..Default::default()
+            },
+            no_vm: true,
+            ..Default::default()
+        })
+        .unwrap();
+        session.write_to(&cache_dir).unwrap();
+
+        // Introduce a valid lock entry that cannot match the project's installed dependencies.
+        std::fs::write(
+            project.path().join("foundry.lock"),
+            r#"{"lib/missing":{"rev":"0000000000000000000000000000000000000000"}}"#,
+        )
+        .unwrap();
+        let loaded = ChiselSession::<EthEvmNetwork>::load_from(
+            session.id.as_deref().unwrap(),
+            &cache_dir,
+            ExecutorBuilder::<EthEvmNetwork>::new(),
+        )
+        .unwrap();
+
+        assert_eq!(loaded.source.config.foundry_config.root, project.path());
+        let err = loaded.source.build().unwrap_err();
+        assert!(
+            err.to_string().contains("foundry.lock does not match installed dependencies"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn legacy_session_uses_current_project_root() {
+        let session = session_for_normalization_tests();
+        let mut value = serde_json::to_value(session).unwrap();
+        value.as_object_mut().unwrap().remove("project_root");
+
+        let loaded = ChiselSession::<EthEvmNetwork>::deserialize_cached(
+            &serde_json::to_string(&value).unwrap(),
+            ExecutorBuilder::<EthEvmNetwork>::new(),
+        )
+        .unwrap();
+
+        assert_eq!(loaded.source.config.foundry_config.root, find_project_root(None).unwrap());
     }
 
     #[cfg(feature = "monad")]

--- a/crates/chisel/src/source.rs
+++ b/crates/chisel/src/source.rs
@@ -5,6 +5,7 @@
 //! execution helpers.
 
 use eyre::Result;
+use foundry_cli::lockfile::check_foundry_lock;
 use foundry_compilers::{
     Artifact, ProjectCompileOutput,
     artifacts::{ConfigurableContractArtifact, Source, Sources},
@@ -423,6 +424,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
     ///
     /// A new instance of [SessionSource]
     pub fn new(mut config: SessionSourceConfig<FEN>) -> Result<Self> {
+        check_foundry_lock(&config.foundry_config.root, false)?;
         config.detect_solc()?;
         Ok(Self {
             file_name: "ReplContract.sol".to_string(),
@@ -528,6 +530,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
 
     /// Compiles the source if necessary.
     pub fn build(&self) -> Result<&GeneratedOutput> {
+        check_foundry_lock(&self.config.foundry_config.root, false)?;
         // TODO: mimics `get_or_try_init`
         if let Some(output) = self.output.get() {
             return Ok(output);
@@ -668,6 +671,54 @@ mod tests {
     use foundry_compilers::artifacts::remappings::{RelativeRemapping, RelativeRemappingPathBuf};
     use foundry_evm::core::evm::EthEvmNetwork;
     use std::fs;
+
+    fn test_config(root: &std::path::Path) -> SessionSourceConfig<EthEvmNetwork> {
+        SessionSourceConfig {
+            foundry_config: Config {
+                root: root.to_path_buf(),
+                solc: Some(SolcReq::Version(Version::new(0, 8, 29))),
+                ..Default::default()
+            },
+            no_vm: true,
+            ..Default::default()
+        }
+    }
+
+    fn assert_invalid_lock(err: eyre::Report) {
+        assert!(err.to_string().contains("Failed to read foundry.lock"), "{err:?}");
+    }
+
+    #[test]
+    fn new_checks_lock_before_compiler_detection() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("foundry.lock"), "not json").unwrap();
+        let mut config = test_config(tmp.path());
+        config.foundry_config.solc = None;
+
+        assert_invalid_lock(SessionSource::new(config).unwrap_err());
+    }
+
+    #[test]
+    fn cached_build_rechecks_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = SessionSource::new(test_config(tmp.path())).unwrap();
+        source.build().unwrap();
+        fs::write(tmp.path().join("foundry.lock"), "not json").unwrap();
+
+        assert_invalid_lock(source.build().unwrap_err());
+    }
+
+    #[test]
+    fn deserialized_cold_build_checks_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = SessionSource::new(test_config(tmp.path())).unwrap();
+        let encoded = serde_json::to_string(&source).unwrap();
+        let mut source = serde_json::from_str::<SessionSource<EthEvmNetwork>>(&encoded).unwrap();
+        source.config.foundry_config.root = tmp.path().to_path_buf();
+        fs::write(tmp.path().join("foundry.lock"), "not json").unwrap();
+
+        assert_invalid_lock(source.build().unwrap_err());
+    }
 
     #[test]
     fn initialize_local_context_migrates_legacy_session() {

--- a/crates/cli/src/install.rs
+++ b/crates/cli/src/install.rs
@@ -1,7 +1,7 @@
 //! Dependency installation shared by Forge commands.
 
 use crate::{
-    lockfile::{DepIdentifier, DepMap, FOUNDRY_LOCK, Lockfile},
+    lockfile::{DepIdentifier, DepMap, FOUNDRY_LOCK, Lockfile, check_foundry_lock},
     opts::Dependency,
     utils::{Git, LoadConfig},
 };
@@ -280,7 +280,7 @@ impl DependencyInstallOpts {
 
                 if new_insertion
                     || out_of_sync_deps.as_ref().is_some_and(|o| !o.is_empty())
-                    || !lockfile.exists()
+                    || !lockfile.try_exists()?
                 {
                     lockfile.write()?;
                 }
@@ -337,14 +337,15 @@ impl DependencyInstallOpts {
 }
 
 /// Installs missing dependencies and reloads config only to discover new remappings.
-pub fn install_missing_dependencies<E>(
+pub fn install_missing_dependencies<E: Into<eyre::Report>>(
     config: &mut Config,
     reload: impl FnOnce() -> Result<Config, E>,
-) -> Result<(), E> {
+) -> Result<()> {
+    check_foundry_lock(&config.root, false)?;
     if DependencyInstallOpts::default().install_missing_dependencies(config)
         && config.auto_detect_remappings
     {
-        *config = reload()?;
+        *config = reload().map_err(Into::into)?;
     }
     Ok(())
 }

--- a/crates/cli/src/lockfile.rs
+++ b/crates/cli/src/lockfile.rs
@@ -6,10 +6,41 @@ use eyre::{Context, OptionExt, Result};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, hash_map::Entry},
+    fmt::Write,
+    io::ErrorKind,
     path::{Path, PathBuf},
 };
 
 pub const FOUNDRY_LOCK: &str = "foundry.lock";
+
+/// Validates direct Git dependencies before consuming a project's sources or artifacts.
+///
+/// Without an explicit lock requirement, projects without a lockfile are unchanged.
+/// This never installs dependencies or updates the lockfile.
+pub fn check_foundry_lock(root: &Path, required: bool) -> Result<()> {
+    let path = root.join(FOUNDRY_LOCK);
+    if !required && !path_entry_exists(&path).wrap_err("Failed to access foundry.lock")? {
+        return Ok(());
+    }
+    let git = Git::new(root);
+    let mismatches = Lockfile::new(root).with_git(&git).check()?;
+    if mismatches.is_empty() {
+        return Ok(());
+    }
+    let mut message = String::from("foundry.lock does not match installed dependencies:");
+    for mismatch in mismatches {
+        write!(message, "\n  {mismatch}")?;
+    }
+    eyre::bail!(message)
+}
+
+fn path_entry_exists(path: &Path) -> std::io::Result<bool> {
+    match path.symlink_metadata() {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
+}
 
 /// A type alias for a HashMap of dependencies keyed by relative path to the submodule dir.
 pub type DepMap = HashMap<PathBuf, DepIdentifier>;
@@ -183,7 +214,7 @@ impl<'a> Lockfile<'a> {
 
     /// Checks whether the lockfile matches dependency submodules without modifying either.
     pub fn check(&mut self) -> Result<Vec<LockfileMismatch>> {
-        let lockfile_exists = self.exists();
+        let lockfile_exists = self.try_exists()?;
         if lockfile_exists {
             self.read().wrap_err("Failed to read foundry.lock")?;
         } else {
@@ -286,7 +317,7 @@ impl<'a> Lockfile<'a> {
     ///
     /// Throws an error if the lockfile does not exist.
     pub fn read(&mut self) -> Result<()> {
-        if !self.lockfile_path.exists() {
+        if !path_entry_exists(&self.lockfile_path)? {
             return Err(eyre::eyre!("Lockfile not found at {}", self.lockfile_path.display()));
         }
 
@@ -373,6 +404,11 @@ impl<'a> Lockfile<'a> {
 
     pub fn exists(&self) -> bool {
         self.lockfile_path.exists()
+    }
+
+    /// Returns whether a directory entry exists at the lockfile path.
+    pub(crate) fn try_exists(&self) -> Result<bool> {
+        Ok(path_entry_exists(&self.lockfile_path)?)
     }
 }
 
@@ -519,6 +555,9 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
     #[test]
     fn serde_dep_identifier() {
         let branch = DepIdentifier::Branch {
@@ -615,5 +654,17 @@ mod tests {
   }
 }"#;
         assert_eq!(contents.trim(), expected.trim());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_lockfile_symlink_is_not_absent() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(FOUNDRY_LOCK);
+        symlink("missing-lock-target", &path).unwrap();
+
+        let err = check_foundry_lock(dir.path(), false).unwrap_err();
+        assert!(err.to_string().contains("Failed to read foundry.lock"));
+        assert_eq!(fs::read_link(path).unwrap(), Path::new("missing-lock-target"));
     }
 }

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -1,5 +1,5 @@
 use super::ProjectPathOpts;
-use crate::{opts::CompilerOpts, utils::LoadConfig};
+use crate::{lockfile::check_foundry_lock, opts::CompilerOpts, utils::LoadConfig};
 use clap::{Parser, ValueHint};
 use eyre::Result;
 use foundry_compilers::{
@@ -166,6 +166,7 @@ impl BuildOpts {
     /// [`foundry_config::Config::project()`]).
     pub fn project(&self) -> Result<Project<MultiCompiler>> {
         let config = self.load_config()?;
+        check_foundry_lock(&config.root, false)?;
         Ok(config.project()?)
     }
 

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -179,14 +179,14 @@ pub trait LoadConfig {
     }
 
     /// Loads config and installs missing project dependencies.
-    fn load_config_with_dependencies(&self) -> Result<Config, ExtractConfigError> {
+    fn load_config_with_dependencies(&self) -> Result<Config> {
         let mut config = self.load_config()?;
         self.install_missing_dependencies(&mut config)?;
         Ok(config)
     }
 
     /// Installs missing dependencies, reloading config only for automatic remapping discovery.
-    fn install_missing_dependencies(&self, config: &mut Config) -> Result<(), ExtractConfigError> {
+    fn install_missing_dependencies(&self, config: &mut Config) -> Result<()> {
         crate::install::install_missing_dependencies(config, || self.load_config())
     }
 

--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -135,6 +135,7 @@ impl BindArgs {
         };
         let artifacts = config.out.clone();
         let enum_definitions = if self.skip_build {
+            foundry_cli::lockfile::check_foundry_lock(&config.root, false)?;
             let paths = config.project_paths();
             cached_enum_definitions(&paths, self.get_json_files(&artifacts)?.map(|(_, path)| path))
         } else {

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -1,5 +1,4 @@
 use super::watch::WatchArgs;
-use crate::Lockfile;
 use clap::Parser;
 use eyre::Result;
 use forge_lint::{
@@ -7,8 +6,9 @@ use forge_lint::{
     sol::{DeniedLintDiagnostics, SolidityLinter},
 };
 use foundry_cli::{
+    lockfile::check_foundry_lock,
     opts::{BuildOpts, configure_pcx_from_solc, get_solar_sources_from_compile_output},
-    utils::{Git, LoadConfig, cache_local_signatures},
+    utils::{LoadConfig, cache_local_signatures},
 };
 use foundry_common::{
     compile::{ContractSizeLimits, ProjectCompiler},
@@ -34,7 +34,7 @@ use solar::{
     interface::{Session, config::CompileOpts},
     sema::Compiler,
 };
-use std::{fmt::Write, path::PathBuf};
+use std::path::PathBuf;
 
 foundry_config::merge_impl_figment_convert!(BuildArgs, build);
 
@@ -94,7 +94,7 @@ impl BuildArgs {
         let mut config = self.load_config()?;
 
         if locked {
-            self.check_foundry_lock_consistency(&config)?;
+            check_foundry_lock(&config.root, true)?;
         }
 
         self.install_missing_dependencies(&mut config)?;
@@ -255,7 +255,13 @@ impl BuildArgs {
         self.watch.watchexec_config(|| {
             let config = self.load_config()?;
             let foundry_toml: PathBuf = config.root.join(Config::FILE_NAME);
-            Ok([config.src, config.test, config.script, foundry_toml])
+            Ok([
+                config.src,
+                config.test,
+                config.script,
+                foundry_toml,
+                config.root.join(foundry_cli::lockfile::FOUNDRY_LOCK),
+            ])
         })
     }
 
@@ -293,22 +299,6 @@ impl BuildArgs {
                 }
             }
         }
-    }
-
-    /// Checks foundry.lock file consistency with Git submodules.
-    fn check_foundry_lock_consistency(&self, config: &Config) -> Result<()> {
-        let git = Git::new(&config.root);
-        let mut lockfile = Lockfile::new(&config.root).with_git(&git);
-        let mismatches = lockfile.check()?;
-        if mismatches.is_empty() {
-            return Ok(());
-        }
-
-        let mut message = String::from("foundry.lock does not match installed dependencies:");
-        for mismatch in mismatches {
-            write!(message, "\n  {mismatch}")?;
-        }
-        Err(eyre::eyre!(message))
     }
 }
 

--- a/crates/forge/src/cmd/clone.rs
+++ b/crates/forge/src/cmd/clone.rs
@@ -714,6 +714,7 @@ fn source_import(root: &Path, index: usize, path: &Path) -> Result<String> {
 /// Compile the project in the root directory, and return the compilation result.
 pub fn compile_project(root: &Path) -> Result<ProjectCompileOutput> {
     let mut config = Config::load_with_root(root)?.sanitized();
+    foundry_cli::lockfile::check_foundry_lock(&config.root, false)?;
     config.extra_output.push(ContractOutputSelection::StorageLayout);
     let mut project = config.project()?;
     project.no_artifacts = true;

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -143,11 +143,14 @@ impl CreateArgs {
             );
         }
 
+        // Validate local project inputs before RPC discovery or wallet interaction.
+        let config = self.load_config()?;
+        foundry_cli::lockfile::check_foundry_lock(&config.root, false)?;
+
         // Resolve chain early so we can dispatch to the correct network type.
         let chain = if let Some(chain) = self.chain_id() {
             chain
         } else {
-            let config = self.load_config()?;
             let provider = ProviderBuilder::<Ethereum>::from_config(&config)?.build()?;
             let chain_id = provider.get_chain_id().await?;
             let chain = Chain::from(chain_id);

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -74,7 +74,9 @@ pub enum ForgeSubcommand {
     /// - forge build --watch (rebuild on file changes)
     #[command(verbatim_doc_comment, visible_aliases = ["b", "compile"])]
     Build {
-        /// Require foundry.lock to match direct Git dependency submodules.
+        /// Require foundry.lock to match direct Git dependency submodules even when absent.
+        ///
+        /// Existing foundry.lock files are always checked before building.
         #[arg(long)]
         locked: bool,
         #[command(flatten)]

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -1012,7 +1012,7 @@ forgetest!(locked_is_build_only, |_prj, cmd| {
 forgetest_init!(build_locked_rejects_malformed_lockfile, |prj, cmd| {
     fs::write(prj.root().join("foundry.lock"), "not json").unwrap();
 
-    cmd.args(["build", "--locked"]).assert_failure().stdout_eq("").stderr_eq(str![[r#"
+    cmd.args(["build"]).assert_failure().stdout_eq("").stderr_eq(str![[r#"
 Error: Failed to read foundry.lock
 
 Context:
@@ -1021,7 +1021,7 @@ Context:
 "#]]);
 });
 
-forgetest_init!(build_checks_foundry_lock_only_when_locked, |prj, cmd| {
+forgetest_init!(build_checks_foundry_lock_by_default, |prj, cmd| {
     let foundry_lock = prj.root().join("foundry.lock");
     let lockfile = r#"{
   "lib/forge-std": {
@@ -1030,18 +1030,37 @@ forgetest_init!(build_checks_foundry_lock_only_when_locked, |prj, cmd| {
 }"#;
     fs::write(&foundry_lock, lockfile).unwrap();
 
-    cmd.args(["build"]).assert_success().stderr_eq("");
-
     fs::write(prj.root().join("src/Broken.sol"), "this is not Solidity").unwrap();
 
-    cmd.forge_fuse().args(["build", "--locked"]).assert_failure().stdout_eq("").stderr_eq(str![[
-        r#"
+    cmd.forge_fuse().args(["build"]).assert_failure().stdout_eq("").stderr_eq(str![[r#"
 Error: foundry.lock does not match installed dependencies:
   lib/forge-std: expected 0000000000000000000000000000000000000000, found [..]
 
-"#
-    ]]);
+"#]]);
     assert_eq!(fs::read_to_string(foundry_lock).unwrap(), lockfile);
+});
+
+forgetest_init!(project_commands_check_foundry_lock_before_compiling, |prj, cmd| {
+    // Populate the build cache first; cached artifacts must not bypass validation.
+    cmd.args(["build"]).assert_success();
+    let path = prj.root().join("foundry.lock");
+    let contents = r#"{"lib/forge-std":{"rev":"0000000000000000000000000000000000000000"}}"#;
+    fs::write(&path, contents).unwrap();
+    for args in [
+        vec!["build"],
+        vec!["test"],
+        vec!["script", "script/Counter.s.sol:CounterScript"],
+        vec!["create", "src/Counter.sol:Counter"],
+        vec!["inspect", "src/Counter.sol:Counter", "abi"],
+        vec!["bind", "--skip-build"],
+    ] {
+        cmd.forge_fuse().args(args).assert_failure().stdout_eq("").stderr_eq(str![[r#"
+Error: foundry.lock does not match installed dependencies:
+  lib/forge-std: expected 0000000000000000000000000000000000000000, found [..]
+
+"#]]);
+        assert_eq!(fs::read_to_string(&path).unwrap(), contents);
+    }
 });
 
 forgetest_init!(build_locked_reports_uninitialized_dependency_without_installing, |prj, cmd| {
@@ -1056,7 +1075,7 @@ forgetest_init!(build_locked_reports_uninitialized_dependency_without_installing
     let index = fs::read(root.join(".git/index")).unwrap();
     let git_config = fs::read(root.join(".git/config")).unwrap();
 
-    cmd.args(["build", "--locked"]).assert_failure().stdout_eq("").stderr_eq(str![[r#"
+    cmd.args(["build"]).assert_failure().stdout_eq("").stderr_eq(str![[r#"
 Error: foundry.lock does not match installed dependencies:
   lib/forge-std: dependency submodule is not initialized (expected [..])
 
@@ -1065,6 +1084,29 @@ Error: foundry.lock does not match installed dependencies:
     assert_eq!(fs::read(root.join(".git/index")).unwrap(), index);
     assert_eq!(fs::read(root.join(".git/config")).unwrap(), git_config);
     assert!(!root.join("lib/forge-std/.git").exists());
+});
+
+#[cfg(unix)]
+forgetest_init!(build_rejects_dangling_lockfile_symlink_without_side_effects, |prj, cmd| {
+    let root = prj.root();
+    let lockfile = root.join("foundry.lock");
+    fs::remove_file(&lockfile).unwrap();
+    symlink("missing-foundry-lock", &lockfile).unwrap();
+    let index = fs::read(root.join(".git/index")).unwrap();
+    let git_config = fs::read(root.join(".git/config")).unwrap();
+    let dependency_head = git(&root.join("lib/forge-std"), &["rev-parse", "HEAD"]);
+
+    cmd.args(["build"]).assert_failure().stdout_eq("").stderr_eq(str![[r#"
+Error: Failed to read foundry.lock
+
+Context:
+- failed to read from "[..]/foundry.lock": No such file or directory (os error 2)
+
+"#]]);
+    assert_eq!(fs::read_link(lockfile).unwrap(), Path::new("missing-foundry-lock"));
+    assert_eq!(fs::read(root.join(".git/index")).unwrap(), index);
+    assert_eq!(fs::read(root.join(".git/config")).unwrap(), git_config);
+    assert_eq!(git(&root.join("lib/forge-std"), &["rev-parse", "HEAD"]), dependency_head);
 });
 
 forgetest_init!(build_locked_preserves_uninitialized_state_without_lock_entry, |prj, cmd| {

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -29,6 +29,10 @@ forgetest_init!(can_install_missing_deps_build, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.clear();
 
+    // Record the pinned forge-std revision before exercising auto-install without a lockfile.
+    cmd.git_add();
+    fs::remove_file(prj.root().join("foundry.lock")).unwrap();
+
     // wipe forge-std
     let forge_std_dir = prj.root().join("lib/forge-std");
     pretty_err(&forge_std_dir, fs::remove_dir_all(&forge_std_dir));
@@ -64,6 +68,10 @@ forgetest_init!(can_install_missing_deps_test, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.clear();
 
+    // Record the pinned forge-std revision before exercising auto-install without a lockfile.
+    cmd.git_add();
+    fs::remove_file(prj.root().join("foundry.lock")).unwrap();
+
     // wipe forge-std
     let forge_std_dir = prj.root().join("lib/forge-std");
     pretty_err(&forge_std_dir, fs::remove_dir_all(&forge_std_dir));
@@ -98,6 +106,10 @@ Missing dependencies found. Installing now...
 forgetest_init!(can_install_missing_deps_lint, |prj, cmd| {
     prj.initialize_default_contracts();
     prj.clear();
+
+    // Record the pinned forge-std revision before exercising auto-install without a lockfile.
+    cmd.git_add();
+    fs::remove_file(prj.root().join("foundry.lock")).unwrap();
 
     // Wipe forge-std.
     let forge_std_dir = prj.root().join("lib/forge-std");


### PR DESCRIPTION
Towards OSS-795

An existing `foundry.lock` now automatically requires installed dependencies to match its recorded revisions before Forge, Cast, or Chisel compile or consume project artifacts. Validation runs before automatic dependency installation and also covers warm compiler caches, preventing commands from silently using different dependencies without `--locked`.

Chisel saves the owning project root with its sessions so restored sessions validate the correct lockfile. Dangling lockfile symlinks fail instead of being treated as absent. Projects without a lockfile retain their current behavior, and validation preserves the existing direct Git dependency scope.

Implementation was prepared with Codex and revised by the maintainer. This PR description was drafted with Codex.
