### PR TITLE
fix(foundryup): abort bootstrap on signals

### DIFF
--- a/.changelog/foundryup-signal-cancellation.md
+++ b/.changelog/foundryup-signal-cancellation.md
@@ -1,0 +1,5 @@
+---
+foundry-cli: patch
+---
+
+Fixed the `foundryup` migration bootstrap so SIGINT and SIGTERM abort without replacing the launcher.

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -10,7 +10,7 @@ set -eo pipefail
 # Read by external tooling from the raw URL, so it stays even though the bootstrap
 # no longer self-updates.
 # shellcheck disable=SC2034
-FOUNDRYUP_INSTALLER_VERSION="2.0.0"
+FOUNDRYUP_INSTALLER_VERSION="2.0.1"
 
 # ----------------------------------------------------------------------------
 # Rust foundryup migration bootstrap
@@ -80,7 +80,9 @@ bootstrap() {
 
   mkdir -p "$FOUNDRY_BIN_DIR"
 
-  trap cleanup EXIT INT TERM
+  trap cleanup EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
   _init="$(mktemp)"
   # Stage beside the launcher so the final move is an atomic same-filesystem rename.
   _stage="$(mktemp -d "$(dirname "$FOUNDRY_BIN_PATH")/.foundryup-bootstrap.XXXXXX")"

--- a/foundryup/test.sh
+++ b/foundryup/test.sh
@@ -63,12 +63,12 @@ teardown_case() {
   rm -f "$exec_marker"
 }
 
-# A `download` that writes a fake foundryup-init.sh installing a working fake
+# A helper that writes a fake foundryup-init.sh installing a working fake
 # binary into the staging FOUNDRY_DIR. `$fake_bin_body` controls the binary.
 fake_bin_body='#!/usr/bin/env sh
 echo "foundryup 0.0.8 (test 2020)"'
-download() {
-  cat > "$2" <<EOF
+write_fake_installer() {
+  cat > "$1" <<EOF
 #!/usr/bin/env sh
 echo "installer chatter that must not reach stdout"
 mkdir -p "\$FOUNDRY_DIR/bin"
@@ -77,6 +77,45 @@ $fake_bin_body
 BIN
 chmod +x "\$FOUNDRY_DIR/bin/foundryup"
 EOF
+}
+download() {
+  write_fake_installer "$2"
+  return 0
+}
+
+# --- signal cancellation --------------------------------------------------
+
+setup_case
+signal_to_send=TERM
+download() {
+  kill -"$signal_to_send" "$BASHPID"
+  write_fake_installer "$2"
+  return 0
+}
+rc=0; ( bootstrap 2>/dev/null ) || rc=$?
+check_eq "SIGTERM aborts bootstrap with conventional status" "143" "$rc"
+check_eq "SIGTERM leaves launcher untouched" \
+  "original-launcher" "$(cat "$FOUNDRY_BIN_PATH")"
+check_eq "SIGTERM does not exec" "" "$(cat "$exec_marker")"
+teardown_case
+
+setup_case
+signal_to_send=INT
+download() {
+  kill -"$signal_to_send" "$BASHPID"
+  write_fake_installer "$2"
+  return 0
+}
+rc=0; ( bootstrap 2>/dev/null ) || rc=$?
+check_eq "SIGINT aborts bootstrap with conventional status" "130" "$rc"
+check_eq "SIGINT leaves launcher untouched" \
+  "original-launcher" "$(cat "$FOUNDRY_BIN_PATH")"
+check_eq "SIGINT does not exec" "" "$(cat "$exec_marker")"
+teardown_case
+
+unset signal_to_send
+download() {
+  write_fake_installer "$2"
   return 0
 }
 


### PR DESCRIPTION
The foundryup bootstrap currently uses the same cleanup trap for EXIT, SIGINT, and SIGTERM. Because the cleanup handler returns successfully, cancelling the bootstrap can clean up the temp files and then continue running instead of stopping.

This changes signal handling so SIGINT exits with 130 and SIGTERM exits with 143, while the EXIT trap still handles cleanup. That keeps the existing launcher untouched when the bootstrap is interrupted.

I also added regression tests for both signals to make sure the bootstrap exits with the expected status, does not replace the launcher, and does not reach the final exec.

This was introduced as part of the Rust foundryup migration in #15498.
