### PR TITLE
fix(cast): preserve nested batch call arguments

### DIFF
--- a/.changelog/cast-batch-nested-args.md
+++ b/.changelog/cast-batch-nested-args.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fixed `cast batch-send` and `cast batch-mktx` to correctly parse array and tuple arguments containing commas, such as `[1,2]` and `(7,hello)`.

--- a/crates/cast/src/call_spec.rs
+++ b/crates/cast/src/call_spec.rs
@@ -72,7 +72,8 @@ impl CallSpec {
                 spec.sig = Some(part.to_string());
                 if !tail.is_empty() {
                     // Args are comma-separated; rejoin any colons that were split off.
-                    spec.args = tail.join(":").split(',').map(|s| s.trim().to_string()).collect();
+                    let args_str = tail.join(":");
+                    spec.args = split_call_args(&args_str);
                 }
             }
             _ => {}
@@ -111,6 +112,33 @@ impl CallSpec {
         };
         Ok(Call { to: self.to.into(), value: self.value, input })
     }
+}
+
+/// Split call arguments on top-level commas, respecting nested parentheses and brackets.
+///
+/// This ensures that array and tuple arguments containing internal commas are not incorrectly
+/// split. For example:
+/// - `[1,2]` stays as one argument
+/// - `(7,hello),9` splits into `(7,hello)` and `9`
+fn split_call_args(s: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+
+    for (idx, ch) in s.char_indices() {
+        match ch {
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                args.push(s[start..idx].trim().to_string());
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    args.push(s[start..].trim().to_string());
+    args
 }
 
 #[cfg(test)]
@@ -184,5 +212,59 @@ mod tests {
                 "Unexpected trailing field(s) after raw calldata"
             );
         }
+    }
+
+    #[test]
+    fn test_parse_array_args() {
+        let spec =
+            CallSpec::parse("0x1234567890123456789012345678901234567890::foo(uint256[]):[1,2]")
+                .unwrap();
+        assert_eq!(spec.sig, Some("foo(uint256[])".to_string()));
+        assert_eq!(spec.args, vec!["[1,2]"]);
+
+        let spec = CallSpec::parse(
+            "0x1234567890123456789012345678901234567890::foo(uint256[][]):[[1,2],[3,4]]",
+        )
+        .unwrap();
+        assert_eq!(spec.sig, Some("foo(uint256[][])".to_string()));
+        assert_eq!(spec.args, vec!["[[1,2],[3,4]]"]);
+    }
+
+    #[test]
+    fn test_parse_tuple_args() {
+        let spec = CallSpec::parse(
+            "0x1234567890123456789012345678901234567890::foo((uint256,string)):(7,hello)",
+        )
+        .unwrap();
+        assert_eq!(spec.sig, Some("foo((uint256,string))".to_string()));
+        assert_eq!(spec.args, vec!["(7,hello)"]);
+
+        let spec = CallSpec::parse(
+            "0x1234567890123456789012345678901234567890::foo((uint256,string),uint256):(7,hello),9",
+        )
+        .unwrap();
+        assert_eq!(spec.sig, Some("foo((uint256,string),uint256)".to_string()));
+        assert_eq!(spec.args, vec!["(7,hello)", "9"]);
+    }
+
+    #[test]
+    fn test_parse_nested_structures() {
+        let spec = CallSpec::parse(
+            "0x1234567890123456789012345678901234567890::foo((uint256[],string)):([(1,2),(3,4)],hello)",
+        )
+        .unwrap();
+        assert_eq!(spec.sig, Some("foo((uint256[],string))".to_string()));
+        assert_eq!(spec.args, vec!["([(1,2),(3,4)],hello)"]);
+    }
+
+    #[test]
+    fn test_split_call_args() {
+        assert_eq!(split_call_args("[1,2]"), vec!["[1,2]"]);
+        assert_eq!(split_call_args("[[1,2],[3,4]]"), vec!["[[1,2],[3,4]]"]);
+        assert_eq!(split_call_args("(7,hello)"), vec!["(7,hello)"]);
+        assert_eq!(split_call_args("(7,hello),9"), vec!["(7,hello)", "9"]);
+        assert_eq!(split_call_args("1,2,3"), vec!["1", "2", "3"]);
+        assert_eq!(split_call_args("(1,2),(3,4)"), vec!["(1,2)", "(3,4)"]);
+        assert_eq!(split_call_args("[1,2],[3,4]"), vec!["[1,2]", "[3,4]"]);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The argument parser in `call_spec.rs` naively split on all commas without respecting nested structures, breaking valid ABI arguments:

```rust
// Before: split on every comma
spec.args = tail.join(":").split(',').map(|s| s.trim().to_string()).collect();
```

This caused arguments like `[1,2]` to be split into `["[1", "2]"]` and `(7,hello),9` to become `["(7", "hello)", "9"]`.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implemented `split_call_args()` that tracks parenthesis and bracket depth, splitting only on top-level commas (depth == 0). This approach mirrors the existing `split_selector_rule_parts()` in `tempo_policy_args.rs`.

The fix handles:
- Arrays: `[1,2]`
- Nested arrays: `[[1,2],[3,4]]`
- Tuples: `(7,hello)`  
- Mixed arguments: `(7,hello),9`

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
