### PR TITLE
fix(symbolic): stop symbolic-size code forks from bypassing the path limit

### DIFF
--- a/.changelog/symbolic-create-size-path-limit.md
+++ b/.changelog/symbolic-create-size-path-limit.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm-symbolic: patch
+---
+
+Enforced the symbolic path budget when symbolic-size initcode forks completed paths, reporting incomplete execution when the budget is exhausted.

--- a/crates/evm/symbolic/src/executor/mod.rs
+++ b/crates/evm/symbolic/src/executor/mod.rs
@@ -288,6 +288,11 @@ impl SymbolicExecutor {
                             let mut out_of_bounds_constraints = state.constraints.clone();
                             out_of_bounds_constraints.push(condition.not(&mut self.cx));
                             if self.is_sat_with_state(&state, &out_of_bounds_constraints)? {
+                                if *completed_paths >= path_limit {
+                                    return Err(SymbolicError::Unsupported(
+                                        "symbolic path limit exceeded",
+                                    ));
+                                }
                                 let mut halted = state.clone();
                                 halted.constraints = out_of_bounds_constraints;
                                 *completed_paths += 1;

--- a/crates/forge/tests/cli/test_cmd/symbolic_limits.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_limits.rs
@@ -146,6 +146,57 @@ incomplete symbolic execution (Stuck)
     );
 });
 
+forgetest_init!(symbolic_limits_create_size_respects_path_width, |prj, cmd| {
+    if should_skip("symbolic_limits_create_size_respects_path_width") {
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicLimitsCreateSize.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicLimitsCreateSize is Test {
+    function checkCreateSizeRespectsPathWidth(uint256 size) public {
+        vm.assume(size <= 64);
+        bytes memory code = new bytes(64);
+        for (uint256 i = 0; i < 64; i++) {
+            code[i] = 0x5b;
+        }
+        address created;
+        assembly {
+            created := create(0, add(code, 0x20), size)
+        }
+        assert(created != address(0));
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--symbolic-width",
+            "2",
+            "--match-test",
+            "checkCreateSizeRespectsPathWidth",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+(paths: 2,
+incomplete symbolic execution (Stuck)
+symbolic path limit exceeded
+checkCreateSizeRespectsPathWidth(uint256)
+"#]],
+    );
+});
+
 forgetest_init!(symbolic_limits_reports_execution_depth_exhaustion, |prj, cmd| {
     if should_skip("symbolic_limits_reports_execution_depth_exhaustion") {
         return;


### PR DESCRIPTION
Symbolic execution could exceed `--symbolic-width` when contract creation used a symbolic initcode length, doing more work than the user requested. The regression case reached 66 completed paths with a limit of 2.

Check the budget before recording each additional completed path and report incomplete execution when it is exhausted. This fixes enforcement of the existing limit; users can raise `--symbolic-width` to explore more paths. Adds a regression test for the configured limit.

AI assistance: Claude Code and OpenAI Codex.
